### PR TITLE
fix: add missing comma in mint.json array at position 6435

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -277,7 +277,7 @@
         "docs/features/guardrails",
         "docs/features/handoffs",
         "docs/features/multi-provider-advanced",
-        "docs/features/quality-based-rag"
+        "docs/features/quality-based-rag",
         "docs/features/workflow-validation",
         "docs/features/handoffs"
       ]


### PR DESCRIPTION
Fixed JSON syntax error by adding missing comma after "docs/features/quality-based-rag" on line 280

Closes #46

Generated with [Claude Code](https://claude.ai/code)