### PR TITLE
fix(claude): prevent double-triggering on issue creation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -113,12 +113,7 @@ jobs:
     # Block: dependabot, cursor, renovate, other bots
     # Allow 'opened' events ONLY for owner/member/collaborator
     if: |
-      (
-        github.event.action != 'opened' ||
-        github.event.issue.author_association == 'OWNER' ||
-        github.event.issue.author_association == 'MEMBER' ||
-        github.event.issue.author_association == 'COLLABORATOR'
-      ) &&
+      github.event.action != 'opened' &&
       (github.event.action != 'labeled' || github.event.label.name == 'claude') &&
       (github.event_name != 'issue_comment' || contains(github.event.comment.body, '@claude')) &&
       (


### PR DESCRIPTION
Claude was running twice on new issues created by owners because both the 'opened' trigger and the triage-labeled 'claude' trigger were firing. This PR removes the redundant 'opened' check, relying strictly on the label (which is automatically added for owners) to trigger Claude once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation configuration to refine when the AI assistant responds to issues. The assistant will no longer respond automatically to newly created issues, but continues to engage with subsequent comments and labeled events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->