### PR TITLE
docs: Add Platform Guides Index Page (fixes #116)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -182,6 +182,17 @@
                 ]
               },
               {
+                "group": "Platform",
+                "icon": "server",
+                "pages": [
+                  "docs/guides/platform/index",
+                  "docs/guides/platform/getting-started",
+                  "docs/guides/platform/quick-tutorial",
+                  "docs/guides/platform/assign-agents",
+                  "docs/guides/platform/organize-issues"
+                ]
+              },
+              {
                 "group": "Recipes",
                 "icon": "book",
                 "pages": [

--- a/docs/guides/platform/index.mdx
+++ b/docs/guides/platform/index.mdx
@@ -1,0 +1,81 @@
+---
+title: "Platform Guides"
+sidebarTitle: "Platform"
+description: "Learn how to run the PraisonAI Platform — a workspace for managing AI agents, issues, and projects."
+icon: "server"
+---
+
+The PraisonAI Platform is a self-hosted backend for organizing AI agent work. It provides a REST API for workspaces, projects, issues, agents, comments, labels, and dependencies with JWT authentication, auto-numbered issues, and activity logging. The Python SDK offers programmatic access for seamless integration.
+
+## Guide Pages
+
+<CardGroup cols={2}>
+  <Card title="Getting Started" icon="rocket" href="getting-started">
+    Install, start the server, make your first API call
+  </Card>
+  
+  <Card title="Quick Tutorial" icon="clock" href="quick-tutorial">
+    Full workflow in 10 minutes: user → workspace → project → issue → agent
+  </Card>
+  
+  <Card title="Assign Work to Agents" icon="user-plus" href="assign-agents">
+    Register AI agents and assign issues to them
+  </Card>
+  
+  <Card title="Organize with Labels & Dependencies" icon="tags" href="organize-issues">
+    Tag issues and link related work
+  </Card>
+</CardGroup>
+
+---
+
+## Feature Reference
+
+Explore detailed documentation for platform features:
+
+<CardGroup cols={2}>
+  <Card title="Authentication" icon="shield-check" href="/docs/features/platform/authentication">
+    JWT authentication system
+  </Card>
+  
+  <Card title="Workspaces" icon="building" href="/docs/features/platform/workspaces">
+    Multi-tenant workspace management
+  </Card>
+  
+  <Card title="Projects" icon="folder" href="/docs/features/platform/projects">
+    Project organization and management
+  </Card>
+  
+  <Card title="Issues" icon="bug" href="/docs/features/platform/issues">
+    Issue tracking and management
+  </Card>
+  
+  <Card title="Agents" icon="robot" href="/docs/features/platform/agents">
+    AI agent registration and management
+  </Card>
+  
+  <Card title="Comments" icon="message-circle" href="/docs/features/platform/comments">
+    Issue commenting system
+  </Card>
+  
+  <Card title="Labels" icon="tag" href="/docs/features/platform/labels">
+    Issue labeling system
+  </Card>
+  
+  <Card title="Dependencies" icon="link" href="/docs/features/platform/dependencies">
+    Issue dependency tracking
+  </Card>
+</CardGroup>
+
+---
+
+## Quick Install
+
+Get started with the PraisonAI Platform in seconds:
+
+```bash
+pip install praisonai-platform
+uvicorn praisonai_platform.api.app:create_app --factory --port 8000
+```
+
+The platform server will be available at `http://localhost:8000` with interactive API documentation at `/docs`.


### PR DESCRIPTION
## Summary

This PR creates the **Platform Guides Index Page** as requested in issue #116.

### Changes Made:
- ✅ Created `docs/guides/platform/index.mdx` with required content structure
- ✅ Added proper Mintlify frontmatter (title, sidebarTitle, description, icon)
- ✅ Included CardGroup with links to all 4 guide pages:
  - Getting Started
  - Quick Tutorial  
  - Assign Work to Agents
  - Organize with Labels & Dependencies
- ✅ Added Feature Reference section linking to platform documentation
- ✅ Included Quick Install snippet
- ✅ Updated `docs.json` navigation to include Platform group under Guides

### Content Structure:
- **What is PraisonAI Platform**: Brief description as requested
- **Guide Pages**: CardGroup with 4 guide cards
- **Feature Reference**: Links to detailed feature docs
- **Quick Install**: Copy-paste installation snippet

### Navigation:
The page is now accessible as the first page in the Platform group under the Guides tab in the navigation.

Fixes #116

Generated with [Claude Code](https://claude.ai/code)