### PR TITLE
docs: Add Platform CLI entry point documentation (fixes #126)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -635,9 +635,10 @@
                 "group": "Platform",
                 "icon": "server",
                 "pages": [
-                  "docs/features/platform/comments"
-                  "docs/features/platform/members"
-                  "docs/features/platform/pagination"
+                  "docs/features/platform/cli",
+                  "docs/features/platform/comments",
+                  "docs/features/platform/members",
+                  "docs/features/platform/pagination",
                   "docs/features/platform/workspaces"
                 ]
               }

--- a/docs/features/platform/cli.mdx
+++ b/docs/features/platform/cli.mdx
@@ -1,0 +1,142 @@
+---
+title: "Platform CLI"
+sidebarTitle: "CLI"
+description: "Start the PraisonAI platform server from command line"
+icon: "terminal"
+---
+
+Start the PraisonAI platform server with `python -m praisonai_platform` for local development and production deployment.
+
+```mermaid
+graph LR
+    subgraph "Platform CLI"
+        A[📋 CLI Command] --> B[🚀 Server Start]
+        B --> C[✅ Running Platform]
+    end
+    
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A input
+    class B process
+    class C output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Basic Usage">
+Start the platform server with default settings:
+
+```bash
+python -m praisonai_platform
+```
+
+This starts the server on `http://0.0.0.0:8000` with automatic reload disabled.
+</Step>
+
+<Step title="Development Mode">
+Start with auto-reload for development:
+
+```bash
+python -m praisonai_platform --port 9000 --reload
+```
+
+This enables automatic restart when code changes are detected.
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant CLI
+    participant Uvicorn
+    participant Platform
+    
+    CLI->>Uvicorn: Start server
+    Uvicorn->>Platform: Load create_app()
+    Platform-->>Uvicorn: FastAPI app
+    Uvicorn-->>CLI: Server running
+```
+
+| Component | Purpose |
+|-----------|---------|
+| **CLI Entry Point** | `python -m praisonai_platform` command |
+| **Uvicorn** | ASGI server with factory mode |
+| **Platform App** | FastAPI application with routes |
+
+---
+
+## Configuration Options
+
+<Card title="CLI Arguments" icon="sliders" href="#cli-arguments">
+  Command line flags and options
+</Card>
+
+### CLI Arguments
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--host` | `str` | `"0.0.0.0"` | Server bind address |
+| `--port` | `int` | `8000` | Server port number |
+| `--reload` | `bool` | `False` | Enable auto-reload on changes |
+
+---
+
+## Common Patterns
+
+### Production Deployment
+
+```bash
+# Bind to specific host and port
+python -m praisonai_platform --host 127.0.0.1 --port 8080
+```
+
+### Development Server
+
+```bash
+# Auto-reload with custom port
+python -m praisonai_platform --port 9000 --reload
+```
+
+### Docker Container
+
+```bash
+# Bind to all interfaces for container access
+python -m praisonai_platform --host 0.0.0.0 --port 8000
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Use auto-reload for development only">
+The `--reload` flag monitors file changes and restarts the server automatically. Only use this during development as it adds overhead and can cause issues in production.
+</Accordion>
+
+<Accordion title="Bind to specific hosts in production">
+Use `--host 127.0.0.1` to bind only to localhost in production, or use a reverse proxy like nginx for public access instead of binding to `0.0.0.0`.
+</Accordion>
+
+<Accordion title="Choose appropriate ports">
+Use standard ports like `8000` or `8080` for HTTP services. Ensure the port is available and not blocked by firewalls.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Platform Authentication" icon="shield-check" href="/docs/features/platform/authentication">
+  Set up authentication for your platform server
+</Card>
+<Card title="Platform SDK Client" icon="plug" href="/docs/features/platform/sdk-client">
+  Connect to platform programmatically
+</Card>
+</CardGroup>


### PR DESCRIPTION
Fixes #126

Created comprehensive CLI documentation for praisonai_platform module:

- Documents `python -m praisonai_platform` command usage
- Includes --host, --port, --reload flags with examples
- Agent-centric Quick Start with development and production patterns
- Follows AGENTS.md standards with Mermaid diagrams and Mintlify components
- Added to Platform group in docs.json navigation

🤖 Generated with [Claude Code](https://claude.ai/code)