### PR TITLE
docs: fix Agent cache= parameter to caching= in architecture examples (fixes #152)

### DIFF
--- a/docs/sdk/praisonaiagents/architecture.mdx
+++ b/docs/sdk/praisonaiagents/architecture.mdx
@@ -127,7 +127,7 @@ from praisonai.cache import RedisCache
 from praisonaiagents import Agent
 
 cache = RedisCache("redis://localhost:6379")
-agent = Agent(name="CachedAgent", cache=cache)
+agent = Agent(name="CachedAgent", caching=cache)
 ```
 
 ### Testing (Mock)
@@ -148,7 +148,7 @@ class MockCache:
 
 def test_agent_with_cache():
     cache = MockCache()
-    agent = Agent(cache=cache)  # Fast, free, deterministic
+    agent = Agent(caching=cache)  # Fast, free, deterministic
 ```
 
 ---


### PR DESCRIPTION
Fixes #152

This PR fixes the invalid `Agent(cache=...)` examples in the SDK architecture page that were causing TypeError for users.

## Changes
- Changed `Agent(cache=cache)` to `Agent(caching=cache)` in production example
- Fixed `Agent(cache=cache)` to `Agent(caching=cache)` in testing mock example
- Both examples now align with the actual SDK API which uses `caching=` parameter

## Impact
- Prevents TypeError when users copy-paste the examples
- Aligns with canonical caching documentation in `docs/concepts/caching.mdx`
- Maintains consistency with the SDK's parameter consolidation (`cache, prompt_caching → caching=`)

Generated with [Claude Code](https://claude.ai/code)