### PR TITLE
docs: External agents (Claude/Gemini/Codex/Cursor) toggles in all UI entry points

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -269,7 +269,8 @@
                   "docs/features/whatsapp-bot",
                   "docs/features/model-failover",
                   "docs/features/sandbox",
-                  "docs/features/external-cli-integrations"
+                  "docs/features/external-cli-integrations",
+                  "docs/features/external-agents-ui"
                 ]
               },
               {

--- a/docs/code/external-agents.mdx
+++ b/docs/code/external-agents.mdx
@@ -213,6 +213,12 @@ except Exception as e:
     print(f"Error: {e}")
 ```
 
+## Using from PraisonAI UI
+
+<Tip>
+Instead of writing Python code, you can enable external agents directly from any PraisonAI UI by flipping toggles in the interface. See [External Agents in UI](/docs/features/external-agents-ui) for complete documentation on UI-based external agent management.
+</Tip>
+
 ## Next Steps
 
 <CardGroup cols={2}>

--- a/docs/features/external-agents-ui.mdx
+++ b/docs/features/external-agents-ui.mdx
@@ -1,0 +1,297 @@
+---
+title: "External Agents in UI"
+sidebarTitle: "External Agents (UI)"
+description: "Toggle Claude / Gemini / Codex / Cursor sub-agents from any PraisonAI UI"
+icon: "toggle-on"
+---
+
+External Agents in UI allows you to flip toggles in any PraisonAI interface to instantly add Claude Code, Gemini CLI, Codex CLI, or Cursor CLI as sub-agents to your main agent.
+
+```mermaid
+graph LR
+    subgraph "External Agents UI Flow"
+        A[👤 User] --> B[🔘 UI Toggle]
+        B --> C[🤖 PraisonAI Agent]
+        C --> D[🧠 External Sub-agent]
+        D --> E[📋 Result]
+    end
+    
+    classDef user fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef toggle fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agent fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef subagent fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef result fill:#6366F1,stroke:#7C90A0,color:#fff
+    
+    class A user
+    class B toggle
+    class C agent
+    class D subagent
+    class E result
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Install External CLI">
+Install one of the supported CLIs:
+
+```bash
+# Claude Code
+npm install -g @anthropic-ai/claude-code
+
+# Gemini CLI  
+npm install -g @google/gemini-cli
+
+# Codex CLI
+npm install -g @openai/codex-cli
+
+# Cursor CLI
+# Download from cursor.com
+```
+</Step>
+
+<Step title="Launch PraisonAI UI">
+Run any PraisonAI UI entry point:
+
+```bash
+praisonai ui chat         # Chat interface with sidebar toggles
+praisonai ui code         # Code interface with sidebar toggles
+praisonai ui agents       # Agent team interface with toggles per agent
+praisonai ui              # Multi-agent interface with auto-shown checkboxes
+```
+</Step>
+
+<Step title="Enable External Agent">
+Open the sidebar settings — toggles for installed CLIs appear automatically. Flip the toggle for your desired external agent:
+
+- **Claude Code**: Enable for file edits and coding tasks
+- **Gemini CLI**: Enable for analysis and search tasks  
+- **Codex CLI**: Enable for refactoring and optimization
+- **Cursor CLI**: Enable for IDE-style development tasks
+</Step>
+
+<Step title="Start Coding">
+Your agent now delegates coding tasks to the external sub-agent:
+
+```python
+# Your agent automatically gains access to external tools
+agent.start("Refactor the auth module and add error handling")
+# → Delegates to Claude Code or Codex CLI based on your toggles
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant UI as UI Settings
+    participant Toggle as Toggle Switch
+    participant Agent as PraisonAI Agent
+    participant External as External CLI
+    
+    UI->>Toggle: User flips toggle
+    Toggle->>Agent: Add external agent tool
+    Agent->>External: Delegate coding task
+    External-->>Agent: Return result
+    Agent-->>UI: Display response
+```
+
+| Component | Purpose | Features |
+|-----------|---------|----------|
+| **UI Toggles** | Enable/disable external agents | Auto-detection, persistence, per-entry-point |
+| **External Agent Tools** | Bridge to CLI tools | Streaming, workspace context, error handling |
+| **CLI Integration** | Execute external commands | Subprocess management, JSON output, session continuation |
+
+---
+
+## Which Agent for Which Job
+
+```mermaid
+graph TB
+    subgraph "Choose Your External Agent"
+        A[🤔 What task?]
+        A --> B[📝 File Editing?]
+        A --> C[🔍 Analysis?]
+        A --> D[🔧 Refactoring?]  
+        A --> E[💻 IDE Tasks?]
+        
+        B --> F[🟦 Claude Code<br/>File edits, coding]
+        C --> G[🟩 Gemini CLI<br/>Analysis, search]
+        D --> H[🟨 Codex CLI<br/>Refactoring, optimization]
+        E --> I[🟪 Cursor CLI<br/>IDE-style development]
+    end
+    
+    classDef decision fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef claude fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef gemini fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef codex fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef cursor fill:#189AB4,stroke:#7C90A0,color:#fff
+    
+    class A,B,C,D,E decision
+    class F claude
+    class G gemini
+    class H codex
+    class I cursor
+```
+
+---
+
+## Per-Entry-Point Toggles
+
+| Entry point | How toggles appear | Persistence | Workspace |
+|---|---|---|---|
+| `praisonai ui` | aiui checkboxes (auto-shown for installed CLIs) | session | `PRAISONAI_WORKSPACE` |
+| `praisonai ui chat` | Chainlit `Switch` widgets in sidebar | persistent (`save_setting`) | `PRAISONAI_WORKSPACE` |
+| `praisonai ui code` | Chainlit `Switch` widgets (replaces old single Claude toggle) | persistent (`save_setting`) | `PRAISONAI_CODE_REPO_PATH` |
+| `praisonai ui agents` | Chainlit `Switch` widgets per `AgentTeam` member | persistent + per-agent merging with YAML tools | `PRAISONAI_WORKSPACE` |
+
+### Auto-Availability Detection
+
+Only CLIs that resolve via `shutil.which(...)` show a toggle. The CLI → command mapping is:
+
+- `claude_enabled` → `claude` command
+- `gemini_enabled` → `gemini` command  
+- `codex_enabled` → `codex` command
+- `cursor_enabled` → `cursor-agent` command
+
+### Toggle IDs and Labels
+
+| Toggle ID | Label | CLI Command | Integration Class |
+|---|---|---|---|
+| `claude_enabled` | "Claude Code (coding, file edits)" | `claude` | `ClaudeCodeIntegration` |
+| `gemini_enabled` | "Gemini CLI (analysis, search)" | `gemini` | `GeminiCLIIntegration` |
+| `codex_enabled` | "Codex CLI (refactoring)" | `codex` | `CodexCLIIntegration` |
+| `cursor_enabled` | "Cursor CLI (IDE tasks)" | `cursor-agent` | `CursorCLIIntegration` |
+
+<Note>
+**Backward Compatibility**: The legacy `claude_code_enabled` setting and `PRAISONAI_CLAUDECODE_ENABLED=true` environment variable still work and auto-migrate to `claude_enabled` on next save. No user action required.
+</Note>
+
+---
+
+## External Agent Tools Implementation
+
+When you enable an external agent toggle, the UI automatically adds the corresponding tool to your agent:
+
+```python
+from praisonaiagents import Agent
+from praisonai.integrations import ClaudeCodeIntegration
+
+# What happens when you flip the Claude Code toggle:
+claude_integration = ClaudeCodeIntegration(workspace="/path/to/workspace")
+
+agent = Agent(
+    name="Development Assistant",
+    tools=[claude_integration.as_tool()]  # Added automatically
+)
+
+# Agent can now delegate to Claude Code:
+agent.start("Fix the authentication bug in auth.py")
+```
+
+The integration tools provide:
+- **Workspace Context**: Operate against `PRAISONAI_WORKSPACE` or `PRAISONAI_CODE_REPO_PATH`
+- **Streaming Output**: Real-time feedback from external CLIs  
+- **Error Handling**: Graceful fallbacks when external CLIs fail
+- **Session Management**: Continuation across multiple requests
+
+---
+
+## Dynamic Instructions (Code UI)
+
+In `praisonai ui code`, enabled external agents also modify the agent's instructions dynamically:
+
+```python
+# Base instructions
+instructions = "You are a helpful coding assistant..."
+
+# When Claude Code is enabled:
+instructions += "\n\nYou have access to Claude Code for file editing and code analysis."
+
+# When multiple agents are enabled:
+instructions += "\n\nAvailable external agents: Claude Code, Gemini CLI"
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Which Agent for Which Task">
+Choose external agents based on task requirements:
+
+- **Claude Code**: File edits, refactoring, adding features
+- **Gemini CLI**: Code analysis, documentation, search
+- **Codex CLI**: Performance optimization, code quality
+- **Cursor CLI**: IDE-integrated development workflows
+
+You can enable multiple agents simultaneously for complex workflows.
+</Accordion>
+
+<Accordion title="Combining Multiple Toggles">
+Enable multiple external agents for comprehensive development support:
+
+```python
+# All four external agents enabled
+agent = Agent(
+    name="Full Stack Assistant",
+    tools=[
+        claude_code.as_tool(),    # File editing
+        gemini_cli.as_tool(),     # Analysis
+        codex_cli.as_tool(),      # Refactoring  
+        cursor_cli.as_tool()      # IDE tasks
+    ]
+)
+
+# Agent intelligently delegates based on task type
+agent.start("Analyze the codebase, then refactor the auth module")
+```
+</Accordion>
+
+<Accordion title="Toggle Persistence and Migration">
+Toggle settings persist automatically:
+
+- **Chat/Code/Agents UI**: Saved to Chainlit settings, persist across sessions
+- **Main UI**: Session-based, reset on restart
+- **Migration**: Legacy `claude_code_enabled` auto-migrates to `claude_enabled`
+
+```bash
+# Environment variable override (all UIs)
+PRAISONAI_CLAUDECODE_ENABLED=true praisonai ui chat
+# → Automatically enables claude_enabled toggle
+```
+</Accordion>
+
+<Accordion title="CLI Not Showing Up Troubleshooting">
+If a CLI toggle doesn't appear:
+
+1. **Check Installation**: Ensure CLI is installed and on PATH
+2. **Verify Command**: Test CLI command manually in terminal
+3. **Restart UI**: Refresh browser or restart PraisonAI UI
+4. **Check Logs**: Look for integration errors in console
+
+```bash
+# Test CLI availability
+which claude        # Should return path
+which gemini        # Should return path  
+which codex         # Should return path
+which cursor-agent  # Should return path
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="External CLI Integrations (Python API)" icon="code" href="/docs/features/external-cli-integrations">
+  Use external agents programmatically in your code
+</Card>
+<Card title="External Agents (Code)" icon="terminal" href="/docs/code/external-agents">
+  Python API reference for external agent integrations
+</Card>
+</CardGroup>

--- a/docs/features/external-cli-integrations.mdx
+++ b/docs/features/external-cli-integrations.mdx
@@ -491,6 +491,14 @@ async def stream_with_progress(integration, prompt):
 
 ---
 
+## Using from PraisonAI UI
+
+<Tip>
+You can also enable external CLI integrations directly from the PraisonAI user interface without writing code. All PraisonAI UI entry points include toggles for external agents when the corresponding CLIs are installed. See [External Agents in UI](/docs/features/external-agents-ui) for complete documentation.
+</Tip>
+
+---
+
 ## Related
 
 <CardGroup cols={2}>

--- a/docs/ui/chat.mdx
+++ b/docs/ui/chat.mdx
@@ -70,6 +70,40 @@ To use this feature:
 
 These new features significantly expand the capabilities of PraisonAI Chat, allowing for more diverse and informative interactions.
 
+## External Agents
+
+The PraisonAI Chat interface includes sidebar Switch widgets that allow you to toggle external AI coding CLI tools when they are installed on your system. These toggles enhance your chat experience by adding specialized coding capabilities.
+
+### Available External Agents
+
+When the corresponding CLIs are installed, the following toggle switches appear in the sidebar:
+
+- **Claude Code**: Toggle for Claude Code CLI integration (file editing, coding tasks)
+- **Gemini CLI**: Toggle for Google Gemini CLI (analysis, search capabilities)  
+- **Codex CLI**: Toggle for OpenAI Codex CLI (refactoring, optimization)
+- **Cursor CLI**: Toggle for Cursor CLI (IDE-style development)
+
+### How It Works
+
+1. **Automatic Detection**: Only CLIs that are installed and available on PATH show toggles
+2. **Persistent Settings**: Toggle states are saved to Chainlit settings and persist across sessions
+3. **Enhanced Capability**: Enabled external agents add specialized tools to your chat agent
+4. **Workspace Integration**: External agents operate within your `PRAISONAI_WORKSPACE` directory
+
+### Usage Example
+
+When you enable external agents and ask coding-related questions, your chat agent can delegate to the appropriate external CLI:
+
+```text
+User: "Refactor the authentication module in my project"
+Assistant: "I'll use Claude Code to analyze and refactor the auth module..."
+→ Delegates to Claude Code CLI
+```
+
+<Note>
+For complete documentation on external agents across all PraisonAI interfaces, see [External Agents in UI](/docs/features/external-agents-ui).
+</Note>
+
 ## Custom Database
 
 PraisonAI Chat supports custom database configurations, allowing you to use PostgreSQL or other databases instead of the default SQLite database. This is particularly useful for production environments or when you need more advanced database features.

--- a/docs/ui/code-ui.mdx
+++ b/docs/ui/code-ui.mdx
@@ -197,6 +197,36 @@ To use this feature:
 
 These new features significantly expand the capabilities of PraisonAI Code, allowing for more comprehensive and up-to-date coding assistance.
 
+## External Agents
+
+The PraisonAI Code interface now includes sidebar toggles for external AI coding CLIs. These toggles appear automatically when the corresponding CLI tools are installed and available on your system PATH.
+
+### Available External Agents
+
+- **Claude Code Toggle**: Enable Claude Code CLI integration for advanced file editing and code analysis
+- **Gemini CLI Toggle**: Enable Google Gemini CLI for code analysis and search capabilities  
+- **Codex CLI Toggle**: Enable OpenAI Codex CLI for code refactoring and optimization
+- **Cursor CLI Toggle**: Enable Cursor CLI for IDE-style development tasks
+
+### How It Works
+
+1. **Auto-Detection**: Toggles only appear for CLIs that are installed and available via `shutil.which()`
+2. **Sidebar Integration**: Toggle switches appear in the Code UI sidebar settings
+3. **Persistence**: Toggle states persist across sessions via Chainlit settings
+4. **Dynamic Instructions**: Enabled agents modify the assistant's system instructions
+5. **Workspace Context**: External agents operate against `PRAISONAI_CODE_REPO_PATH`
+
+### Backward Compatibility
+
+The new toggles replace the previous single "Enable Claude Code" switch. Legacy settings are automatically migrated:
+
+- `claude_code_enabled` setting → `claude_enabled`  
+- `PRAISONAI_CLAUDECODE_ENABLED` environment variable → `claude_enabled`
+
+<Note>
+For complete documentation on external agents UI toggles across all PraisonAI interfaces, see [External Agents in UI](/docs/features/external-agents-ui).
+</Note>
+
 ## Local Docker Development with Live Reload
 
 To facilitate local development with live reload, you can use Docker. Follow the steps below:

--- a/docs/ui/ui.mdx
+++ b/docs/ui/ui.mdx
@@ -35,6 +35,44 @@ The UI will automatically start on `http://localhost:8081` and load the default 
 - **Customizable:** Provide your own `app.py` or `agents.yaml` file to define custom agents or tasks.
 - **Auto-Reload:** Supports developer-friendly dynamic reloading.
 
+## External Agents
+
+The PraisonAI UI automatically detects installed external CLI tools and shows checkboxes for available agents. When working with `AgentTeam` configurations, enabled external agents add tools that can be merged with YAML-defined role tools.
+
+### Available Agent Toggles
+
+When external CLIs are installed, the following checkboxes appear automatically:
+
+- **Claude Code**: Enable for file editing and advanced coding tasks
+- **Gemini CLI**: Enable for code analysis and search capabilities  
+- **Codex CLI**: Enable for refactoring and optimization tasks
+- **Cursor CLI**: Enable for IDE-integrated development workflows
+
+### AgentTeam Integration
+
+External agent tools merge seamlessly with `AgentTeam` member configurations:
+
+```python
+# YAML-defined agent with role tools
+agent_config = {
+    "role": "Senior Developer", 
+    "tools": ["file_reader", "web_search"]  # From YAML
+}
+
+# External agents add additional tools when toggles are enabled:
+# → ["file_reader", "web_search", "claude_code_tool", "gemini_cli_tool"]
+```
+
+### Session-Based Settings
+
+- **Persistence**: Session-based toggles reset on browser refresh
+- **Auto-Detection**: Only available/installed CLIs show checkboxes
+- **Workspace Context**: External agents operate within `PRAISONAI_WORKSPACE`
+
+<Note>
+For comprehensive documentation on external agents across all PraisonAI interfaces, see [External Agents in UI](/docs/features/external-agents-ui).
+</Note>
+
 ## CLI Options
 
 You can customize how the UI starts using flags:


### PR DESCRIPTION
Fixes #166

## Summary

Creates comprehensive documentation for external agents UI toggles feature that allows users to flip switches in any PraisonAI UI to add Claude Code, Gemini CLI, Codex CLI, or Cursor CLI as sub-agents.

## Changes

- **New page**: docs/features/external-agents-ui.mdx
  - Hero Mermaid diagram showing UI toggle workflow
  - Quick Start with Steps component (install CLI → launch UI → enable toggle → start coding)
  - Choice diagram for selecting appropriate external agent for specific tasks
  - Per-entry-point matrix table covering all UI interfaces
  - Auto-availability detection and backward compatibility documentation
  - Best Practices with troubleshooting guide

- **Updated UI documentation** with External Agents sections:
  - docs/ui/code-ui.mdx: Sidebar toggles replace old single Claude switch
  - docs/ui/chat.mdx: Chainlit Switch widgets with persistent settings
  - docs/ui/ui.mdx: AgentTeam integration with auto-shown checkboxes

- **Added UI cross-links** to existing documentation:
  - docs/code/external-agents.mdx: Tip pointing to UI toggles alternative
  - docs/features/external-cli-integrations.mdx: UI usage section

- **Updated navigation**: Added new page to docs.json Features group

## Documentation Standards

Follows AGENTS.md requirements:
- ✅ Standard Mermaid color scheme (#8B0000, #189AB4, #10B981, #F59E0B, #6366F1, #fff)
- ✅ Required Mintlify components (Steps, AccordionGroup, CardGroup, Tip, Note)
- ✅ Agent-centric approach with copy-paste runnable examples
- ✅ Placement in docs/features/ (not concepts)
- ✅ Concise writing with active voice
- ✅ Hero diagram and choice diagram included
- ✅ Cross-links to related pages

## Acceptance Criteria

- [x] docs/features/external-agents-ui.mdx created, follows AGENTS.md template
- [x] Choice/decision Mermaid diagram included
- [x] All four toggles documented with exact *_enabled IDs and CLI commands
- [x] Backward-compat (claude_code_enabled, PRAISONAI_CLAUDECODE_ENABLED) documented
- [x] Auto-availability behavior (shutil.which) documented
- [x] Cross-links added to UI documentation pages
- [x] Cross-links added to existing external-agents pages
- [x] docs.json updated under Features group
- [x] Valid JSON verified

Generated with [Claude Code](https://claude.ai/code)