### PR TITLE
docs: update --external-agent docs for manager delegation default (PR #1436)

### DIFF
--- a/docs/cli/claude-cli.mdx
+++ b/docs/cli/claude-cli.mdx
@@ -36,9 +36,16 @@ claude setup-token
 
 ## Basic Usage with PraisonAI
 
+<Note>
+`--external-agent claude` invokes Claude CLI via a manager Agent by default. The manager reasons and calls Claude as a subagent tool. Use `--external-agent-direct` for pass-through proxy behavior.
+</Note>
+
 ```bash
-# Use Claude as external agent
+# Manager delegation (default — manager reasons + calls claude as subagent tool)
 praisonai "Fix the bug in auth.py" --external-agent claude
+
+# Direct proxy (escape hatch — no manager, passes prompt straight to claude)
+praisonai "Fix the bug in auth.py" --external-agent claude --external-agent-direct
 
 # With verbose output
 praisonai "Refactor this module" --external-agent claude --verbose

--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -256,7 +256,8 @@ praisonai
 | `--trust` | flag | Auto-approve tools |
 | `--approve-level` | str | Risk level approval |
 | `--sandbox` | str | Sandbox mode |
-| `--external-agent` | str | External CLI tool (claude/gemini/codex/cursor) |
+| `--external-agent` | str | External CLI tool (claude/gemini/codex/cursor) — uses manager-Agent delegation by default |
+| `--external-agent-direct` | flag | Use external agent as direct proxy (skip manager Agent delegation) |
 | `--image` | str | Image analysis |
 | `--image-generate` | flag | Image generation |
 | `--file` | str | Input file |
@@ -378,8 +379,11 @@ praisonai "Task" --memory --planning
 # Agent with web search and tools
 praisonai "Research topic" --web-search --tools
 
-# Agent with external CLI tool
+# Agent with external CLI tool (delegated via manager)
 praisonai "Refactor code" --external-agent claude
+
+# Agent with external CLI tool (direct proxy)
+praisonai "Refactor code" --external-agent claude --external-agent-direct
 
 # Agent with guardrails and metrics
 praisonai "Generate content" --guardrail --metrics

--- a/docs/cli/codex-cli.mdx
+++ b/docs/cli/codex-cli.mdx
@@ -39,9 +39,16 @@ export OPENAI_API_KEY=your-api-key
 
 ## Basic Usage with PraisonAI
 
+<Note>
+`--external-agent codex` invokes Codex CLI via a manager Agent by default. The manager reasons and calls Codex as a subagent tool. Use `--external-agent-direct` for pass-through proxy behavior.
+</Note>
+
 ```bash
-# Use Codex as external agent
+# Manager delegation (default — manager reasons + calls codex as subagent tool)
 praisonai "Fix the bug in auth.py" --external-agent codex
+
+# Direct proxy (escape hatch — no manager, passes prompt straight to codex)
+praisonai "Fix the bug in auth.py" --external-agent codex --external-agent-direct
 
 # With verbose output
 praisonai "Refactor this module" --external-agent codex --verbose

--- a/docs/cli/cursor-cli.mdx
+++ b/docs/cli/cursor-cli.mdx
@@ -36,9 +36,16 @@ export CURSOR_API_KEY=your-api-key
 
 ## Basic Usage with PraisonAI
 
+<Note>
+`--external-agent cursor` invokes Cursor CLI via a manager Agent by default. The manager reasons and calls Cursor as a subagent tool. Use `--external-agent-direct` for pass-through proxy behavior.
+</Note>
+
 ```bash
-# Use Cursor as external agent
+# Manager delegation (default — manager reasons + calls cursor as subagent tool)
 praisonai "Fix the bug in auth.py" --external-agent cursor
+
+# Direct proxy (escape hatch — no manager, passes prompt straight to cursor)
+praisonai "Fix the bug in auth.py" --external-agent cursor --external-agent-direct
 
 # With verbose output
 praisonai "Refactor this module" --external-agent cursor --verbose

--- a/docs/cli/gemini-cli.mdx
+++ b/docs/cli/gemini-cli.mdx
@@ -32,9 +32,16 @@ export GEMINI_API_KEY=your-api-key
 
 ## Basic Usage with PraisonAI
 
+<Note>
+`--external-agent gemini` invokes Gemini CLI via a manager Agent by default. The manager reasons and calls Gemini as a subagent tool. Use `--external-agent-direct` for pass-through proxy behavior.
+</Note>
+
 ```bash
-# Use Gemini as external agent
+# Manager delegation (default — manager reasons + calls gemini as subagent tool)
 praisonai "Analyze this codebase" --external-agent gemini
+
+# Direct proxy (escape hatch — no manager, passes prompt straight to gemini)
+praisonai "Analyze this codebase" --external-agent gemini --external-agent-direct
 
 # With verbose output
 praisonai "Refactor this module" --external-agent gemini --verbose

--- a/docs/code/external-agents.mdx
+++ b/docs/code/external-agents.mdx
@@ -100,6 +100,82 @@ agent = Agent(
 result = agent.start("Refactor the authentication module")
 ```
 
+## CLI Usage: Manager Delegation vs Direct Proxy
+
+PraisonAI now offers two modes for external CLI integration, balancing power and simplicity.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Manager as Manager Agent
+    participant CLI as External CLI Tool
+    participant User2 as User (Direct)
+    participant CLI2 as External CLI Tool (Direct)
+    
+    Note over User,CLI: Manager Delegation (Default)
+    User->>Manager: "Refactor auth.py"
+    Manager->>CLI: Call claude_tool
+    CLI-->>Manager: Result
+    Manager-->>User: Aggregated response
+    
+    Note over User2,CLI2: Direct Proxy (--external-agent-direct)
+    User2->>CLI2: "Refactor auth.py"
+    CLI2-->>User2: Direct result
+    
+    classDef user fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef manager fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef cli fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class User,User2 user
+    class Manager manager
+    class CLI,CLI2 cli
+```
+
+### Manager Delegation (Default)
+
+When using `--external-agent`, a manager Agent wraps the external CLI as a subagent tool, providing reasoning and planning capabilities.
+
+```python
+from praisonaiagents import Agent
+from praisonai.integrations import ClaudeCodeIntegration
+
+claude = ClaudeCodeIntegration(workspace=".")
+manager = Agent(
+    name="Manager",
+    instructions="Delegate coding tasks to claude_tool.",
+    tools=[claude.as_tool()],
+    llm="gpt-4o-mini",
+)
+manager.start("Refactor the auth module")
+```
+
+**When to use manager delegation:**
+- Multi-step tasks requiring planning
+- Need reasoning across multiple tools
+- Want aggregated responses
+- Complex workflows with decision-making
+
+**Manager LLM:** Defaults to `gpt-4o-mini`, configurable via `--llm` or `MODEL_NAME` environment variable.
+
+### Direct Proxy (Escape Hatch)
+
+Use `--external-agent-direct` for pass-through behavior — fastest execution with no manager overhead.
+
+```bash
+# Manager delegation (new default)
+praisonai "Say hi in 5 words" --external-agent claude
+
+# Direct proxy (escape hatch)  
+praisonai "Say hi in 5 words" --external-agent claude --external-agent-direct
+```
+
+**When to use direct proxy:**
+- Single-shot calls
+- Scripting scenarios
+- Fastest execution needed
+- No manager LLM overhead wanted
+
 ## Environment Variables
 
 Set the appropriate API keys for each integration:

--- a/docs/features/external-cli-integrations.mdx
+++ b/docs/features/external-cli-integrations.mdx
@@ -102,6 +102,50 @@ sequenceDiagram
 
 ---
 
+## CLI: Manager Delegation (Default)
+
+PraisonAI CLI offers two execution modes for external agents, providing flexibility between automated reasoning and direct execution.
+
+```mermaid
+graph TB
+    A[User Command] --> B{Need planning/reasoning?}
+    B -->|Yes| C[Manager Delegation]
+    B -->|No| D[Direct Proxy]
+    C --> E["--external-agent"]
+    D --> F["--external-agent-direct"]
+    E --> G[Manager Agent + Subagent Tool]
+    F --> H[Pass-through CLI]
+    
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff  
+    classDef mode fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef flag fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef execution fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A input
+    class B decision
+    class C,D mode
+    class E,F flag
+    class G,H execution
+```
+
+| Mode | Flag | Behaviour | Best for |
+|------|------|-----------|----------|
+| Manager delegation (default) | `--external-agent X` | Manager Agent wraps the CLI as a tool, reasons, then calls it | Multi-step tasks, planning, aggregation |
+| Direct proxy | `--external-agent X --external-agent-direct` | Pass-through — CLI runs the prompt verbatim | Fast single-shot calls, scripting, when you don't want a manager LLM |
+
+**Usage Examples:**
+
+```bash
+# Manager delegation - manager reasons, then calls claude as tool
+praisonai "Fix the bug in auth.py" --external-agent claude
+
+# Direct proxy - no manager overhead, straight to claude  
+praisonai "Fix the bug in auth.py" --external-agent claude --external-agent-direct
+```
+
+---
+
 ## Configuration Options
 
 <Card title="External CLI Integrations API Reference" icon="code" href="/docs/sdk/reference/typescript/classes/ExternalAgentRegistry">


### PR DESCRIPTION
## Summary

Updates documentation for the new `--external-agent` behavior introduced in PraisonAI PR #1436, which changed external agents from direct proxy to manager delegation by default.

### Changes Made

- **CLI Reference**: Added `--external-agent-direct` flag to global flags table
- **External Agents Guide**: Added comprehensive "Manager Delegation vs Direct Proxy" section with:
  - Mermaid sequence diagram showing both modes
  - Agent-centric Python example
  - Clear usage guidelines for each mode  
- **External CLI Integrations**: Added decision diagram and comparison table
- **Per-CLI Pages**: Updated all 4 CLI pages (claude, gemini, codex, cursor) with Note callouts

### Technical Details

- **New Default**: `--external-agent X` creates manager Agent that uses X as subagent tool
- **Escape Hatch**: `--external-agent-direct` preserves old direct proxy behavior  
- **Manager LLM**: Defaults to `gpt-4o-mini`, configurable via `--llm` or `MODEL_NAME`

### Compliance

- ✅ Follows AGENTS.md structure template and writing style
- ✅ Uses standard Mermaid color scheme (#8B0000, #189AB4, #10B981, #F59E0B, #6366F1)
- ✅ Includes agent-centric examples with proper imports
- ✅ All code examples are copy-paste runnable
- ✅ No changes to docs/concepts/ (human-approved only)

Fixes #171

🤖 Generated with [Claude Code](https://claude.ai/code)