### PR TITLE
docs: Update thread-safety, async callbacks, and multi-team HTTP launch docs

### DIFF
--- a/docs/deploy/servers/agents.mdx
+++ b/docs/deploy/servers/agents.mdx
@@ -90,6 +90,10 @@ agents.launch(path="/content", port=8000, host="0.0.0.0")
 📚 API documentation available at http://0.0.0.0:8000/docs
 ```
 
+<Note>
+Multiple `Agent` / `Agents` instances may call `.launch(port=N)` concurrently from different threads — registration is atomic. If two launch calls use the same path on the same port, the second gets an auto-suffixed path (`/path_abc123`) and a warning is logged. Server readiness is signalled deterministically (no fixed sleep); `.launch()` returns only after the port is accepting connections (5s timeout).
+</Note>
+
 ## agents.yaml
 
 ```yaml

--- a/docs/features/agent-api-launch.mdx
+++ b/docs/features/agent-api-launch.mdx
@@ -252,6 +252,10 @@ support_agent.launch(
 # - http://localhost:8000/support
 ```
 
+<Note>
+Multiple `Agent` / `Agents` instances may call `.launch(port=N)` concurrently from different threads — registration is atomic. If two launch calls use the same path on the same port, the second gets an auto-suffixed path (`/path_abc123`) and a warning is logged. Server readiness is signalled deterministically (no fixed sleep); `.launch()` returns only after the port is accepting connections (5s timeout).
+</Note>
+
 ### Example 5: Debug Mode for Development
 
 ```python

--- a/docs/features/async.mdx
+++ b/docs/features/async.mdx
@@ -560,7 +560,7 @@ async def process_multiple_tasks():
 </ResponseField>
 
 <ResponseField name="callback" type="function">
-  Set sync or async callback function
+  Set sync or async callback function (async callbacks are dispatched safely even when the caller is inside a running event loop)
 </ResponseField>
 
 ## Next Steps

--- a/docs/features/callbacks.mdx
+++ b/docs/features/callbacks.mdx
@@ -718,6 +718,8 @@ Async callbacks allow you to handle events asynchronously, which is particularly
     # Register the async callback
     register_display_callback('interaction', async_interaction_callback)
     ```
+
+Async callbacks are safe to use from inside a running event loop (e.g. FastAPI handlers, Jupyter); the SDK detects the running loop and schedules the coroutine without calling `asyncio.run()`.
   </Tab>
   <Tab title="No Code">
 ```yaml

--- a/docs/features/thread-safety.mdx
+++ b/docs/features/thread-safety.mdx
@@ -178,6 +178,38 @@ def test_thread_safety():
 test_thread_safety()
 ```
 
+### Multi-team HTTP launch
+
+PraisonAI provides comprehensive thread-safety for HTTP server deployment:
+
+- Multiple `Agent` / `Agents` instances may call `.launch(port=N)` concurrently from different threads — registration is atomic.
+- If two launch calls use the same path on the same port, the second gets an auto-suffixed path (`/path_abc123`) and a warning is logged.
+- Server readiness is signalled deterministically (no fixed sleep); `.launch()` returns only after the port is accepting connections (5s timeout).
+- `aworkflow()` state lock is created inside the running async context, so workflows remain stable when invoked under pytest-asyncio or when nested inside another loop.
+
+```python
+import threading
+from praisonaiagents import AgentTeam
+
+def launch_team(team_name, port, path):
+    team = AgentTeam(name=team_name)
+    team.launch(port=port, path=path)
+
+# Safe concurrent launches
+thread1 = threading.Thread(target=launch_team, args=("TeamA", 8000, "/team_a"))
+thread2 = threading.Thread(target=launch_team, args=("TeamB", 8000, "/team_b"))
+
+thread1.start()
+thread2.start()
+
+thread1.join()
+thread2.join()
+
+# Both teams available at:
+# - http://localhost:8000/team_a
+# - http://localhost:8000/team_b
+```
+
 ## Related
 
 - [Thread Safety CLI](/docs/cli/thread-safety)


### PR DESCRIPTION
This PR updates documentation for three architectural improvements made in upstream PR MervinPraison/PraisonAI#1450:

## Areas Updated

### 1. Multi-team HTTP launch thread-safety
- Added thread-safety notes to docs/features/agent-api-launch.mdx and docs/deploy/servers/agents.mdx
- Documents atomic registration, path collision handling, and deterministic server readiness

### 2. Async callback event-loop safety  
- Added safety note to docs/features/callbacks.mdx for async callbacks
- Updated API reference in docs/features/async.mdx with event-loop safety info
- Documents safe dispatch within running event loops (FastAPI, Jupyter)

### 3. Workflow state lock improvements
- Added new Multi-team HTTP launch subsection to docs/features/thread-safety.mdx
- Documents workflow state lock creation within async context
- Includes example of safe concurrent team launches

## Changes Made

- docs/features/agent-api-launch.mdx: Added Note after Example 4 with thread-safety guarantees
- docs/deploy/servers/agents.mdx: Added identical thread-safety note after Multi-Agent HTTP API example
- docs/features/thread-safety.mdx: Added new subsection with workflow state lock info and example
- docs/features/callbacks.mdx: Added event-loop safety sentence for async callbacks
- docs/features/async.mdx: Updated callback API reference with safety note

All changes follow AGENTS.md guidelines with agent-centric examples, progressive disclosure, and user-focused language.

Fixes #177

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on concurrent agent launch behavior: registration is atomic, and conflicting port/path combinations trigger auto-suffixed paths with warnings.
  * Documented deterministic server readiness signaling (no fixed sleep) with 5-second timeout for `.launch()` calls.
  * Clarified that async callbacks can be safely dispatched from within already-running event loops.
  * Added new thread-safety guide for multi-team HTTP deployment with concurrent launch examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->