### PR TITLE
docs: Add PraisonAI dashboard command documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -999,6 +999,7 @@
                   "docs/cli/auto",
                   "docs/cli/init",
                   "docs/cli/serve",
+                  "docs/cli/dashboard",
                   "docs/cli/mcp-server",
                   "docs/cli/workflow"
                 ]

--- a/docs/cli/dashboard.mdx
+++ b/docs/cli/dashboard.mdx
@@ -1,0 +1,223 @@
+---
+title: "Dashboard"
+sidebarTitle: "Dashboard"
+description: "Launch the unified PraisonAI dashboard with Flow, Claw, and Chat UI auto-started"
+icon: "layout-dashboard"
+---
+
+The `praisonai dashboard` command launches a unified interface that auto-starts Flow Builder, Claw, and Chat UI — one command to open all PraisonAI services.
+
+```mermaid
+graph LR
+    CLI[🖥️ praisonai dashboard] --> Launcher[🚀 Unified Launcher<br/>port 3000]
+    Launcher --> Flow[🎨 Flow Builder<br/>:7860]
+    Launcher --> Claw[🦞 Claw Dashboard<br/>:8082]
+    Launcher --> UI[💬 Chat UI<br/>:8081]
+    Launcher -.optional.-> AIUI[✨ aiui Enhanced<br/>experimental]
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef service fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef optional fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class CLI input
+    class Launcher process
+    class Flow,Claw,UI service
+    class AIUI optional
+```
+
+## Quick Start
+
+<Steps>
+<Step title="One-command launch">
+Launch all services with a single command that auto-opens port 3000 and starts Flow, Claw, and Chat UI:
+
+```bash
+praisonai dashboard
+```
+
+This starts the unified dashboard on port 3000 and automatically launches all three services.
+</Step>
+
+<Step title="Standalone dashboard only">
+Use when services are already running or you want to manage them manually:
+
+```bash
+praisonai dashboard --no-auto-start
+```
+
+This launches only the dashboard interface without starting the backend services.
+</Step>
+
+<Step title="Experimental enhanced UI">
+Try the enhanced dashboard interface with additional features:
+
+```bash
+praisonai dashboard --aiui
+```
+
+<Note>Requires `pip install aiui`. Falls back gracefully to standard dashboard if not installed.</Note>
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Services as Auto-start Services
+    participant Dashboard as Unified Dashboard
+    participant Browser
+
+    User->>CLI: praisonai dashboard
+    CLI->>Services: Spawn Flow, Claw, UI
+    Services-->>CLI: Readiness check
+    CLI->>Dashboard: Start FastAPI dashboard
+    Dashboard-->>Browser: Open unified interface
+    Browser->>Dashboard: Access all services
+```
+
+The dashboard follows this process:
+
+| Phase | Description |
+|-------|-------------|
+| **Spawn** | Launches Flow (7860), Claw (8082), and UI (8081) services |
+| **Readiness** | Polls each service for up to 15 seconds until ports accept connections |
+| **Dashboard** | Starts unified FastAPI interface linking to all services |
+| **Cleanup** | Gracefully terminates child services on exit |
+
+---
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--port`, `-p` | `int` | `3000` | Port to run the unified dashboard on |
+| `--host` | `str` | `127.0.0.1` | Host to bind to (use `0.0.0.0` to expose remotely) |
+| `--auto-start / --no-auto-start` | `bool` | `True` | Auto-start Flow, Claw, and UI services before opening dashboard |
+| `--aiui` | `bool` | `False` | Use enhanced dashboard interface (experimental; requires `aiui` package) |
+
+### Ports Used
+
+| Service | Default Port | Started by |
+|---------|--------------|------------|
+| Unified Dashboard | **3000** | `praisonai dashboard` |
+| Flow Builder | **7860** | Auto-started (`praisonai flow --no-open`) |
+| Claw Dashboard | **8082** | Auto-started (`praisonai claw`) |
+| Chat UI | **8081** | Auto-started (`praisonai ui`) |
+
+### Log Files
+
+Per-service logs are written to:
+
+```
+~/.praisonai/unified/logs/flow.log
+~/.praisonai/unified/logs/claw.log
+~/.praisonai/unified/logs/ui.log
+```
+
+---
+
+## Common Patterns
+
+### Expose dashboard on LAN
+
+```bash
+praisonai dashboard --host 0.0.0.0 --port 9000
+```
+
+### Attach to existing services
+
+```bash
+praisonai dashboard --no-auto-start
+```
+
+Use when Flow, Claw, and UI are already running and you only want the unified interface.
+
+### Try experimental aiui interface
+
+```bash
+# First install the package
+pip install aiui
+
+# Then launch with enhanced UI
+praisonai dashboard --aiui
+```
+
+### Troubleshoot failed auto-start
+
+Check service logs if a service fails to start:
+
+```bash
+# Check individual service logs
+tail -f ~/.praisonai/unified/logs/flow.log
+tail -f ~/.praisonai/unified/logs/claw.log
+tail -f ~/.praisonai/unified/logs/ui.log
+```
+
+---
+
+## Which Option Should I Use?
+
+```mermaid
+graph TB
+    Q{What do you want?}
+    Q -->|Open everything fast| A[praisonai dashboard]
+    Q -->|Services already running| B[praisonai dashboard --no-auto-start]
+    Q -->|Try enhanced UI| C[praisonai dashboard --aiui]
+    Q -->|Just one service| D[Run praisonai flow / claw / ui directly]
+
+    classDef default fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef manual fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef experimental fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef single fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class A default
+    class B manual
+    class C experimental
+    class D single
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Default to unified launch for local development">
+Use `praisonai dashboard` as your standard command for local development. It's designed to feel like launching a single application while giving you access to all PraisonAI interfaces.
+</Accordion>
+
+<Accordion title="Use --no-auto-start in containerized environments">
+In CI, Docker, or other managed environments where services are started separately, use `--no-auto-start` to launch only the dashboard interface.
+</Accordion>
+
+<Accordion title="Treat --aiui as experimental">
+The `--aiui` flag provides enhanced features but requires the separate `aiui` package. It gracefully falls back to the standard dashboard if the package is missing, but treat it as experimental for production use.
+</Accordion>
+
+<Accordion title="Check logs before assuming port conflicts">
+Before concluding there's a port conflict, check the per-service logs in `~/.praisonai/unified/logs/` to see the actual error messages from failed services.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Claw Dashboard" icon="claw" href="/docs/ui/claw">
+    Full administrative dashboard for managing agents, tools, and channels
+  </Card>
+  <Card title="Flow Builder" icon="workflow" href="/docs/ui/flow">
+    Visual workflow designer with drag-and-drop interface
+  </Card>
+  <Card title="Chat UI" icon="message-circle" href="/docs/ui/ui">
+    Clean, distraction-free chat interface
+  </Card>
+  <Card title="Unified Server" icon="server" href="/docs/deploy/servers/unified">
+    Different feature: HTTP API server (not the desktop launcher)
+  </Card>
+</CardGroup>

--- a/docs/ui/overview.mdx
+++ b/docs/ui/overview.mdx
@@ -11,6 +11,7 @@ PraisonAI provides several ready-to-use user interfaces and dashboards out of th
 
 | Interface | Purpose | Best For | Link |
 |---|---|---|---|
+| **PraisonAI Dashboard** | One-command unified launcher | Launching Flow + Claw + Chat UI together | [View Docs](/docs/cli/dashboard) |
 | **PraisonAI Claw** | Full Administrative Dashboard | Channel management (Telegram, Slack, etc.), Agents, Tools, Memory, RAG | [View Docs](/docs/ui/claw) |
 | **PraisonAI Flow** | Visual Workflow Builder | Drag-and-drop orchestration, connecting multiple agents and tasks | [View Docs](/docs/ui/flow) |
 | **PraisonAI UI** | Clean Chat Interface | Single-page, distraction-free chatting with agents | [View Docs](/docs/ui/ui) |
@@ -37,6 +38,9 @@ If you need to embed agents into your own web applications, PraisonAI supports s
 ## Which Interface Should I Choose?
 
 <AccordionGroup>
+<Accordion title="I want to launch everything with one command">
+Use **[PraisonAI Dashboard](/docs/cli/dashboard)**. It auto-starts Flow Builder, Claw Dashboard, and Chat UI together in a unified interface — perfect for development and testing.
+</Accordion>
 <Accordion title="I need to deploy a Slack or Telegram bot">
 Use **[PraisonAI Claw](/docs/ui/claw)**. It provides a full dashboard that allows you to easily connect, manage, and monitor bots across multiple messaging platforms.
 </Accordion>


### PR DESCRIPTION
Fixes #185

## Summary
- Created comprehensive documentation for the praisonai dashboard command following AGENTS.md template
- Added hero Mermaid diagram showing the unified launcher architecture
- Documented all CLI options (--port, --host, --auto-start, --aiui) with types and defaults
- Included Quick Start section with Steps component showing three main usage patterns
- Added troubleshooting guidance with log file locations
- Created decision diagram to help users choose between dashboard options
- Updated navigation in docs.json and cross-referenced in docs/ui/overview.mdx

## Content Structure
- Hero diagram: Shows how one CLI command fans out to three services
- Quick Start: One-command launch, standalone mode, and experimental aiui
- Configuration: Complete options table with ports and log paths  
- Common Patterns: LAN exposure, existing services, troubleshooting
- Decision diagram: Helps users pick the right dashboard option
- Best Practices: Accordion with development, containerized, and production guidance
- Related: Links to individual service documentation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the PraisonAI Dashboard CLI command, a unified launcher that auto-starts Flow Builder, Claw Dashboard, and Chat UI together on configurable ports. Documentation covers usage modes, configuration options, troubleshooting, best practices, and a decision guide to help users choose the right setup approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->