### PR TITLE
docs: Update scheduler docs for unified retry logic, lazy telemetry, and async-safe primitives

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -457,6 +457,7 @@
                 "pages": [
                   "docs/features/activity-log",
                   "docs/features/async",
+                  "docs/features/async-scheduler",
                   "docs/features/async-jobs",
                   "docs/features/background-tasks",
                   "docs/features/middleware"

--- a/docs/cli/scheduler.mdx
+++ b/docs/cli/scheduler.mdx
@@ -415,8 +415,8 @@ asyncio.run(main())
 
 ### Core Features
 - **Interval-based scheduling**: Run agents at regular intervals
-- **Background execution**: CLI daemon process, won't block terminal
-- **Automatic retry**: Retry failed executions with exponential backoff
+- **Background execution**: Runs in daemon thread, won't block terminal
+- **Automatic retry**: Exponential backoff + jitter, capped at 300s, shared between sync & async
 - **Graceful shutdown**: Clean stop with Ctrl+C
 - **YAML configuration**: Simple configuration in agents.yaml
 - **CLI overrides**: Override any setting from command line
@@ -447,6 +447,32 @@ Result: [agent output]
 Estimated cost this run: $0.0001, Total: $0.0001
 Budget remaining: $0.9999
 Next execution in 3600 seconds (1.0 hours)
+```
+
+### Callbacks
+
+Both schedulers accept `on_success` and `on_failure` callbacks in the constructor.
+Callbacks may be sync or async functions; a raising callback is logged and swallowed
+— it will not stop the scheduler.
+
+- `on_success(result)` — called with the agent's return value after a successful run.
+- `on_failure(exc)` — called with the final `Exception` after all retries are exhausted.
+  (Previously sync passed a formatted string; as of PR #1474 both sync and async
+  pass the exception object.)
+
+```python
+def success_callback(result):
+    print(f"Success: {result}")
+
+def failure_callback(exception):
+    print(f"Failed: {exception}")
+
+scheduler = AgentScheduler(
+    agent=agent,
+    task="Check news",
+    on_success=success_callback,
+    on_failure=failure_callback
+)
 ```
 
 ### Statistics
@@ -484,15 +510,16 @@ stats = await scheduler.get_stats()
 
 ## Error Handling
 
-The scheduler automatically retries failed executions with exponential backoff. The retry behavior depends on the execution method:
+The scheduler retries failed executions with exponential backoff + jitter:
 
-**CLI Daemon Process:** Follows the traditional pattern with longer waits
-**Python API (AsyncAgentScheduler):** Uses `min(2^attempt, 60)` seconds between attempts:
-- **Attempt 1:** Execute immediately  
-- **Attempt 2:** Wait 1s, retry
-- **Attempt 3:** Wait 2s, retry
-- **Attempt 4:** Wait 4s, retry
-- **Attempt 5:** Wait 8s, retry (up to 60s max)
+- **Attempt 1:** Run immediately.
+- **On failure:** Wait `backoff_delay(attempt)` seconds, then retry.
+- Delay formula: `min(max(30, 2 ** attempt), 300)` seconds, with ±10% jitter.
+- **Cap:** 300s between attempts. **Floor:** ~27s.
+- Both sync (`AgentScheduler`) and async (`AsyncAgentScheduler`) use the same curve.
+
+`max_retries` is the **total** number of attempts (including the first run).
+`max_retries=3` → 1 initial attempt + up to 2 retries.
 
 ## Stopping the Scheduler
 

--- a/docs/features/async-scheduler.mdx
+++ b/docs/features/async-scheduler.mdx
@@ -1,0 +1,286 @@
+---
+title: "Async Agent Scheduler"
+sidebarTitle: "Async Scheduler"
+description: "Async-native scheduler for running agents with proper cancellation and event loop safety"
+icon: "clock"
+---
+
+Async-native agent scheduler that replaces daemon threads with proper async execution and cooperative cancellation.
+
+```mermaid
+graph LR
+    subgraph "Async Scheduler Flow"
+        A[📋 Agent] --> B[🔄 Async Loop]
+        B --> C[⏰ Schedule]
+        C --> D[🚫 Cancellable Wait]
+        D --> E[✅ Execute]
+        E --> F[📊 Stats]
+        F --> D
+    end
+    
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A agent
+    class B,C,D process
+    class E,F result
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Simple Usage">
+Create and start an async scheduler with basic configuration.
+
+```python
+import asyncio
+from praisonaiagents import Agent
+from praisonai.async_agent_scheduler import AsyncAgentScheduler
+
+async def main():
+    agent = Agent(
+        name="NewsChecker", 
+        instructions="Summarise the latest AI news."
+    )
+    
+    scheduler = AsyncAgentScheduler(
+        agent=agent, 
+        task="Summarise top 3 AI stories"
+    )
+    
+    await scheduler.start("hourly", max_retries=3, run_immediately=True)
+    
+    # Let it run for 2 hours
+    await asyncio.sleep(3600 * 2)
+    await scheduler.stop()
+
+asyncio.run(main())
+```
+</Step>
+
+<Step title="With Callbacks and Configuration">
+Add success/failure callbacks and custom configuration.
+
+```python
+import asyncio
+from praisonaiagents import Agent
+from praisonai.async_agent_scheduler import AsyncAgentScheduler
+
+def success_callback(result):
+    print(f"✅ Success: {result}")
+
+async def async_failure_callback(exception):
+    print(f"❌ Async failure: {exception}")
+
+async def main():
+    agent = Agent(
+        name="DataProcessor",
+        instructions="Process and analyze data efficiently."
+    )
+    
+    scheduler = AsyncAgentScheduler(
+        agent=agent,
+        task="Process latest data batch",
+        config={"timeout": 120},
+        on_success=success_callback,
+        on_failure=async_failure_callback
+    )
+    
+    await scheduler.start("*/30m", max_retries=5)
+    
+    # Monitor stats
+    stats = await scheduler.get_stats()
+    print(f"Stats: {stats}")
+    
+    await scheduler.stop()
+
+asyncio.run(main())
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Scheduler
+    participant Agent
+    participant EventLoop
+    
+    User->>Scheduler: await start()
+    Scheduler->>EventLoop: create_task(run_schedule)
+    
+    loop Every Interval
+        Scheduler->>Agent: await execute()
+        Agent-->>Scheduler: result
+        Scheduler->>User: on_success(result)
+        Scheduler->>EventLoop: wait_for(cancel_event, timeout=interval)
+        Note over Scheduler: Cooperative cancellation
+    end
+    
+    User->>Scheduler: await stop()
+    Scheduler->>EventLoop: cancel_event.set()
+    Scheduler-->>User: graceful shutdown
+```
+
+| Phase | Description |
+|-------|-------------|
+| **Initialization** | Creates async primitives lazily on first use |
+| **Scheduling** | Runs agent at specified intervals with exponential backoff |
+| **Execution** | Uses thread pool for sync agents, direct await for async agents |
+| **Cancellation** | Cooperative cancellation via `asyncio.Event` |
+
+---
+
+## Configuration Options
+
+<Card title="AsyncAgentScheduler API Reference" icon="code" href="/docs/sdk/reference/praisonai/classes/AsyncAgentScheduler">
+  Complete parameter documentation and examples
+</Card>
+
+### Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `agent` | `Any` | Required | Agent instance to schedule |
+| `task` | `str` | Required | Task description to execute |
+| `config` | `Dict[str, Any]` | `{}` | Optional configuration |
+| `on_success` | `Callable` | `None` | Success callback (sync or async) |
+| `on_failure` | `Callable` | `None` | Failure callback (sync or async) |
+
+### Start Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `schedule_expr` | `str` | Required | Schedule interval expression |
+| `max_retries` | `int` | `3` | Total attempts (1 initial + retries) |
+| `run_immediately` | `bool` | `False` | Execute immediately before scheduling |
+
+---
+
+## Common Patterns
+
+### Pattern 1: Event Loop Safety
+
+The scheduler is safe to construct outside an event loop:
+
+```python
+# Safe to create in sync code
+scheduler = AsyncAgentScheduler(agent, task)
+
+async def run_later():
+    # Async primitives created here
+    await scheduler.start("hourly")
+```
+
+### Pattern 2: FastAPI Integration
+
+```python
+from fastapi import FastAPI
+from contextlib import asynccontextmanager
+
+scheduler = None
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global scheduler
+    scheduler = AsyncAgentScheduler(agent, "Background task")
+    await scheduler.start("*/10m")
+    yield
+    await scheduler.stop()
+
+app = FastAPI(lifespan=lifespan)
+```
+
+### Pattern 3: Cancellation Handling
+
+```python
+async def graceful_shutdown():
+    try:
+        await scheduler.start("hourly")
+    except asyncio.CancelledError:
+        print("Scheduler cancelled")
+    finally:
+        await scheduler.stop()
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Event Loop Safety">
+Always create async primitives lazily. The scheduler binds `asyncio.Event` and `asyncio.Lock` to the caller's loop on first async entry, preventing "different loop" errors.
+
+```python
+# ✅ Good: Constructor safe in sync code
+scheduler = AsyncAgentScheduler(agent, task)
+
+async def later():
+    # ✅ Good: Async primitives created here
+    await scheduler.start("hourly")
+```
+</Accordion>
+
+<Accordion title="Callback Best Practices">
+Use both sync and async callbacks safely. The `safe_call` utility handles both types automatically.
+
+```python
+def sync_callback(result):
+    print(f"Sync: {result}")
+
+async def async_callback(result):
+    await log_to_database(result)
+
+# ✅ Both work seamlessly
+scheduler = AsyncAgentScheduler(
+    agent=agent,
+    task=task,
+    on_success=async_callback,
+    on_failure=sync_callback
+)
+```
+</Accordion>
+
+<Accordion title="Retry Strategy">
+Use exponential backoff with jitter. Both sync and async schedulers share the same `backoff_delay` algorithm for consistency.
+
+```python
+# Delay formula: min(max(30, 2 ** attempt), 300) * jitter
+# - Floor: ~27s, Cap: 300s
+# - Same behavior as sync AgentScheduler
+await scheduler.start("hourly", max_retries=5)
+```
+</Accordion>
+
+<Accordion title="Graceful Shutdown">
+Always await `stop()` for proper cleanup and statistics reporting.
+
+```python
+try:
+    await scheduler.start("hourly")
+    await asyncio.sleep(3600)
+finally:
+    stats = await scheduler.get_stats()
+    await scheduler.stop()
+    print(f"Final stats: {stats}")
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Sync Agent Scheduler" icon="clock" href="/docs/cli/scheduler">
+  Thread-based scheduler for sync environments
+</Card>
+<Card title="Shared Scheduler Utilities" icon="gear" href="/docs/features/scheduler-shared">
+  Common primitives used by both schedulers
+</Card>
+</CardGroup>

--- a/docs/observability/langfuse.mdx
+++ b/docs/observability/langfuse.mdx
@@ -134,6 +134,13 @@ export LANGFUSE_BASE_URL=http://localhost:3000
 export LANGFUSE_HOST=http://localhost:3000
 ```
 
+<Note>
+As of PraisonAI's wrapper-layer refactor, `OTEL_SDK_DISABLED` and `EC_TELEMETRY` are
+only set on first observability use, not at import. User-set values are preserved
+(`setdefault`). If `LANGFUSE_PUBLIC_KEY` is set or `~/.praisonai/langfuse.env` exists,
+`OTEL_SDK_DISABLED=false` is set explicitly so Langfuse v4 can use OTel internally.
+</Note>
+
 ---
 
 ## CLI Observability — `--observe langfuse`

--- a/docs/sdk/praisonai/scheduler.mdx
+++ b/docs/sdk/praisonai/scheduler.mdx
@@ -57,7 +57,7 @@ scheduler.stop()
 
 ### `ScheduleParser`
 
-Parses schedule expressions into scheduling parameters.
+Parses schedule expressions into scheduling parameters. `ScheduleParser` is also re-exported from `praisonai.scheduler.shared` and used internally by `AgentScheduler` / `AsyncAgentScheduler`.
 
 ```python
 from praisonai.scheduler import ScheduleParser

--- a/docs/sdk/reference/praisonai/classes/AgentScheduler.mdx
+++ b/docs/sdk/reference/praisonai/classes/AgentScheduler.mdx
@@ -34,23 +34,23 @@ graph LR
 ## Constructor
 
 <ParamField query="agent" type="Any" required={true}>
-  No description available.
+  The PraisonAI agent or `AsyncPraisonAgentExecutor` instance to run.
 </ParamField>
 
 <ParamField query="task" type="str" required={true}>
-  No description available.
+  The prompt / task string passed to the agent on each run.
 </ParamField>
 
-<ParamField query="config" type="Optional" required={false}>
-  No description available.
+<ParamField query="config" type="Optional[Dict[str, Any]]" required={false}>
+  Optional extra config (reserved; currently unused).
 </ParamField>
 
-<ParamField query="on_success" type="Optional" required={false}>
-  No description available.
+<ParamField query="on_success" type="Optional[Callable[[Any], None]]" required={false}>
+  Invoked with the agent's result after a successful run. Sync or async; exceptions are logged, not raised.
 </ParamField>
 
-<ParamField query="on_failure" type="Optional" required={false}>
-  No description available.
+<ParamField query="on_failure" type="Optional[Callable[[Exception], None]]" required={false}>
+  Invoked with the last captured exception after `max_retries` attempts fail. Sync or async; exceptions are logged, not raised.
 </ParamField>
 
 ## Methods


### PR DESCRIPTION
Fixes #189

Updates scheduler documentation to reflect changes from upstream PR #1474 with unified retry logic, lazy telemetry, and async-safe primitives.

## Summary
- Unified retry logic: Updated retry documentation to reflect exponential backoff + jitter shared between sync and async schedulers
- Callback documentation: Added proper documentation for on_success and on_failure callbacks with type changes
- Async scheduler page: New comprehensive documentation for AsyncAgentScheduler with event loop safety
- Lazy telemetry: Added note about lazy OTEL/EC telemetry initialization
- Parameter descriptions: Completed empty parameter descriptions in SDK reference

## Changes
### Updated Files
- docs/cli/scheduler.mdx - Fixed retry logic description and added callbacks section
- docs/sdk/reference/praisonai/classes/AgentScheduler.mdx - Added parameter descriptions
- docs/observability/langfuse.mdx - Added lazy telemetry initialization note
- docs/sdk/praisonai/scheduler.mdx - Added shared module cross-reference

### New Files
- docs/features/async-scheduler.mdx - Complete async scheduler documentation following AGENTS.md template

### Configuration
- docs.json - Added async-scheduler page to Features > Async & Background navigation

Generated with [Claude Code](https://claude.ai/code)