### PR TITLE
docs: Update push-notifications.mdx for PushClient/transports wrapper refactor

### DIFF
--- a/docs/features/push-notifications.mdx
+++ b/docs/features/push-notifications.mdx
@@ -7,6 +7,10 @@ icon: "bell"
 
 Push notifications deliver real-time messages from a PraisonAI gateway to subscribed clients over WebSocket (with HTTP polling fallback).
 
+<Note>
+`PushClient` requires the `praisonai` wrapper package (`pip install praisonai`). The core `praisonaiagents` package only ships the push **protocols** and `ChannelMessage` model — concrete client and transport implementations live in the wrapper. You can still import via `from praisonaiagents.push import PushClient` (a lazy re-export), or directly via `from praisonai.push import PushClient`.
+</Note>
+
 ```mermaid
 graph LR
     subgraph "Real-Time Push"
@@ -26,6 +30,16 @@ graph LR
 ## Quick Start
 
 <Steps>
+
+<Step title="Install Prerequisites">
+`PushClient` and its transports ship in the `praisonai` wrapper package. Install it before importing:
+
+```bash
+pip install praisonai
+```
+
+The core `praisonaiagents` package contains only the push **protocols** and the `ChannelMessage` model. The concrete `PushClient`, `WebSocketTransport`, and `PollingTransport` classes live in the wrapper.
+</Step>
 
 <Step title="Enable Push on Gateway">
 ```python
@@ -86,6 +100,29 @@ await client.wait_closed()
 
 ---
 
+## Import Paths
+
+Two equivalent import paths are supported:
+
+```python
+# Recommended (explicit wrapper import)
+from praisonai.push import PushClient, WebSocketTransport, PollingTransport
+
+# Backward-compatible (lazy re-export from core)
+from praisonaiagents.push import PushClient, WebSocketTransport, PollingTransport
+```
+
+Both resolve to the same classes in the `praisonai` wrapper package. The `praisonaiagents.push` path is kept for backward compatibility and will raise a clear `ImportError` if the `praisonai` wrapper is not installed.
+
+The core `praisonaiagents.push` module only exports protocol-level types:
+
+```python
+from praisonaiagents.push import ChannelMessage           # dataclass
+from praisonaiagents.push import PushTransportProtocol    # typing.Protocol
+```
+
+---
+
 ## How It Works
 
 ```mermaid
@@ -119,6 +156,34 @@ sequenceDiagram
 | **Channels** | Named message streams for pub/sub |
 | **Presence** | Track online/offline status of clients |
 | **Delivery Guarantees** | At-least-once message delivery with ACKs |
+
+```mermaid
+graph LR
+    subgraph "Core SDK — praisonaiagents.push"
+        P[📜 PushTransportProtocol]
+        M[📦 ChannelMessage]
+        S[🔀 Lazy re-export shim]
+    end
+    subgraph "Wrapper — praisonai.push"
+        C[🤖 PushClient]
+        W[🌐 WebSocketTransport]
+        PO[🔁 PollingTransport]
+    end
+
+    S -.lazy import.-> C
+    S -.lazy import.-> W
+    S -.lazy import.-> PO
+    W -.implements.-> P
+    PO -.implements.-> P
+
+    classDef core fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef wrapper fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef shim fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class P,M core
+    class C,W,PO wrapper
+    class S shim
+```
 
 ---
 
@@ -173,6 +238,32 @@ sequenceDiagram
 | `enabled` | `bool` | `True` | Toggle polling fallback |
 | `long_poll_timeout` | `int` | `30` | Long-poll hang duration (seconds) |
 | `max_batch_size` | `int` | `100` | Max messages per poll response |
+
+---
+
+## Custom Transports (Advanced)
+
+Implement `PushTransportProtocol` to plug in a custom transport (e.g. SSE, gRPC):
+
+```python
+from praisonaiagents.push import PushTransportProtocol
+
+class MyTransport:
+    @property
+    def is_connected(self) -> bool: ...
+    async def connect(self) -> None: ...
+    async def disconnect(self) -> None: ...
+    async def send(self, data: dict) -> None: ...
+    async def receive(self) -> dict: ...
+```
+
+| Method / Property | Purpose |
+|---|---|
+| `is_connected` (property) | Whether the transport is currently connected |
+| `connect()` | Establish the underlying connection |
+| `disconnect()` | Close the connection |
+| `send(data)` | Send a JSON-serialisable dict to the gateway |
+| `receive()` | Await and return the next JSON message from the gateway |
 
 ---
 


### PR DESCRIPTION
## Summary

Updates the push-notifications.mdx documentation to reflect the PushClient/transports wrapper refactor from PraisonAI PR #1483.

### Changes Made

✅ Prerequisites Step: Added installation requirement for praisonai wrapper package
✅ Note Callout: Added explanation after hero diagram about wrapper package requirement  
✅ Import Paths Section: Documents both praisonai.push and praisonaiagents.push import patterns
✅ Custom Transports Section: Added documentation for PushTransportProtocol 
✅ Architecture Diagram: Shows protocol/implementation split using standard color scheme
✅ Backward Compatibility: Maintains existing import examples with proper context

### Refactor Details

The refactor moved:
- PushClient from praisonaiagents/push/client.py → praisonai/push/client.py
- Transports from praisonaiagents/push/transports.py → praisonai/push/transports.py  
- Created PushTransportProtocol in praisonaiagents/push/protocols.py
- Added lazy re-export shim in praisonaiagents/push/__init__.py

Users can still import via 'from praisonaiagents.push import PushClient' but now require the praisonai wrapper package to be installed.

Fixes #199

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated push notifications documentation to clarify package dependencies and installation requirements.
  * Added import path guidance for both recommended and backward-compatible import routes.
  * Introduced architecture diagram illustrating core and wrapper package relationships.
  * Added "Custom Transports" section documenting advanced implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->