### PR TITLE
docs: document gateway CLI commands, daemon service, and update /health response

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -178,7 +178,8 @@
                   "docs/guides/deployment/index",
                   "docs/guides/deployment/overview",
                   "docs/gateway",
-                  "docs/guides/deployment/docker"
+                  "docs/guides/deployment/docker",
+                  "docs/guides/troubleshoot-gateway"
                 ]
               },
               {
@@ -295,6 +296,7 @@
                     "icon": "settings",
                     "pages": [
                       "docs/features/gateway",
+                      "docs/features/gateway-cli",
                       "docs/features/autonomy-loop",
                       "docs/features/model-failover",
                       "docs/features/sandbox",

--- a/docs/deploy/api/health-api.mdx
+++ b/docs/deploy/api/health-api.mdx
@@ -122,3 +122,4 @@ Health endpoint is automatically added to all servers. No configuration required
 ## Related
 
 - [Discovery API](/docs/deploy/api/discovery-api) - Full discovery document
+- [Gateway Health](/features/gateway-cli) - Gateway-specific health endpoint with different response format

--- a/docs/features/bot-gateway.mdx
+++ b/docs/features/bot-gateway.mdx
@@ -256,9 +256,27 @@ gateway.get_agent("personal")    # Returns Agent instance
     "uptime": 120.5,
     "agents": 2,
     "sessions": 3,
-    "clients": 1
+    "clients": 1,
+    "channels": {
+      "telegram": {
+        "platform": "telegram",
+        "running": true
+      },
+      "discord": {
+        "platform": "discord", 
+        "running": false
+      }
+    },
+    "push": {
+      "enabled": true,
+      "push_channels": 2,
+      "online_clients": 5,
+      "redis_connected": true
+    }
   }
   ```
+  
+  The `push` section is only included when push notifications are enabled.
 </Accordion>
 
 <Accordion title="Advanced: Standalone Bot Mode">

--- a/docs/features/gateway-cli.mdx
+++ b/docs/features/gateway-cli.mdx
@@ -1,0 +1,248 @@
+---
+title: "Gateway CLI"
+sidebarTitle: "Gateway CLI"
+description: "Command-line interface for managing the PraisonAI Gateway daemon and server"
+icon: "tower-broadcast"
+---
+
+Gateway CLI provides commands for starting, monitoring, and managing the PraisonAI Gateway server and its daemon service.
+
+```mermaid
+graph LR
+    subgraph "Gateway CLI Flow"
+        User[👤 User] --> CLI[💻 CLI]
+        CLI --> Daemon[⚙️ Daemon]
+        Daemon --> Gateway[🗼 Gateway]
+        Gateway --> Health[🏥 Health Check]
+    end
+    
+    classDef user fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    
+    class User user
+    class CLI,Daemon tool
+    class Gateway,Health success
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Start Gateway">
+```bash
+praisonai gateway start
+```
+</Step>
+
+<Step title="Check Status">
+```bash
+praisonai gateway status
+```
+</Step>
+
+<Step title="Test Health Endpoint">
+```bash
+curl http://127.0.0.1:8765/health
+```
+</Step>
+</Steps>
+
+---
+
+## Commands
+
+### Gateway Management
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `praisonai gateway start` | Start the gateway server | `praisonai gateway start --port 9000` |
+| `praisonai gateway status` | Check gateway and daemon status | `praisonai gateway status --daemon-only` |
+| `praisonai gateway channels` | List configured channels | `praisonai gateway channels --json` |
+
+### Daemon Service
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `praisonai gateway install` | Install as OS daemon | `praisonai gateway install --no-start` |
+| `praisonai gateway uninstall` | Remove daemon service | `praisonai gateway uninstall` |
+| `praisonai gateway logs` | Show daemon logs | `praisonai gateway logs -n 100` |
+
+### Testing & Debugging
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `praisonai gateway send` | Send test message | `praisonai gateway send --channel telegram --channel-id 12345 -m "test"` |
+
+---
+
+## Command Reference
+
+<Tabs>
+<Tab title="start">
+```bash
+praisonai gateway start [OPTIONS]
+
+Options:
+  --host TEXT         Host to bind to [default: 127.0.0.1]
+  --port INTEGER      Port to listen on [default: 8765]
+  --agents TEXT       Path to agent configuration file
+  --config TEXT       Path to gateway.yaml for multi-bot mode
+
+Examples:
+  praisonai gateway start
+  praisonai gateway start --config gateway.yaml
+  praisonai gateway start --agents agents.yaml --port 9000
+```
+</Tab>
+
+<Tab title="status">
+```bash
+praisonai gateway status [OPTIONS]
+
+Options:
+  --host TEXT         Gateway host [default: 127.0.0.1]
+  --port INTEGER      Gateway port [default: 8765]
+  --daemon-only       Show only daemon status
+
+Examples:
+  praisonai gateway status
+  praisonai gateway status --port 9000
+  praisonai gateway status --daemon-only
+```
+</Tab>
+
+<Tab title="channels">
+```bash
+praisonai gateway channels [OPTIONS]
+
+Options:
+  -c, --config TEXT   Path to gateway.yaml [default: gateway.yaml]
+  --json              Output JSON format
+
+Examples:
+  praisonai gateway channels
+  praisonai gateway channels --config my-gateway.yaml --json
+```
+</Tab>
+</Tabs>
+
+---
+
+## Status Output Examples
+
+### Healthy Gateway
+```bash
+$ praisonai gateway status
+Daemon service: Running (launchd)
+Process ID: 12345
+Gateway server: Reachable at http://127.0.0.1:8765/health
+  Status: healthy
+  Uptime: 3600.5 seconds
+  Agents: 2
+  Sessions: 1
+  Clients: 3
+  Channels: 2 configured
+```
+
+### Daemon Issues
+```bash
+$ praisonai gateway status
+Daemon service: Installed but not running (launchd)
+Gateway not reachable at http://127.0.0.1:8765/health
+```
+
+### Not Installed
+```bash
+$ praisonai gateway status --daemon-only
+Daemon service: Not installed (systemd)
+```
+
+---
+
+## Platform Support
+
+Gateway CLI works across platforms with native daemon integration:
+
+| Platform | Service Type | Log Location | Management |
+|----------|--------------|--------------|------------|
+| **macOS** | LaunchAgent | `~/.praisonai/logs/bot-stderr.log` | `launchctl` |
+| **Linux** | systemd user service | `journalctl --user -u praisonai` | `systemctl --user` |
+| **Windows** | Scheduled Task | Windows Event Log | Task Scheduler |
+
+---
+
+## Configuration Files
+
+<Tabs>
+<Tab title="agents.yaml">
+```yaml
+# Simple agent configuration
+agent:
+  name: "support"
+  instructions: "You are a helpful support agent"
+  model: "gpt-4o-mini"
+  tools:
+    - search_web
+  memory: true
+```
+</Tab>
+
+<Tab title="gateway.yaml">
+```yaml
+# Multi-bot configuration
+agents:
+  support:
+    instructions: "You are a support agent"
+    model: "gpt-4o-mini"
+  sales:
+    instructions: "You are a sales agent"
+    model: "claude-3-5-sonnet-20241022"
+
+channels:
+  telegram:
+    token: "${TELEGRAM_BOT_TOKEN}"
+    routing:
+      default: support
+  discord:
+    token: "${DISCORD_BOT_TOKEN}"
+    routing:
+      default: sales
+```
+</Tab>
+</Tabs>
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Use daemon-only for health checks">
+    Use `--daemon-only` flag when monitoring daemon status in scripts or CI/CD pipelines to avoid gateway connection attempts.
+  </Accordion>
+  
+  <Accordion title="Check logs for troubleshooting">
+    Always check `praisonai gateway logs` when the daemon is running but gateway is unreachable - this reveals startup errors.
+  </Accordion>
+  
+  <Accordion title="Test channel configuration">
+    Use `praisonai gateway send` to test channel bot configuration before deploying to production environments.
+  </Accordion>
+  
+  <Accordion title="Monitor daemon status regularly">
+    Set up monitoring that runs `praisonai gateway status --daemon-only` to detect service failures quickly.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Gateway Server" icon="tower-broadcast" href="/features/gateway">
+    Gateway architecture and configuration
+  </Card>
+  <Card title="Troubleshooting" icon="wrench" href="/guides/troubleshoot-gateway">
+    Common gateway issues and solutions
+  </Card>
+</CardGroup>

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -45,7 +45,7 @@ config = GatewayConfig(
 
 <Step title="Start Gateway Server">
 ```bash
-praisonai serve gateway --port 8765
+praisonai gateway start --port 8765
 ```
 </Step>
 
@@ -341,16 +341,22 @@ session_config = SessionConfig(
 
 ```bash
 # Start gateway server
-praisonai serve gateway --port 8765
+praisonai gateway start --port 8765
 
-# Start with authentication
-praisonai serve gateway --port 8765 --auth-token "secret"
+# Start with configuration file
+praisonai gateway start --config gateway.yaml
+
+# Start with agents file
+praisonai gateway start --agents agents.yaml --port 9000
 
 # Check gateway status
-praisonai serve gateway status
+praisonai gateway status
 
-# Start with SSL
-praisonai serve gateway --ssl-cert cert.pem --ssl-key key.pem
+# Check only daemon status
+praisonai gateway status --daemon-only
+
+# List channels from config
+praisonai gateway channels --config gateway.yaml
 ```
 
 ---

--- a/docs/guides/troubleshoot-gateway.mdx
+++ b/docs/guides/troubleshoot-gateway.mdx
@@ -1,0 +1,394 @@
+---
+title: "Gateway Troubleshooting"
+sidebarTitle: "Gateway Troubleshooting"
+description: "Common gateway issues and step-by-step solutions"
+icon: "wrench"
+---
+
+Common issues with the PraisonAI Gateway daemon and server, with step-by-step troubleshooting guides.
+
+```mermaid
+graph TB
+    subgraph "Troubleshooting Flow"
+        Check[🔍 Check Status] --> Running{Daemon Running?}
+        Running -->|Yes| Reachable{Gateway Reachable?}
+        Running -->|No| Install{Daemon Installed?}
+        Install -->|Yes| Restart[🔄 Restart Service]
+        Install -->|No| Reinstall[📦 Run Onboard]
+        Reachable -->|Yes| Success[✅ All Good]
+        Reachable -->|No| Debug[🐛 Check Logs]
+        Debug --> Fix[🔧 Fix & Restart]
+        Restart --> Success
+        Fix --> Success
+    end
+    
+    classDef check fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef warning fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    
+    class Check check
+    class Running,Reachable,Install warning
+    class Success success
+    class Debug,Fix,Restart,Reinstall error
+```
+
+## Common Issues
+
+### Daemon Running But Gateway Unreachable
+
+**Symptom:** `praisonai gateway status` shows `Daemon service: Running (launchd)` but `Gateway not reachable at http://127.0.0.1:8765/health`.
+
+<Steps>
+<Step title="Verify daemon is actually running">
+```bash
+praisonai gateway status --daemon-only
+```
+
+Look for `Running` status and process ID.
+</Step>
+
+<Step title="Check daemon logs for errors">
+```bash
+praisonai gateway logs
+
+# Or check raw log files:
+# macOS: tail ~/.praisonai/logs/bot-stderr.log
+# Linux: journalctl --user -u praisonai
+```
+
+Look for Python tracebacks or port binding errors.
+</Step>
+
+<Step title="Check if another process is using the port">
+```bash
+lsof -i :8765
+# or
+netstat -tulpn | grep :8765
+```
+
+If another process is using port 8765, either stop it or change the gateway port.
+</Step>
+
+<Step title="Verify PraisonAI version">
+```bash
+praisonai --version
+```
+
+Upgrade to ≥ v4.6.23 if you see older versions - earlier versions had IndentationError bugs fixed in PR #1484.
+</Step>
+
+<Step title="Restart the daemon">
+```bash
+# macOS
+launchctl kickstart -k gui/$(id -u)/ai.praison.bot
+
+# Linux  
+systemctl --user restart praisonai
+
+# Or reinstall completely
+praisonai onboard
+```
+</Step>
+</Steps>
+
+---
+
+### Rapidly Growing Log Files
+
+**Symptom:** `~/.praisonai/logs/bot-stderr.log` grows to multiple MB per minute.
+
+<Steps>
+<Step title="Check log file size">
+```bash
+ls -lh ~/.praisonai/logs/bot-stderr.log
+```
+
+If growing rapidly (>1MB/min), this indicates a crash loop.
+</Step>
+
+<Step title="View recent errors">
+```bash
+tail -50 ~/.praisonai/logs/bot-stderr.log
+```
+
+Look for repeated Python tracebacks, especially IndentationError.
+</Step>
+
+<Step title="Stop the daemon">
+```bash
+# macOS
+launchctl unload ~/Library/LaunchAgents/ai.praison.bot.plist
+
+# Linux
+systemctl --user stop praisonai
+```
+</Step>
+
+<Step title="Clear logs and restart">
+```bash
+# Clear the log file
+> ~/.praisonai/logs/bot-stderr.log
+
+# Upgrade PraisonAI
+pip install --upgrade praisonai
+
+# Restart daemon
+praisonai gateway install --start
+```
+</Step>
+</Steps>
+
+---
+
+### Daemon Not Installed
+
+**Symptom:** `praisonai gateway status` shows `Daemon service: Not installed (systemd)`.
+
+<Steps>
+<Step title="Run the onboarding wizard">
+```bash
+praisonai onboard
+```
+
+This installs the daemon service for your platform.
+</Step>
+
+<Step title="Verify installation">
+```bash
+praisonai gateway status --daemon-only
+```
+
+Should show `Installed but not running` or `Running`.
+</Step>
+
+<Step title="Start the service">
+```bash
+# Manual start
+praisonai gateway install --start
+
+# Or check platform-specific commands
+praisonai gateway status
+```
+</Step>
+</Steps>
+
+---
+
+### HTTP 500 on Health Endpoint
+
+**Symptom:** `curl http://127.0.0.1:8765/health` returns 500 Internal Server Error.
+
+<Steps>
+<Step title="Check PraisonAI version">
+```bash
+praisonai --version
+```
+
+Versions before v4.6.23 had AttributeError bugs in the health endpoint.
+</Step>
+
+<Step title="Upgrade PraisonAI">
+```bash
+pip install --upgrade praisonai
+```
+</Step>
+
+<Step title="Restart the gateway">
+```bash
+praisonai gateway install --start
+```
+</Step>
+
+<Step title="Test health endpoint">
+```bash
+curl http://127.0.0.1:8765/health
+```
+
+Should return JSON with status, uptime, agents, sessions, clients, and channels.
+</Step>
+</Steps>
+
+---
+
+### Permission Denied Errors
+
+**Symptom:** Daemon fails to start with permission errors in logs.
+
+<Tabs>
+<Tab title="macOS">
+```bash
+# Check LaunchAgent permissions
+ls -la ~/Library/LaunchAgents/ai.praison.bot.plist
+
+# Reload LaunchAgent
+launchctl unload ~/Library/LaunchAgents/ai.praison.bot.plist
+launchctl load ~/Library/LaunchAgents/ai.praison.bot.plist
+```
+</Tab>
+
+<Tab title="Linux">
+```bash
+# Check systemd user service
+systemctl --user status praisonai
+
+# Enable user lingering (allows services to run when not logged in)
+sudo loginctl enable-linger $(whoami)
+
+# Restart service
+systemctl --user daemon-reload
+systemctl --user restart praisonai
+```
+</Tab>
+
+<Tab title="Windows">
+```powershell
+# Run as administrator
+# Check Task Scheduler for PraisonAI task
+schtasks /query /tn "PraisonAI Bot"
+
+# Delete and recreate
+praisonai gateway uninstall
+praisonai gateway install
+```
+</Tab>
+</Tabs>
+
+---
+
+### Clean Reinstall Process
+
+When all else fails, perform a clean reinstall:
+
+<Steps>
+<Step title="Stop and uninstall">
+```bash
+praisonai gateway uninstall
+```
+</Step>
+
+<Step title="Clear configuration">
+```bash
+# Backup first if needed
+rm -rf ~/.praisonai/logs
+rm -rf ~/.praisonai/config
+```
+</Step>
+
+<Step title="Upgrade PraisonAI">
+```bash
+pip install --upgrade praisonai
+```
+</Step>
+
+<Step title="Run onboarding">
+```bash
+praisonai onboard
+```
+
+Follow the wizard to reinstall the daemon service.
+</Step>
+
+<Step title="Verify installation">
+```bash
+praisonai gateway status
+```
+
+Should show daemon running and gateway reachable.
+</Step>
+</Steps>
+
+---
+
+## Diagnostic Commands
+
+Quick commands for gathering diagnostic information:
+
+```bash
+# Full status check
+praisonai gateway status
+
+# Daemon-only check (for scripts)
+praisonai gateway status --daemon-only
+
+# Recent logs (last 50 lines)
+praisonai gateway logs -n 50
+
+# Check port usage
+lsof -i :8765
+
+# Test health endpoint directly
+curl -v http://127.0.0.1:8765/health
+
+# Check PraisonAI version
+praisonai --version
+
+# Platform daemon status
+# macOS: launchctl list | grep ai.praison
+# Linux: systemctl --user status praisonai
+# Windows: schtasks /query /tn "PraisonAI*"
+```
+
+---
+
+## Platform-Specific Notes
+
+<Tabs>
+<Tab title="macOS">
+**LaunchAgent Path:** `~/Library/LaunchAgents/ai.praison.bot.plist`
+**Log Path:** `~/.praisonai/logs/bot-stderr.log`
+
+```bash
+# Manual management
+launchctl load ~/Library/LaunchAgents/ai.praison.bot.plist
+launchctl unload ~/Library/LaunchAgents/ai.praison.bot.plist
+launchctl kickstart -k gui/$(id -u)/ai.praison.bot
+
+# Check if loaded
+launchctl list | grep ai.praison
+```
+</Tab>
+
+<Tab title="Linux">
+**Service Path:** `~/.config/systemd/user/praisonai.service`
+**Logs:** `journalctl --user -u praisonai`
+
+```bash
+# Manual management
+systemctl --user start praisonai
+systemctl --user stop praisonai
+systemctl --user restart praisonai
+systemctl --user enable praisonai
+
+# Check status
+systemctl --user status praisonai
+```
+</Tab>
+
+<Tab title="Windows">
+**Task Path:** Task Scheduler → PraisonAI Bot
+**Logs:** Windows Event Log
+
+```powershell
+# Manual management via Task Scheduler or:
+schtasks /run /tn "PraisonAI Bot"
+schtasks /end /tn "PraisonAI Bot"
+
+# Check status
+schtasks /query /tn "PraisonAI Bot"
+```
+</Tab>
+</Tabs>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Gateway CLI" icon="tower-broadcast" href="/features/gateway-cli">
+    Gateway command reference
+  </Card>
+  <Card title="Gateway Server" icon="settings" href="/features/gateway">
+    Gateway configuration and setup
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Fixes #201

Updated gateway documentation following PR #1484 that fixed daemon issues:
- Fixed CLI syntax to use praisonai gateway commands
- Updated /health response to include channels and push sections  
- Added gateway-cli.mdx with comprehensive command reference
- Added troubleshoot-gateway.mdx with step-by-step issue resolution
- Updated navigation in docs.json

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced new Gateway CLI documentation page covering command reference, real-world examples, and platform-specific daemon configuration guidance.
  * Introduced comprehensive Gateway troubleshooting guide with decision flowchart and detailed step-by-step troubleshooting procedures for common issues.
  * Enhanced health endpoint documentation with new response fields for per-platform channels and push notification configuration status.
  * Updated gateway command syntax documentation and improved overall documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->