### PR TITLE
docs: document praisonai onboard flow, --no-onboard flag, and localhost-only dashboard note (fixes #207)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -255,7 +255,8 @@
                       "docs/features/image-generation",
                       "docs/features/structured",
                       "docs/features/mini",
-                      "docs/features/autoagents"
+                      "docs/features/autoagents",
+                      "docs/features/onboard"
                     ]
                   },
                   {

--- a/docs/cli/dashboard.mdx
+++ b/docs/cli/dashboard.mdx
@@ -91,6 +91,21 @@ The dashboard follows this process:
 
 ---
 
+## Security
+
+<Warning>
+The dashboard binds to `127.0.0.1` (localhost only) with **no URL-level authentication** by default. 
+
+Anyone with local machine access can reach the dashboard. Exposing with `--host 0.0.0.0` without a reverse proxy or auth layer is **not recommended**.
+</Warning>
+
+For production deployments:
+- Use a reverse proxy (nginx, Apache) with authentication
+- Consider VPN access for remote management
+- Review the [Bot Security Guide](/docs/best-practices/bot-security) for additional measures
+
+---
+
 ## Configuration Options
 
 | Option | Type | Default | Description |

--- a/docs/developers/scripts.mdx
+++ b/docs/developers/scripts.mdx
@@ -42,6 +42,7 @@ iwr -useb https://praison.ai/install.ps1 | iex
 - **Package Manager Support** - brew, apt, dnf, pacman, winget, chocolatey
 - **Virtual Environment** - Creates isolated venv at `~/.praisonai/`
 - **PATH Configuration** - Adds to shell profile automatically
+- **Interactive Onboarding** - Prompts for bot setup after installation
 - **Dry Run Mode** - Preview changes before applying
 
 ### Environment Variables
@@ -52,6 +53,7 @@ iwr -useb https://praison.ai/install.ps1 | iex
 | `PRAISONAI_EXTRAS` | `""` | Comma-separated extras (ui,chat,api) |
 | `PRAISONAI_SKIP_VENV` | `0` | Skip virtual environment |
 | `PRAISONAI_DRY_RUN` | `0` | Preview mode |
+| `PRAISONAI_NO_ONBOARD` | `0` | Skip interactive onboarding entirely |
 
 ### Examples
 

--- a/docs/features/onboard.mdx
+++ b/docs/features/onboard.mdx
@@ -1,0 +1,293 @@
+---
+title: "Bot Onboarding"
+sidebarTitle: "Onboarding"
+description: "Set up Telegram, Discord, Slack, or WhatsApp bots in 60 seconds"
+icon: "wand-magic-sparkles"
+---
+
+Interactive wizard that configures messaging bots and sets up the daemon services to run them.
+
+```mermaid
+graph LR
+    User[👤 User] --> Wizard[🧙 Onboard Wizard]
+    Wizard --> Platform{📱 Choose Platform}
+    Platform --> Telegram[📱 Telegram]
+    Platform --> Discord[💬 Discord]  
+    Platform --> Slack[💼 Slack]
+    Platform --> WhatsApp[📞 WhatsApp]
+    Telegram --> Daemon[⚙️ Install Daemon]
+    Discord --> Daemon
+    Slack --> Daemon
+    WhatsApp --> Daemon
+    Daemon --> Done[✅ Done Panel]
+    
+    classDef user fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef wizard fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef platform fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class User user
+    class Wizard wizard
+    class Platform,Telegram,Discord,Slack,WhatsApp platform
+    class Daemon,Done result
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Run the onboard wizard">
+Launch the interactive bot setup wizard:
+
+```bash
+praisonai onboard
+```
+
+The wizard prompts you to choose a platform and walks you through token setup.
+</Step>
+
+<Step title="Pick your platform">
+Select from the supported messaging platforms:
+
+```
+Choose a platform:
+1. Telegram
+2. Discord  
+3. Slack
+4. WhatsApp
+```
+
+Each platform has different token requirements and setup steps.
+</Step>
+
+<Step title="Paste your token">
+Follow the platform-specific instructions to get your bot token, then paste it when prompted:
+
+```
+Enter your bot token: <paste_token_here>
+```
+
+The wizard validates the token and installs the daemon service.
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Wizard
+    participant Platform
+    participant Daemon
+    
+    User->>Wizard: praisonai onboard
+    Wizard->>User: Choose platform
+    User->>Wizard: Select platform
+    Wizard->>Platform: Validate token
+    Platform-->>Wizard: Token valid
+    Wizard->>Daemon: Install service
+    Daemon-->>Wizard: Service installed
+    Wizard->>User: ✅ Done panel
+```
+
+The onboarding process follows these phases:
+
+| Phase | Description |
+|-------|-------------|
+| **Platform Selection** | Choose Telegram, Discord, Slack, or WhatsApp |
+| **Token Entry** | Paste the bot token for your chosen platform |
+| **Validation** | Wizard tests the token with the platform API |
+| **Daemon Install** | Sets up the platform daemon (launchd/systemd/Windows Task) |
+| **Configuration** | Writes config files to `~/.praisonai/` |
+| **Completion** | Shows the ✅ Done panel with all connection details |
+
+---
+
+## What Gets Installed
+
+When onboarding completes successfully, the wizard installs:
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| **Platform daemon** | System service (launchd/systemd/Windows Task) | Keeps bot running in background |
+| **Bot configuration** | `~/.praisonai/config/` | Stores tokens and settings |
+| **Gateway auth token** | `~/.praisonai/gateway/` | Authentication for web dashboard |
+| **Dashboard URL** | Printed in Done panel | Local web interface |
+
+---
+
+## The ✅ Done Panel
+
+When onboarding completes, you'll see a comprehensive summary panel:
+
+```
+✅ Bot onboarding complete!
+
+Dashboard: http://127.0.0.1:8082 (localhost only)
+Start bot: praisonai bot start
+Gateway status: praisonai gateway status
+Health check: curl http://127.0.0.1:8080/health
+Info endpoint: curl http://127.0.0.1:8080/info
+Auth token: abc123...
+
+Run 'praisonai doctor' if you encounter any issues.
+```
+
+This panel contains everything you need to:
+- Access the web dashboard
+- Start/stop your bot
+- Check service health
+- Authenticate API requests
+
+---
+
+## Re-running Onboarding
+
+The wizard is **idempotent** - safe to run multiple times:
+
+```bash
+# Update an existing bot's token
+praisonai onboard
+
+# Switch from Telegram to Discord
+praisonai onboard
+```
+
+Re-running the wizard will:
+- Update tokens and configurations in place
+- Restart the daemon service with new settings
+- Preserve existing chat histories and agent memory
+
+---
+
+## Relationship to Setup
+
+PraisonAI has two configuration commands that run in sequence:
+
+```mermaid
+graph TB
+    Install[Installer] --> Setup[praisonai setup<br/>LLM/API Keys]
+    Setup --> Onboard[praisonai onboard<br/>Messaging Bots]
+    Onboard --> Ready[✅ Ready to Use]
+    
+    classDef command fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class Setup,Onboard command
+    class Ready result
+```
+
+- **`praisonai setup`** - Configures LLM providers (OpenAI, Anthropic, etc.)
+- **`praisonai onboard`** - Configures messaging bots (Telegram, Discord, etc.)
+
+Both are called automatically by the installer, but can be run independently.
+
+---
+
+## Common Patterns
+
+### Skip onboarding during install
+
+```bash
+# Skip during installation
+curl -fsSL https://praison.ai/install.sh | bash -s -- --no-onboard
+
+# Or via environment variable
+PRAISONAI_NO_ONBOARD=1 curl -fsSL https://praison.ai/install.sh | bash
+```
+
+### Run onboarding separately later
+
+```bash
+# Install first without onboarding
+curl -fsSL https://praison.ai/install.sh | bash -s -- --no-onboard
+
+# Set up LLM keys
+praisonai setup
+
+# Set up messaging bot when ready
+praisonai onboard
+```
+
+### Switch platforms
+
+```bash
+# Currently using Telegram, switch to Discord
+praisonai onboard
+# Choose Discord and enter Discord bot token
+```
+
+### Re-generate auth token
+
+```bash
+# Run onboarding again to get a fresh auth token
+praisonai onboard
+```
+
+---
+
+## Which Platform Should I Use?
+
+```mermaid
+graph TB
+    Start{What's your use case?}
+    Start -->|Personal assistant| Telegram[🎯 Telegram<br/>Easy setup, great for individuals]
+    Start -->|Team collaboration| Slack[🎯 Slack<br/>Integrates with team workflows]
+    Start -->|Gaming/Community| Discord[🎯 Discord<br/>Rich features, voice support]
+    Start -->|Business/Customer support| WhatsApp[🎯 WhatsApp<br/>Wide adoption, mobile-first]
+    
+    classDef platform fill:#189AB4,stroke:#7C90A0,color:#fff
+    
+    class Telegram,Slack,Discord,WhatsApp platform
+```
+
+Choose based on:
+
+| Platform | Best For | Setup Difficulty | Features |
+|----------|----------|------------------|----------|
+| **Telegram** | Personal use, experimentation | Easy | Rich bot API, inline keyboards |
+| **Discord** | Gaming communities, developer teams | Medium | Voice channels, rich embeds |
+| **Slack** | Business teams, professional workflows | Medium | Thread support, workspace integration |
+| **WhatsApp** | Customer support, global reach | Hard | Business accounts required |
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Start with Telegram for testing">
+Telegram has the simplest setup process and most permissive API limits. Use it for initial testing before moving to your target platform.
+</Accordion>
+
+<Accordion title="Keep tokens secure">
+Bot tokens are stored in `~/.praisonai/config/`. Ensure this directory has proper permissions (600) and exclude it from version control.
+</Accordion>
+
+<Accordion title="Test the dashboard connection">
+After onboarding, visit the dashboard URL from the Done panel to confirm the web interface is working and authentication is set up correctly.
+</Accordion>
+
+<Accordion title="Use 'praisonai doctor' for troubleshooting">
+If bots aren't responding or services seem down, run `praisonai doctor` for diagnostic information and common fixes.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Installation Guide" icon="download" href="/docs/install/installer">
+    Complete installer documentation including onboarding flow
+  </Card>
+  <Card title="Dashboard" icon="layout-dashboard" href="/docs/cli/dashboard">
+    Web dashboard for managing agents and monitoring bots
+  </Card>
+  <Card title="Bot Security" icon="shield" href="/docs/best-practices/bot-security">
+    Security best practices for messaging bots
+  </Card>
+  <Card title="Quick Install" icon="bolt" href="/docs/install/quickstart">
+    One-liner installation including onboarding prompt
+  </Card>
+</CardGroup>

--- a/docs/install/installer.mdx
+++ b/docs/install/installer.mdx
@@ -23,10 +23,16 @@ flowchart TD
     H --> I[pip install]:::tool
     I --> J[Setup PATH]:::tool
     J --> K[Verify]:::agent
-    K --> L[Done!]:::agent
+    K --> L[Setup wizard]:::process
+    L --> M{Onboard?}:::agent
+    M -->|Yes| N[Bot onboarding]:::process
+    M -->|No| O[Next Steps]:::success
+    N --> P[✅ Done panel]:::success
     
     classDef agent fill:#8B0000,color:#fff
     classDef tool fill:#189AB4,color:#fff
+    classDef process fill:#F59E0B,color:#fff
+    classDef success fill:#10B981,color:#fff
 ```
 
 ## install.sh (macOS/Linux)
@@ -59,6 +65,15 @@ flowchart TD
   <Step title="Verify Installation">
     Tests import and CLI availability
   </Step>
+  <Step title="Interactive Setup">
+    Runs `praisonai setup` for LLM configuration
+  </Step>
+  <Step title="Bot Onboarding">
+    Optional `praisonai onboard` for messaging bots (Telegram/Discord/Slack/WhatsApp)
+  </Step>
+  <Step title="Final Summary">
+    Shows either onboard wizard's ✅ Done panel or installer's Next Steps
+  </Step>
 </Steps>
 
 ### CLI Flags
@@ -75,6 +90,7 @@ curl -fsSL https://praison.ai/install.sh | bash -s -- --help
 | `--python PATH` | Use specific Python |
 | `--dry-run` | Preview without changes |
 | `--no-prompt` | Non-interactive mode |
+| `--no-onboard` | Skip interactive onboarding |
 | `-h, --help` | Show help |
 
 ### Environment Variables
@@ -87,6 +103,7 @@ curl -fsSL https://praison.ai/install.sh | bash -s -- --help
 | `PRAISONAI_PYTHON` | Python executable path |
 | `PRAISONAI_DRY_RUN` | Dry run mode (`1` to enable) |
 | `PRAISONAI_NO_PROMPT` | Skip prompts (`1` to enable) |
+| `PRAISONAI_NO_ONBOARD` | Skip onboarding (`1` to enable) |
 
 ## install.ps1 (Windows)
 
@@ -129,6 +146,22 @@ curl -fsSL https://praison.ai/install.sh | bash -s -- --help
 | `-Python` | Use specific Python |
 | `-DryRun` | Preview without changes |
 | `-Help` | Show help |
+
+## Post-Install Flow
+
+After successful installation and verification, the installer runs an interactive onboarding sequence:
+
+1. **Setup wizard** (`praisonai setup`) - Configure LLM API keys
+2. **Bot onboarding** (`praisonai onboard`) - Set up messaging bots (default: Yes)
+3. **Final summary** - Either the onboard wizard's ✅ Done panel or installer's Next Steps
+
+**Two possible end states:**
+- **Onboarding completed**: Shows the ✅ Done panel with dashboard URL, bot commands, and gateway endpoints
+- **Onboarding skipped**: Shows the installer's Next Steps block
+
+<Note>
+PR #1486 ensures only one summary appears - never both. The onboard wizard's ✅ Done panel is the canonical final summary when onboarding completes.
+</Note>
 
 ## CI/CD Usage
 

--- a/docs/install/quickstart.mdx
+++ b/docs/install/quickstart.mdx
@@ -62,6 +62,18 @@ The installer automatically:
 | **Python 3.10+** | If not already installed |
 | **Virtual environment** | Isolated at `~/.praisonai/venv` |
 
+<Info>
+The installer ends with an interactive bot-onboarding prompt:
+
+```
+Set up a messaging bot (Telegram / Discord / Slack / WhatsApp) now? [Y/n]
+```
+
+- **Default is Yes** - Safe to accept on desktop installations
+- **Skip with `n`** or use `--no-onboard` / `PRAISONAI_NO_ONBOARD=1`  
+- **Auto-skipped** in CI/headless environments (no TTY detected)
+</Info>
+
 ## Quick Start
 
 After installation, try this:
@@ -119,6 +131,7 @@ export OPENAI_API_KEY=your_key
 | `PRAISONAI_SKIP_VENV` | Skip venv creation | `0` |
 | `PRAISONAI_PYTHON` | Python executable path | auto-detect |
 | `PRAISONAI_DRY_RUN` | Preview mode | `0` |
+| `PRAISONAI_NO_ONBOARD` | Skip onboarding | `0` |
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- Extended installer flow documentation with onboarding steps and two possible end states
- Added comprehensive `docs/features/onboard.mdx` page for bot onboarding wizard
- Updated CLI flags, environment variables, and security documentation
- Added navigation entry for new onboard page

## Changes Made

### Updated Existing Pages
- **`docs/install/installer.mdx`**: Extended Mermaid diagram with onboard branch, added Steps 8-10, added `--no-onboard` flag and `PRAISONAI_NO_ONBOARD` env var
- **`docs/install/quickstart.mdx`**: Added Info block about onboarding prompt with TTY detection details
- **`docs/cli/dashboard.mdx`**: Added Security section warning about localhost-only binding
- **`docs/developers/scripts.mdx`**: Added missing `PRAISONAI_NO_ONBOARD` environment variable
- **`docs.json`**: Added new onboard page to Features navigation group

### New Page Created
- **`docs/features/onboard.mdx`**: Comprehensive documentation for `praisonai onboard` command following AGENTS.md standards:
  - Hero Mermaid diagram with platform selection flow
  - Quick Start with 3 clear steps
  - Platform decision tree (Telegram/Discord/Slack/WhatsApp)
  - Complete ✅ Done panel documentation
  - Idempotent re-running capabilities
  - Relationship to `praisonai setup`
  - Common patterns and best practices

## Verification
- ✅ All changes verified against SDK source code in `install.sh`
- ✅ Followed AGENTS.md documentation standards
- ✅ Used standard Mermaid color scheme (#8B0000, #189AB4, #10B981, #F59E0B, #6366F1)
- ✅ Validated `docs.json` is valid JSON
- ✅ All code examples are copy-paste runnable

## Test plan
- [ ] Verify new onboard page renders correctly in Mintlify
- [ ] Check that all internal links work correctly
- [ ] Ensure navigation shows new onboard page under Features
- [ ] Validate Mermaid diagrams render with correct colors

Fixes #207

🤖 Generated with [Claude Code](https://claude.ai/code)