### PR TITLE
docs(onboard): update wizard docs for leaner 4-question flow + drop home_channel (PR #1491)

### DIFF
--- a/docs/features/onboard.mdx
+++ b/docs/features/onboard.mdx
@@ -35,38 +35,23 @@ graph LR
 ## Quick Start
 
 <Steps>
-<Step title="Run the onboard wizard">
-Launch the interactive bot setup wizard:
-
+<Step>
 ```bash
 praisonai onboard
 ```
-
-The wizard prompts you to choose a platform and walks you through token setup.
 </Step>
 
-<Step title="Pick your platform">
-Select from the supported messaging platforms:
+<Step>
+The wizard asks exactly 4 questions — everything else uses sensible defaults:
 
-```
-Choose a platform:
-1. Telegram
-2. Discord  
-3. Slack
-4. WhatsApp
-```
-
-Each platform has different token requirements and setup steps.
+1. **Which platform(s)?** — Telegram, Discord, Slack, WhatsApp (multi-select)
+2. **Paste your bot token** — hidden input, validated against the platform API
+3. **Allowed user IDs** — comma-separated allowlist (security). Leave blank for open access (not recommended).
+4. **Install as background service?** — `Y` on desktop, auto-skipped on CI/headless.
 </Step>
 
-<Step title="Paste your token">
-Follow the platform-specific instructions to get your bot token, then paste it when prompted:
-
-```
-Enter your bot token: <paste_token_here>
-```
-
-The wizard validates the token and installs the daemon service.
+<Step title="You're done">
+The wizard writes `~/.praisonai/bot.yaml`, persists tokens to `~/.praisonai/.env` (chmod 600), and shows the ✅ Done panel with your dashboard URL.
 </Step>
 </Steps>
 
@@ -97,23 +82,25 @@ The onboarding process follows these phases:
 |-------|-------------|
 | **Platform Selection** | Choose Telegram, Discord, Slack, or WhatsApp |
 | **Token Entry** | Paste the bot token for your chosen platform |
-| **Validation** | Wizard tests the token with the platform API |
+| **Security Setup** | Set allowed user IDs (or leave blank for open access) |
 | **Daemon Install** | Sets up the platform daemon (launchd/systemd/Windows Task) |
 | **Configuration** | Writes config files to `~/.praisonai/` |
 | **Completion** | Shows the ✅ Done panel with all connection details |
 
 ---
 
-## What Gets Installed
+## What The Wizard Writes
 
-When onboarding completes successfully, the wizard installs:
+| File | Contents |
+|------|----------|
+| `~/.praisonai/bot.yaml` | Platform routing, token env-var references, allowlist, agent defaults |
+| `~/.praisonai/.env` | Bot token(s), `*_ALLOWED_USERS`, `GATEWAY_AUTH_TOKEN` (chmod 600) |
 
-| Component | Location | Purpose |
-|-----------|----------|---------|
-| **Platform daemon** | System service (launchd/systemd/Windows Task) | Keeps bot running in background |
-| **Bot configuration** | `~/.praisonai/config/` | Stores tokens and settings |
-| **Gateway auth token** | `~/.praisonai/gateway/` | Authentication for web dashboard |
-| **Dashboard URL** | Printed in Done panel | Local web interface |
+Agent name (`assistant`) and instructions (`"You are a helpful AI assistant."`) use sensible defaults — edit `~/.praisonai/bot.yaml` to customise. The file contains the full schema as inline documentation.
+
+<Note>
+**Upgrading?** Older `bot.yaml` files may contain a `home_channel: ${TELEGRAM_HOME_CHANNEL}` line (or the equivalent for Discord / Slack / WhatsApp). This was never read by the gateway and is safe to delete. Re-running `praisonai onboard` and accepting the overwrite regenerates a clean file.
+</Note>
 
 ---
 
@@ -158,6 +145,8 @@ Re-running the wizard will:
 - Update tokens and configurations in place
 - Restart the daemon service with new settings
 - Preserve existing chat histories and agent memory
+
+The config file path is **always** `~/.praisonai/bot.yaml` (no longer prompted for). Use `praisonai doctor` to discover the path. When re-running, the overwrite prompt now says `{path} exists. Overwrite with fresh config?` with `Kept existing file` on decline.
 
 ---
 

--- a/docs/install/installer.mdx
+++ b/docs/install/installer.mdx
@@ -69,7 +69,7 @@ flowchart TD
     Runs `praisonai setup` for LLM configuration
   </Step>
   <Step title="Bot Onboarding">
-    Optional `praisonai onboard` for messaging bots (Telegram/Discord/Slack/WhatsApp)
+    Optional `praisonai onboard` for messaging bots — asks 4 questions to configure Telegram/Discord/Slack/WhatsApp
   </Step>
   <Step title="Final Summary">
     Shows either onboard wizard's ✅ Done panel or installer's Next Steps
@@ -152,7 +152,7 @@ curl -fsSL https://praison.ai/install.sh | bash -s -- --help
 After successful installation and verification, the installer runs an interactive onboarding sequence:
 
 1. **Setup wizard** (`praisonai setup`) - Configure LLM API keys
-2. **Bot onboarding** (`praisonai onboard`) - Set up messaging bots (default: Yes)
+2. **Bot onboarding** (`praisonai onboard`) - Asks 4 questions to set up messaging bots (default: Yes). See the [onboard guide](/docs/features/onboard) for details.
 3. **Final summary** - Either the onboard wizard's ✅ Done panel or installer's Next Steps
 
 **Two possible end states:**


### PR DESCRIPTION
## Summary
- Updated onboard wizard documentation to reflect the new 4-question flow from upstream PR #1491
- Replaced verbose Quick Start steps with real wizard flow showing exactly what users see
- Added migration note about removed home_channel YAML lines that are safe to delete
- Updated installer.mdx to reference the 4-question flow

## Changes Made
- **docs/features/onboard.mdx**: Major content updates to reflect leaner wizard
  - Quick Start now shows the actual 4 questions users see
  - Updated phases table to show security setup instead of validation
  - Changed "What Gets Installed" to "What The Wizard Writes" with file contents
  - Added migration note for upgrading users about removed home_channel
  - Updated re-running behavior to mention fixed config path
- **docs/install/installer.mdx**: Light touch changes
  - Added "asks 4 questions" to bot onboarding step
  - Added link to onboard guide in Post-Install Flow

## Test Plan
- [x] Verified all Mintlify components render correctly
- [x] Confirmed migration note is clearly visible for upgrading users
- [x] Updated content aligns with PR #1491 specifications
- [x] Documentation maintains user-friendly, non-developer focus

Fixes #212

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the onboarding wizard configuration process, specifying it asks 4 questions to set up messaging platforms (Telegram, Discord, Slack, WhatsApp).
  * Updated documentation on configuration file locations and token security best practices.
  * Streamlined installation and setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->