### PR TITLE
docs: update onboarding & gateway docs for daemon-by-default flow

### DIFF
--- a/docs/features/gateway-cli.mdx
+++ b/docs/features/gateway-cli.mdx
@@ -28,6 +28,10 @@ graph LR
 
 ## Quick Start
 
+<Note>
+**Important**: `praisonai gateway start` runs in the **foreground**. The daemon is installed by `praisonai gateway install` (or automatically by `praisonai onboard`).
+</Note>
+
 <Steps>
 <Step title="Start Gateway">
 ```bash
@@ -56,7 +60,7 @@ curl http://127.0.0.1:8765/health
 
 | Command | Description | Example |
 |---------|-------------|---------|
-| `praisonai gateway start` | Start the gateway server | `praisonai gateway start --port 9000` |
+| `praisonai gateway start` | Start the gateway server (foreground) | `praisonai gateway start --port 9000` |
 | `praisonai gateway status` | Check gateway and daemon status | `praisonai gateway status --daemon-only` |
 | `praisonai gateway channels` | List configured channels | `praisonai gateway channels --json` |
 
@@ -67,6 +71,7 @@ curl http://127.0.0.1:8765/health
 | `praisonai gateway install` | Install as OS daemon | `praisonai gateway install --no-start` |
 | `praisonai gateway uninstall` | Remove daemon service | `praisonai gateway uninstall` |
 | `praisonai gateway logs` | Show daemon logs | `praisonai gateway logs -n 100` |
+| `praisonai gateway restart` | Restart the daemon | See restart commands below |
 
 ### Testing & Debugging
 
@@ -129,6 +134,32 @@ Examples:
 
 ---
 
+## Restart the Daemon
+
+Use these OS-specific commands to restart the daemon service (same commands shown in the onboard Done panel):
+
+<Tabs>
+<Tab title="macOS">
+```bash
+launchctl kickstart -k gui/$(id -u)/ai.praison.bot
+```
+</Tab>
+
+<Tab title="Linux">
+```bash
+systemctl --user restart praisonai-bot
+```
+</Tab>
+
+<Tab title="Windows">
+```bash
+schtasks /End /TN PraisonAIGateway && schtasks /Run /TN PraisonAIGateway
+```
+</Tab>
+</Tabs>
+
+---
+
 ## Status Output Examples
 
 ### Healthy Gateway
@@ -166,9 +197,9 @@ Gateway CLI works across platforms with native daemon integration:
 
 | Platform | Service Type | Log Location | Management |
 |----------|--------------|--------------|------------|
-| **macOS** | LaunchAgent | `~/.praisonai/logs/bot-stderr.log` | `launchctl` |
-| **Linux** | systemd user service | `journalctl --user -u praisonai` | `systemctl --user` |
-| **Windows** | Scheduled Task | Windows Event Log | Task Scheduler |
+| **macOS** | LaunchAgent (`ai.praison.bot`) | `~/.praisonai/logs/bot-stderr.log` | `launchctl kickstart -k gui/$(id -u)/ai.praison.bot` |
+| **Linux** | systemd user service (`praisonai-bot`) | `journalctl --user -u praisonai-bot` | `systemctl --user restart praisonai-bot` |
+| **Windows** | Scheduled Task (`PraisonAIGateway`) | Windows Event Log | `schtasks /End /TN PraisonAIGateway && schtasks /Run /TN PraisonAIGateway` |
 
 ---
 

--- a/docs/features/onboard.mdx
+++ b/docs/features/onboard.mdx
@@ -5,7 +5,7 @@ description: "Set up Telegram, Discord, Slack, or WhatsApp bots in 60 seconds"
 icon: "wand-magic-sparkles"
 ---
 
-Interactive wizard that configures messaging bots and sets up the daemon services to run them.
+Interactive wizard that configures messaging bots and automatically installs the daemon service to run them in the background.
 
 ```mermaid
 graph LR
@@ -15,7 +15,7 @@ graph LR
     Platform --> Discord[💬 Discord]  
     Platform --> Slack[💼 Slack]
     Platform --> WhatsApp[📞 WhatsApp]
-    Telegram --> Daemon[⚙️ Install Daemon]
+    Telegram --> Daemon[⚙️ Auto-install Daemon]
     Discord --> Daemon
     Slack --> Daemon
     WhatsApp --> Daemon
@@ -39,10 +39,14 @@ graph LR
 Launch the interactive bot setup wizard:
 
 ```bash
+# Zero prompts once you have the token — wizard configures the bot
+# and installs the background daemon automatically.
 praisonai onboard
 ```
 
-The wizard prompts you to choose a platform and walks you through token setup.
+<Note>
+Once tokens are collected, the daemon is installed automatically by default. Run `praisonai gateway uninstall` if you don't want it.
+</Note>
 </Step>
 
 <Step title="Pick your platform">
@@ -59,14 +63,14 @@ Choose a platform:
 Each platform has different token requirements and setup steps.
 </Step>
 
-<Step title="Paste your token">
-Follow the platform-specific instructions to get your bot token, then paste it when prompted:
+<Step title="Configure tokens and security">
+The wizard now supports multiple platforms and reads environment variables first. For each platform:
 
-```
-Enter your bot token: <paste_token_here>
-```
+- Enter bot tokens (password-hidden)
+- Configure user allowlists for security
+- Set home channels for proactive messages
 
-The wizard validates the token and installs the daemon service.
+Tokens are automatically validated and the daemon is installed silently.
 </Step>
 </Steps>
 
@@ -98,7 +102,7 @@ The onboarding process follows these phases:
 | **Platform Selection** | Choose Telegram, Discord, Slack, or WhatsApp |
 | **Token Entry** | Paste the bot token for your chosen platform |
 | **Validation** | Wizard tests the token with the platform API |
-| **Daemon Install** | Sets up the platform daemon (launchd/systemd/Windows Task) |
+| **Auto-install Daemon** | Automatically sets up the platform daemon (launchd/systemd/Windows Task) |
 | **Configuration** | Writes config files to `~/.praisonai/` |
 | **Completion** | Shows the ✅ Done panel with all connection details |
 
@@ -112,33 +116,44 @@ When onboarding completes successfully, the wizard installs:
 |-----------|----------|---------|
 | **Platform daemon** | System service (launchd/systemd/Windows Task) | Keeps bot running in background |
 | **Bot configuration** | `~/.praisonai/config/` | Stores tokens and settings |
-| **Gateway auth token** | `~/.praisonai/gateway/` | Authentication for web dashboard |
+| **Gateway auth token** | `~/.praisonai/.env` (env var `GATEWAY_AUTH_TOKEN`) | Authentication for web dashboard |
 | **Dashboard URL** | Printed in Done panel | Local web interface |
 
 ---
 
 ## The ✅ Done Panel
 
-When onboarding completes, you'll see a comprehensive summary panel:
+When onboarding completes, you'll see a comprehensive summary panel with four main sections:
 
 ```
-✅ Bot onboarding complete!
-
-Dashboard: http://127.0.0.1:8082 (localhost only)
-Start bot: praisonai bot start
-Gateway status: praisonai gateway status
-Health check: curl http://127.0.0.1:8080/health
-Info endpoint: curl http://127.0.0.1:8080/info
-Auth token: abc123...
-
-Run 'praisonai doctor' if you encounter any issues.
+╭─ ✅ Done ──────────────────────────────────────────────────────╮
+│ Setup complete! Your bot is now running in the background.     │
+│                                                                │
+│ 🦞 Dashboard UI:                                               │
+│   praisonai claw          → http://127.0.0.1:8082              │
+│                                                                │
+│ Gateway endpoints:                                             │
+│   Health (public):  http://127.0.0.1:8765/health               │
+│   Info (authed):    http://127.0.0.1:8765/info?token=…         │
+│   Token abcd…wxyz stored in ~/.praisonai/.env as               │
+│   GATEWAY_AUTH_TOKEN                                           │
+│                                                                │
+│ Manage the daemon:                                             │
+│   praisonai gateway status     # is it running?                │
+│   praisonai gateway logs       # tail the logs                 │
+│   launchctl kickstart -k gui/$(id -u)/ai.praison.bot           │
+│   praisonai gateway uninstall  # remove the daemon             │
+│                                                                │
+│ Re-run or reconfigure:                                         │
+│   praisonai onboard            # change tokens / add platforms │
+│   praisonai gateway start      # run in foreground (no daemon) │
+│   praisonai doctor             # diagnose the whole stack      │
+╰────────────────────────────────────────────────────────────────╯
 ```
 
-This panel contains everything you need to:
-- Access the web dashboard
-- Start/stop your bot
-- Check service health
-- Authenticate API requests
+The headline changes based on daemon install success:
+- **Success**: "Setup complete! Your bot is now running in the background."
+- **Failed**: "Setup complete! Configuration complete."
 
 ---
 
@@ -156,8 +171,76 @@ praisonai onboard
 
 Re-running the wizard will:
 - Update tokens and configurations in place
-- Restart the daemon service with new settings
+- Skip daemon installation if already installed and running (prints `✓ Daemon already installed and running`)
 - Preserve existing chat histories and agent memory
+
+<Note>
+If the daemon is already installed, re-running `praisonai onboard` is a no-op for the daemon service. Only configuration files are updated.
+</Note>
+
+---
+
+## Manage the Daemon
+
+The onboard wizard installs platform-specific daemon services. Use these commands to restart after configuration changes:
+
+<Tabs>
+<Tab title="macOS">
+```bash
+# Restart the daemon service
+launchctl kickstart -k gui/$(id -u)/ai.praison.bot
+
+# Check daemon status
+launchctl list | grep ai.praison
+```
+
+Service label: `ai.praison.bot` (launchd)
+</Tab>
+
+<Tab title="Linux">
+```bash
+# Restart the daemon service
+systemctl --user restart praisonai-bot
+
+# Check daemon status
+systemctl --user status praisonai-bot
+```
+
+Service unit: `praisonai-bot` (systemd)
+</Tab>
+
+<Tab title="Windows">
+```bash
+# Restart the daemon service
+schtasks /End /TN PraisonAIGateway && schtasks /Run /TN PraisonAIGateway
+
+# Check daemon status
+schtasks /Query /TN PraisonAIGateway
+```
+
+Service name: `PraisonAIGateway` (Task Scheduler)
+</Tab>
+</Tabs>
+
+---
+
+## Terminology
+
+Understanding the commands and what they actually do:
+
+<Note>
+**Important distinction**: `praisonai gateway start` runs in the **foreground** (not a daemon). The daemon is installed by `praisonai gateway install` or automatically by `praisonai onboard`.
+</Note>
+
+| Command | What it does |
+|---------|--------------|
+| `praisonai gateway start` | Runs the gateway **in the foreground**. Not a daemon. |
+| `praisonai gateway install` | Installs the launchd/systemd/Task-Scheduler service that auto-runs `praisonai gateway start` in the background with `KeepAlive=true`. |
+| `praisonai gateway status` | Reports whether the daemon is loaded + running. |
+| `praisonai gateway uninstall` | Removes the daemon service. |
+| `praisonai onboard` | Configures messaging bots and automatically runs `praisonai gateway install` |
+
+The daemon service literally wraps `praisonai gateway start --config ~/.praisonai/bot.yaml` to run it persistently in the background.
 
 ---
 

--- a/docs/guides/troubleshoot-gateway.mdx
+++ b/docs/guides/troubleshoot-gateway.mdx
@@ -54,7 +54,7 @@ praisonai gateway logs
 
 # Or check raw log files:
 # macOS: tail ~/.praisonai/logs/bot-stderr.log
-# Linux: journalctl --user -u praisonai
+# Linux: journalctl --user -u praisonai-bot
 ```
 
 Look for Python tracebacks or port binding errors.
@@ -84,7 +84,7 @@ Upgrade to ≥ v4.6.23 if you see older versions - earlier versions had Indentat
 launchctl kickstart -k gui/$(id -u)/ai.praison.bot
 
 # Linux  
-systemctl --user restart praisonai
+systemctl --user restart praisonai-bot
 
 # Or reinstall completely
 praisonai onboard
@@ -121,7 +121,7 @@ Look for repeated Python tracebacks, especially IndentationError.
 launchctl unload ~/Library/LaunchAgents/ai.praison.bot.plist
 
 # Linux
-systemctl --user stop praisonai
+systemctl --user stop praisonai-bot
 ```
 </Step>
 
@@ -230,14 +230,14 @@ launchctl load ~/Library/LaunchAgents/ai.praison.bot.plist
 <Tab title="Linux">
 ```bash
 # Check systemd user service
-systemctl --user status praisonai
+systemctl --user status praisonai-bot
 
 # Enable user lingering (allows services to run when not logged in)
 sudo loginctl enable-linger $(whoami)
 
 # Restart service
 systemctl --user daemon-reload
-systemctl --user restart praisonai
+systemctl --user restart praisonai-bot
 ```
 </Tab>
 
@@ -245,7 +245,7 @@ systemctl --user restart praisonai
 ```powershell
 # Run as administrator
 # Check Task Scheduler for PraisonAI task
-schtasks /query /tn "PraisonAI Bot"
+schtasks /Query /TN PraisonAIGateway
 
 # Delete and recreate
 praisonai gateway uninstall
@@ -300,6 +300,32 @@ Should show daemon running and gateway reachable.
 
 ---
 
+## Restart After Config Change
+
+When you update bot configuration files, restart the daemon using these OS-specific commands (matching the onboard Done panel):
+
+<Tabs>
+<Tab title="macOS">
+```bash
+launchctl kickstart -k gui/$(id -u)/ai.praison.bot
+```
+</Tab>
+
+<Tab title="Linux">
+```bash
+systemctl --user restart praisonai-bot
+```
+</Tab>
+
+<Tab title="Windows">
+```bash
+schtasks /End /TN PraisonAIGateway && schtasks /Run /TN PraisonAIGateway
+```
+</Tab>
+</Tabs>
+
+---
+
 ## Diagnostic Commands
 
 Quick commands for gathering diagnostic information:
@@ -325,8 +351,8 @@ praisonai --version
 
 # Platform daemon status
 # macOS: launchctl list | grep ai.praison
-# Linux: systemctl --user status praisonai
-# Windows: schtasks /query /tn "PraisonAI*"
+# Linux: systemctl --user status praisonai-bot
+# Windows: schtasks /Query /TN PraisonAIGateway
 ```
 
 ---
@@ -350,32 +376,32 @@ launchctl list | grep ai.praison
 </Tab>
 
 <Tab title="Linux">
-**Service Path:** `~/.config/systemd/user/praisonai.service`
-**Logs:** `journalctl --user -u praisonai`
+**Service Path:** `~/.config/systemd/user/praisonai-bot.service`
+**Logs:** `journalctl --user -u praisonai-bot`
 
 ```bash
 # Manual management
-systemctl --user start praisonai
-systemctl --user stop praisonai
-systemctl --user restart praisonai
-systemctl --user enable praisonai
+systemctl --user start praisonai-bot
+systemctl --user stop praisonai-bot
+systemctl --user restart praisonai-bot
+systemctl --user enable praisonai-bot
 
 # Check status
-systemctl --user status praisonai
+systemctl --user status praisonai-bot
 ```
 </Tab>
 
 <Tab title="Windows">
-**Task Path:** Task Scheduler → PraisonAI Bot
+**Task Path:** Task Scheduler → PraisonAIGateway
 **Logs:** Windows Event Log
 
 ```powershell
 # Manual management via Task Scheduler or:
-schtasks /run /tn "PraisonAI Bot"
-schtasks /end /tn "PraisonAI Bot"
+schtasks /Run /TN PraisonAIGateway
+schtasks /End /TN PraisonAIGateway
 
 # Check status
-schtasks /query /tn "PraisonAI Bot"
+schtasks /Query /TN PraisonAIGateway
 ```
 </Tab>
 </Tabs>


### PR DESCRIPTION
Updates documentation to reflect changes from PraisonAI PR #1493 where the onboard wizard now installs daemon by default.

## Changes Made

### docs/features/onboard.mdx (major update)
- ✅ Updated Done panel with exact 4-block structure (Dashboard UI → Gateway endpoints → Manage daemon → Re-run/reconfigure)
- ✅ Changed port from 8080 to 8765 in all examples
- ✅ Added daemon-by-default messaging (no prompt anymore)
- ✅ Updated gateway auth token location to ~/.praisonai/.env as GATEWAY_AUTH_TOKEN
- ✅ Added OS-specific restart commands (macOS/Linux/Windows)
- ✅ Added terminology section disambiguating gateway start vs install
- ✅ Added idempotency note about already-running daemons

### docs/features/gateway-cli.mdx (minor update)
- ✅ Added foreground vs daemon distinction note
- ✅ Added restart command section with OS-specific commands
- ✅ Updated platform support table with exact service names and restart commands

### docs/guides/troubleshoot-gateway.mdx (correctness fixes)
- ✅ Fixed systemd service name: praisonai → praisonai-bot
- ✅ Fixed Windows task name: "PraisonAI Bot" → PraisonAIGateway  
- ✅ Added restart commands section
- ✅ Updated all service paths and management commands

All changes follow AGENTS.md standards and use correct Mintlify components.

Fixes #214

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Clarified daemon behavior and management across platforms
* Added OS-specific commands for restarting and managing the gateway daemon (macOS, Linux, Windows)
* Updated onboarding documentation with improved token configuration and daemon installation details
* Enhanced troubleshooting guide with updated service names and restart procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->