### PR TITLE
docs: fix Agent reflection API in home.mdx marketing snippet

### DIFF
--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -81,11 +81,20 @@ seo:
     Unlike simple chatbots, PraisonAI agents can **reflect on their outputs** and iteratively improve them. Built-in reasoning capabilities enable multi-step problem solving without manual prompting.
     
     ```python
+    from praisonaiagents import Agent, ReflectionConfig
+    
+    # Simple reflection
     agent = Agent(
         name="analyst",
-        self_reflect=True,      # Enable self-correction
-        reasoning=True,         # Enable chain-of-thought
-        max_reflect=3           # Up to 3 reflection cycles
+        instructions="You analyze data carefully.",
+        reflection=True          # Enable self-correction
+    )
+    
+    # Advanced reflection with custom iterations
+    agent = Agent(
+        name="analyst",
+        instructions="You analyze data carefully.",
+        reflection=ReflectionConfig(max_iterations=3)
     )
     ```
   </Accordion>


### PR DESCRIPTION
## Summary

Fixes the architectural drift between marketing documentation and actual Agent API implementation.

**Problem:** The Self-Reflection & Reasoning section in docs/home.mdx showed invalid legacy reflection parameters that caused immediate TypeError for users copying code from the homepage.

**Solution:** Updated to use the current consolidated reflection API with working examples.

## Changes
- Fixed invalid reflection parameters in home.mdx  
- Added proper imports for ReflectionConfig
- Added working instructions parameter for complete examples
- Tested both simple and advanced examples - no TypeError

## Testing
Both examples confirmed to work without errors.

Fixes #204

Generated with [Claude Code](https://claude.ai/code)