### PR TITLE
docs: fix Agent API architectural drift in home.mdx

### DIFF
--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -94,10 +94,14 @@ seo:
     Agents remember past interactions across sessions. Short-term, long-term, and episodic memory systems keep context without re-prompting.
     
     ```python
+    from praisonaiagents import Agent, MemoryConfig
+    
     agent = Agent(
         name="assistant",
-        memory=True,             # Enable persistent memory
-        user_id="user_123"       # Scoped to specific user
+        memory=MemoryConfig(
+            backend="file",
+            user_id="user_123"
+        )
     )
     ```
   </Accordion>
@@ -106,10 +110,12 @@ seo:
     Connect agents to your documents, databases, and APIs. Built-in RAG with auto-chunking, embeddings, and semantic search.
     
     ```python
+    from praisonaiagents import Agent
+    
     agent = Agent(
         name="researcher",
-        knowledge="./docs/",       # Local documents
-        knowledge_sources=[        # Or multiple sources
+        knowledge=[                # Multiple knowledge sources
+            "./docs/",
             "https://example.com/api",
             "./pdfs/"
         ]


### PR DESCRIPTION
## Summary

Fixes architectural drift between `docs/home.mdx` code examples and actual PraisonAI Agent constructor API.

- Fixed memory example: moved `user_id` parameter into `MemoryConfig` instead of invalid top-level Agent kwarg
- Fixed RAG example: consolidated knowledge sources into single `knowledge=` parameter, removed non-existent `knowledge_sources=` parameter  
- Added proper imports for `MemoryConfig` class
- Ensured examples are copy-paste runnable and match actual SDK API

## Changes

### Memory Example (Lines 96-106)
**Before:** Invalid `user_id` as top-level Agent parameter
```python
agent = Agent(
    name="assistant", 
    memory=True,
    user_id="user_123"  # ❌ Invalid - not an Agent constructor parameter
)
```

**After:** Proper nested configuration
```python
from praisonaiagents import Agent, MemoryConfig

agent = Agent(
    name="assistant",
    memory=MemoryConfig(
        backend="file",
        user_id="user_123"  # ✅ Correct - user_id belongs in MemoryConfig
    )
)
```

### RAG Example (Lines 112-123)
**Before:** Conflicting parameters  
```python
agent = Agent(
    name="researcher",
    knowledge="./docs/",
    knowledge_sources=[    # ❌ Invalid - not an Agent constructor parameter
        "https://example.com/api", 
        "./pdfs/"
    ]
)
```

**After:** Consolidated single parameter
```python
from praisonaiagents import Agent

agent = Agent(
    name="researcher",
    knowledge=[            # ✅ Correct - single consolidated parameter
        "./docs/",
        "https://example.com/api",
        "./pdfs/"
    ]
)
```

## Test Plan

- [x] Verified examples are syntactically correct
- [x] Confirmed `user_id` and `session_id` are defined in `MemoryConfig` class (praisonaiagents/config/feature_configs.py:191-193)
- [x] Confirmed `knowledge_sources` parameter does not exist on Agent constructor
- [x] Confirmed Agent accepts `knowledge=` as list of sources
- [x] Ensured proper imports are included for copy-paste success

Fixes #205

🤖 Generated with [Claude Code](https://claude.ai/code)