### PR TITLE
docs: fix parameter-resolution.mdx memory examples (fixes #203)

### DIFF
--- a/docs/reference/parameter-resolution.mdx
+++ b/docs/reference/parameter-resolution.mdx
@@ -18,8 +18,8 @@ When multiple configuration sources are provided, the system resolves them in th
 |----------|------|---------|-------------|
 | 1 | **Instance** | `memory=db_instance` | Pre-configured object instance |
 | 2 | **Config** | `memory=MemoryConfig(...)` | Explicit configuration object |
-| 3 | **Dict** | `memory={"provider": "redis"}` | Config shorthand (strict validation) |
-| 4 | **Array** | `memory=["redis", {"port": 6380}]` | Preset with overrides |
+| 3 | **Dict** | `memory={"backend": "redis"}` | Config shorthand (strict validation) |
+| 4 | **Array** | `knowledge=["docs/", "data.pdf"]` | Multiple sources (feature-specific) |
 | 5 | **String** | `memory="redis"` or `memory="postgresql://..."` | Preset name or URL |
 | 6 | **Bool** | `memory=True` | Enable with defaults |
 | 7 | **Default** | (not specified) | Feature disabled or default config |
@@ -44,14 +44,14 @@ agent = Agent(instructions="...", memory="redis")
 # 3. String - Use a URL
 agent = Agent(instructions="...", memory="postgresql://localhost:5432/mydb")
 
-# 4. Array - Preset with overrides
-agent = Agent(instructions="...", memory=["redis", {"port": 6380}])
+# 4. String URL - Direct connection string 
+agent = Agent(instructions="...", memory="redis://localhost:6379")
 
 # 5. Dict - Config shorthand (strict validation)
-agent = Agent(instructions="...", memory={"provider": "redis", "port": 6380})
+agent = Agent(instructions="...", memory={"backend": "redis", "config": {"port": 6380}})
 
 # 6. Config - Full control
-agent = Agent(instructions="...", memory=MemoryConfig(provider="redis", port=6380))
+agent = Agent(instructions="...", memory=MemoryConfig(backend="redis", config={"port": 6380}))
 
 # 7. Instance - Pre-configured
 db = create_memory_backend("redis", port=6380)
@@ -62,7 +62,7 @@ agent = Agent(instructions="...", memory=db)
 
 | Param | Surfaces | Bool | String | Array | Config Class |
 |-------|----------|------|--------|-------|--------------|
-| `memory` | Agent, Agents | ✅ Enable file-based | Preset/URL | `[preset, {overrides}]` | `MemoryConfig` |
+| `memory` | Agent, Agents | ✅ Enable file-based | Preset/URL | `["url"]` (single item only) | `MemoryConfig` |
 | `knowledge` | Agent, Agents | ✅ Enable | Path/URL | `[path1, path2]` | `KnowledgeConfig` |
 | `planning` | Agent, Agents | ✅ Enable | LLM model | `[model, {opts}]` | `PlanningConfig` |
 | `reflection` | Agent, Agents | ✅ Enable | Preset | `[preset, {opts}]` | `ReflectionConfig` |
@@ -220,6 +220,20 @@ agent = Agent(
 
 ## Array Parsing Rules
 
+<Note>
+**Memory Parameter**: The `memory` parameter uses `ArrayMode.SINGLE_OR_LIST`, which only accepts **single-item arrays**. For multiple values or preset + overrides, use dict or config object instead.
+
+```python
+# ❌ This fails for memory parameter
+memory=["redis", {"port": 6380}]  # Multiple items not allowed
+
+# ✅ Use these instead
+memory="redis://localhost:6380"   # URL string
+memory={"backend": "redis", "config": {"port": 6380}}  # Dict
+memory=MemoryConfig(backend="redis", config={"port": 6380})  # Config
+```
+</Note>
+
 ### Preset with Overrides
 
 The most common array pattern combines a preset with custom options:
@@ -273,11 +287,13 @@ from praisonaiagents import MemoryConfig
 agent = Agent(
     instructions="...",
     memory=MemoryConfig(
-        provider="redis",
-        host="localhost",
-        port=6379,
-        db=0,
-        ttl=3600,
+        backend="redis",
+        config={
+            "host": "localhost",
+            "port": 6379,
+            "db": 0,
+            "ttl": 3600,
+        }
     )
 )
 ```


### PR DESCRIPTION
Fixes the architectural mismatch between parameter-resolution.mdx and the actual Agent memory resolver implementation.

## Summary

Fixed broken examples #4-6 in the memory progression section that were failing with TypeError when executed against the current SDK.

## Changes

- **Fixed array example**: Replaced memory array with correct single-item patterns
- **Fixed dict example**: Changed provider/port keys to backend/config structure  
- **Fixed config example**: Updated MemoryConfig to use correct backend and config fields
- **Updated table**: Changed memory array column to reflect ArrayMode.SINGLE_OR_LIST behavior
- **Added explanatory note**: Clarified memory parameter array limitations with correct alternatives

## Validation

✅ All examples now use valid MemoryConfig fields (backend, config, user_id, etc.)  
✅ Array patterns match ArrayMode.SINGLE_OR_LIST behavior from agent.py:1100  
✅ Dict examples pass strict validation in param_resolver.py  

Fixes #203

🤖 Generated with [Claude Code](https://claude.ai/code)