### PR TITLE
docs: Update messaging-bots for smart defaults + auto-approve behavioral changes

### DIFF
--- a/docs/features/bot-gateway.mdx
+++ b/docs/features/bot-gateway.mdx
@@ -26,6 +26,8 @@ flowchart LR
 
 Run all your bots from one command. The Gateway Server manages multiple bot connections and routes messages to the right AI agent.
 
+**Parity with Bot()**: `praisonai gateway start` now applies the same smart defaults as `praisonai bot start`, resolving the previous "zero tools in daemon mode" issue. Both entry points produce identical behavior with safe tools auto-injected and auto-approval enabled by default.
+
 ## Quick Start
 
 <Steps>

--- a/docs/features/messaging-bots.mdx
+++ b/docs/features/messaging-bots.mdx
@@ -293,6 +293,84 @@ The streaming bridge hooks into the same `StreamEventEmitter` used by the web ch
 
 ---
 
+## Smart Defaults
+
+Bots ship with sensible defaults so you can start chatting immediately — no tool wiring required.
+
+```mermaid
+graph LR
+    A[🤖 Agent<br/>tools=None] --> SD[⚙️ Smart Defaults]
+    SD --> T[🔍 search_web<br/>📅 schedule_*<br/>🧠 memory<br/>📚 learning]
+    SD --> AA[✅ auto-approve<br/>for safe tools]
+    SD --> H[💬 session history<br/>last 20 messages]
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef tools fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A agent
+    class SD config
+    class T tools
+    class AA,H result
+```
+
+Both `praisonai bot start` and `praisonai gateway start` apply the same defaults:
+
+| Default | Applied when | What you get |
+|---------|--------------|--------------|
+| Safe tools | Agent has no `tools` configured | `search_web`, `web_crawl`, `schedule_*`, `store_memory`/`search_memory`, `store_learning`/`search_learning` |
+| Auto-approval | `auto_approve_tools=True` (default) | Tool calls run without CLI prompts — chat bots can't show them anyway |
+| Session history | Agent has no `memory` configured | Last 20 messages remembered per user, zero-dep |
+
+### Opting out
+
+| Goal | How |
+|------|-----|
+| Run with **zero** tools | Set `tools: []` explicitly in YAML, or pass `tools=[]` to `Agent` |
+| Require manual approval | Set `auto_approve_tools: false` in the channel config |
+| Override the tool list | Set `default_tools: [...]` under the channel — destructive tools are still filtered |
+
+<Warning>
+Destructive tools (`execute_command`, `delete_file`, `write_file`, `shell_command`) are **never auto-injected**, even if you add them to `default_tools`. Wire them explicitly on the agent and add a chat-level approval flow.
+</Warning>
+
+<Info>
+Upgrading from an older release? `auto_approve_tools` used to default to `False`. If your bot relied on manual approval, set `auto_approve_tools: false` explicitly.
+</Info>
+
+```python
+from praisonaiagents import Agent
+from praisonai.bots import Bot
+
+# Zero config — gets search_web, schedule_*, memory, learning, and auto-approval
+agent = Agent(name="assistant", instructions="Help the user")
+bot = Bot("telegram", agent=agent)
+bot.run()
+```
+
+```bash
+# Same result — no YAML tool list needed
+praisonai bot telegram --token $TELEGRAM_BOT_TOKEN
+```
+
+```mermaid
+sequenceDiagram
+    participant U as 👤 User (Telegram)
+    participant B as 🤖 Bot
+    participant A as 🧠 Agent
+    participant T as 🔍 search_web
+
+    U->>B: "What's the latest on Llama 4?"
+    B->>A: Forward message (no tool prompt)
+    A->>T: auto-approved call
+    T-->>A: Results
+    A-->>B: Answer
+    B-->>U: 📰 Here's the latest...
+```
+
+---
+
 ## Socket Mode vs Webhook
 
 PraisonAI bots support two connection modes:
@@ -345,7 +423,7 @@ config = BotConfig(
     reply_in_thread=False,          # Reply in threads (default: inline)
     thread_threshold=500,           # Auto-thread if response > N chars (0 = disabled)
     group_policy="mention_only",    # Group chat policy: respond_all, mention_only, command_only
-    auto_approve_tools=False,       # Auto-approve tool executions (skip confirmation)
+    auto_approve_tools=True,        # Auto-approve safe tool executions (default: True for chat bots)
 )
 ```
 
@@ -363,8 +441,8 @@ config = BotConfig(
 | `reply_in_thread` | `bool` | `False` | Always reply in threads |
 | `thread_threshold` | `int` | `500` | Auto-thread responses longer than N chars (0 = disabled) |
 | `group_policy` | `str` | `"mention_only"` | Group chat behavior: `respond_all`, `mention_only`, or `command_only` |
-| `default_tools` | `list` | `["execute_command", ...]` | Default tools enabled for all bots |
-| `auto_approve_tools` | `bool` | `False` | Skip tool execution confirmation (for trusted environments) |
+| `default_tools` | `list[str]` | `["search_web", "web_crawl", "schedule_add", "schedule_list", "schedule_remove", "store_memory", "search_memory", "store_learning", "search_learning"]` | Safe tools auto-injected when the agent has no tools configured. Destructive tools (`execute_command`, `delete_file`, `write_file`, `shell_command`) are excluded from auto-injection even if listed. |
+| `auto_approve_tools` | `bool` | `True` | Skip confirmation for safe tool execution. Chat bots can't show CLI approval prompts, so this defaults to `True`. Set `False` to require approval (only useful if you wire a chat-level approval flow). |
 | `retry_attempts` | `int` | `3` | Number of retry attempts for failed operations |
 | `polling_interval` | `float` | `1.0` | Interval for polling mode (seconds) |
 
@@ -1198,6 +1276,10 @@ channels:
   slack:
     token: "${SLACK_BOT_TOKEN}"
     app_token: "${SLACK_APP_TOKEN}"
+    auto_approve_tools: true        # NEW (default: true for chat bots)
+    # default_tools:                # NEW — override the safe tool list per channel
+    #   - search_web
+    #   - store_memory
     routing:
       dm: "personal"
       channel: "support"
@@ -1222,6 +1304,8 @@ channels:
 ```bash
 praisonai gateway --config gateway.yaml
 ```
+
+The gateway now produces identical results to `Bot()` — agents get the same safe tools and auto-approval in both entry points.
 
 ```mermaid
 graph LR
@@ -1264,6 +1348,8 @@ agent:
 ```bash
 praisonai bot start --config bot.yaml
 ```
+
+> **Tip:** You can omit `tools:` entirely — the bot auto-injects safe defaults (`search_web`, schedule, memory, learning). Keep `tools: []` only if you want the bot to run with zero tools.
 
 <Tip>
 The `.env` file in the current directory is auto-loaded, so you can store tokens there and reference them with `${VAR_NAME}` syntax.
@@ -1344,6 +1430,14 @@ Web mode uses a reverse-engineered protocol. Your number may be banned by Meta. 
   
   <Accordion title="Handle rate limits gracefully">
     Configure `retry_attempts` and implement exponential backoff for API rate limits.
+  </Accordion>
+  
+  <Accordion title="Safe default tools only">
+    The default tool list is intentionally safe (`search_web`, `schedule_*`, memory/learning). Tools like `execute_command` require explicit opt-in and should be paired with an approval backend. See [Approval Protocol](/features/approval-protocol).
+  </Accordion>
+
+  <Accordion title="Set approval flow for auto-approve disabled">
+    Only set `auto_approve_tools: false` if you've wired a chat-level approval flow (e.g. `SlackApproval`). Otherwise tool calls will hang silently waiting for a CLI prompt the user cannot see.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
Fixes #219

Updates the messaging-bots documentation to reflect the smart defaults and behavioral changes from PraisonAI PR #1498.

## Changes Made

### docs/features/messaging-bots.mdx
- **Edit 1**: Updated Configuration Options table and code block
  - Changed auto_approve_tools default from False to True
  - Updated default_tools list to remove execute_command and show only safe tools
  - Updated descriptions to clarify chat bot behavior
- **Edit 2**: Added new Smart Defaults section
  - Comprehensive section with Mermaid diagrams showing smart defaults behavior
  - Tables explaining when defaults are applied and how to opt out
  - Agent-centric code examples and CLI examples
  - Sequence diagram showing user interaction flow
- **Edit 3**: Updated Multi-Channel Gateway YAML example
  - Added new channel-level auto_approve_tools and default_tools options
  - Added callout about gateway parity with Bot()
- **Edit 4**: Added Best Practices accordion entries
  - Safe default tools only explaining safe vs destructive tools
  - Set approval flow for auto-approve disabled warning about CLI prompts
- **Edit 5**: Updated Zero-Code Mode YAML example
  - Added tip about omitting tools to use smart defaults

### docs/features/bot-gateway.mdx
- **Edit 7**: Added parity note
  - Explained that gateway now applies same smart defaults as Bot()
  - Mentions resolution of zero tools in daemon mode issue

## Implementation Notes

- All changes follow AGENTS.md standards:
  - Uses standard Mermaid color scheme (#8B0000, #189AB4, #10B981, etc.)
  - Agent-centric code examples with proper imports
  - Concise explanations and active voice
  - Proper use of Mintlify components (Warning, Info, AccordionGroup)

- Based on issue description of merged PR #1498 behavioral changes:
  - auto_approve_tools now defaults to True
  - default_tools excludes destructive tools like execute_command
  - Gateway applies same smart defaults as Bot()
  - YAML tools: [] is honored as explicit opt-out

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated bot gateway documentation to describe smart default behavior and verify consistency with the primary bot entry point
* Added comprehensive "Smart Defaults" section explaining automatic safe tool injection, session history defaults, and auto-approval behavior when tools are not configured
* Clarified default settings for tool auto-approval and safe default tool configuration options
* Provided enhanced guidance for users to customize default tools or opt out of automatic defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->