### PR TITLE
docs(bot-security): update Gateway Pairing section — document list_pending schema, CLI subcommands, and REST API (follow-up to PraisonAI#1520)

### DIFF
--- a/docs/best-practices/bot-security.mdx
+++ b/docs/best-practices/bot-security.mdx
@@ -214,9 +214,6 @@ WhatsApp has the **strongest security defaults** and serves as the reference imp
 
 ## Gateway Pairing
 
-<Warning>
-**Note:** The pairing system described below represents planned functionality. Current SDK implementation may differ. Verify against actual SDK documentation.
-</Warning>
 
 For production deployments, use **gateway pairing** to authorize channels dynamically:
 
@@ -233,8 +230,7 @@ Without `PRAISONAI_GATEWAY_SECRET`, pairing codes will **not persist across rest
 ### 2. Generate Pairing Code
 
 ```python
-# Note: This API is conceptual - verify implementation
-from praisonaiagents.gateway.pairing import PairingStore
+from praisonai.gateway.pairing import PairingStore
 
 store = PairingStore()
 code = store.generate_code(channel_type="telegram")
@@ -254,8 +250,7 @@ The bot will verify the HMAC signature and authorize the channel.
 ### 4. Check Status
 
 ```python
-# Check if channel is paired  
-# Note: Verify this API exists in current SDK
+# Check if channel is paired
 paired = store.is_paired("@username", "telegram")
 print(f"Channel paired: {paired}")
 
@@ -263,6 +258,128 @@ print(f"Channel paired: {paired}")
 for channel in store.list_paired():
     print(f"{channel.channel_type}: {channel.channel_id}")
 ```
+
+### 5. List Pending Requests
+
+List all pending pairing codes waiting for approval:
+
+```python
+from praisonai.gateway.pairing import PairingStore
+
+store = PairingStore()
+
+# All pending codes across every channel
+for req in store.list_pending():
+    print(req["code"], req["channel_type"], req["channel_id"], req["age_seconds"])
+
+# Filter by channel
+telegram_only = store.list_pending(channel_type="telegram")
+```
+
+**Response Schema:**
+
+| Key | Type | Source | Notes |
+|-----|------|--------|-------|
+| `code` | `str` | canonical | 8-char pairing code |
+| `channel_type` | `str` | canonical | e.g. `"telegram"`, `"discord"`, `"slack"`, `"whatsapp"` |
+| `channel_id` | `str \| None` | canonical | Bound channel id if code was generated with one |
+| `created_at` | `float` | canonical | Unix timestamp (seconds) when code was generated |
+| `channel` | `str` | UI alias | Same value as `channel_type`, kept for UI banner compatibility |
+| `user_id` | `str` | UI alias | Currently equals `code` (see note in `approve()` docstring) |
+| `user_name` | `str` | UI alias | Formatted as `"User {code}"` |
+| `age_seconds` | `int` | UI alias | `int(now - created_at)` |
+
+<Note>
+Canonical keys (`code`, `channel_type`, `channel_id`, `created_at`) are the stable contract. The `channel`, `user_id`, `user_name`, and `age_seconds` aliases are provided for UI consumers and should not be relied on for scripting — use the canonical keys.
+</Note>
+
+### 6. CLI Commands
+
+Use the `praisonai pairing` commands to manage pairings from the command line:
+
+```bash
+# List all paired channels
+praisonai pairing list
+
+# Approve a pairing code (this is the exact command shown to users)
+praisonai pairing approve telegram abc12345
+
+# Revoke a paired channel
+praisonai pairing revoke telegram @username
+
+# Clear all paired channels
+praisonai pairing clear
+```
+
+**Available Commands:**
+
+| Command | Purpose | Required Args |
+|---------|---------|---------------|
+| `praisonai pairing list` | List all paired channels | — |
+| `praisonai pairing approve PLATFORM CODE [CHANNEL_ID]` | Approve an 8-char pairing code | `platform`, `code` |
+| `praisonai pairing revoke PLATFORM CHANNEL_ID` | Revoke a paired channel | `platform`, `channel_id` |
+| `praisonai pairing clear` | Clear all paired channels | — |
+
+**Platform values:** `telegram`, `discord`, `slack`, `whatsapp`
+
+**Pairing Flow:**
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Bot
+    participant PairingStore
+    participant CLI
+    
+    User->>Bot: unknown message (triggers pairing)
+    Bot->>PairingStore: generate_code(channel_type, channel_id)
+    PairingStore-->>Bot: abc12345
+    Bot->>User: Ask owner to run: praisonai pairing approve telegram abc12345
+    CLI->>PairingStore: approve(telegram, abc12345)
+    PairingStore->>PairingStore: verify_and_pair()
+    PairingStore-->>CLI: success
+    User->>Bot: now authorised
+    Bot-->>User: response
+    
+    classDef user fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef bot fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class User user
+    class Bot,PairingStore,CLI bot
+```
+
+### 7. REST API
+
+The gateway exposes REST endpoints for pairing management:
+
+| Method | Path | Body / Query | Response | Auth Required |
+|--------|------|--------------|----------|---------------|
+| `GET` | `/api/pairing/pending` | — | `list_pending()` schema | ✅ |
+| `POST` | `/api/pairing/approve` | `{ "channel": str, "code": str }` | `{ "approved": true, ... }` | ✅ |
+| `POST` | `/api/pairing/revoke` | `{ "channel": str, "user_id": str }` | `{ "revoked": true, ... }` | ✅ |
+
+**Example Usage:**
+
+```bash
+# List pending requests
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/api/pairing/pending
+
+# Approve a code  
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -d '{"channel":"telegram","code":"abc12345"}' \
+  http://localhost:8000/api/pairing/approve
+
+# Revoke a channel
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -d '{"channel":"telegram","user_id":"@username"}' \
+  http://localhost:8000/api/pairing/revoke
+```
+
+<Note>
+All endpoints are **authenticated** and **rate-limited**. Rate limits are applied per client IP with separate buckets for `pairing_pending`, `pairing_approve`, and `pairing_revoke` operations.
+</Note>
 
 ## Doctor Security Check
 
@@ -471,6 +588,11 @@ def is_verified_user(user_id: str) -> bool:
 **Solution:** 
 1. Set `PRAISONAI_GATEWAY_SECRET` env var
 2. Codes without persistent secret are temporary
+
+**Problem:** `praisonai pairing approve` reports "Invalid or expired code" even though a code was just generated from the UI
+**Solution:** 
+1. Upgrade to the latest `praisonai` version (fix included in 2026-04-22 release)
+2. Older builds had a duplicate internal method that stripped the canonical `code` key when the UI pairing banner was loaded
 
 ### Allowlist Issues
 


### PR DESCRIPTION
## Summary
Comprehensive documentation update for Gateway Pairing functionality as a follow-up to **PraisonAI#1520** — *fix(gateway): remove duplicate `PairingStore.list_pending` and preserve legacy keys*.

## Changes Made
- ✅ Removed stale "planned functionality" warnings from Gateway Pairing section
- ✅ Documented `list_pending()` response schema with canonical and alias keys
- ✅ Added comprehensive CLI subcommands documentation for `praisonai pairing` commands
- ✅ Documented REST API endpoints (`/api/pairing/{pending,approve,revoke}`) with auth requirements
- ✅ Added Mermaid sequence diagram following AGENTS.md color standards  
- ✅ Included troubleshooting section for PR #1520 duplicate method fix
- ✅ Verified all import paths using correct `praisonai.gateway.pairing` module

## Test plan
- [x] All code examples use copy-paste runnable syntax
- [x] Import paths verified against SDK source files  
- [x] Mermaid diagram follows AGENTS.md color scheme (#8B0000, #189AB4, #10B981, #fff text)
- [x] docs.json passes JSON validation
- [x] Documentation follows AGENTS.md quality checklist

🤖 Generated with [Claude Code](https://claude.ai/code)

Fixes #231