### PR TITLE
docs: Update JSON Persistence page with cross-platform (Windows/Unix) support note

### DIFF
--- a/docs/features/persistence-json.mdx
+++ b/docs/features/persistence-json.mdx
@@ -99,6 +99,59 @@ JSON files organize data in a simple directory structure:
 
 ---
 
+## Cross-Platform Support
+
+JSON persistence works the same on macOS, Linux, and Windows — no extra configuration.
+
+```mermaid
+graph LR
+    subgraph "Cross-Platform File Locking"
+        A[🧠 Agent] --> B{🖥️ Platform?}
+        B -->|macOS / Linux| C[🔒 fcntl lock]
+        B -->|Windows| D[🔒 msvcrt lock]
+        C --> E[💾 Safe Write]
+        D --> E
+    end
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef detect fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef lock fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef write fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A agent
+    class B detect
+    class C,D lock
+    class E write
+```
+
+The same agent code runs everywhere:
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="FileBot",
+    instructions="You are a helpful assistant.",
+    session_id="cross-platform-session"
+)
+
+agent.chat("Hello! Works on macOS, Linux, and Windows.")
+```
+
+| Platform | File Lock Mechanism | Multi-Process Safe |
+|----------|---------------------|--------------------|
+| macOS    | `fcntl.flock`       | ✅ Yes              |
+| Linux    | `fcntl.flock`       | ✅ Yes              |
+| Windows  | `msvcrt.locking`    | ✅ Yes              |
+
+<Note>
+If you run multiple agent processes that share the same `session_dir`, the
+store automatically prevents concurrent writers from corrupting session
+files — on every supported OS.
+</Note>
+
+---
+
 ## Configuration Options
 
 ### Directory Structure

--- a/docs/features/persistence.mdx
+++ b/docs/features/persistence.mdx
@@ -122,7 +122,7 @@ Choose the right backend for your use case:
   Analytics database for large-scale data processing
 </Card>
 <Card title="JSON Files" icon="file-code" href="/docs/features/persistence-json">
-  Simple file-based storage for lightweight applications
+  Simple file-based storage with cross-platform locking — works on macOS, Linux, and Windows
 </Card>
 </CardGroup>
 


### PR DESCRIPTION
Fixes #243

## Summary
- Add Cross-Platform Support section to docs/features/persistence-json.mdx after How It Works section
- Include Mermaid diagram showing platform-specific file locking mechanisms 
- Add agent-centric code example demonstrating cross-platform compatibility
- Include platform comparison table (macOS/Linux use fcntl, Windows uses msvcrt)
- Update docs/features/persistence.mdx JSON Files card to mention cross-platform locking
- Follow AGENTS.md style guidelines with standard color scheme and progressive disclosure

## Changes Made
- **Added new Cross-Platform Support section** with visual Mermaid diagram
- **Agent-centric code example** showing same code works on all platforms
- **Platform comparison table** detailing file lock mechanisms per OS
- **Note callout** explaining multi-process safety guarantees
- **Updated persistence overview** to mention cross-platform support

## Verification
- Follows AGENTS.md Section 2 page structure template
- Uses standard Mermaid color scheme (#8B0000, #189AB4, #10B981, #F59E0B)
- Agent-centric examples with friendly imports
- Progressive disclosure pattern: simple example → table → callout
- One-sentence section introduction as required

🤖 Generated with [Claude Code](https://claude.ai/code)