### PR TITLE
docs(platform): add data-model page + DB configuration for praisonai-platform

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -437,6 +437,7 @@
                 "pages": [
                   "docs/features/assign-agents",
                   "docs/features/platform/dependencies",
+                  "docs/features/platform/data-model",
                   "docs/features/platform/exceptions",
                   "docs/features/platform/authentication",
                   "docs/features/platform/workspaces",

--- a/docs/features/platform/data-model.mdx
+++ b/docs/features/platform/data-model.mdx
@@ -1,0 +1,405 @@
+---
+title: "Data Model"
+sidebarTitle: "Data Model"
+description: "Database schema and configuration for the PraisonAI Platform"
+icon: "database"
+---
+
+Every workspace, issue, agent, and comment you create is stored in these tables.
+
+```mermaid
+graph LR
+    subgraph "Core Entities"
+        A[👤 User] --> B[🏢 Workspace]
+        B --> C[📂 Project]
+        C --> D[📋 Issue]
+        D --> E[💬 Comment]
+        B --> F[🤖 Agent]
+        D --> G[🏷️ Label]
+        D --> H[🔗 Dependency]
+        B --> I[📊 Activity Log]
+    end
+    
+    classDef user fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef workspace fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef entity fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef system fill:#F59E0B,stroke:#7C90A0,color:#fff
+    
+    class A user
+    class B workspace
+    class C,D,E,F,G,H entity
+    class I system
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Zero Configuration (Default)">
+```python
+from praisonai_platform.client import PlatformClient
+
+# In-memory SQLite - data lost on restart
+client = PlatformClient(base_url="http://localhost:8000")
+client.login(email="me@example.com", password="...")
+
+workspace = client.workspaces.create(name="Research")
+issue = client.issues.create(workspace_id=workspace.id, title="Setup database")
+```
+</Step>
+
+<Step title="Persistent SQLite">
+```bash
+# Set database URL for persistence
+export DATABASE_URL="sqlite+aiosqlite:///./platform.db"
+
+# Initialize database tables
+python -c "import asyncio; from praisonai_platform.db import init_db; asyncio.run(init_db())"
+```
+</Step>
+
+<Step title="PostgreSQL Production">
+```bash
+# Switch to PostgreSQL
+export DATABASE_URL="postgresql+asyncpg://user:pass@host/db"
+
+# Initialize tables
+python -c "import asyncio; from praisonai_platform.db import init_db; asyncio.run(init_db())"
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant Session
+    participant Engine
+    participant DB
+    
+    Client->>API: Request
+    API->>Session: get_db dependency
+    Session->>Engine: get_session_factory()
+    Engine->>Engine: get_engine() (cached)
+    Engine->>Session: AsyncSession
+    Session-->>API: Session yielded
+    API->>DB: Query/Update
+    DB-->>API: Result
+    API->>Session: Auto-commit on success
+    API-->>Client: Response
+```
+
+| Component | Purpose | Lifecycle |
+|-----------|---------|-----------|
+| **Engine** | Database connection pool | Cached globally, first call wins |
+| **Session** | Per-request transaction | Created/disposed per API call |
+| **get_db** | FastAPI dependency | Yields session, auto-commits |
+| **init_db** | Table creation | Call once for persistent databases |
+
+---
+
+## Entities
+
+### User (users)
+
+Authentication and identity for platform access.
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `str` | UUID | Primary key |
+| `name` | `str` | — | Username (unique) |
+| `email` | `str` | — | Email address (unique) |
+| `password_hash` | `str` | — | Hashed password |
+| `created_at` | `datetime` | UTC now | Creation timestamp |
+| `updated_at` | `datetime` | UTC now | Last update timestamp |
+
+### Workspace (workspaces)
+
+Top-level container for organizing projects and issues.
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `str` | UUID | Primary key |
+| `name` | `str` | — | Workspace name |
+| `description` | `str` | `None` | Optional description |
+| `settings` | `dict` | `{}` | JSON configuration |
+| `issue_prefix` | `str` | `"ISSUE"` | Issue numbering prefix |
+| `created_at` | `datetime` | UTC now | Creation timestamp |
+| `updated_at` | `datetime` | UTC now | Last update timestamp |
+
+### Member (members)
+
+User membership and roles within workspaces.
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `str` | UUID | Primary key |
+| `user_id` | `str` | — | Foreign key to users |
+| `workspace_id` | `str` | — | Foreign key to workspaces |
+| `role` | `str` | `"member"` | Role: `owner`, `admin`, `member` |
+| `created_at` | `datetime` | UTC now | Creation timestamp |
+| `updated_at` | `datetime` | UTC now | Last update timestamp |
+
+**Constraints:** Unique (user_id, workspace_id)
+
+### Project (projects)
+
+Optional grouping for issues within a workspace.
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `str` | UUID | Primary key |
+| `workspace_id` | `str` | — | Foreign key to workspaces |
+| `name` | `str` | — | Project name |
+| `description` | `str` | `None` | Optional description |
+| `settings` | `dict` | `{}` | JSON configuration |
+| `created_at` | `datetime` | UTC now | Creation timestamp |
+| `updated_at` | `datetime` | UTC now | Last update timestamp |
+
+### Issue (issues)
+
+Work items and tasks within a workspace.
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `str` | UUID | Primary key |
+| `workspace_id` | `str` | — | Foreign key to workspaces |
+| `project_id` | `str` | `None` | Optional foreign key to projects |
+| `title` | `str` | — | Issue title |
+| `description` | `str` | `None` | Optional description |
+| `status` | `str` | `"backlog"` | Status: backlog, in-progress, done |
+| `priority` | `str` | `"medium"` | Priority: low, medium, high, urgent |
+| `assignee_id` | `str` | `None` | Optional foreign key to users |
+| `created_by_id` | `str` | `None` | Optional foreign key to users |
+| `issue_number` | `int` | `None` | Auto-incrementing number |
+| `created_at` | `datetime` | UTC now | Creation timestamp |
+| `updated_at` | `datetime` | UTC now | Last update timestamp |
+
+### Comment (comments)
+
+Discussion threads on issues.
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `str` | UUID | Primary key |
+| `issue_id` | `str` | — | Foreign key to issues |
+| `author_id` | `str` | `None` | Optional foreign key to users |
+| `content` | `str` | — | Comment text |
+| `created_at` | `datetime` | UTC now | Creation timestamp |
+| `updated_at` | `datetime` | UTC now | Last update timestamp |
+
+### Agent (agents)
+
+AI agents assigned to workspaces.
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `str` | UUID | Primary key |
+| `workspace_id` | `str` | — | Foreign key to workspaces |
+| `name` | `str` | — | Agent name |
+| `description` | `str` | `None` | Optional description |
+| `status` | `str` | `"idle"` | Status: idle, active, error |
+| `config` | `dict` | `{}` | JSON configuration |
+| `created_at` | `datetime` | UTC now | Creation timestamp |
+| `updated_at` | `datetime` | UTC now | Last update timestamp |
+
+### IssueLabel (issue_labels)
+
+Label definitions for categorizing issues.
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `str` | UUID | Primary key |
+| `workspace_id` | `str` | — | Foreign key to workspaces |
+| `name` | `str` | — | Label name |
+| `color` | `str` | `"#000000"` | Hex color code |
+| `description` | `str` | `None` | Optional description |
+| `created_at` | `datetime` | UTC now | Creation timestamp |
+| `updated_at` | `datetime` | UTC now | Last update timestamp |
+
+### IssueLabelLink (issue_label_links)
+
+Many-to-many relationship between issues and labels.
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `str` | UUID | Primary key |
+| `issue_id` | `str` | — | Foreign key to issues |
+| `label_id` | `str` | — | Foreign key to issue_labels |
+| `created_at` | `datetime` | UTC now | Creation timestamp |
+
+**Constraints:** Unique (issue_id, label_id)
+
+### IssueDependency (issue_dependencies)
+
+Dependency relationships between issues.
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `str` | UUID | Primary key |
+| `issue_id` | `str` | — | Foreign key to issues |
+| `depends_on_id` | `str` | — | Foreign key to issues |
+| `dependency_type` | `str` | — | Type: `blocks`, `blocked_by`, `related` |
+| `created_at` | `datetime` | UTC now | Creation timestamp |
+
+**Constraints:** Unique (issue_id, depends_on_id, dependency_type)
+
+### ActivityLog (activity_logs)
+
+Audit trail for workspace activities.
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `str` | UUID | Primary key |
+| `workspace_id` | `str` | — | Foreign key to workspaces |
+| `entity_type` | `str` | — | Entity type: issue, project, workspace |
+| `entity_id` | `str` | — | ID of the affected entity |
+| `action` | `str` | — | Action: created, updated, deleted |
+| `actor_id` | `str` | `None` | Optional foreign key to users |
+| `details` | `dict` | `{}` | JSON details |
+| `created_at` | `datetime` | UTC now | Creation timestamp |
+
+---
+
+## Configuration Options
+
+| Name | Where | Default | Description |
+|------|-------|---------|-------------|
+| `DATABASE_URL` | env var | `sqlite+aiosqlite:///:memory:` | SQLAlchemy async URL used by `get_engine()` |
+| `get_engine(database_url=None)` | `praisonai_platform.db` | — | Returns the cached `AsyncEngine`; first call wins, pass `database_url` to override env |
+| `get_session()` | `praisonai_platform.db` | — | Async generator yielding an `AsyncSession` per request |
+| `init_db()` | `praisonai_platform.db` | — | Creates all tables via `Base.metadata.create_all` |
+| `reset_engine()` | `praisonai_platform.db` | — | Disposes and clears the cached engine (tests / URL switch) |
+
+---
+
+## Common Patterns
+
+### Running One-Off Queries
+
+```python
+import asyncio
+from praisonai_platform.db import get_session, init_db
+from praisonai_platform.db.models import Workspace
+from sqlalchemy import select
+
+async def count_workspaces():
+    await init_db()  # Ensure tables exist
+    async for session in get_session():
+        result = await session.execute(select(Workspace))
+        workspaces = result.scalars().all()
+        print(f"Found {len(workspaces)} workspaces")
+        break
+
+asyncio.run(count_workspaces())
+```
+
+### Switching to PostgreSQL in Production
+
+```bash
+# 1. Install driver
+pip install asyncpg
+
+# 2. Set database URL
+export DATABASE_URL="postgresql+asyncpg://user:password@localhost/platform"
+
+# 3. Initialize tables
+python -c "import asyncio; from praisonai_platform.db import init_db; asyncio.run(init_db())"
+
+# 4. Start platform server
+python -m praisonai_platform
+```
+
+### Resetting Engine in Tests
+
+```python
+import pytest
+from praisonai_platform.db import reset_engine, init_db
+
+@pytest.fixture(autouse=True)
+async def clean_db():
+    await reset_engine()  # Clear cached engine
+    await init_db()       # Create fresh tables
+    yield
+    await reset_engine()  # Clean up
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Initialize Database Once">
+For non-memory databases, call `init_db()` once at application startup, not per request. The default in-memory SQLite creates tables automatically.
+
+```python
+# In your app startup
+import asyncio
+from praisonai_platform.db import init_db
+
+if __name__ == "__main__":
+    asyncio.run(init_db())  # Only for persistent databases
+    # Start your server...
+```
+</Accordion>
+
+<Accordion title="Don't Mix Database URLs">
+The engine is cached globally - if you need to switch `DATABASE_URL` values, call `reset_engine()` first to avoid connection pool conflicts.
+
+```python
+from praisonai_platform.db import reset_engine, get_engine
+
+# Switch from SQLite to Postgres
+await reset_engine()
+engine = get_engine("postgresql+asyncpg://user:pass@host/db")
+```
+</Accordion>
+
+<Accordion title="Keep SQLite for Development Only">
+Use SQLite for development and testing, but switch to PostgreSQL for production workloads. SQLite doesn't handle concurrent writes well in server environments.
+
+```bash
+# Development
+export DATABASE_URL="sqlite+aiosqlite:///./dev.db"
+
+# Production
+export DATABASE_URL="postgresql+asyncpg://user:pass@prod-host/platform"
+```
+</Accordion>
+
+<Accordion title="Use Sessions Properly">
+Always use the `get_db` dependency in FastAPI routes - it handles session lifecycle, commits, and rollbacks automatically. Don't create sessions manually.
+
+```python
+from fastapi import Depends
+from praisonai_platform.api.deps import get_db
+
+@app.get("/workspaces")
+async def list_workspaces(session: AsyncSession = Depends(get_db)):
+    # Session is auto-managed
+    return await workspace_service.list_all(session)
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Workspaces" icon="building" href="/docs/features/platform/workspaces">
+  Manage teams and organize work
+</Card>
+<Card title="Issues" icon="circle-check" href="/docs/features/platform/issues">
+  Track and manage work items
+</Card>
+<Card title="Agents" icon="robot" href="/docs/features/platform/agents">
+  Deploy AI agents to workspaces
+</Card>
+<Card title="Authentication" icon="shield" href="/docs/features/platform/authentication">
+  User authentication and sessions
+</Card>
+</CardGroup>

--- a/docs/guides/platform/getting-started.mdx
+++ b/docs/guides/platform/getting-started.mdx
@@ -99,6 +99,56 @@ Your Platform server is now ready for API calls.
 
 ---
 
+## Configure the Database (Optional)
+
+<Steps>
+<Step title="Default: In-Memory SQLite">
+By default, the platform uses an in-memory SQLite database — your data is lost when the server restarts.
+
+This is perfect for testing and development:
+
+```bash
+# No configuration needed
+uvicorn praisonai_platform.api.app:create_app --factory --port 8000
+```
+</Step>
+
+<Step title="Persistent SQLite">
+To keep your data between server restarts, set a database URL:
+
+```bash
+export DATABASE_URL="sqlite+aiosqlite:///./platform.db"
+uvicorn praisonai_platform.api.app:create_app --factory --port 8000
+```
+
+The database file will be created automatically on first use.
+</Step>
+
+<Step title="Production PostgreSQL">
+For production, use PostgreSQL:
+
+```bash
+# Install PostgreSQL driver
+pip install asyncpg
+
+# Set database URL
+export DATABASE_URL="postgresql+asyncpg://user:password@localhost/platform"
+
+# Initialize tables (one-time)
+python -c "import asyncio; from praisonai_platform.db import init_db; asyncio.run(init_db())"
+
+# Start server
+uvicorn praisonai_platform.api.app:create_app --factory --port 8000
+```
+
+<Note>
+For complete database schema documentation, see the [Data Model](/docs/features/platform/data-model) page.
+</Note>
+</Step>
+</Steps>
+
+---
+
 ## Register Your First User
 
 <Steps>

--- a/docs/guides/platform/index.mdx
+++ b/docs/guides/platform/index.mdx
@@ -65,6 +65,10 @@ Explore detailed documentation for platform features:
   <Card title="Dependencies" icon="link" href="/docs/features/platform/dependencies">
     Issue dependency tracking
   </Card>
+  
+  <Card title="Data Model" icon="database" href="/docs/features/platform/data-model">
+    Database schema and configuration
+  </Card>
 </CardGroup>
 
 ---


### PR DESCRIPTION
Fixes #251

## Summary

- Creates comprehensive data-model.mdx page documenting the complete PraisonAI Platform database schema
- Documents all 11 database entities with accurate column information from source code
- Includes hero Mermaid ER diagram using standard color scheme
- Adds database configuration section to getting-started guide  
- Updates platform index page with Data Model card
- Registers new page in docs.json navigation

## Key Features

- **Complete Schema Documentation**: All 11 entities (User, Workspace, Member, Project, Issue, Comment, Agent, IssueLabel, IssueLabelLink, IssueDependency, ActivityLog)
- **Agent-Centric Examples**: Copy-paste code examples showing real-world usage
- **Configuration Guide**: DATABASE_URL options for SQLite and PostgreSQL
- **Best Practices**: Accordion sections for common patterns and recommendations
- **Proper Navigation**: Added to Platform features group in docs.json

## Source Verification

All schema information was extracted directly from praisonai_platform/db/ source files including models.py, base.py, and deps.py for accurate documentation.

Generated with [Claude Code](https://claude.ai/code)