### PR TITLE
docs: framework-adapter plugins, Typer-first CLI dispatch, run_sync() loop safety

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -575,6 +575,7 @@
                   "docs/features/recipe-registry",
                   "docs/features/event-bus",
                   "docs/features/plugins",
+                  "docs/features/framework-adapter-plugins",
                   "docs/features/agent-server",
                   "docs/features/agent-profiles",
                   "docs/features/messaging-channels-strategy",

--- a/docs/cli/cli.mdx
+++ b/docs/cli/cli.mdx
@@ -14,6 +14,37 @@ pip install praisonai
 export OPENAI_API_KEY=your_api_key
 ```
 
+## How CLI Dispatch Works
+
+PraisonAI uses a unified CLI entry point with Typer as the primary dispatcher:
+
+```mermaid
+graph TB
+    Start[🚀 praisonai command] --> Version{--version?}
+    Version -->|Yes| PrintVersion[📄 Print version & exit]
+    Version -->|No| LegacyCheck{Bare prompt/YAML?}
+    LegacyCheck -->|Yes| Legacy[🔄 Legacy shim]
+    LegacyCheck -->|No| Typer[⚡ Typer dispatcher]
+    
+    Legacy --> PromptCheck{Contains spaces?}
+    PromptCheck -->|Yes| FreeText[💬 Free-text prompt]
+    PromptCheck -->|No| FileCheck{YAML file exists?}
+    FileCheck -->|Yes| YAMLFile[📄 YAML workflow]
+    FileCheck -->|No| Typer
+    
+    classDef version fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef legacy fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef typer fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class PrintVersion version
+    class Legacy,FreeText,YAMLFile legacy
+    class Typer typer
+```
+
+<Note>
+PraisonAI now fails loud on CLI registration errors. If you see a new ImportError after upgrading, a Typer subcommand or one of its dependencies failed to import — fix the import rather than ignoring the error.
+</Note>
+
 ## Quick Start
 
 ### Direct Prompt Execution

--- a/docs/features/framework-adapter-plugins.mdx
+++ b/docs/features/framework-adapter-plugins.mdx
@@ -1,0 +1,371 @@
+---
+title: "Framework Adapter Plugins"
+sidebarTitle: "Framework Adapter Plugins"
+description: "Extend PraisonAI with custom framework adapters via Python entry points"
+icon: "puzzle-piece"
+---
+
+Framework adapter plugins enable third-party developers to add new execution frameworks to PraisonAI without modifying core code.
+
+```mermaid
+graph LR
+    subgraph "Framework Plugin System"
+        A[📦 Third-party Package] --> B[🔌 Entry Point]
+        B --> C[📝 Registry]
+        C --> D[🚀 CLI Framework Selection]
+    end
+    
+    classDef package fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef entrypoint fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef registry fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef cli fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A package
+    class B entrypoint
+    class C registry
+    class D cli
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Programmatic Registration">
+
+Register a framework adapter directly in your code:
+
+```python
+from praisonai.framework_adapters.registry import FrameworkAdapterRegistry
+from praisonai.framework_adapters.base import BaseFrameworkAdapter
+
+class MyFrameworkAdapter(BaseFrameworkAdapter):
+    name = "myframework"
+    
+    def is_available(self) -> bool:
+        try:
+            import myframework
+            return True
+        except ImportError:
+            return False
+    
+    def run(self, config, llm_config, topic):
+        # Framework execution logic
+        return "Framework execution result"
+    
+    def cleanup(self) -> None:
+        # Optional cleanup
+        pass
+
+# Register the adapter
+registry = FrameworkAdapterRegistry.get_instance()
+registry.register("myframework", MyFrameworkAdapter)
+```
+
+</Step>
+
+<Step title="Entry Point Plugin">
+
+Create a pip-installable plugin using `pyproject.toml`:
+
+```toml
+# pyproject.toml
+[project]
+name = "myframework-praisonai"
+version = "1.0.0"
+
+[project.entry-points."praisonai.framework_adapters"]
+myframework = "myframework_praisonai.adapter:MyFrameworkAdapter"
+```
+
+```bash
+# Use the framework after installation
+pip install myframework-praisonai
+praisonai --framework myframework agents.yaml
+```
+
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Registry
+    participant Plugin
+    participant Framework
+    
+    User->>CLI: pip install plugin
+    CLI->>Registry: Discover entry points
+    Registry->>Plugin: Load adapter class
+    Plugin-->>Registry: Register framework
+    User->>CLI: praisonai --framework myframework agents.yaml
+    CLI->>Registry: get_adapter("myframework")
+    Registry->>Plugin: create() instance
+    Plugin->>Framework: run(config, llm_config, topic)
+    Framework-->>User: Execution result
+```
+
+The framework adapter registry provides a central point for managing framework implementations:
+
+| Operation | Description | When Called |
+|-----------|-------------|-------------|
+| Discovery | Entry points auto-loaded on first registry access | Import time |
+| Registration | Adapters registered by name | Plugin installation |
+| Creation | Adapter instances created on demand | CLI framework selection |
+| Availability | Framework dependencies checked | Before execution |
+
+---
+
+## Configuration
+
+<Card title="Framework Adapter Registry API" icon="code" href="/docs/sdk/reference/python/modules/framework_adapters.registry">
+  Complete API reference for FrameworkAdapterRegistry
+</Card>
+
+### Registry Methods
+
+| Method | Parameters | Description |
+|--------|------------|-------------|
+| `get_instance()` | None | Get singleton registry instance |
+| `register(name, adapter_class)` | `name: str`, `adapter_class: Type[FrameworkAdapter]` | Register new adapter |
+| `unregister(name)` | `name: str` | Remove adapter by name |
+| `create(name)` | `name: str` | Create adapter instance |
+| `list_registered()` | None | List all registered adapter names |
+| `is_available(name)` | `name: str` | Check if adapter is functional |
+
+### Adapter Protocol
+
+Framework adapters must implement the `FrameworkAdapter` protocol:
+
+| Method | Required | Description |
+|--------|----------|-------------|
+| `name` | ✅ | Unique framework identifier |
+| `is_available()` | ✅ | Check framework dependencies |
+| `run(config, llm_config, topic)` | ✅ | Execute framework logic |
+| `cleanup()` | ✅ | Clean up resources |
+
+---
+
+## Common Patterns
+
+### Override Built-in Adapter
+
+```python
+from praisonai.framework_adapters.registry import FrameworkAdapterRegistry
+from praisonai.framework_adapters.base import BaseFrameworkAdapter
+
+class CustomCrewAIAdapter(BaseFrameworkAdapter):
+    name = "crewai"
+    
+    def is_available(self) -> bool:
+        try:
+            import crewai
+            return True
+        except ImportError:
+            return False
+    
+    def run(self, config, llm_config, topic):
+        # Custom CrewAI execution logic
+        return "Custom CrewAI result"
+
+# Override built-in CrewAI adapter
+registry = FrameworkAdapterRegistry.get_instance()
+registry.register("crewai", CustomCrewAIAdapter)
+```
+
+### Subprocess Framework Wrapper
+
+```python
+import subprocess
+from praisonai.framework_adapters.base import BaseFrameworkAdapter
+
+class NonPythonAdapter(BaseFrameworkAdapter):
+    name = "external_framework"
+    
+    def is_available(self) -> bool:
+        try:
+            subprocess.run(["external_framework", "--version"], 
+                         capture_output=True, check=True)
+            return True
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return False
+    
+    def run(self, config, llm_config, topic):
+        # Convert config to external format
+        cmd = ["external_framework", "run", "--topic", topic]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        return result.stdout
+```
+
+### Conditional Dependencies
+
+```python
+import logging
+from praisonai.framework_adapters.base import BaseFrameworkAdapter
+
+logger = logging.getLogger(__name__)
+
+class OptionalDepsAdapter(BaseFrameworkAdapter):
+    name = "advanced_framework"
+    
+    def is_available(self) -> bool:
+        try:
+            # Check multiple optional dependencies
+            import advanced_framework
+            import optional_plugin
+            return True
+        except ImportError as e:
+            logger.debug(f"Framework not available: {e}")
+            return False
+    
+    def run(self, config, llm_config, topic):
+        if not self.is_available():
+            raise RuntimeError("Framework dependencies not installed")
+        
+        import advanced_framework
+        return advanced_framework.execute(config, llm_config, topic)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Handle Missing Dependencies Gracefully">
+
+Always implement defensive `is_available()` checks:
+
+```python
+def is_available(self) -> bool:
+    try:
+        # Check all required dependencies
+        import required_framework
+        import optional_dependency
+        
+        # Verify minimum versions if needed
+        if hasattr(required_framework, 'version'):
+            version = required_framework.version
+            if version < (1, 0, 0):
+                return False
+        
+        return True
+    except ImportError:
+        # Log debug info, don't raise
+        logging.getLogger(__name__).debug(
+            "Framework dependencies not available"
+        )
+        return False
+```
+
+</Accordion>
+
+<Accordion title="Avoid Import-Time Failures">
+
+Don't import heavy dependencies at module level:
+
+```python
+# ❌ Bad - imports at module level
+import heavy_framework
+from expensive.module import Component
+
+class BadAdapter(BaseFrameworkAdapter):
+    pass
+
+# ✅ Good - lazy imports
+class GoodAdapter(BaseFrameworkAdapter):
+    def run(self, config, llm_config, topic):
+        # Import only when needed
+        import heavy_framework
+        from expensive.module import Component
+        return heavy_framework.run(config)
+```
+
+</Accordion>
+
+<Accordion title="Use Structured Logging">
+
+Log framework events for debugging:
+
+```python
+import logging
+from praisonai.framework_adapters.base import BaseFrameworkAdapter
+
+class LoggingAdapter(BaseFrameworkAdapter):
+    def __init__(self):
+        super().__init__()
+        self.logger = logging.getLogger(__name__)
+    
+    def run(self, config, llm_config, topic):
+        self.logger.info(f"Starting {self.name} execution for topic: {topic}")
+        try:
+            result = self._execute_framework(config, llm_config, topic)
+            self.logger.info(f"Execution completed successfully")
+            return result
+        except Exception as e:
+            self.logger.error(f"Framework execution failed: {e}")
+            raise
+```
+
+</Accordion>
+
+<Accordion title="Implement Proper Resource Cleanup">
+
+Always clean up resources in the `cleanup()` method:
+
+```python
+class ResourceAwareAdapter(BaseFrameworkAdapter):
+    def __init__(self):
+        super().__init__()
+        self._connections = []
+        self._temp_files = []
+    
+    def run(self, config, llm_config, topic):
+        # Create resources during execution
+        conn = self._create_connection()
+        self._connections.append(conn)
+        
+        temp_file = self._create_temp_file()
+        self._temp_files.append(temp_file)
+        
+        # Use resources...
+        return result
+    
+    def cleanup(self) -> None:
+        # Close connections
+        for conn in self._connections:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        
+        # Clean up temp files
+        for temp_file in self._temp_files:
+            try:
+                temp_file.unlink()
+            except Exception:
+                pass
+        
+        self._connections.clear()
+        self._temp_files.clear()
+```
+
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Plugin Development" icon="plug" href="/docs/features/plugins">
+  Learn about PraisonAI's plugin system for tools and hooks
+</Card>
+<Card title="CrewAI Integration" icon="users" href="/docs/framework/crewai">
+  See how built-in framework adapters are implemented
+</Card>
+</CardGroup>

--- a/docs/features/thread-safety.mdx
+++ b/docs/features/thread-safety.mdx
@@ -8,6 +8,20 @@ icon: "lock"
 
 PraisonAI Agents v0.5.0+ includes thread-safe management of chat history and caches; PR #1567 makes the underlying lock re-entrant and adds a per-event-loop async lock.
 
+<Warning>
+**Behaviour change in PR #1548**: `run_sync()` now raises `RuntimeError` when called from inside a running event loop. Previously it would auto-fallback to a background loop.
+
+```python
+# Before PR #1548 (worked, but unsafe)
+async def handler():
+    result = run_sync(some_coro())  # silently used background loop
+
+# After PR #1548 (raises RuntimeError)
+async def handler():
+    result = await some_coro()  # use this from async context
+```
+</Warning>
+
 ## Thread-Safe Components
 
 ### Chat History
@@ -398,6 +412,14 @@ for t in threads:
 ### Failure-safe cache
 
 A transient discovery error does not lock the CLI into a broken state — the next call retries instead of permanently breaking dispatch. This ensures reliable operation in multi-threaded server environments where temporary import failures might occur.
+
+### New Thread-Safe Components in PR #1548
+
+**AsyncAgentScheduler** is now loop-aware. The `start()` method binds its async primitives (`asyncio.Event`, `asyncio.Lock`) to the running loop, and `stop()` raises `RuntimeError` if called from a different loop than `start()`.
+
+**Lazy loaders in `praisonai/auto.py`** are now thread-safe. A single `_load_optional(key, loader)` helper with a module-level lock replaces the previous unguarded module-level globals.
+
+**Integration registry** (`praisonai/integrations/registry.py`) now has a per-instance `threading.Lock` guarding `register`/`unregister`/`create`/`list_registered` operations.
 
 ## Related
 

--- a/docs/framework/autogen.mdx
+++ b/docs/framework/autogen.mdx
@@ -6,6 +6,10 @@ icon: "robot"
 
 AG2 is the community fork of AutoGen. PraisonAI supports AG2 as a dedicated framework backend with GroupChat orchestration, automatic tool registration, and native AWS Bedrock support.
 
+<Note>
+Need a framework that isn't listed here? See [Framework Adapter Plugins](/docs/features/framework-adapter-plugins) to register your own via Python entry points.
+</Note>
+
 ```mermaid
 graph LR
     subgraph "AG2 Framework"

--- a/docs/framework/crewai.mdx
+++ b/docs/framework/crewai.mdx
@@ -8,6 +8,10 @@ icon: "users"
 
 Low-code solution to run CrewAI with integrated tools and features.
 
+<Note>
+Need a framework that isn't listed here? See [Framework Adapter Plugins](/docs/features/framework-adapter-plugins) to register your own via Python entry points.
+</Note>
+
 ## Installation
 
 ```bash

--- a/docs/framework/praisonaiagents.mdx
+++ b/docs/framework/praisonaiagents.mdx
@@ -6,6 +6,10 @@ icon: "users-gear"
 
 A lightweight package dedicated to creating and managing AI agents with advanced capabilities.
 
+<Note>
+Need a framework that isn't listed here? See [Framework Adapter Plugins](/docs/features/framework-adapter-plugins) to register your own via Python entry points.
+</Note>
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Fixes #276

## Summary
- New framework adapter plugin documentation with extensibility via Python entry points 
- Updated CLI documentation with Typer-first dispatch flow and fail-loud behavior
- Thread safety updates for run_sync() behavior change in PR #1548

## Documentation Changes

### NEW: Framework Adapter Plugins (docs/features/framework-adapter-plugins.mdx)
- Complete developer guide for creating custom framework adapters
- Quick Start with programmatic registration and pyproject.toml entry points
- Common patterns: override built-ins, subprocess wrappers, conditional dependencies
- Best practices: error handling, lazy imports, resource cleanup
- Mermaid diagrams showing plugin flow and sequence

### UPDATED: CLI Documentation (docs/cli/cli.mdx)
- Added CLI dispatch flow diagram showing Typer-first routing
- Documented legacy shim behavior for bare prompts and YAML files
- Added fail-loud behavior note for registration errors

### UPDATED: Thread Safety (docs/features/thread-safety.mdx) 
- Added behavior change warning for run_sync() in PR #1548
- Before/after code examples for proper async usage
- New thread-safe components: AsyncAgentScheduler, lazy loaders, integration registry

### Cross-Links Added
- Framework pages now link to adapter plugin documentation
- Updated docs.json to include new page in Features group

🤖 Generated with [Claude Code](https://claude.ai/code)