### PR TITLE
docs: Mirror 'self-improving' tagline update from PraisonAI PR #1574

### DIFF
--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -44,7 +44,7 @@ seo:
 </div>
 
 <div className="text-lg text-gray-600 dark:text-gray-400 mb-8 max-w-3xl">
-  Build production-ready AI agents that reason, remember, and act autonomously — with just a few lines of code.
+  Build production-ready AI agents that reason, remember, self-improve, and act autonomously — with just a few lines of code.
 </div>
 
 ---

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -29,7 +29,7 @@ mode: "custom"
   </h1>
   
   <p className="text-xl text-gray-600 dark:text-gray-400 mb-6 max-w-2xl mx-auto">
-    Multi-agent teams that solve complex tasks, automate workflows, and deliver to Telegram, Discord, Slack — with low-code simplicity.
+    Self-improving multi-agent teams that solve complex tasks, automate workflows, and deliver to Telegram, Discord, Slack — with low-code simplicity.
   </p>
   
   <div className="flex justify-center gap-3 flex-wrap mb-6">

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -6,11 +6,11 @@ icon: "book-open"
 
 ## What is PraisonAI?
 
-PraisonAI is a powerful Multi-Agent Framework for building and deploying AI agents that can understand, reason, and execute complex tasks autonomously.
+PraisonAI is a powerful Multi-Agent Framework for building and deploying autonomous, self-improving AI agents that can understand, reason, and execute complex tasks.
 
 <CardGroup cols={1}>
   <Card title="Welcome to PraisonAI" icon="wand-magic-sparkles">
-    Build powerful autonomous agents that understand, decide, and execute with unprecedented capability.
+    Build powerful autonomous, self-improving agents that understand, decide, and execute with unprecedented capability.
   </Card>
 </CardGroup>
 
@@ -227,10 +227,11 @@ agents:
 ## Key Features
 
 <CardGroup cols={3}>
-  <Card title="Autonomous Agents" icon="robot">
+  <Card title="Autonomous, Self-Improving Agents" icon="robot">
     - Understand natural language
     - Make decisions
     - Execute tasks
+    - Learn and persist new skills
   </Card>
 
   <Card title="Flexible Architecture" icon="cubes">


### PR DESCRIPTION
This PR mirrors the self-improving tagline updates from PraisonAI PR #1574 to the documentation landing pages.

## Changes Made

- docs/index.mdx: Updated hero subhead to include self-improving in the description of multi-agent teams
- docs/introduction.mdx: 
  - Updated What is PraisonAI paragraph to describe autonomous, self-improving AI agents
  - Updated welcome Card to include self-improving
  - Updated Autonomous Agents card to Autonomous, Self-Improving Agents and added Learn and persist new skills bullet point
- docs/home.mdx: Updated hero text to include self-improve in the verb list (reason, remember, self-improve, and act)

## Context

This brings the docs marketing copy into parity with the main PraisonAI repository README, ensuring consistent messaging across all surfaces about PraisonAI's self-improving agent capabilities.

The underlying self-improving functionality is already documented in existing feature pages like docs/features/skill-manage.mdx.

Fixes #280

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Documentation**
  * Updated marketing copy and feature descriptions across documentation to emphasize agent self-improving capabilities.
  * Added "self-improving" descriptor to multi-agent teams presentation.
  * Highlighted new key feature: agents can learn and persist new skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->