### PR TITLE
docs: Update wrapper async bridge + CLI dispatcher docs after PraisonAI #1575

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -657,6 +657,7 @@
                 "icon": "gear",
                 "pages": [
                   "docs/features/cli",
+                  "docs/features/cli-dispatcher",
                   "docs/features/windows-terminal-encoding",
                   "docs/features/async-agent-scheduler",
                   "docs/features/clarify-tool",

--- a/docs/features/async-bridge.mdx
+++ b/docs/features/async-bridge.mdx
@@ -7,6 +7,10 @@ icon: "arrows-left-right"
 
 The async bridge lets your tools and callbacks move between sync and async without crashing the event loop.
 
+<Note>
+This page covers the **SDK-level** async bridge (`praisonaiagents.utils.async_bridge`) used inside tools and callbacks. PraisonAI also ships a **wrapper-level** async bridge (`praisonai._async_bridge`) used internally by long-running servers (gateway, a2u, mcp_server). They are different modules — see the [CLI Dispatcher](/features/cli-dispatcher) and [Gateway](/features/gateway#graceful-shutdown) pages for the wrapper bridge.
+</Note>
+
 ```mermaid
 graph LR
     subgraph "Async Bridge"

--- a/docs/features/cli-dispatcher.mdx
+++ b/docs/features/cli-dispatcher.mdx
@@ -1,0 +1,209 @@
+---
+title: "CLI Dispatcher"
+sidebarTitle: "CLI Dispatcher"
+description: "How praisonai routes your command line — version, legacy YAML/prompt, or Typer subcommand"
+icon: "terminal"
+---
+
+PraisonAI picks one of three paths based on what you type.
+
+```mermaid
+graph TB
+    Start[📋 praisonai argv] --> V{🔍 --version/-V?}
+    V -->|Yes| Print[⚡ Print version<br/>no Typer import]
+    V -->|No| L{🔍 Legacy?<br/>free-text or<br/>existing YAML}
+    L -->|Yes| Legacy[🤖 PraisonAI().main()]
+    L -->|No| Typer[🧰 Typer app()]
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef route fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Start input
+    class V,L check
+    class Print,Legacy,Typer route
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Version Check">
+```bash
+praisonai --version
+# Fast — prints version without importing Typer
+```
+</Step>
+
+<Step title="Legacy Invocation">
+```bash
+# Free-text prompt (has spaces)
+praisonai "Build a weather agent"
+
+# Existing YAML file
+praisonai agents.yaml
+```
+</Step>
+
+<Step title="Typer Subcommand">
+```bash
+# Registered subcommands route to Typer
+praisonai chat --model gpt-4o
+praisonai ui --port 8080
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Dispatcher
+    participant Version
+    participant Legacy
+    participant Typer
+    
+    User->>Dispatcher: praisonai [args]
+    Dispatcher->>Version: --version/-V?
+    alt Version flag
+        Version-->>User: Print version
+    else Legacy invocation
+        Dispatcher->>Legacy: PraisonAI().main()
+        Legacy-->>User: Execute
+    else Everything else
+        Dispatcher->>Typer: Typer app()
+        Typer-->>User: Execute subcommand
+    end
+```
+
+---
+
+## Routing Rules
+
+| What you type | Route | Why |
+|---|---|---|
+| `praisonai --version` / `praisonai -V` | Version short-circuit | Prints version without importing `praisonai.cli.*` (stays fast even with broken optional deps) |
+| `praisonai` (no args) | Typer | No legacy match → Typer shows help |
+| `praisonai --help` | Typer | Leading flag is never legacy |
+| `praisonai chat ...` (registered subcommand) | Typer | Bare identifier with no spaces, not a YAML file → Typer |
+| `praisonai "Build a weather agent"` (free-text, has spaces) | Legacy `PraisonAI()` | First token contains a space |
+| `praisonai agents.yaml` (file exists) | Legacy `PraisonAI()` | Ends in `.yaml`/`.yml` AND `os.path.isfile()` is true |
+| `praisonai /typo/agents.yaml` (does NOT exist) | Typer | YAML-looking path that doesn't exist falls through so Typer can show "command not found" |
+
+---
+
+## Common Patterns
+
+<Tabs>
+<Tab title="Version Check">
+```bash
+# Fast version reporting
+praisonai --version
+praisonai -V
+
+# Works even if optional dependencies are broken
+```
+</Tab>
+
+<Tab title="Legacy Mode">
+```bash
+# Free-text prompts
+praisonai "Create a research agent for market analysis"
+praisonai "Build a chatbot with web search"
+
+# YAML configuration files
+praisonai ./config/agents.yaml
+praisonai /path/to/workflow.yml
+```
+</Tab>
+
+<Tab title="Modern CLI">
+```bash
+# Help and subcommands
+praisonai --help
+praisonai chat --model claude-3-5-sonnet-20241022
+praisonai ui --port 3000 --host 0.0.0.0
+praisonai gateway start --config gateway.yaml
+```
+</Tab>
+</Tabs>
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Use --version for health checks">
+`praisonai --version` is the fastest way to check if PraisonAI is installed and working. It short-circuits before importing heavy modules, so it works even if optional dependencies are missing.
+
+```bash
+# In scripts or health checks
+if praisonai --version > /dev/null 2>&1; then
+    echo "PraisonAI is available"
+fi
+```
+</Accordion>
+
+<Accordion title="Quote free-text prompts">
+Always wrap multi-word prompts in quotes to ensure they're treated as a single argument:
+
+```bash
+# Good
+praisonai "Build a weather forecast agent"
+
+# Bad (parsed as separate arguments)
+praisonai Build a weather forecast agent
+```
+</Accordion>
+
+<Accordion title="Check YAML files exist">
+Non-existent YAML paths fall through to Typer for better error messages. If you have a typo in your path, you'll see "command not found" instead of silent failure:
+
+```bash
+# Typo in filename → clear error
+praisonai agentss.yaml
+# Error: No such command 'agentss.yaml'
+```
+</Accordion>
+
+<Accordion title="Prefer subcommands for automation">
+Use specific subcommands instead of legacy mode in scripts for better error handling and flag support:
+
+```bash
+# Good for scripts
+praisonai chat --model gpt-4o --max-tokens 1000
+
+# Works but less flexible
+praisonai "Chat with GPT-4o"
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Dispatcher Behavior
+
+**`--version` is fast** — short-circuits before importing `praisonai.cli.*`, so version reporting works even if optional deps are broken.
+
+**`sys.argv` is always restored** after dispatch — relevant if you're calling `praisonai.__main__.main()` programmatically.
+
+**Errors fail loud** — if `register_commands()` raises (e.g. missing optional dep), the exception propagates instead of silently routing to legacy.
+
+**Exit codes propagate** — legacy `main()` returning `False` → exit code 1; `SystemExit(2)` from Typer → exit code 2.
+
+**Non-existent YAML paths route to Typer**, not legacy — so `praisonai /typo/agents.yaml` shows a clean "command not found" instead of being silently swallowed by the legacy runner.
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Workflow CLI" icon="terminal" href="/features/cli">
+Learn about specific CLI commands and options
+</Card>
+<Card title="Gateway" icon="tower-broadcast" href="/features/gateway">
+Long-running server processes and graceful shutdown
+</Card>
+</CardGroup>

--- a/docs/features/cli.mdx
+++ b/docs/features/cli.mdx
@@ -147,6 +147,9 @@ praisonai workflow help
 ## Next Steps
 
 <CardGroup>
+  <Card title="CLI Dispatcher" icon="terminal" href="/features/cli-dispatcher">
+    How praisonai routes command line arguments
+  </Card>
   <Card title="YAML Workflows" icon="file-code" href="/docs/features/yaml-workflows">
     Learn about YAML workflow configuration and patterns
   </Card>

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -339,16 +339,16 @@ session_config = SessionConfig(
 
 ## Graceful Shutdown
 
-Long-running servers can stop the wrapper's background async loop explicitly:
+The wrapper's background async loop runs on a `daemon=True` thread, so short-lived scripts (CLI commands, smoke tests) exit cleanly without any explicit cleanup. Long-running servers (gateway, a2u, mcp_server) should call `shutdown()` explicitly on `SIGTERM` / shutdown signal so in-flight async tasks (telemetry exporter flushes, async HTTP/DB client closes) finish before the process exits.
 
 ```python
 from praisonai._async_bridge import shutdown
 
-# On SIGTERM / server stop
+# On SIGTERM / server stop — explicit, deterministic cleanup
 shutdown()
 ```
 
-`shutdown()` is also registered via `atexit`, so it runs automatically on interpreter exit. Call it manually when you need deterministic cleanup (flushing telemetry exporters, closing async HTTP/DB clients) before the process exits.
+If you skip the explicit call, in-flight tasks on the bridge loop are abandoned at process exit (because the loop thread is daemon).
 
 ---
 


### PR DESCRIPTION
## Summary

Updates documentation to reflect changes from PraisonAI PR #1575 which modified the wrapper-layer async bridge and added comprehensive test coverage for the CLI dispatcher.

### Changes Made

1. **Fixed incorrect atexit statement in gateway.mdx**
   - Removed claim that shutdown() is registered via atexit
   - Updated to reflect daemon=True thread behavior
   - Explains when explicit cleanup is needed vs automatic cleanup

2. **Created new CLI dispatcher documentation**
   - Added docs/features/cli-dispatcher.mdx with comprehensive routing documentation
   - Hero Mermaid diagram showing 3-tier routing (version → legacy → Typer)
   - Complete routing rules table matching _is_legacy_invocation logic
   - Documented all 5 key behaviors from test suite
   - Added to docs.json under Features group

3. **Updated async-bridge.mdx disambiguation**
   - Added Note callout distinguishing SDK-level vs wrapper-level bridges
   - Cross-links to CLI dispatcher and gateway pages for wrapper bridge info

4. **Updated navigation and cross-links**
   - Added CLI dispatcher entry to docs.json
   - Added cross-link from cli.mdx to new dispatcher page
   - Validated JSON structure

### Quality Assurance

- All claims verified against actual source code in /tmp/PraisonAI
- Follows AGENTS.md page structure template exactly
- Uses standard Mermaid color scheme with classDef declarations
- All code examples are copy-paste runnable
- No forbidden phrases, concise writing style
- docs.json validated as valid JSON

### Test Coverage Reference

All documented CLI dispatcher behaviors are sourced from the 20 tests in src/praisonai/tests/unit/cli/test_main_dispatcher.py which pin the exact contract.

Fixes #282

Generated with [Claude Code](https://claude.ai/code)