### PR TITLE
docs(spider): document built-in URL safety + SSRF-smuggling rejections (PraisonAI #1578)

### DIFF
--- a/docs/best-practices/security.mdx
+++ b/docs/best-practices/security.mdx
@@ -1254,6 +1254,10 @@ All built-in tools that perform **side effects** (file writes, shell commands, c
 | **Spider** | `scrape_page` | — | No |
 | **Spider** | `crawl` | — | No |
 
+<Note>
+**Why spider tools don't require approval:** `scrape_page`, `extract_links`, `crawl`, and `extract_text` only read public web content and reject any URL that points to private networks, loopback, cloud metadata endpoints, or that contains SSRF-smuggling characters (backslashes, ASCII control characters). See [Spider Tools → Built-in URL Safety](/tools/spider_tools#built-in-url-safety) for the full rejection list.
+</Note>
+
 ### Configuring Approval
 
 <Tabs>

--- a/docs/tools/spider_tools.mdx
+++ b/docs/tools/spider_tools.mdx
@@ -215,6 +215,72 @@ agents.start()
   </Accordion>
 </AccordionGroup>
 
+## Built-in URL Safety
+
+Spider tools (`scrape_page`, `extract_links`, `crawl`, `extract_text`) refuse to fetch dangerous URLs **before any network request is made**. You don't need to wrap them in a custom validator.
+
+```mermaid
+graph LR
+    URL([URL from agent]) --> V{Built-in<br/>_validate_url}
+    V -->|Safe public URL| FETCH([HTTP request])
+    V -->|Private / smuggled / control char| BLK([Refused — error returned])
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef bad fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class URL input
+    class V check
+    class FETCH ok
+    class BLK bad
+```
+
+### What gets refused
+
+| URL pattern | Example | Why |
+|---|---|---|
+| Non-`http`/`https` schemes | `file:///etc/passwd`, `gopher://x` | Only web protocols are allowed |
+| Loopback | `http://127.0.0.1/`, `http://localhost/` | Blocks access to the local machine |
+| Private / reserved IPs | `http://10.0.0.5/`, `http://192.168.1.1/` | Blocks internal network access |
+| Link-local | `http://169.254.169.254/` | Blocks cloud metadata services |
+| Internal TLDs | `http://intranet.local/`, `http://svc.internal/` | Blocks corporate internal hosts |
+| Backslash in URL | `http://127.0.0.1:6666\@1.1.1.1` | SSRF-smuggling: `urlparse` says `1.1.1.1`, `requests` actually hits `127.0.0.1` |
+| ASCII control chars (`< 0x20` or `0x7f`) | `http://example.com\x00.evil.com`, `http://example.com\r\n.evil.com` | CRLF / NUL injection in the authority |
+| Non-string input | `None`, `123` | Defensive — returns `False` instead of raising |
+
+<Note>
+The backslash and control-character rejections (the last two rows above) were added in PraisonAI [#1578](https://github.com/MervinPraison/PraisonAI/pull/1578) to close an SSRF bypass where `urllib.parse.urlparse` and the HTTP client (`requests` / `httpx`) disagreed on the destination host.
+</Note>
+
+### What it looks like to your agent
+
+When the validator refuses a URL, the tool returns an error dict instead of fetching:
+
+```python
+from praisonaiagents.tools import scrape_page
+
+# Smuggled URL — looks like 1.1.1.1, would actually hit 127.0.0.1
+scrape_page("http://127.0.0.1:6666\\@1.1.1.1")
+# {'error': 'Invalid or potentially dangerous URL: http://127.0.0.1:6666\\@1.1.1.1'}
+
+# Loopback
+scrape_page("http://localhost/admin")
+# {'error': 'Invalid or potentially dangerous URL: http://localhost/admin'}
+
+# Cloud metadata endpoint
+scrape_page("http://169.254.169.254/latest/meta-data/")
+# {'error': 'Invalid or potentially dangerous URL: http://169.254.169.254/latest/meta-data/'}
+
+# Normal public URL — works as expected
+scrape_page("https://example.com/")
+# {'url': 'https://example.com/', 'status_code': 200, 'content': '...', ...}
+```
+
+<Tip>
+This validation is **always on** for the bundled spider tools. It runs on every URL passed to `scrape_page`, `extract_links`, `crawl`, and `extract_text`. There is no flag to disable it, and it does not require `enable_security()`.
+</Tip>
+
 ## Common Patterns
 
 ### Web Scraping Pipeline


### PR DESCRIPTION
## Summary

Documents the URL validation security features added in PraisonAI PR [#1578](https://github.com/MervinPraison/PraisonAI/pull/1578) that harden spider tools against SSRF attacks.

## Changes

### docs/tools/spider_tools.mdx
- Added new 'Built-in URL Safety' section with:
  - Mermaid diagram showing URL validation flow
  - Complete table of rejected URL patterns
  - Code examples showing error responses
  - Security note referencing PraisonAI #1578

### docs/best-practices/security.mdx  
- Added explanatory note to Tool Approval Matrix explaining why spider tools don't require approval
- Links to the new URL safety documentation

## Technical Details

The new validation rejects URLs containing:
- Backslashes (SSRF-smuggling bypass)
- ASCII control characters (CRLF injection)
- Private IPs, loopback, metadata endpoints
- Non-HTTP/HTTPS schemes

This is a **content-only update** - no new pages created, following AGENTS.md guidelines.

Fixes #284

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced spider tools documentation with built-in URL safety information, including validation rules and rejected URL categories.
  * Clarified security restrictions for spider tools (non-HTTP schemes, private IPs, internal TLDs, control characters).
  * Added code examples demonstrating validation behavior and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->