### PR TITLE
docs: extend PRAISONAI_ALLOW_LOCAL_TOOLS coverage + document async bridge migration

### DIFF
--- a/docs/features/approval-protocol.mdx
+++ b/docs/features/approval-protocol.mdx
@@ -60,6 +60,10 @@ class WebhookBackend:
     def request_approval_sync(self, request: ApprovalRequest) -> ApprovalDecision:
         return ApprovalDecision(approved=True, approver="webhook")
 
+<Warning>
+**Calling `request_approval_sync()` from inside an async function is no longer supported.** As of PR #1583, both `WebhookApproval.request_approval_sync()` and `HTTPApproval.request_approval_sync()` delegate to `praisonai._async_bridge.run_sync()`, which raises `RuntimeError` when called from a running event loop. Use `await approval.request_approval(request)` from async code; reserve `request_approval_sync` for synchronous entry points (CLI, sync test harnesses).
+</Warning>
+
 agent = Agent(
     name="bot",
     instructions="You are a helpful assistant.",

--- a/docs/features/async-agent-scheduler.mdx
+++ b/docs/features/async-agent-scheduler.mdx
@@ -135,6 +135,10 @@ sequenceDiagram
 
 The AsyncAgentScheduler uses async-native execution with cooperative cancellation, replacing the old thread-based scheduler.
 
+<Note>
+The scheduler's async primitives (`_stop_event`, `_cancel_event`, `_stats_lock`) are now created lazily inside `_ensure_async_primitives()` and bound to the loop that `start()` runs on. Tests that call `stop()` without first calling `start()` must invoke `scheduler._ensure_async_primitives()` explicitly — see `tests/unit/scheduler/test_async_agent_scheduler.py` in PR #1583 for the canonical pattern.
+</Note>
+
 ---
 
 ## Schedule Expression Reference

--- a/docs/features/async-bridge.mdx
+++ b/docs/features/async-bridge.mdx
@@ -264,6 +264,21 @@ async def smart_helper_async():
 
 ---
 
+## Used by
+
+The following synchronous APIs route through `run_sync()` and therefore honour `PRAISONAI_RUN_SYNC_TIMEOUT` consistently:
+
+- `praisonai.bots.WebhookApproval.request_approval_sync()`
+- `praisonai.bots.HTTPApproval.request_approval_sync()`
+- `praisonai.integrations.get_available_integrations()`
+- All ~77 wrapper-side `run_sync` call sites (gateway, a2u, mcp_server, scheduler) — see PR #1583 for the full list.
+
+<Warning>
+These sync wrappers now raise `RuntimeError("run_sync() cannot be called from a running event loop; await the coroutine directly instead.")` when called from inside an active asyncio loop. Previously they would silently spawn a worker thread. **If you call any of these from async code, switch to `await request_approval(...)` (or the equivalent async method) directly.** This is a deliberate fail-fast change — the silent thread spawn was masking architectural bugs in multi-agent setups.
+</Warning>
+
+---
+
 ## Troubleshooting
 
 ### RuntimeError: run_coroutine_from_any_context() cannot be called from async context

--- a/docs/features/security-environment-variables.mdx
+++ b/docs/features/security-environment-variables.mdx
@@ -99,12 +99,20 @@ export PRAISONAI_ALLOW_LOCAL_TOOLS=true
 unset PRAISONAI_ALLOW_LOCAL_TOOLS
 ```
 
-**Affected Components**:
-- Tool resolver system
-- Agent API calls
-- Real-time UI interactions
+**Affected Components** (verified against PR #1583 head `12eb019b`):
+- `praisonaiagents` agent generator (`load_tools_from_tools_py`, `generate_crew_and_kickoff`)
+- `praisonai run` YAML workflows (recipe `tools.py` under `_run_yaml_workflow`)
+- `praisonai research --tools <file.py>`
+- `praisonai chat --rewrite-tools <file.py>` and `--expand-tools <file.py>`
+- Generic CLI `_load_tools(tools_path)`
+- HTTP API: `praisonai.api.call.import_tools_from_file` (raises `ValueError` if disabled)
+- Path-traversal guard: files outside the current working directory are refused even when `PRAISONAI_ALLOW_LOCAL_TOOLS=true`
 
-As of recent PraisonAI versions, the `PRAISONAI_ALLOW_LOCAL_TOOLS` gate is enforced consistently across the CLI (`praisonai run`), YAML workflows, and Python (`AgentsGenerator`) entry points. Previously it was only enforced on one path.
+<Note>
+Even when `PRAISONAI_ALLOW_LOCAL_TOOLS=true`, the loader refuses any path outside the current working directory. This is a deliberate defence-in-depth layer for HTTP-API callers (`praisonai.api.call.import_tools_from_file`) where the path can come from network input. Move the `tools.py` you want to load into your CWD if you hit `Refusing to exec ... outside working directory.` in the logs.
+</Note>
+
+`PRAISONAI_ALLOW_LOCAL_TOOLS` accepts only `true` (case-insensitive). Values like `1`, `yes`, or `on` are **not** truthy for this variable (unlike `PRAISONAI_ALLOW_TEMPLATE_TOOLS`).
 
 **Usage Example**:
 ```python
@@ -118,6 +126,16 @@ agent = Agent(
 
 agent.start("Calculate using local tools")
 ```
+
+**Error & Warning Messages**
+
+| When | Where it appears | Message |
+|------|------------------|---------|
+| Env var unset, CLI tool loader (research/rewrite/expand/recipe) | stdout (rich `[yellow]`) | `Warning: Tools loading disabled. Set PRAISONAI_ALLOW_LOCAL_TOOLS=true to enable.` |
+| Env var unset, agent generator | logger.warning | `Refusing to exec tools.py: set PRAISONAI_ALLOW_LOCAL_TOOLS=true to enable.` |
+| Env var unset, HTTP API (`api/call.py`) | raised exception | `ValueError("Local tools loading disabled. Set PRAISONAI_ALLOW_LOCAL_TOOLS=true to enable.")` |
+| Path outside CWD, env var **set** | logger.warning | `Refusing to exec <path>: outside working directory.` |
+| Path outside CWD via HTTP API, env var **set** | raised exception | `LocalToolsDisabled("Refusing to exec <path>: outside working directory.")` |
 
 ### PRAISONAI_ALLOW_JOB_WORKFLOWS
 
@@ -271,6 +289,7 @@ Check if you use any of these features:
 - Local `tools.py` files
 - Job or hybrid workflows with shell/script execution
 - Browser server binding to `0.0.0.0`
+- HTTP API callers that pass a `file_path` to `praisonai.api.call.import_tools_from_file` — these now raise `ValueError` until you opt in
 </Step>
 
 <Step title="Add Environment Variables">
@@ -383,6 +402,8 @@ These environment variables address the following security vulnerabilities:
 **Fixed Versions**:
 - **praisonai**: `>=0.0.57` 
 - **praisonaiagents**: `>=0.0.23`
+
+PR #1583 (2026-04-30) extended `PRAISONAI_ALLOW_LOCAL_TOOLS` enforcement to research/rewrite/expand/recipe tool-loading paths and the HTTP API, and added a CWD-only path constraint as defence-in-depth. No new advisory was filed; the threat model is unchanged from GHSA-g985-wjh9-qxxc.
 
 ---
 


### PR DESCRIPTION
Fixes #291

This PR updates the documentation to reflect the changes from upstream PR #1583, which extended PRAISONAI_ALLOW_LOCAL_TOOLS enforcement and migrated approval/integration systems to use the async bridge.

## Changes Made

### docs/features/security-environment-variables.mdx
- **Affected Components**: Updated with complete list of 7 components now covered by PRAISONAI_ALLOW_LOCAL_TOOLS
- **Path-traversal guard**: Added note about CWD-only restriction as defence-in-depth
- **Truthy value clarification**: Documented that only 'true' (case-insensitive) is accepted
- **Error & Warning Messages table**: Added comprehensive reference for all warning/error messages
- **Migration Guide**: Added HTTP API callers bullet point
- **Security Advisories**: Added note about PR #1583 extending coverage

### docs/features/async-bridge.mdx
- **Used by section**: Added new section listing APIs that route through run_sync()
- **RuntimeError warning**: Added warning about calling sync wrappers from async contexts

### docs/features/approval-protocol.mdx
- **Async context callout**: Added warning about request_approval_sync() no longer working from async code

### docs/features/async-agent-scheduler.mdx
- **Lifecycle note**: Added note about _ensure_async_primitives() for test scenarios

All changes follow AGENTS.md standards and were verified against the actual source code from the upstream PR.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced guidance on async/sync approval workflows with error handling details
  * Clarified scheduler lifecycle requirements and initialization patterns
  * Expanded security documentation for environment variables with comprehensive rule sets and error messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->