### PR TITLE
docs: cover PR #1597 — persistence registry/plugins, schema-prefix change, secure-by-default API server, MCP rules path safety, thread-safe LLM registry

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -580,6 +580,7 @@
                   "docs/features/event-bus",
                   "docs/features/plugins",
                   "docs/features/framework-adapter-plugins",
+                  "docs/features/persistence-backend-plugins",
                   "docs/features/agent-server",
                   "docs/features/agent-profiles",
                   "docs/features/messaging-channels-strategy",

--- a/docs/deploy/api/index.mdx
+++ b/docs/deploy/api/index.mdx
@@ -22,7 +22,33 @@ export OPENAI_API_KEY="your-key"
 praisonai serve unified --host 127.0.0.1 --port 8765
 ```
 
+<Warning>
+**Security Note (PR #1597):** PraisonAI API servers are now **secure-by-default**. Authentication is enabled and servers bind to `127.0.0.1` by default. If no token is provided, a random bearer token is generated and printed to stderr.
+</Warning>
+
 **Server running at:** `http://127.0.0.1:8765`
+
+### Authentication
+
+Use the bearer token printed at startup:
+
+```bash
+curl http://127.0.0.1:8765/agents \
+  -H "Authorization: Bearer $PRAISONAI_API_TOKEN"
+```
+
+Override defaults with environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PRAISONAI_API_AUTH` | `enabled` | Set to `disabled` to turn off authentication |
+| `PRAISONAI_API_TOKEN` | auto-generated | Custom bearer token |
+| `PRAISONAI_API_HOST` | `127.0.0.1` | Bind host (use `0.0.0.0` for external access) |
+| `PRAISONAI_API_PORT` | `8765` | Port number |
+
+<Warning>
+Setting `PRAISONAI_API_HOST=0.0.0.0` exposes the server on all interfaces. Always pair external binding with authentication or a fronting proxy.
+</Warning>
 
 ## Base URL
 

--- a/docs/features/knowledge-backends.mdx
+++ b/docs/features/knowledge-backends.mdx
@@ -179,6 +179,30 @@ except BackendNotAvailableError as e:
     print(f"Backend not available: {e}")
 ```
 
+## Collection Naming Rules
+
+<Note>
+**Enhanced Security (PR #1597):** Knowledge stores now validate collection names to prevent SQL injection attacks.
+</Note>
+
+Knowledge stores that interpolate collection names into DDL/DML now require collection names to match `^[A-Za-z0-9_]+$`. Affected backends:
+- Cassandra
+- pgvector
+- SingleStore vector
+
+Invalid names raise: `ValueError("collection_name must be non-empty and contain only alphanumerics and underscores")`
+
+**Valid examples:**
+- `my_collection`
+- `UserData123`
+- `agent_v2_docs`
+
+**Invalid examples:**
+- `my-collection` (contains hyphen)
+- `user.docs` (contains dot)
+- `data collection` (contains space)
+- `../../etc` (path traversal attempt)
+
 ## Best Practices
 
 1. **Always provide scope identifiers** for mem0 backend
@@ -186,3 +210,4 @@ except BackendNotAvailableError as e:
 3. **Use agent_id for shared agent knowledge** (company policies, FAQs)
 4. **Use run_id for ephemeral session data** (conversation context)
 5. **Prefer Agent API over direct Knowledge API** for most use cases
+6. **Use alphanumeric collection names** to ensure compatibility across all backends

--- a/docs/features/persistence-backend-plugins.mdx
+++ b/docs/features/persistence-backend-plugins.mdx
@@ -1,0 +1,242 @@
+---
+title: "Persistence Backend Plugins"
+sidebarTitle: "Persistence Backend Plugins"
+description: "Add custom conversation, knowledge, and state stores via Python entry points"
+icon: "puzzle-piece"
+---
+
+Persistence backend plugins extend PraisonAI with custom storage solutions for conversations, knowledge, and state management through a centralized registry system.
+
+```mermaid
+graph LR
+    subgraph "Plugin System"
+        A[📦 Third-party Package] --> B[🔌 Entry Point]
+        B --> C[📝 StoreRegistry]
+        C --> D{Kind?}
+        D -->|conversation| E[💬 Conversation]
+        D -->|knowledge|    F[📚 Knowledge]
+        D -->|state|        G[🔄 State]
+    end
+    
+    classDef package fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef entrypoint fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef registry fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef stores fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A package
+    class B entrypoint
+    class C registry
+    class D,E,F,G stores
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Register a Custom Backend">
+```python
+from praisonai.persistence.registry import CONVERSATION_STORES
+
+def my_store_factory(url=None, **kwargs):
+    from my_pkg import MyConversationStore
+    return MyConversationStore(url=url, **kwargs)
+
+CONVERSATION_STORES.register("mybackend", my_store_factory, aliases=("mb",))
+
+store = CONVERSATION_STORES.create("mb", url="proto://host")
+```
+</Step>
+
+<Step title="Create an Entry-Point Plugin">
+```toml
+[project.entry-points."praisonai.conversation_stores"]
+mybackend = "my_pkg.factory:create_store"
+
+[project.entry-points."praisonai.knowledge_stores"]
+mybackend = "my_pkg.factory:create_kstore"
+
+[project.entry-points."praisonai.state_stores"]
+mybackend = "my_pkg.factory:create_sstore"
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant Registry as StoreRegistry
+    participant Factory as Backend Factory
+    participant Store as Store Instance
+    
+    App->>Registry: create("backend", **kwargs)
+    Registry->>Registry: resolve alias → canonical
+    Registry->>Factory: factory(**kwargs)
+    Factory->>Store: instantiate store
+    Store-->>Factory: store instance
+    Factory-->>Registry: store instance
+    Registry-->>App: store instance
+```
+
+The plugin system provides three global registries for different storage types:
+
+| Registry | Kind | Entry-point Group | Purpose |
+|----------|------|-------------------|---------|
+| `CONVERSATION_STORES` | `"conversation"` | `praisonai.conversation_stores` | Chat history and sessions |
+| `KNOWLEDGE_STORES` | `"knowledge"` | `praisonai.knowledge_stores` | Vector databases and RAG |
+| `STATE_STORES` | `"state"` | `praisonai.state_stores` | Application state and cache |
+
+---
+
+## Registry API Reference
+
+Each `StoreRegistry` provides a thread-safe API for backend management:
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `register` | `register(name: str, factory: Callable, *, aliases=()) -> None` | Register a backend factory with optional aliases |
+| `create` | `create(name: str, **kwargs) -> Any` | Create a store instance by name or alias |
+| `list_registered` | `() -> list[str]` | Get all registered backend names (sorted) |
+| `list_aliases` | `() -> dict[str, str]` | Get alias → canonical name mappings |
+
+---
+
+## Built-in Backends
+
+### Conversation Stores
+
+**Primary backends:** `postgres`, `async_postgres`, `mysql`, `async_mysql`, `sqlite`, `async_sqlite`, `json`, `singlestore`, `supabase`, `surrealdb`, `turso`
+
+**Aliases available:**
+- `neon`, `cockroachdb`, `crdb`, `cockroach`, `xata` → `postgres`
+- `asyncpg`, `postgres_async` → `async_postgres` 
+- `aiomysql`, `mysql_async` → `async_mysql`
+- `aiosqlite`, `sqlite_async` → `async_sqlite`
+- `libsql` → `turso`
+
+### Knowledge Stores
+
+**Primary backends:** `chroma`, `qdrant`, `pinecone`, `weaviate`, `lancedb`, `milvus`, `pgvector`, `redis`, `cassandra`, `clickhouse`, `mongodb_vector`, `couchbase`, `singlestore_vector`, `surrealdb_vector`, `upstash_vector`, `lightrag`, `langchain`, `llamaindex`, `cosmosdb`
+
+**Aliases available:**
+- `chromadb` → `chroma`
+- `mongodb_atlas`, `mongo_vector` → `mongodb_vector`
+- `singlestore_v` → `singlestore_vector`
+- `surrealdb_v` → `surrealdb_vector`
+- `upstash_v` → `upstash_vector`
+- `langchain_adapter` → `langchain`
+- `llama_index`, `llamaindex_adapter` → `llamaindex`
+- `cosmos`, `azure_cosmos`, `cosmosdb_vector` → `cosmosdb`
+
+### State Stores
+
+**Primary backends:** `redis`, `dynamodb`, `firestore`, `mongodb`, `async_mongodb`, `upstash`, `memory`, `gcs`
+
+**Aliases available:**
+- `motor`, `mongodb_async` → `async_mongodb`
+
+---
+
+## Common Patterns
+
+<AccordionGroup>
+<Accordion title="Custom Database Adapter">
+```python
+from praisonai.persistence.registry import CONVERSATION_STORES
+
+class CustomDBConversationStore:
+    def __init__(self, url=None, **kwargs):
+        self.url = url
+        # Initialize your database connection
+        
+    def save_session(self, session):
+        # Save implementation
+        pass
+        
+    def load_session(self, session_id):
+        # Load implementation  
+        pass
+
+def create_custom_db(url=None, **kwargs):
+    return CustomDBConversationStore(url=url, **kwargs)
+
+# Register at runtime
+CONVERSATION_STORES.register("customdb", create_custom_db)
+
+# Use it
+store = CONVERSATION_STORES.create("customdb", url="custom://localhost:5432/db")
+```
+</Accordion>
+
+<Accordion title="Multi-Backend Package">
+```python
+# my_storage_package/__init__.py
+def register_all_backends():
+    from praisonai.persistence.registry import (
+        CONVERSATION_STORES, KNOWLEDGE_STORES, STATE_STORES
+    )
+    
+    CONVERSATION_STORES.register("myconv", create_conversation_store)
+    KNOWLEDGE_STORES.register("myknow", create_knowledge_store) 
+    STATE_STORES.register("mystate", create_state_store)
+
+# Auto-register on import
+register_all_backends()
+```
+</Accordion>
+
+<Accordion title="Listing Available Backends">
+```python
+from praisonai.persistence.registry import (
+    CONVERSATION_STORES, KNOWLEDGE_STORES, STATE_STORES,
+)
+
+print("Conversation backends:", CONVERSATION_STORES.list_registered())
+print("Knowledge backends:", KNOWLEDGE_STORES.list_registered())
+print("State backends:", STATE_STORES.list_registered())
+
+# Check aliases
+print("Aliases:", CONVERSATION_STORES.list_aliases())
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Thread Safety">
+All registries are thread-safe with `threading.Lock` protection. Registrations and creations can be called concurrently without external synchronization. Factory functions should also be thread-safe if used in multi-threaded environments.
+</Accordion>
+
+<Accordion title="Error Handling">
+Registry creation raises `ValueError` for unknown backends with a list of available options. Factory functions should handle their own connection errors and invalid parameters appropriately.
+</Accordion>
+
+<Accordion title="Lazy Loading">
+Built-in backends use lazy imports to avoid loading unused dependencies. Follow this pattern in custom backends to minimize startup time and reduce import-time failures.
+</Accordion>
+
+<Accordion title="Naming Conventions">
+- Use lowercase names without special characters
+- Provide meaningful aliases for user convenience  
+- Follow existing patterns: `async_*` for async variants, `*_vector` for vector stores
+- Avoid conflicts with built-in backend names
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Framework Adapter Plugins" icon="plug" href="/docs/features/framework-adapter-plugins">
+  Plugin system for multi-agent frameworks
+</Card>
+<Card title="Persistence Overview" icon="database" href="/docs/persistence/overview">
+  Storage backends and configuration
+</Card>
+</CardGroup>

--- a/docs/features/rules.mdx
+++ b/docs/features/rules.mdx
@@ -248,6 +248,24 @@ project/
         └── global.md
 ```
 
+## Security & Path Safety
+
+<Note>
+**Enhanced in PR #1597:** MCP `praisonai.rules.*` tools now validate `rule_name` against path traversal attacks.
+</Note>
+
+The `praisonai.rules.show`, `create`, and `delete` MCP tools validate rule names to prevent path traversal:
+
+**Rejected inputs:**
+- Contains `/`, `\`, or `\x00` (NUL byte)
+- Starts with `.` (blocks hidden files and `..`)
+- Equals `.` or `..`
+- The resolved path escapes `~/.praison/rules/` (symlink-safe)
+
+**Allowed pattern:** Single filename with alphanumerics, underscores, hyphens, and dots (not leading), located strictly inside `~/.praison/rules/`.
+
+**Error format:** `Error: invalid rule_name: '<value>'`
+
 ## Programmatic Rules Management
 
 ```python

--- a/docs/models/custom-provider.mdx
+++ b/docs/models/custom-provider.mdx
@@ -43,6 +43,24 @@ register_llm_provider("my-custom", MyCustomProvider)
 provider = create_llm_provider("my-custom/my-model")
 ```
 
+## Thread Safety
+
+<Note>
+**Enhanced in PR #1597:** `LLMProviderRegistry` is now thread-safe with singleton access and `RLock` protection for all operations.
+</Note>
+
+All registry methods (`register`, `unregister`, `resolve`, alias lookup, and listing) are **safe to call concurrently** from threads. Built-in providers are registered automatically on first instantiation.
+
+**Singleton access pattern (preferred for app code):**
+
+```python
+from praisonai.llm.registry import LLMProviderRegistry
+
+registry = LLMProviderRegistry.get_instance()  # double-checked-locked singleton
+```
+
+The existing helpers `register_llm_provider` / `create_llm_provider` continue to work unchanged (backwards compatible).
+
 ## How Provider Resolution Works
 
 The registry resolves providers in this order:

--- a/docs/persistence/overview.mdx
+++ b/docs/persistence/overview.mdx
@@ -36,9 +36,28 @@ pip install "praisonaiagents[tools]"
 
 | Category | Backends | Count |
 |----------|----------|-------|
-| **Conversation** | PostgreSQL, MySQL, SQLite, SingleStore, Supabase, SurrealDB | 6 |
-| **Knowledge** | Qdrant, ChromaDB, Pinecone, Weaviate, LanceDB, Milvus, PGVector, Redis, Cassandra, ClickHouse | 10 |
-| **State** | Redis, MongoDB, DynamoDB, Firestore, Upstash, Memory | 6 |
+| **Conversation** | PostgreSQL, MySQL, SQLite, SingleStore, Supabase, SurrealDB, Turso | 7 |
+| **Knowledge** | Qdrant, ChromaDB, Pinecone, Weaviate, LanceDB, Milvus, PGVector, Redis, Cassandra, ClickHouse, MongoDB Vector, Couchbase, SingleStore Vector, SurrealDB Vector, Upstash Vector, LightRAG, LangChain, LlamaIndex, CosmosDB | 19 |
+| **State** | Redis, MongoDB, DynamoDB, Firestore, Upstash, Memory, GCS | 7 |
+
+## Backend Aliases
+
+The persistence registry provides user-friendly aliases for common databases:
+
+**Conversation stores:**
+- `neon`, `cockroachdb`, `xata` → `postgres`
+- `asyncpg`, `postgres_async` → `async_postgres` 
+- `aiomysql`, `mysql_async` → `async_mysql`
+- `aiosqlite`, `sqlite_async` → `async_sqlite`
+- `libsql` → `turso`
+
+**Knowledge stores:**
+- `chromadb` → `chroma`
+- `mongodb_atlas`, `cosmos`, `azure_cosmos` → Vector store variants
+- `llama_index`, `langchain_adapter` → Framework adapters
+
+**State stores:**
+- `motor`, `mongodb_async` → `async_mongodb`
 
 ## Architecture
 
@@ -78,8 +97,27 @@ The `DbAdapter`'s lazy store initialisation is also race-free: the first thread 
 These improvements were added in PraisonAI PR #1466 to ensure robust multi-threaded operation in production environments.
 </Note>
 
+## Schema Migration (PR #1597)
+
+<Warning>
+**Breaking change:** All async conversation stores (`async_sqlite`, `async_postgres`, `async_mysql`) now default to **`table_prefix="praison_"`** (previously `"praisonai_"`). Sync stores were already on `praison_`.
+</Warning>
+
+If you ran an async store before this release, either:
+1. Pass `table_prefix="praisonai_"` explicitly to keep your old tables, **or**
+2. Rename existing tables: `ALTER TABLE praisonai_sessions RENAME TO praison_sessions;` (and likewise for `_messages`).
+
+**New columns:** Async session/message schemas now include `state` (sessions), and `tool_calls` + `tool_call_id` (messages). The store creates them automatically on first connect via `CREATE TABLE IF NOT EXISTS`. Existing tables on a pre-#1597 schema will not auto-migrate; add the columns with:
+
+```sql
+ALTER TABLE praison_sessions ADD COLUMN state TEXT;
+ALTER TABLE praison_messages ADD COLUMN tool_calls TEXT;
+ALTER TABLE praison_messages ADD COLUMN tool_call_id TEXT;
+```
+
 ## Next Steps
 
 - [Quickstart](/docs/persistence/quickstart) - Get started in 5 minutes
 - [Session Resume](/docs/persistence/session-resume) - Continue conversations
 - [CLI Reference](/docs/cli/persistence) - Command-line usage
+- [Backend Plugins](/docs/features/persistence-backend-plugins) - Custom storage backends


### PR DESCRIPTION
Fixes #302

This PR comprehensively documents all 6 user-visible changes from PraisonAI PR #1597:

## 📝 New Documentation

- **New page:** docs/features/persistence-backend-plugins.mdx - Complete guide to the persistence registry system with entry-point plugins

## 🔄 Updated Documentation

- **Persistence Overview** - Added backend aliases section and schema migration notes for the praisonai_ → praison_ prefix change
- **API Documentation** - Documented secure-by-default changes (auth enabled, localhost binding, auto-generated tokens)
- **Custom Provider** - Added thread-safe LLM registry information with singleton pattern
- **Rules & Instructions** - Added MCP path validation security to prevent traversal attacks  
- **Knowledge Backends** - Added collection naming rules to prevent SQL injection
- **Navigation** - Updated docs.json with new persistence plugins page

## ✅ Verified from Source Code

All technical details verified against actual source code in /tmp/PraisonAI/src/praisonai/:
- Registry implementation with 3 global stores and entry-point groups
- API server security defaults and environment variables
- LLM registry thread safety with RLock and singleton
- MCP _resolve_rule_path validation logic
- Knowledge store validate_identifier function

🤖 Generated with Claude Code