### PR TITLE
docs: update sandbox, async scheduler, and persistence docs for PraisonAI PR #1609

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -308,6 +308,7 @@
                       "docs/features/model-failover",
                       "docs/features/reliability",
                       "docs/features/sandbox",
+                      "docs/features/sandbox-backends",
                       "docs/features/external-cli-integrations",
                       "docs/features/cli-backend-protocol",
                       "docs/features/external-agents-ui",

--- a/docs/features/async-agent-scheduler.mdx
+++ b/docs/features/async-agent-scheduler.mdx
@@ -96,8 +96,8 @@ async def main():
         await asyncio.sleep(3600)  # Run for 1 hour
     finally:
         await scheduler.stop()
-        stats = await scheduler.get_stats()
-        print(f"Completed {stats['success_count']} successful executions")
+        stats = await scheduler.get_stats_async()
+        print(f"Completed {stats['successful_executions']} successful executions")
 
 asyncio.run(main())
 ```
@@ -174,16 +174,46 @@ The scheduler's async primitives (`_stop_event`, `_cancel_event`, `_stats_lock`)
 | `max_retries` | `int` | `3` | Maximum retry attempts on failure |
 | `run_immediately` | `bool` | `False` | If True, run agent immediately before starting schedule |
 
-### get_stats() Response
+### Reading Stats
+
+Statistics can be read in both sync and async contexts with different guarantees:
+
+```mermaid
+graph LR
+    A[Async Caller] --> B[get_stats_async()]
+    B --> C[_stats_lock]
+    C --> D[Atomic Snapshot]
+    
+    E[Sync Caller] --> F[get_stats() / get_stats_sync()]
+    F --> G[Direct Read]
+    G --> H[May Tear]
+    
+    classDef async fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef sync fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef atomic fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef tear fill:#8B0000,stroke:#7C90A0,color:#fff
+    
+    class A,B async
+    class E,F sync
+    class C,D atomic
+    class H tear
+```
+
+| Method | Sync/Async | Atomicity | When to Use |
+|--------|-----------|-----------|-------------|
+| `get_stats()` | sync | **Best-effort, NOT atomic** — counters may be observed mid-update | Quick sync checks, tests, scripts |
+| `get_stats_sync()` | sync | Alias for `get_stats()` (same best-effort behaviour, named for clarity) | When you want the sync intent obvious in code |
+| `get_stats_async()` | async | **Atomic snapshot** under `_stats_lock` | Inside async code paths where consistency matters |
+
+### Stats Response Format
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `is_running` | `bool` | Whether scheduler is currently running |
-| `execution_count` | `int` | Total number of execution attempts |
-| `success_count` | `int` | Number of successful executions |
-| `failure_count` | `int` | Number of failed executions |
-| `agent_name` | `str` | Name of the agent being scheduled |
-| `task` | `str` | Task description being executed |
+| `total_executions` | `int` | Total number of execution attempts |
+| `successful_executions` | `int` | Number of successful executions |
+| `failed_executions` | `int` | Number of failed executions |
+| `success_rate` | `float` | Success percentage (0-100) |
 
 ---
 
@@ -282,7 +312,7 @@ async def main():
     finally:
         if scheduler:
             await scheduler.stop()
-            stats = await scheduler.get_stats()
+            stats = await scheduler.get_stats_async()
             print(f"Final stats: {stats}")
 
 asyncio.run(main())

--- a/docs/features/async-scheduler.mdx
+++ b/docs/features/async-scheduler.mdx
@@ -93,7 +93,7 @@ async def main():
     await scheduler.start("*/30m", max_retries=5)
     
     # Monitor stats
-    stats = await scheduler.get_stats()
+    stats = await scheduler.get_stats_async()
     print(f"Stats: {stats}")
     
     await scheduler.stop()

--- a/docs/features/sandbox-backends.mdx
+++ b/docs/features/sandbox-backends.mdx
@@ -1,0 +1,333 @@
+---
+title: "Sandbox Backends"
+sidebarTitle: "Sandbox Backends"
+description: "Execute commands safely with configurable shell control across different backends"
+icon: "shield"
+---
+
+Sandbox backends provide isolated command execution environments with explicit shell control to prevent injection attacks while enabling shell features when needed.
+
+```mermaid
+graph LR
+    subgraph "Sandbox Command Execution"
+        A[📝 Command] --> B{🔍 shell=?}
+        B -->|False| C[🛡️ Safe Parse]
+        B -->|True| D[⚠️ Shell Features]
+        C --> E[✅ Execute]
+        D --> E
+    end
+    
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef safe fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef shell fill:#8B0000,stroke:#7C90A0,color:#fff
+    
+    class A input
+    class B decision
+    class C,E safe
+    class D shell
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Safe Command Execution">
+Execute commands safely without shell features:
+
+```python
+from praisonaiagents import Agent
+from praisonai.sandbox import SubprocessSandbox
+
+# Create agent with safe command execution
+agent = Agent(
+    name="System Agent",
+    instructions="Execute system commands safely",
+)
+
+# Create sandbox for safe execution
+sandbox = SubprocessSandbox()
+
+# Execute without shell (default, safe)
+result = await sandbox.run_command("ls -la")
+print(result.stdout)
+```
+</Step>
+
+<Step title="With Shell Features">
+Enable shell features when needed:
+
+```python
+from praisonaiagents import Agent
+from praisonai.sandbox import DockerSandbox
+
+agent = Agent(
+    name="Data Agent", 
+    instructions="Process data with shell pipelines"
+)
+
+sandbox = DockerSandbox()
+
+# Execute with shell features (explicit opt-in)
+result = await sandbox.run_command(
+    "cat data.txt | grep 'error' | wc -l",
+    shell=True
+)
+print(f"Error count: {result.stdout.strip()}")
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Sandbox
+    participant Shell
+    participant Process
+    
+    Agent->>Sandbox: run_command(cmd, shell=False)
+    alt shell=False (Safe)
+        Sandbox->>Shell: shlex.split(cmd)
+        Shell->>Process: exec(*argv)
+    else shell=True (Features)
+        Sandbox->>Shell: sh -c "cmd"
+        Shell->>Process: shell execution
+    end
+    Process-->>Sandbox: Result
+    Sandbox-->>Agent: SandboxResult
+```
+
+| Backend | Use Case | Security Level |
+|---------|----------|----------------|
+| `SubprocessSandbox` | Local development, scripts | Medium (OS-level isolation) |
+| `DockerSandbox` | Production, untrusted code | High (container isolation) |
+| `SSHSandbox` | Remote execution | High (network isolation) |
+
+---
+
+## Configuration Options
+
+### Shell Parameter Control
+
+<Tabs>
+<Tab title="shell=False (Default)">
+```python
+# String commands are parsed safely
+result = await sandbox.run_command("python script.py --arg value")
+
+# List commands are executed directly
+result = await sandbox.run_command(["python", "script.py", "--arg", "value"])
+```
+
+**Security**: No shell injection possible. String commands are parsed with `shlex.split()`.
+</Tab>
+
+<Tab title="shell=True (Opt-in)">
+```python
+# Shell features available: pipes, redirects, globs
+result = await sandbox.run_command(
+    "find . -name '*.py' | xargs grep 'TODO' > todos.txt",
+    shell=True
+)
+
+# Environment variable expansion
+result = await sandbox.run_command(
+    "echo $HOME && ls $PWD/*.log", 
+    shell=True
+)
+```
+
+**Security**: Shell evaluation enabled. Only use with trusted input.
+</Tab>
+</Tabs>
+
+<Warning>
+Set `shell=True` only when you need shell features (pipes, `&&`, globbing). With untrusted input always keep `shell=False`.
+</Warning>
+
+### Decision Guide
+
+```mermaid
+graph TB
+    A[Need to run command?] --> B{Need pipes/globs?}
+    B -->|No| C[Use shell=False]
+    B -->|Yes| D{Input trusted?}
+    D -->|Yes| E[Use shell=True]
+    D -->|No| F[Sanitize OR use shell=False]
+    
+    classDef safe fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef caution fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef danger fill:#8B0000,stroke:#7C90A0,color:#fff
+    
+    class C,F safe
+    class D,E caution
+```
+
+| Use Case | Recommended `shell` Value |
+|----------|---------------------------|
+| Running a single executable with arguments | `False` |
+| Pipelines (`grep \| sort`) | `True` |
+| Globs and env-var expansion | `True` |
+| Untrusted / model-generated commands | `False` |
+
+---
+
+## Common Patterns
+
+### Backend Selection
+
+<Tabs>
+<Tab title="Development">
+```python
+from praisonai.sandbox import SubprocessSandbox
+
+# Local development with subprocess
+sandbox = SubprocessSandbox()
+result = await sandbox.run_command("python test.py")
+```
+</Tab>
+
+<Tab title="Production">
+```python  
+from praisonai.sandbox import DockerSandbox
+
+# Isolated container execution
+sandbox = DockerSandbox(
+    image="python:3.11-slim",
+    timeout=30
+)
+result = await sandbox.run_command("python app.py", shell=False)
+```
+</Tab>
+
+<Tab title="Remote">
+```python
+from praisonai.sandbox import SSHSandbox
+
+# Remote server execution
+sandbox = SSHSandbox(
+    host="remote.server.com",
+    username="runner"
+)
+result = await sandbox.run_command(["python", "remote_task.py"])
+```
+</Tab>
+</Tabs>
+
+### Safe Data Processing
+
+```python
+from praisonai.sandbox import DockerSandbox
+
+sandbox = DockerSandbox()
+
+# Process user data safely
+async def process_file(filename):
+    # Safe: no shell injection possible
+    result = await sandbox.run_command([
+        "python", "process.py", "--input", filename
+    ], shell=False)
+    return result.stdout
+
+# Process with shell features when controlled
+async def count_errors(log_file):
+    import shlex
+    # Trusted input, need shell features  
+    result = await sandbox.run_command(
+        f"grep 'ERROR' {shlex.quote(log_file)} | wc -l",
+        shell=True
+    )
+    return int(result.stdout.strip())
+```
+
+### Resource Limits
+
+```python
+from praisonai.sandbox import ResourceLimits, SubprocessSandbox
+
+limits = ResourceLimits(
+    timeout_seconds=30,
+    memory_mb=512
+)
+
+sandbox = SubprocessSandbox()
+result = await sandbox.run_command(
+    "python heavy_task.py",
+    limits=limits,
+    shell=False
+)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Always use shell=False for untrusted input">
+Model-generated commands or user input should never use `shell=True` to prevent injection attacks. The default `shell=False` provides automatic protection.
+
+```python
+# ✅ Safe with any user input
+user_script = request.get("script")
+result = await sandbox.run_command(f"python {user_script}", shell=False)
+
+# ❌ Vulnerable to injection
+result = await sandbox.run_command(f"python {user_script}", shell=True)
+```
+</Accordion>
+
+<Accordion title="Quote arguments when building shell commands">
+If you must use `shell=True`, quote all dynamic arguments with `shlex.quote()`:
+
+```python
+import shlex
+
+filename = user_input  # Could contain special characters
+command = f"process.py --file {shlex.quote(filename)}"
+result = await sandbox.run_command(command, shell=True)
+```
+</Accordion>
+
+<Accordion title="Prefer list form for complex commands">
+Using argument lists avoids shell parsing entirely:
+
+```python
+# ✅ Clear and injection-safe
+result = await sandbox.run_command([
+    "python", "script.py", 
+    "--input", input_file,
+    "--output", output_file
+], shell=False)
+
+# ❌ Requires careful quoting
+import shlex
+command = f"python script.py --input {shlex.quote(input_file)} --output {shlex.quote(output_file)}"
+result = await sandbox.run_command(command, shell=True)
+```
+</Accordion>
+
+<Accordion title="Use appropriate backend for your security needs">
+Choose the sandbox backend based on your isolation requirements:
+
+- **Development**: `SubprocessSandbox` for speed and convenience
+- **Production**: `DockerSandbox` for container-level isolation  
+- **Remote**: `SSHSandbox` for network-isolated execution
+- **High Security**: Always use Docker or SSH backends with `shell=False`
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Resource Limits" icon="gauge" href="/docs/cli/sandbox-execution">
+  Configure timeouts and memory limits for sandbox execution
+</Card>
+<Card title="Thread Safety" icon="lock" href="/docs/features/thread-safety">
+  Understanding thread-safe operations across PraisonAI components
+</Card>
+</CardGroup>

--- a/docs/features/thread-safety.mdx
+++ b/docs/features/thread-safety.mdx
@@ -130,6 +130,7 @@ with threading.ThreadPoolExecutor(max_workers=5) as executor:
 |-----------|-----------|--------|
 | `chat_history` | `AsyncSafeState` (DualLock: RLock + per-loop `asyncio.Lock`) | Re-entrant on same thread; non-blocking in async contexts |
 | `_cache_lock` | `threading.RLock` | Allows reentrant access from cached helpers |
+| `PersistenceOrchestrator._cache_lock` | `threading.RLock` | Protects `_session_cache` reads/writes; reads return `deepcopy()` to prevent shared mutable state |
 | `RateLimiter` (sync) | `threading.Lock` | Protects `_tokens`, `_api_tokens`, and refill state from races in multi-threaded acquire calls |
 | `RateLimiter` (async) | `asyncio.Lock` | Same protection for coroutine contexts |
 
@@ -154,6 +155,44 @@ class Agent:
 ### Why a re-entrant lock?
 
 Nested calls (e.g. a helper that holds the lock and then assigns `chat_history`, which itself acquires the lock) used to deadlock. `RLock` permits the same thread to re-enter. See [PR #1567](https://github.com/MervinPraison/PraisonAI/pull/1567) for details.
+
+### Persistence Orchestrator session cache
+
+`PersistenceOrchestrator` now guards its in-memory session cache with `threading.RLock` and returns deep copies on read, so concurrent agents can share an orchestrator without corrupting cached `ConversationSession` objects.
+
+```python
+from praisonaiagents import Agent
+from praisonai.persistence import PersistenceOrchestrator
+import threading
+
+# Create shared orchestrator
+orchestrator = PersistenceOrchestrator()
+
+def agent_worker(agent_name, session_id):
+    agent = Agent(name=agent_name)
+    
+    # Safe: orchestrator returns deep copy of cached session
+    history = orchestrator.on_agent_start(agent, session_id=session_id)
+    
+    # Multiple agents can safely read/update sessions concurrently
+    orchestrator.on_message(session_id, "user", "Hello from " + agent_name)
+    orchestrator.on_agent_end(agent, session_id)
+
+# Multiple threads can safely share the orchestrator
+threads = [
+    threading.Thread(target=agent_worker, args=(f"Agent{i}", "session-123"))
+    for i in range(3)
+]
+
+for t in threads:
+    t.start()
+for t in threads:
+    t.join()
+```
+
+<Note>
+Reference: PraisonAI PR #1609. The session cache uses defensive copying to prevent shared mutable state between concurrent operations.
+</Note>
 
 ## Best Practices
 

--- a/docs/persistence/overview.mdx
+++ b/docs/persistence/overview.mdx
@@ -93,6 +93,8 @@ Persistence sync wrappers (`get_session`, `add_message`, `get`, `set`, `delete`,
 
 The `DbAdapter`'s lazy store initialisation is also race-free: the first thread to touch the adapter constructs the stores, and subsequent threads see the ready instance.
 
+The session cache inside `PersistenceOrchestrator` is also thread-safe as of PR #1609. Reads return a `deepcopy` of the cached `ConversationSession`, so multiple agents sharing one orchestrator can read/update sessions concurrently without races.
+
 <Note>
 These improvements were added in PraisonAI PR #1466 to ensure robust multi-threaded operation in production environments.
 </Note>


### PR DESCRIPTION
## Summary

Updates documentation to cover three new features introduced in PraisonAI PR #1609:

### 1. New shell parameter on sandbox backends
- Created comprehensive docs/features/sandbox-backends.mdx
- Documents shell=False (safe default) vs shell=True (opt-in shell features)
- Includes security warnings, decision guide, and usage patterns
- Covers SubprocessSandbox, DockerSandbox, and SSHSandbox backends

### 2. New async scheduler stats methods
- Fixed get_stats() return table in async-agent-scheduler.mdx (correct field names)
- Added documentation for get_stats_async() with atomic snapshot guarantees
- Added get_stats_sync() alias documentation 
- Updated examples to use get_stats_async() in async contexts

### 3. Thread-safe persistence orchestrator session cache
- Added section to thread-safety.mdx documenting _cache_lock RLock protection
- Updated persistence/overview.mdx with PR #1609 concurrency note
- Documented defensive copying to prevent shared mutable state

## Changes Made

- New file: docs/features/sandbox-backends.mdx - Complete agent-centric documentation
- Updated: docs/features/async-agent-scheduler.mdx - Fixed stats table, added new methods
- Updated: docs/features/async-scheduler.mdx - Fixed stats method calls  
- Updated: docs/features/thread-safety.mdx - Added persistence orchestrator section
- Updated: docs/persistence/overview.mdx - Added PR #1609 concurrency note
- Updated: docs.json - Added sandbox-backends to navigation

All documentation follows AGENTS.md standards with agent-centric examples, Mermaid diagrams, Mintlify components, security callouts and decision guides.

Fixes #311

Generated with Claude Code