### PR TITLE
docs: Document automatic agents.yaml field validation with typo suggestions

### DIFF
--- a/docs/features/config-file.mdx
+++ b/docs/features/config-file.mdx
@@ -63,6 +63,10 @@ agent = Agent(
     memory=True  # Uses [defaults.memory] settings
 )
 ```
+
+<Info>
+PraisonAI now validates field names automatically — see [Automatic Field Validation](./yaml-configuration-reference#automatic-field-validation) for typo detection and suggestions.
+</Info>
 </Step>
 </Steps>
 

--- a/docs/features/yaml-configuration-reference.mdx
+++ b/docs/features/yaml-configuration-reference.mdx
@@ -120,6 +120,135 @@ PraisonAI accepts both old and new field names. **Use canonical names for new pr
 
 ---
 
+## Automatic Field Validation
+
+PraisonAI automatically checks every field name in your `agents.yaml` and warns you about typos when the workflow starts.
+
+```mermaid
+graph LR
+    Y[agents.yaml] --> P[Parser]
+    P --> V{Field known?}
+    V -->|Yes| OK[Use value]
+    V -->|No| F[Fuzzy match]
+    F --> W[Log warning + suggestion]
+    
+    style Y fill:#8B0000,stroke:#7C90A0,color:#fff
+    style P fill:#189AB4,stroke:#7C90A0,color:#fff
+    style V fill:#F59E0B,stroke:#7C90A0,color:#fff
+    style OK fill:#10B981,stroke:#7C90A0,color:#fff
+    style F fill:#6366F1,stroke:#7C90A0,color:#fff
+    style W fill:#EF4444,stroke:#7C90A0,color:#fff
+```
+
+<Steps>
+<Step title="Create YAML with typo">
+```yaml
+# agents.yaml
+framework: praisonai
+topic: "Summarize Python history"
+agents:
+  researcher:
+    role: Research Analyst
+    goal: Provide a historical summary
+    instrutions: "Focus ONLY on years 1989–2000."   # typo
+    backstory: Expert researcher.
+```
+</Step>
+
+<Step title="Run workflow and see warning">
+```bash
+praisonai start agents.yaml
+```
+
+Output:
+```
+WARNING: Unknown field 'instrutions' in agent 'researcher'. Did you mean 'instructions'?
+```
+</Step>
+
+<Step title="Fix the typo">
+```yaml
+    instructions: "Focus ONLY on years 1989–2000."   # fixed
+```
+
+Now the warning disappears and the field is properly used.
+</Step>
+</Steps>
+
+### Recognized Fields
+
+All recognized field names for agents in both `agents:` and `roles:` sections:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `role` | string | Agent's job title |
+| `goal` | string | Agent's objective |
+| `instructions` | string | Behavior instructions |
+| `backstory` | string | Personality/background context |
+| `tools` | array | List of tool names |
+| `tasks` | object | Nested task definitions (legacy) |
+| `llm` | string | Model to use |
+| `function_calling_llm` | string | Model for tool calls |
+| `allow_delegation` | bool | Allow task delegation |
+| `max_iter` | int | Maximum iterations |
+| `max_rpm` | int | Max requests per minute |
+| `max_execution_time` | int | Timeout in seconds |
+| `verbose` | bool | Verbose output |
+| `cache` | bool | Enable response caching |
+| `system_template` | string | Custom system prompt |
+| `prompt_template` | string | Custom prompt template |
+| `response_template` | string | Custom response template |
+| `tool_timeout` | int | Tool execution timeout |
+| `planning_tools` | array | Tools for planning |
+| `planning` | bool | Enable planning |
+| `autonomy` | string/object | Autonomy configuration |
+| `guardrails` | array | Guardrail functions |
+| `streaming` | bool | Enable streaming |
+| `stream` | bool | Alias for streaming |
+| `approval` | bool | Require human approval |
+| `skills` | array | Skill definitions |
+| `cli_backend` | string | CLI backend type |
+| `reflection` | bool/object | Reflection configuration |
+
+### How Suggestions Work
+
+PraisonAI uses Python's built-in `difflib` with a 0.6 similarity cutoff. Only the single closest match is shown, and only when a close match exists.
+
+<Note>
+Warnings are **non-blocking**. Your workflow still runs; the typo'd field is simply ignored. Always check warnings before assuming an agent is configured correctly.
+</Note>
+
+<Tip>
+Set your log level to `WARNING` or below (`INFO`, `DEBUG`) to see these messages. They're emitted via the standard `praisonai` logger.
+</Tip>
+
+### Sample Output
+
+```bash
+WARNING: Unknown field 'instrutions' in agent 'researcher'. Did you mean 'instructions'?
+WARNING: Unknown field 'xyz_random_field' in agent 'test_agent'.
+```
+
+### Both Sections Covered
+
+The validator inspects both `agents:` and `roles:` sections. The warning text changes from `agent 'X'` to `role 'X'` accordingly.
+
+<AccordionGroup>
+<Accordion title="Run once after editing YAML" icon="play">
+Start the workflow once and grep logs for `Unknown field` to catch all typos at once.
+</Accordion>
+
+<Accordion title="Don't disable the warning" icon="shield-alert">
+Instead of disabling warnings, fix the typo or add a comment explaining the custom field. The validator helps catch configuration mistakes.
+</Accordion>
+
+<Accordion title="Custom fields are ignored, not preserved" icon="info">
+If you intentionally use a non-standard key, the parser will not pass it through to the agent. Only recognized fields are used.
+</Accordion>
+</AccordionGroup>
+
+---
+
 ## Root-Level Options
 
 All options available at the root level of your YAML file.


### PR DESCRIPTION
Adds documentation for the automatic field validation feature introduced in PraisonAI PR #1633.

## Changes

- **New section**: Automatic Field Validation in docs/features/yaml-configuration-reference.mdx
  - Hero Mermaid diagram showing validation flow
  - Quick start with Steps component showing typo detection
  - Complete table of all 28 recognized fields
  - Best practices using AccordionGroup
  - Sample warning output examples
  - Coverage of both agents: and roles: sections

- **Cross-reference**: Added callout in docs/features/config-file.mdx linking to the new section

## Features Documented

- Automatic validation of field names in agents.yaml/workflow.yaml
- Fuzzy-matching typo suggestions using Python's difflib (0.6 cutoff)
- Non-blocking warnings that preserve workflow execution
- Support for both agents: and roles: sections
- All 28 recognized fields from the SDK source

## Follows AGENTS.md Requirements

- ✅ Standard color scheme for Mermaid diagrams
- ✅ Mintlify components (Steps, AccordionGroup)  
- ✅ User-friendly, beginner-focused content
- ✅ Copy-paste runnable examples
- ✅ Active voice, concise explanations
- ✅ Placed in docs/features/ (not docs/concepts/)

Fixes #317

Generated with [Claude Code](https://claude.ai/code)