### PR TITLE
docs: cover wrapper fixes from PraisonAI PR #1624

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -719,6 +719,7 @@
                 "icon": "database",
                 "pages": [
                   "docs/features/persistence",
+                  "docs/features/run-history",
                   "docs/features/persistence-sqlite",
                   "docs/features/persistence-postgres",
                   "docs/features/persistence-mysql",

--- a/docs/features/run-history.mdx
+++ b/docs/features/run-history.mdx
@@ -1,0 +1,220 @@
+---
+title: "Run History"
+sidebarTitle: "Run History"
+description: "Read back persisted run and trace data from your state store"
+icon: "clock-rotate-left"
+---
+
+Query the runs and traces your agents have written to the state store.
+
+```mermaid
+graph LR
+    Agent[🧠 Agent] --> StateStore[💾 State Store]
+    StateStore --> GetRuns["📋 db.get_runs()"]
+    StateStore --> GetTraces["🔍 db.get_traces()"]
+    
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef store fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef query fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class Agent agent
+    class StateStore store
+    class GetRuns,GetTraces query
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Configure State Store">
+Set `PRAISONAI_STATE_URL` or pass `state_url=` when creating agents. See [Database Persistence](/docs/features/database-persistence) for configuration options.
+
+```python
+import os
+os.environ["PRAISONAI_STATE_URL"] = "sqlite:///agent_state.db"
+```
+</Step>
+
+<Step title="Query Runs">
+Run an agent, then read its runs back using `get_runs(session_id)`:
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.db import PraisonAIDB
+
+# Run an agent
+agent = Agent(name="Research Agent", instructions="Research the topic")
+result = agent.start("What is quantum computing?")
+
+# Query runs for this session
+db = PraisonAIDB(state_url="sqlite:///agent_state.db")
+runs = db.get_runs(session_id=agent.session_id)
+
+for run in runs:
+    print(f"Run {run['run_id']}: {run['status']} at {run['started_at']}")
+```
+</Step>
+
+<Step title="Query Traces with Filters">
+Use `get_traces()` with optional filters for `session_id`, `user_id`, and `limit`:
+
+```python
+# Get traces for a specific session
+traces = db.get_traces(session_id=agent.session_id, limit=10)
+
+# Get traces for a specific user
+traces = db.get_traces(user_id="user123", limit=5)
+
+# Get all traces (up to limit)
+all_traces = db.get_traces(limit=100)
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant StateStore as State Store
+    participant DB as PraisonAIDB
+    
+    User->>Agent: Start task
+    Agent->>StateStore: Write run data
+    Agent->>StateStore: Write trace data
+    User->>DB: get_runs(session_id)
+    StateStore->>DB: Scan run:{session_id}:*
+    DB->>User: List of run records
+    User->>DB: get_traces(filters)
+    StateStore->>DB: Scan trace:*
+    DB->>User: Filtered trace records
+```
+
+Both methods read persisted data from the configured state store:
+
+| Method | Source keys | Filters | Sort |
+|---|---|---|---|
+| `get_runs` | `run:{session_id}:*` | `session_id` (required), `limit` (optional) | `started_at` desc |
+| `get_traces` | `trace:*` | `session_id`, `user_id`, `limit` (all optional) | `started_at` desc |
+
+---
+
+## Configuration Options
+
+```python
+def get_runs(session_id: str, limit: Optional[int] = None) -> List[dict]:
+    """
+    Get runs for a session.
+    
+    Args:
+        session_id: Session ID to filter by (required)
+        limit: Maximum number of runs to return (optional)
+        
+    Returns:
+        List of run dictionaries sorted by started_at desc
+    """
+
+def get_traces(
+    session_id: Optional[str] = None, 
+    user_id: Optional[str] = None, 
+    limit: Optional[int] = None
+) -> List[dict]:
+    """
+    Get traces with optional filters.
+    
+    Args:
+        session_id: Filter by session ID (optional)
+        user_id: Filter by user ID (optional)
+        limit: Maximum number of traces to return (optional)
+        
+    Returns:
+        List of trace dictionaries sorted by started_at desc
+    """
+```
+
+**Behavior:**
+- If `state_store` is not configured, returns `[]` and logs a warning
+- `limit=0` returns `[]`, `limit=None` returns everything matching
+- Bad/non-dict entries are skipped with a warning
+- Uses `state_store.scan_prefix()` when available, falls back to `state_store.keys()`
+
+---
+
+## Common Patterns
+
+**Show last 10 runs for a user:**
+```python
+# Get user's recent sessions first, then query runs
+recent_sessions = get_user_sessions(user_id="user123")  # Your implementation
+for session in recent_sessions[:5]:  # Last 5 sessions
+    runs = db.get_runs(session_id=session['session_id'], limit=2)
+    print(f"Session {session['session_id']}: {len(runs)} runs")
+```
+
+**Export traces for a session:**
+```python
+import json
+
+# Export complete session trace data
+traces = db.get_traces(session_id="session_abc123")
+with open("session_traces.json", "w") as f:
+    json.dump(traces, f, indent=2, default=str)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Always set state_url before calling these methods">
+Otherwise you get `[]` and a warning: `"get_runs() called but no state_url configured; returning []"`. 
+
+Configure via environment variable or constructor:
+```python
+# Environment variable (recommended)
+os.environ["PRAISONAI_STATE_URL"] = "postgresql://user:pass@host/db"
+
+# Or via constructor
+db = PraisonAIDB(state_url="sqlite:///data.db")
+```
+</Accordion>
+
+<Accordion title="Pick a small limit for UIs">
+These methods scan the store, so use small limits for responsive UIs:
+```python
+# Good for UI pagination
+recent_runs = db.get_runs(session_id, limit=20)
+
+# Avoid large scans in UI code
+all_runs = db.get_runs(session_id)  # Could be thousands
+```
+</Accordion>
+
+<Accordion title="Use these methods outside hot paths">
+Both methods perform store scans which can be expensive for large datasets. Cache results when possible:
+```python
+# Cache for dashboard views
+@lru_cache(maxsize=100)
+def get_cached_runs(session_id: str, limit: int = 10):
+    return tuple(db.get_runs(session_id, limit))  # Tuple for hashability
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Database Persistence" icon="database" href="/docs/features/database-persistence">
+  Configure state stores for persistence
+</Card>
+<Card title="Session Management" icon="users" href="/docs/features/persistence">
+  Manage agent sessions and state
+</Card>
+<Card title="Langfuse Observability" icon="chart-line" href="/docs/observability/langfuse">
+  Advanced trace analysis and monitoring
+</Card>
+</CardGroup>

--- a/docs/models/custom-provider.mdx
+++ b/docs/models/custom-provider.mdx
@@ -9,8 +9,26 @@ icon: "plug"
 The Custom Provider Registry allows you to register custom LLM providers that extend PraisonAI's capabilities beyond the built-in providers (OpenAI, Anthropic, Google via LiteLLM).
 
 <Note>
-**Important**: This registry is for **custom provider extensions only**. Built-in providers (OpenAI, Anthropic, Google, etc.) are handled automatically by LiteLLM in `praisonaiagents`. You only need this registry when integrating providers not supported by LiteLLM.
+**Updated in PR #1624**: Built-in providers (`openai`, `anthropic`, `google`) plus aliases (`oai`, `claude`, `gemini`, `google_genai`) are now auto-registered and backed by LiteLLM. You add custom providers when you need a non-LiteLLM backend or a custom routing/caching/mocking layer.
 </Note>
+
+## Built-in providers
+
+Built-in providers are automatically registered when a registry is created:
+
+| Provider name | Aliases | Backend |
+|---|---|---|
+| `openai` | `oai` | LiteLLM (`litellm.completion` / `litellm.acompletion`) |
+| `anthropic` | `claude` | LiteLLM |
+| `google` | `gemini`, `google_genai` | LiteLLM |
+
+```python
+from praisonai.llm import create_llm_provider
+
+# Both work out of the box
+provider1 = create_llm_provider("openai/gpt-4o")
+provider2 = create_llm_provider("oai/gpt-4o")
+```
 
 ## What Problem Does It Solve?
 
@@ -33,14 +51,20 @@ class MyCustomProvider:
         self.config = config or {}
     
     def generate(self, prompt):
-        # Your implementation here
+        # Your implementation here (sync)
         return f"Response from {self.model_id}"
+    
+    async def generate_async(self, prompt):
+        # Async implementation (does not block event loop)
+        return f"Async response from {self.model_id}"
 
 # Register the provider
 register_llm_provider("my-custom", MyCustomProvider)
 
 # Use it
 provider = create_llm_provider("my-custom/my-model")
+provider.generate("Hello")            # sync
+await provider.generate_async("Hello") # async
 ```
 
 ## Thread Safety
@@ -85,13 +109,13 @@ When no provider is specified, the model name prefix determines the provider:
 | Other | `openai` (default) |
 
 ```python
-# These are equivalent:
-create_llm_provider("gpt-4o-mini")
-create_llm_provider("openai/gpt-4o-mini")
+# Built-in provider examples:
+create_llm_provider("openai/gpt-4o")
+create_llm_provider("oai/gpt-4o")  # Using alias
 
-# These are equivalent:
-create_llm_provider("claude-3-5-sonnet")
-create_llm_provider("anthropic/claude-3-5-sonnet")
+# Custom provider (after registration):
+register_llm_provider("cloudflare", CloudflareProvider)
+create_llm_provider("cloudflare/workers-ai-model")
 ```
 
 ### 3. Custom Provider with Explicit Name
@@ -174,14 +198,15 @@ register_llm_provider("llm", LLMProvider)  # Too generic
 
 ### Reserved Names
 
-These provider names are reserved for model prefix inference and should not be used for custom providers:
+These provider names are now **registered providers** (not just inference defaults):
 
-- `openai` - Used for gpt-*, o1*, o3* models
-- `anthropic` - Used for claude-* models  
-- `google` - Used for gemini-* models
+- `openai` - Auto-registered LiteLLM provider
+- `anthropic` - Auto-registered LiteLLM provider  
+- `google` - Auto-registered LiteLLM provider
+- Their aliases: `oai`, `claude`, `gemini`, `google_genai`
 
 <Note>
-You **can** register these names, but it will override the default inference behavior. Only do this if you're intentionally replacing the built-in provider resolution.
+Re-registering them without `override=True` will raise `ValueError: Provider 'X' is already registered`. Use `override=True` only if you're intentionally replacing the built-in provider.
 </Note>
 
 ## Multi-Agent Guidance

--- a/docs/observability/langfuse.mdx
+++ b/docs/observability/langfuse.mdx
@@ -391,6 +391,10 @@ set_context_emitter(ContextTraceEmitter(sink=sink.context_sink(), enabled=True))
 Without this, only `RouterAgent` and `PlanningAgent` events appear — `Agent.start()` flows are silent.
 </Accordion>
 
+<Accordion title="Parallel tool execution (PR #1624)">
+When an agent runs the same tool concurrently (e.g. two parallel `search_web` calls), each `TOOL_END` event is now correlated to the matching `TOOL_START` via a per-`(agent, tool)` LIFO stack. Earlier versions could attach a `TOOL_END` to the wrong in-flight span. No user-facing API change — the fix is automatic.
+</Accordion>
+
 <Accordion title="Local Development Setup">
 Use CLI for local development:
 1. `praisonai langfuse start`


### PR DESCRIPTION
Fixes #314

This PR documents the three architectural changes from PraisonAI PR #1624:

## Changes Made

### 1. Built-in LLM providers (custom-provider.mdx)
- Updated the page to reflect that built-in providers are now auto-registered
- Added new "Built-in providers" section with provider/alias table
- Updated examples to show both openai/gpt-4o and oai/gpt-4o working
- Clarified that re-registering built-ins requires override=True
- Added async generate_async() method to examples

### 2. Run history querying (new run-history.mdx)
- New page following AGENTS.md template structure
- Documents get_runs() and get_traces() methods from db/adapter.py
- Agent-centric Quick Start examples
- Configuration tables and common usage patterns
- Proper Mermaid diagrams with standard color scheme

### 3. Langfuse parallel-tool correlation (langfuse.mdx)
- Added accordion in Best Practices about PR #1624 parallel-tool fix
- Documents the LIFO stack approach for proper tool correlation
- No API changes, automatic improvement

## Validation
- ✅ All code examples follow agent-centric approach
- ✅ Mintlify components used (Steps, AccordionGroup, CardGroup)  
- ✅ Standard Mermaid color scheme applied
- ✅ docs.json validated as valid JSON
- ✅ New page added under Features group

Generated with [Claude Code](https://claude.ai/code)