### PR TITLE
docs: document configurable agent server readiness timeout (PRAISONAI_SERVER_READY_TIMEOUT)

### DIFF
--- a/docs/deploy/servers/agents.mdx
+++ b/docs/deploy/servers/agents.mdx
@@ -91,7 +91,7 @@ agents.launch(path="/content", port=8000, host="0.0.0.0")
 ```
 
 <Note>
-Multiple `Agent` / `Agents` instances may call `.launch(port=N)` concurrently from different threads — registration is atomic. If two launch calls use the same path on the same port, the second gets an auto-suffixed path (`/path_abc123`) and a warning is logged. Server readiness is signalled deterministically (no fixed sleep); `.launch()` returns only after the port is accepting connections (5s timeout).
+Multiple `Agent` / `Agents` instances may call `.launch(port=N)` concurrently from different threads — registration is atomic. If two launch calls use the same path on the same port, the second gets an auto-suffixed path (`/path_abc123`) and a warning is logged. Server readiness is signalled deterministically (no fixed sleep); `.launch()` returns only after the port is accepting connections. The wait defaults to **5 seconds** and is configurable via the `PRAISONAI_SERVER_READY_TIMEOUT` environment variable. If the server doesn't become ready in time, `.launch()` still returns and a warning is logged — check server logs for startup errors.
 </Note>
 
 ## agents.yaml
@@ -133,6 +133,10 @@ praisonai serve agents --port 8000 --host 0.0.0.0
 
 # With agents file
 praisonai serve agents --file agents.yaml --port 8000
+
+# Give the server more time on slow machines
+export PRAISONAI_SERVER_READY_TIMEOUT=15
+praisonai serve agents --port 8000
 ```
 
 | Option | Default | Description |
@@ -198,6 +202,12 @@ curl -X POST http://SERVER_IP:8000/ask \
   -d '{"query": "Hello"}'
 ```
 
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PRAISONAI_SERVER_READY_TIMEOUT` | `5.0` | Seconds to wait for the FastAPI server to become ready after `.launch()` / `praisonai serve agents`. A warning is logged if exceeded; startup continues. |
+
 ## Troubleshooting
 
 | Issue | Fix |
@@ -208,6 +218,7 @@ curl -X POST http://SERVER_IP:8000/ask \
 | Missing deps | `pip install "praisonaiagents[os]"` |
 | Connection refused | Use `host="0.0.0.0"` for remote |
 | Firewall blocking | Open port in firewall |
+| Agent server slow to start / "did not become ready" warning | Set `PRAISONAI_SERVER_READY_TIMEOUT=10` (seconds) before launching, or check server logs for the underlying startup error. |
 
 ## Related
 

--- a/docs/features/agent-api-launch.mdx
+++ b/docs/features/agent-api-launch.mdx
@@ -253,7 +253,7 @@ support_agent.launch(
 ```
 
 <Note>
-Multiple `Agent` / `Agents` instances may call `.launch(port=N)` concurrently from different threads — registration is atomic. If two launch calls use the same path on the same port, the second gets an auto-suffixed path (`/path_abc123`) and a warning is logged. Server readiness is signalled deterministically (no fixed sleep); `.launch()` returns only after the port is accepting connections (5s timeout).
+Multiple `Agent` / `Agents` instances may call `.launch(port=N)` concurrently from different threads — registration is atomic. If two launch calls use the same path on the same port, the second gets an auto-suffixed path (`/path_abc123`) and a warning is logged. Server readiness is signalled deterministically (no fixed sleep); `.launch()` returns only after the port is accepting connections. The wait defaults to **5 seconds** and is configurable via the `PRAISONAI_SERVER_READY_TIMEOUT` environment variable. If the server doesn't become ready in time, `.launch()` still returns and a warning is logged — check server logs for startup errors.
 </Note>
 
 ### Example 5: Debug Mode for Development
@@ -285,6 +285,12 @@ agent.launch(
 | `port` | int | Port number | 8000 |
 | `path` | str | API endpoint path (HTTP) or base path (MCP) | "/" |
 | `debug` | bool | Enable debug mode with auto-reload | False |
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PRAISONAI_SERVER_READY_TIMEOUT` | `5.0` | Seconds `.launch()` waits for the HTTP server to be ready. On timeout, a warning is logged and execution continues. |
 
 ## Client Integration
 
@@ -493,6 +499,16 @@ server {
     - Check firewall rules
     - Ensure the agent is actually running
     - Try connecting from localhost first
+</Accordion>
+
+  <Accordion title="Agent server slow to start">
+    If you see `Agent server on port N did not become ready within 5.0s` in the logs, the FastAPI server took longer than the default 5s to come up. This is usually safe (`.launch()` still returns and the server keeps starting), but you can raise the wait:
+
+    ```bash
+    export PRAISONAI_SERVER_READY_TIMEOUT=15  # seconds
+    ```
+
+    Common causes: slow imports, cold-start on resource-constrained machines, blocking startup hooks.
 </Accordion>
 </AccordionGroup>
 

--- a/docs/features/thread-safety.mdx
+++ b/docs/features/thread-safety.mdx
@@ -296,7 +296,7 @@ PraisonAI provides comprehensive thread-safety for HTTP server deployment:
 
 - Multiple `Agent` / `Agents` instances may call `.launch(port=N)` concurrently from different threads — registration is atomic.
 - If two launch calls use the same path on the same port, the second gets an auto-suffixed path (`/path_abc123`) and a warning is logged.
-- Server readiness is signalled deterministically (no fixed sleep); `.launch()` returns only after the port is accepting connections (5s timeout).
+- Server readiness is signalled deterministically (no fixed sleep); `.launch()` returns only after the port is accepting connections. The wait defaults to **5 seconds** and is configurable via the `PRAISONAI_SERVER_READY_TIMEOUT` environment variable. If the server doesn't become ready in time, `.launch()` still returns and a warning is logged — check server logs for startup errors.
 - `aworkflow()` state lock is created inside the running async context, so workflows remain stable when invoked under pytest-asyncio or when nested inside another loop.
 
 ```python


### PR DESCRIPTION
## Summary

Updates documentation to reflect the new configurable `PRAISONAI_SERVER_READY_TIMEOUT` environment variable introduced in upstream PR #1655.

### Changes Made

- **docs/deploy/servers/agents.mdx**: 
  - Replaced hard-coded "5s timeout" references with configurable timeout description
  - Added Environment Variables section with `PRAISONAI_SERVER_READY_TIMEOUT` documentation
  - Added troubleshooting entry for slow server startup scenarios
  - Added code example showing usage with custom timeout

- **docs/features/agent-api-launch.mdx**:
  - Updated Note block to reflect configurable timeout
  - Added Environment Variables subsection under Launch Parameters
  - Added new troubleshooting accordion for slow server startup
  
- **docs/features/thread-safety.mdx**:
  - Updated Multi-team HTTP launch section to use configurable timeout description

### Key Details

- Default timeout remains 5.0 seconds
- Environment variable: `PRAISONAI_SERVER_READY_TIMEOUT` (float, seconds)
- On timeout, a warning is logged but execution continues
- Invalid values fall back to default 5.0s with warning

Fixes #347

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified server readiness behavior for agent deployment, including deterministic readiness signaling with a default 5-second wait and configurability via the `PRAISONAI_SERVER_READY_TIMEOUT` environment variable.
  * Enhanced troubleshooting guidance for slow agent server startup scenarios, including how to adjust timeout values and where to check for startup errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAIDocs/pull/348)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->