### PR TITLE
docs(testing): document preserved provider API keys in setup_test_environment fixture

### DIFF
--- a/docs/developers/testing.mdx
+++ b/docs/developers/testing.mdx
@@ -88,6 +88,55 @@ praisonai test --provider all --live
 | `PRAISONAI_TEST_PROVIDERS` | `openai` | Comma-separated provider list |
 | `PRAISONAI_LOCAL_SERVICES` | `0` | Enable local service tests |
 
+### Provider API keys in unit/mock tests
+
+The `setup_test_environment` autouse fixture preserves any provider API key already present in the shell environment.
+
+```mermaid
+graph TB
+    Start[🧪 Test starts] --> Marker{Marked real / network / e2e / provider_*<br/>OR under integration/live/e2e?}
+    Marker -->|Yes| Skip[⏭️ Skip placeholder injection]
+    Marker -->|No| Loop[Check each provider key]
+    Loop --> KeySet{Key set in os.environ?}
+    KeySet -->|Yes| Keep[✅ Preserve real key]
+    KeySet -->|No| Fill[💾 Inject 'test-key' placeholder]
+    Skip --> Run[▶️ Run test]
+    Keep --> Run
+    Fill --> Run
+    Run --> Teardown[🧹 Restore originals / remove placeholders]
+
+    classDef start fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef action fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Start,Run start
+    class Marker,KeySet decision
+    class Loop,Fill,Skip action
+    class Keep,Teardown success
+```
+
+Placeholder `"test-key"` values are injected **only** for keys that are unset, so SDK imports and guardrails never crash on missing keys. On teardown, originally-set keys keep their values; keys that were missing and got placeholders are removed (not left behind as `"test-key"`).
+
+Tests marked `@pytest.mark.real`, `@pytest.mark.network`, `@pytest.mark.e2e`, or any `@pytest.mark.provider_*` skip the placeholder injection entirely, so they always see the real environment. Tests located under `tests/integration/`, `tests/live/`, or `tests/e2e/` are also treated as real and skip placeholder injection.
+
+| Scenario | Behavior |
+|----------|----------|
+| Key set in shell, running unit/mock test | Real key is preserved (used as-is) |
+| Key unset, running unit/mock test | Placeholder `"test-key"` injected, removed on teardown |
+| Test marked `provider_openai` / `real` / `network` / `e2e` | Placeholder injection skipped entirely |
+| Test located under `integration/`, `live/`, or `e2e/` | Placeholder injection skipped entirely |
+
+Provider keys covered by the fixture: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `COHERE_API_KEY`.
+
+<Tip>
+Export your real keys in `~/.bashrc` / `~/.zshrc` if you want local unit tests to call real provider APIs without using the `--live` flag — the autouse fixture will not overwrite them.
+</Tip>
+
+<Note>
+An explicit empty string (`export OPENAI_API_KEY=""`) is also preserved — the fixture only injects placeholders when the variable is fully absent from `os.environ`.
+</Note>
+
 ## CLI Options
 
 ```bash
@@ -208,6 +257,10 @@ def test_long_running():
 ### Using Fixtures
 
 Common fixtures are available in `conftest.py`:
+
+- `setup_test_environment` - autouse fixture that fills missing provider API keys with placeholders; preserves real keys from your shell
+- `mock_llm_response` - provides mock LLM responses for testing
+- `temp_directory` - provides temporary directory for file operations
 
 ```python
 def test_with_mock_llm(mock_llm_response):


### PR DESCRIPTION
Fixes #353

Adds documentation for the preserved provider API keys behavior in the setup_test_environment fixture as detailed in issue #353.

## Changes
- Added new H3 subsection "Provider API keys in unit/mock tests" explaining the preserve-real-keys behavior
- Included Mermaid flow diagram with standard color scheme (#8B0000, #189AB4, #10B981, #F59E0B)  
- Added scenario table showing different test behaviors
- Updated "Using Fixtures" section to mention setup_test_environment
- Added Tip and Note callouts for user guidance

## Key Documentation Points
- The fixture preserves real API keys from the shell environment
- Placeholder "test-key" values are only injected for missing keys
- Tests marked with provider markers or located in specific directories skip placeholder injection
- Covers all six provider keys: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY, XAI_API_KEY, GROQ_API_KEY, COHERE_API_KEY

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guide with detailed information about how provider API keys are handled during unit and mock tests, including placeholder injection behavior and preservation rules for existing keys.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAIDocs/pull/354)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->