### PR TITLE
docs: update python_tools.mdx to reflect lazy function exports from PR #1666

### DIFF
--- a/docs/tools/python_tools.mdx
+++ b/docs/tools/python_tools.mdx
@@ -27,10 +27,14 @@ Use Python Tools to execute and manage Python code with AI agents.
     Import the necessary components:
     ```python
     from praisonaiagents import Agent, Task, AgentTeam
-    from praisonaiagents import (
+    # Preferred (matches SDK)
+    from praisonaiagents.tools import (
         execute_code, analyze_code, format_code,
         lint_code, disassemble_code
     )
+    
+    # Top-level shortcut also works
+    # from praisonaiagents import execute_code
     ```
   </Step>
 
@@ -78,12 +82,17 @@ Use Python Tools to execute and manage Python code with AI agents.
 
 ## Available Functions
 
+### Import Paths
+
 ```python
+# Preferred (matches SDK)
+from praisonaiagents.tools import (
+    execute_code, analyze_code, format_code,
+    lint_code, disassemble_code
+)
+
+# Top-level shortcut also works
 from praisonaiagents import execute_code
-from praisonaiagents import analyze_code
-from praisonaiagents import format_code
-from praisonaiagents import lint_code
-from praisonaiagents import disassemble_code
 ```
 
 ## Function Details
@@ -96,6 +105,10 @@ Safely executes Python code:
 - Error handling
 - Timeout protection
 - Output size limits
+
+<Warning>
+`execute_code` executes Python in the host process (with a timeout). It is **not** a sandbox — do not pass untrusted code from end-users without isolating the host process yourself (subprocess, container, or VM).
+</Warning>
 
 ```python
 # Basic execution
@@ -276,7 +289,7 @@ def add(a, b):
 
 ```python
 from praisonaiagents import Agent
-from praisonaiagents import (
+from praisonaiagents.tools import (
     execute_code, analyze_code, format_code,
     lint_code, disassemble_code
 )
@@ -293,12 +306,17 @@ agent = Agent(
 
 ## Dependencies
 
-The Python tools require the following packages:
-- black: For code formatting (black style)
-- autopep8: For code formatting (PEP 8 style)
-- pylint: For code linting
+`execute_code`, `analyze_code`, and `disassemble_code` work out of the box — they only require the Python standard library.
 
-These will be automatically installed when needed.
+The remaining tools need optional packages installed manually:
+
+| Tool | Optional Dependency | Install |
+|------|--------------------|----------|
+| `format_code` (black style)  | `black`    | `pip install black` |
+| `format_code` (pep8 style)   | `autopep8` | `pip install autopep8` |
+| `lint_code`                  | `pylint`   | `pip install pylint` |
+
+If the dependency is missing, the tool returns a clear error rather than crashing the agent.
 
 ## Error Handling
 
@@ -380,7 +398,7 @@ print(f"Functions: {structure['functions']}")
 
 ```python
 from praisonaiagents import Agent, Task, AgentTeam
-from praisonaiagents import (
+from praisonaiagents.tools import (
     execute_code, analyze_code, format_code,
     lint_code, disassemble_code
 )
@@ -467,6 +485,11 @@ agents.start()
   <Accordion title="Agent Configuration">
     Configure agents with clear Python focus:
     ```python
+    from praisonaiagents.tools import (
+        execute_code, analyze_code, format_code,
+        lint_code, disassemble_code
+    )
+    
     Agent(
         name="PythonExecutor",
         role="Code Execution Specialist",
@@ -494,6 +517,11 @@ agents.start()
 
 ### Python Execution Pipeline
 ```python
+from praisonaiagents.tools import (
+    execute_code, analyze_code, format_code,
+    lint_code, disassemble_code
+)
+
 # Execution agent
 executor = Agent(
     name="Executor",


### PR DESCRIPTION
## Summary

Updates the python_tools.mdx documentation to accurately reflect the lazy function exports implementation from upstream PraisonAI PR #1666.

## Changes Made

- **Import paths**: Updated to show canonical 'from praisonaiagents.tools import ...' form as preferred, with top-level shortcut as alternative
- **Dependencies section**: Replaced auto-install claim with accurate table showing which tools need manual dependency installation  
- **Safety warning**: Added warning callout for 'execute_code' about sandbox limitations
- **Updated all examples**: Changed imports in all code examples throughout the file to use the canonical form

## Test plan

- [x] Verified current SDK source files in PraisonAI repo
- [x] Confirmed AgentTeam is the correct import (not PraisonAIAgents)
- [x] Updated all import examples consistently
- [x] Maintained backwards compatibility information

Generated with [Claude Code](https://claude.ai/code)

Fixes #352