### PR TITLE
docs: document conftest env-var behaviour and add pytest failure-category verification guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -998,7 +998,8 @@
             "icon": "code",
             "pages": [
               "docs/developers/reference-home",
-              "docs/developers/test",
+              "docs/developers/testing",
+              "docs/developers/pytest-failure-categories",
               "docs/developers/agents-playbook",
               "docs/developers/wrapper",
               "docs/developers/wrapper-tools",

--- a/docs/developers/pytest-failure-categories.mdx
+++ b/docs/developers/pytest-failure-categories.mdx
@@ -1,0 +1,225 @@
+---
+title: "Pytest Failure Categories"
+sidebarTitle: "Failure Categories"
+description: "Guide to distinguish real regressions from stale mocks in PraisonAI test failures"
+icon: "bug"
+---
+
+Pytest failures in PraisonAI fall into predictable categories that help distinguish real regressions from outdated test mocks.
+
+```mermaid
+graph TB
+    subgraph "Failure Analysis Flow"
+        A[🔍 Test Failure] --> B{Category?}
+        B -->|Registry| C[Registry get_instance]
+        B -->|Import| D[execute_code Export]
+        B -->|Loader| E[Bot Lazy Loaders]
+        B -->|Path| F[aiui Patch Path]
+        B -->|Environment| G[conftest Key Behavior]
+        
+        C --> H{Mock vs Real?}
+        D --> H
+        E --> H
+        F --> H
+        G --> H
+        
+        H -->|Stale Mock| I[✨ Update Mock]
+        H -->|Real Bug| J[🚨 Fix SDK]
+    end
+    
+    classDef failure fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef category fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef action fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A failure
+    class B,H decision
+    class C,D,E,F,G category
+    class I,J action
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Identify the Category">
+Run the one-liner check to identify which category your test failure belongs to.
+</Step>
+
+<Step title="Determine Real vs Stale">
+Use the verification commands to distinguish between real regressions and outdated mocks.
+</Step>
+
+<Step title="Apply the Fix">
+Update mock targets or escalate to SDK maintainers based on the analysis.
+</Step>
+</Steps>
+
+---
+
+## Failure Categories
+
+### Registry get_instance
+
+**Symptom:** `AttributeError` where registry mock returns `None` instead of registry instance
+
+**One-liner check:**
+```bash
+python -c "from praisonai.llm.registry import LLMProviderRegistry; print(LLMProviderRegistry.get_instance())"
+```
+
+**Likely root cause:** Stale mock — registry API changed in SDK, mock needs updating
+
+**Common failure signature:**
+```python
+AttributeError: 'NoneType' object has no attribute 'resolve'
+```
+
+**Fix approach:**
+- Update mock patch target to match current registry location
+- Verify mock returns actual registry instance, not None
+- Check for singleton pattern changes in LLMProviderRegistry.get_instance()
+
+---
+
+### execute_code Export
+
+**Symptom:** `ImportError` on `from praisonaiagents.tools import execute_code`
+
+**One-liner check:**
+```bash
+python -c "from praisonaiagents.tools import execute_code; print('✓ Import successful')"
+```
+
+**Likely root cause:** Export removed/renamed in SDK
+
+**Common failure signature:**
+```python
+ImportError: cannot import name 'execute_code' from 'praisonaiagents.tools'
+```
+
+**Fix approach:**
+- Check TOOL_MAPPINGS in `praisonaiagents/tools/__init__.py`
+- Verify execute_code is mapped to `.python_tools` module
+- Update import paths if module structure changed
+
+---
+
+### Bot Lazy Loaders
+
+**Symptom:** First call returns `None` instead of bot instance due to lazy loading bypass
+
+**One-liner check:**
+```bash
+pytest tests/unit/test_bot_loaders.py -x
+```
+
+**Likely root cause:** Mock targets the eager path; lazy loader bypasses it
+
+**Common failure signature:**
+```python
+AssertionError: Expected bot instance, got None
+```
+
+**Fix approach:**
+- Mock the lazy loading mechanism itself
+- Ensure mocks cover both eager and lazy initialization paths
+- Check for `__getattr__` method changes in tools modules
+
+---
+
+### aiui Patch Path
+
+**Symptom:** Mock patch silently no-ops, test passes when it should fail
+
+**One-liner check:**
+```bash
+python -c "import praisonai.ui; print(praisonai.ui.__file__)"
+```
+
+**Likely root cause:** Patch target moved; update `mock.patch` path
+
+**Common failure signature:**
+```python
+# Test passes but shouldn't - mock not being applied
+```
+
+**Fix approach:**
+- Verify praisonaiui module location has not changed
+- Update patch paths from `praisonai.aiui` to `praisonaiui` if needed
+- Check for import alias changes (`import praisonaiui as aiui`)
+
+---
+
+### conftest Key Behavior
+
+**Symptom:** Tests pass locally but fail in CI, or vice versa
+
+**One-liner check:**
+```bash
+env | grep -E '^(OPENAI|ANTHROPIC|GOOGLE|XAI|GROQ|COHERE)_API_KEY='
+```
+
+**Likely root cause:** Real key exported in one environment but not the other
+
+**Context:** Since May 2026 (PR #1663), `setup_test_environment` only injects placeholder API keys when variables are **unset or empty**. Real keys from shell environment are preserved.
+
+**Fix approach:**
+- `unset` API keys before running unit tests to force placeholder injection
+- Use clean shell environment for consistent test behavior
+- Mark tests as `real`/`network`/`e2e` if they need real API keys
+
+---
+
+## Troubleshooting Workflow
+
+<AccordionGroup>
+<Accordion title="Before You Escalate Checklist">
+- [ ] Re-pull latest from main branch
+- [ ] Re-install editable package: `pip install -e .`
+- [ ] Check installed version: `pip show praisonai-agents`
+- [ ] Run with verbose output: `pytest -vv --tb=long`
+- [ ] Verify environment isolation (no stale imports)
+</Accordion>
+
+<Accordion title="Real Regression vs Stale Mock">
+**Real Regression Signs:**
+- One-liner checks fail on fresh install
+- Multiple unrelated tests failing simultaneously  
+- Recent SDK changes in related modules
+- Failures persist after mock updates
+
+**Stale Mock Signs:**
+- One-liner checks pass, only mocked tests fail
+- Single test or module affected
+- Mock targets non-existent paths/attributes
+- Failures resolve with mock path updates
+</Accordion>
+
+<Accordion title="Mock Update Strategy">
+1. **Identify current API:** Run one-liner to see actual behavior
+2. **Update patch target:** Match current module location
+3. **Verify mock return:** Ensure mock returns expected type
+4. **Test both paths:** Cover eager and lazy loading scenarios
+</Accordion>
+
+<Accordion title="When to Escalate">
+Escalate to SDK maintainers when:
+- One-liner checks confirm real API breakage
+- Breaking changes affect multiple test categories
+- Public API contracts have changed unexpectedly
+- Fixes require SDK-level changes, not just test updates
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Testing Guide" icon="flask-vial" href="testing">
+  Complete testing documentation and environment setup
+</Card>
+<Card title="Development Setup" icon="code" href="development-setup">
+  Local development environment configuration
+</Card>
+</CardGroup>

--- a/docs/developers/testing.mdx
+++ b/docs/developers/testing.mdx
@@ -87,6 +87,20 @@ praisonai test --provider all --live
 | `PRAISONAI_LIVE_TESTS` | `0` | Enable live API tests |
 | `PRAISONAI_TEST_PROVIDERS` | `openai` | Comma-separated provider list |
 | `PRAISONAI_LOCAL_SERVICES` | `0` | Enable local service tests |
+| `OPENAI_API_KEY` | `'test-key'` | Placeholder injected only if unset/empty for non-real tests |
+| `ANTHROPIC_API_KEY` | `'test-key'` | Placeholder injected only if unset/empty for non-real tests |
+| `GOOGLE_API_KEY` | `'test-key'` | Placeholder injected only if unset/empty for non-real tests |
+| `XAI_API_KEY` | `'test-key'` | Placeholder injected only if unset/empty for non-real tests |
+| `GROQ_API_KEY` | `'test-key'` | Placeholder injected only if unset/empty for non-real tests |
+| `COHERE_API_KEY` | `'test-key'` | Placeholder injected only if unset/empty for non-real tests |
+
+### Placeholder API Keys in Mock Tests
+
+The autouse `setup_test_environment` fixture in `src/praisonai/tests/conftest.py` injects a `'test-key'` placeholder for `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, and `COHERE_API_KEY` so unit tests can construct LLM clients without real credentials.
+
+Since May 2026 (PR #1663), the placeholder is only injected when the variable is **unset or empty**. If you already exported a real key, it is left untouched.
+
+**Implication:** if you export a real key and run mock unit tests, any test that isn't fully mocked will make real, billable API calls. To force the placeholder path, `unset` the keys first (or run in a clean shell). The fixture skips placeholder injection entirely for tests marked `real`, `network`, `e2e`, or `provider_*`, and for tests under `tests/integration/`, `tests/live/`, or `tests/e2e/`.
 
 ## CLI Options
 
@@ -249,3 +263,7 @@ Or mark the test as slow:
 def test_slow_operation():
     pass
 ```
+
+### Pytest Failure Categories
+
+For common test failures and how to distinguish real regressions from stale mocks, see the [Pytest Failure Categories Guide](pytest-failure-categories).


### PR DESCRIPTION
Fixes #351

## Summary

This PR implements the documentation updates requested in issue #351 following the merged PR #1663 changes to PraisonAI's conftest.py behavior.

## Changes Made

### Updated docs/developers/testing.mdx
- Added section documenting new conftest.py conditional API key injection behavior
- Updated environment variables table to reflect placeholder injection only when unset/empty
- Added warning about real keys causing billable API calls in unit tests
- Added link to new pytest failure categories guide in troubleshooting section

### Created docs/developers/pytest-failure-categories.mdx
- Comprehensive guide covering 5 pytest failure categories:
  * Registry get_instance: AttributeError when mock returns None
  * execute_code export: ImportError on tool imports  
  * Bot lazy loaders: First call returns None due to lazy loading bypass
  * aiui patch path: Mock silently no-ops due to moved patch target
  * conftest key behavior: Environment-dependent test results
- Each category includes one-liner verification commands
- Troubleshooting workflow to distinguish real regressions from stale mocks
- Before-you-escalate checklist and mock update strategies

### Updated docs.json
- Added new pytest-failure-categories page to Developers section
- Replaced minimal test.mdx with comprehensive testing.mdx in navigation

## Technical Details

The conftest.py change from PR #1663 modified the setup_test_environment fixture to only inject placeholder API keys when environment variables are unset or empty. This preserves real keys from the shell environment, but means unit tests can make real API calls if not fully mocked.

## Compliance

All changes follow AGENTS.md standards:
- Proper page structure with frontmatter, hero diagrams, Quick Start sections
- Standard Mermaid color scheme
- Required Mintlify components (Steps, AccordionGroup, CardGroup)
- Copy-paste runnable code examples
- Concise writing style with one-sentence section intros
- Placed in AI-writable docs/developers/ folder, not docs/concepts/

🤖 Generated with [Claude Code](https://claude.ai/code)