### PR TITLE
docs: update botos.mdx Platform Registry with unregister() and get_default_bot_registry()

### DIFF
--- a/docs/features/botos.mdx
+++ b/docs/features/botos.mdx
@@ -320,6 +320,17 @@ Add your own messaging platform in 3 steps:
     bot.run()
     ```
   </Step>
+  <Step title="Remove a platform (optional)">
+    Useful for tests, hot-reloads, or multi-tenant cleanup:
+
+    ```python
+    from praisonai.bots._registry import get_default_bot_registry
+
+    removed = get_default_bot_registry().unregister("line")  # bool
+    ```
+
+    `unregister()` returns `True` if the platform was registered and removed, `False` otherwise. It's safe to call even when the platform isn't registered.
+  </Step>
 </Steps>
 
 <Accordion title="Adapter contract">
@@ -415,10 +426,22 @@ botos.run()
 <Accordion title="Platform Registry">
 ```python
 from praisonai.bots._registry import (
-    register_platform,    # Add a custom platform
-    list_platforms,       # List all platforms
-    resolve_adapter,      # Get adapter class by name
-    get_platform_registry # Get full registry dict
+    register_platform,         # Add a custom platform (lower-cased name)
+    list_platforms,            # List all registered platform names
+    resolve_adapter,           # Get adapter class by name
+    get_platform_registry,     # Get the full {name: class} dict
+    get_default_bot_registry,  # Get the underlying BotPlatformRegistry (advanced)
 )
+
+# Remove a previously registered platform (useful for tests, hot-reloads, multi-tenant cleanup)
+get_default_bot_registry().unregister("line")  # returns True if it was registered
 ```
+
+**Error you'll see for unknown platforms:**
+
+```
+ValueError: Unknown praisonai.bots plugin: 'nonexistent_xyz'. Available: ['agentmail', 'discord', 'email', 'linear', 'slack', 'telegram', 'whatsapp']
+```
+
+The error string changed in a recent refactor. If you're migrating from an older PraisonAI, update any `try/except` blocks or test assertions that matched the old `"Unknown platform"` text.
 </Accordion>


### PR DESCRIPTION
Fixes #357

This PR updates the BotOS documentation to reflect the changes from PraisonAI PR #1669, which surfaces two user-visible facts about the bot platform registry:

## Changes Made

1. **Updated Platform Registry accordion** (docs/features/botos.mdx:415-436):
   - Added get_default_bot_registry() factory function to imports
   - Added unregister() usage example for removing registered platforms
   - Documented the new error message format for unknown platforms
   - Added migration note for users updating from older PraisonAI versions

2. **Extended Extending Platforms section** (docs/features/botos.mdx:323-334):
   - Added Step 4 showing how to remove a registered platform
   - Included use cases: tests, hot-reloads, multi-tenant cleanup
   - Documented unregister() return behavior (True/False)

## Technical Details

The underlying changes come from the PluginRegistry refactor (PraisonAI PR #1639):
- _custom_platforms dict was removed and replaced by BotPlatformRegistry(PluginRegistry)
- unregister(name) -> bool method added to remove registered platforms  
- Error message changed from "Unknown platform" to "Unknown praisonai.bots plugin: 'name'. Available: [...]"

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for removing and unregistering platforms.
  * Updated platform registry documentation with expanded functionality details.
  * Documented updated error messages for unknown plugins and platforms, including migration guidance for existing error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAIDocs/pull/358)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->