### PR TITLE
docs: update for wrapper-layer concurrency fixes (PraisonAI PR #1673)

### DIFF
--- a/docs/cli/scheduler.mdx
+++ b/docs/cli/scheduler.mdx
@@ -524,12 +524,32 @@ The scheduler retries failed executions with exponential backoff + jitter:
 - **On failure:** Wait `backoff_delay(attempt)` seconds, then retry.
 - Delay formula: `min(max(30, 2 ** attempt), 300)` seconds, with ±10% jitter.
 - **Cap:** 300s between attempts. **Floor:** ~27s.
-- Both sync (`AgentScheduler`) and async (`AsyncAgentScheduler`) use the same curve.
+- Sync and async schedulers now share the same `backoff_delay()` implementation as of [PR #1673](https://github.com/MervinPraison/PraisonAI/pull/1673), not just the same formula.
 
 `max_retries` is the **total** number of attempts (including the first run).
 `max_retries=3` → 1 initial attempt + up to 2 retries.
 
 ## Stopping the Scheduler
+
+### Interruptible backoff (PR #1673)
+
+Calling `scheduler.stop()` during a retry backoff window now returns within milliseconds. Previously a stop signal could wait out the full backoff delay (up to ~300s).
+
+```python
+import signal
+from praisonai.scheduler import AgentScheduler
+
+scheduler = AgentScheduler(agent, "Monitor logs")
+scheduler.start("hourly", max_retries=3)
+
+# Set up signal handler
+def handle_sigint(signum, frame):
+    print("Ctrl+C pressed - stopping scheduler...")
+    scheduler.stop()  # Returns immediately, even during backoff
+    exit(0)
+
+signal.signal(signal.SIGINT, handle_sigint)
+```
 
 ### CLI Commands
 Use the daemon management commands:

--- a/docs/features/async-jobs.mdx
+++ b/docs/features/async-jobs.mdx
@@ -81,6 +81,10 @@ response = httpx.post(
 )
 ```
 
+<Note>
+Since [PR #1673](https://github.com/MervinPraison/PraisonAI/pull/1673), the in-process store is safe to read concurrently with writes. You can safely share a single `InMemoryJobStore` instance between the FastAPI app and background tasks that periodically read stats.
+</Note>
+
 ## Polling
 
 ```python

--- a/docs/features/thread-safety.mdx
+++ b/docs/features/thread-safety.mdx
@@ -421,6 +421,41 @@ A transient discovery error does not lock the CLI into a broken state — the ne
 
 **Integration registry** (`praisonai/integrations/registry.py`) now has a per-instance `threading.Lock` guarding `register`/`unregister`/`create`/`list_registered` operations.
 
+### New Thread-Safe Components in PR #1673
+
+**InMemoryJobStore — locked reads and async `get_stats()`**
+
+All read methods (`get`, `get_by_idempotency_key`, `list_jobs`, `count`, `get_stats`) now hold an `asyncio.Lock` while reading internal dicts, so concurrent saves cannot tear a read.
+
+<Warning>
+**Breaking change:** `get_stats()` is now a coroutine. Update your code:
+
+```python
+# Before PR #1673
+stats = store.get_stats()
+
+# After PR #1673
+stats = await store.get_stats()
+```
+</Warning>
+
+**AgentScheduler — interruptible retry backoff (sync scheduler)**
+
+`stop()` now becomes responsive within milliseconds even during retry backoff. The sync scheduler also adopts the shared `backoff_delay()` curve so sync and async retries are identical.
+
+```python
+from praisonai.scheduler import AgentScheduler
+
+scheduler = AgentScheduler(agent, "Hourly news check")
+scheduler.start("hourly", max_retries=3)
+# ... later, from another thread or signal handler:
+scheduler.stop()  # returns within ms, even if a backoff sleep was in progress
+```
+
+**ToolRegistry — thread-safe registry operations**
+
+`ToolRegistry` now holds a `threading.Lock` around all reads and mutations, matching `PluginRegistry` / integration registry. Eliminates `RuntimeError: dictionary changed size during iteration` when registering tools concurrently with iteration. Reference: [PR #1673](https://github.com/MervinPraison/PraisonAI/pull/1673).
+
 ## Related
 
 - [Thread Safety CLI](/docs/cli/thread-safety)


### PR DESCRIPTION
## Summary

Updates documentation to reflect the concurrency and thread-safety fixes from PraisonAI PR [#1673](https://github.com/MervinPraison/PraisonAI/pull/1673).

## Changes

### docs/features/thread-safety.mdx
- Added new "New Thread-Safe Components in PR #1673" section
- Documented InMemoryJobStore locked reads with breaking change warning for async get_stats()
- Documented AgentScheduler interruptible retry backoff
- Documented ToolRegistry thread-safe operations

### docs/features/async-jobs.mdx  
- Added concurrency note about safe InMemoryJobStore sharing between FastAPI app and background tasks

### docs/cli/scheduler.mdx
- Added "Interruptible backoff (PR #1673)" section with example
- Updated Error Handling section to mention shared backoff_delay() implementation

## Test plan
- [x] Verify all code examples use correct imports (canonical paths)
- [x] Confirm breaking change warning for get_stats() is clearly marked
- [x] Check that all PR references link correctly
- [x] Ensure examples are copy-paste runnable

Fixes #361

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated scheduler documentation with improved `stop()` behavior—now returns within milliseconds instead of ~300 seconds during retry backoff.
  * Clarified thread-safety guarantees for job store concurrent reads and tool registry mutations.
  * Added Python code example for graceful scheduler shutdown via SIGINT handler.

* **Breaking Changes**
  * Job store statistics retrieval now requires asynchronous handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAIDocs/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->