### PR TITLE
docs: security batch from PraisonAI PR #1684 (10 hardening fixes)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -468,6 +468,7 @@
                   "docs/features/platform-client-sdk-testing",
                   "docs/features/platform/auth-me-endpoint-fix",
                   "docs/features/platform/rbac-enforcement",
+                  "docs/features/platform/auth-configuration",
                   "docs/features/platform-sdk",
                   "docs/features/platform-python-sdk"
                 ]
@@ -709,6 +710,7 @@
                   "docs/features/lite-package",
                   "docs/features/logging-configuration",
                   "docs/features/mcp-lifecycle",
+                  "docs/features/mcp-cli-tools-path-safety",
                   "docs/features/performance-benchmarks",
                   "docs/features/thread-safety",
                   "docs/features/real-api-testing"

--- a/docs/best-practices/security.mdx
+++ b/docs/best-practices/security.mdx
@@ -1170,7 +1170,11 @@ flowchart LR
 
 ### Auto-Rejected Code Patterns
 
-These patterns are **always blocked** — the code never runs:
+These patterns are **always blocked** — the code never runs. The AST validator now runs **before** the sandbox subprocess, so attacks fail earlier:
+
+<Note>
+The AST validator catches malicious code during parsing, before any execution environment is created. This provides defense-in-depth alongside the runtime sandbox protections.
+</Note>
 
 | Category | Code Example | Rejection Layer |
 |---|---|---|
@@ -1184,6 +1188,8 @@ These patterns are **always blocked** — the code never runs:
 | **setattr()** | `setattr(int, 'x', 1)` | AST |
 | **delattr()** | `delattr(obj, 'x')` | AST |
 | **dir()** | `dir(object)` | AST |
+| **vars()** | `vars({})` | AST |
+| **\_\_self\_\_** | `print.__self__` | AST |
 | **\_\_class\_\_** | `().__class__` | AST |
 | **\_\_subclasses\_\_** | `object.__subclasses__()` | AST |
 | **\_\_globals\_\_** | `func.__globals__` | AST |
@@ -1211,6 +1217,10 @@ Real-world sandbox escape techniques and how each layer stops them:
 | **Generator frame** | `gen.gi_frame` | ❌ AST blocks `gi_frame` |
 | **Lambda + setattr** | `lambda: setattr(int, 'x', 1)` | ❌ AST blocks `setattr` call |
 | **Walrus + getattr** | `[x := getattr((), '__class__')]` | ❌ `_safe_getattr` blocks result |
+| **\_\_self\_\_ leak** | `print.__self__` → builtins module | ❌ blocked (GHSA-4mr5-g6f9-cfrh) |
+| **vars() dump** | `vars({})` to dump `__dict__` | ❌ blocked |
+| **Attribute chain** | `(1).__class__.__mro__` | ❌ blocked |
+| **Method call** | `m.exec(...)`, `obj.vars()` | ❌ AST blocks attribute-style calls |
 
 ### Allowed Code Patterns
 

--- a/docs/call.mdx
+++ b/docs/call.mdx
@@ -29,6 +29,75 @@ Buy a number at [PraisonAI Dashboard](https://dashboard.praison.ai/)
 
 Enter the Public URL in the PraisonAI Dashboard phone number field
 
+## Authentication
+
+<Warning>
+**Breaking Change**: When upgrading from earlier versions, the call server requires authentication configuration or it will fail with a 503 error.
+</Warning>
+
+The PraisonAI Call server now requires authentication configuration for security. You have two options:
+
+### Option 1: Token Authentication (Recommended)
+
+Set a secure token for API authentication:
+
+```bash
+export CALL_SERVER_TOKEN="your-secure-token-here"
+praisonai call --public
+```
+
+API requests must include the token in the Authorization header:
+
+```bash
+curl -H "Authorization: Bearer your-secure-token-here" \
+     -H "Content-Type: application/json" \
+     -d '{"message": "Hello"}' \
+     http://localhost:8090/api/v1/agents/assistant/invoke
+```
+
+### Option 2: Disable Authentication (Local Development Only)
+
+For local development, you can explicitly disable authentication:
+
+```bash
+export PRAISONAI_CALL_AUTH=disabled
+praisonai call --public
+```
+
+<Warning>
+Never use `PRAISONAI_CALL_AUTH=disabled` in production environments.
+</Warning>
+
+### Authentication Flow
+
+```mermaid
+graph LR
+    A[📝 Request] --> B{🔐 Has Bearer Token?}
+    B -->|Yes| C[✅ 200 Success]
+    B -->|No| D{⚙️ Auth Disabled?}
+    D -->|Yes| C
+    D -->|No| E{🔧 Token Configured?}
+    E -->|Yes| F[❌ 401 Unauthorized]
+    E -->|No| G[❌ 503 Service Unavailable]
+    
+    classDef request fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    
+    class A request
+    class B,D,E check
+    class C success
+    class F,G error
+```
+
+When `CALL_SERVER_TOKEN` is not configured and the environment is not development, the server returns:
+
+```
+503 Service Unavailable
+CALL_SERVER_TOKEN is not configured. Set CALL_SERVER_TOKEN or PRAISONAI_CALL_AUTH=disabled to run without authentication.
+```
+
 ## Features
 
 - Make and receive phone calls with AI agents

--- a/docs/cli/mentions.mdx
+++ b/docs/cli/mentions.mdx
@@ -111,6 +111,42 @@ praisonai "@url:https://docs.python.org/3/tutorial/index.html summarize this"
 2. HTML is converted to text
 3. Content is truncated if too long (max 10KB)
 
+### URL Safety
+
+`@url:` mentions use the same URL allowlist as [spider tools](/docs/tools/spider_tools#built-in-url-safety) for security. Blocked URLs are rejected before fetching:
+
+```bash
+# Blocked URL example
+praisonai "@url:http://localhost:8080/admin summarize this"
+```
+
+When a URL is blocked, the parser returns a placeholder instead of fetching:
+
+```
+# URL: http://localhost:8080/admin
+[Blocked: URL is not allowed]
+```
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant MentionsParser
+    participant SpiderTools
+    
+    User->>MentionsParser: @url:http://example.com
+    MentionsParser->>SpiderTools: _validate_url(url)
+    SpiderTools-->>MentionsParser: allow/block
+    
+    alt URL allowed
+        MentionsParser->>MentionsParser: fetch content
+        MentionsParser-->>User: content
+    else URL blocked
+        MentionsParser-->>User: [Blocked: URL is not allowed]
+    end
+```
+
+See the [spider tools documentation](/docs/tools/spider_tools#what-gets-refused) for the complete list of blocked URL patterns.
+
 ## Rule Mention
 
 Include a specific rule from `.praison/rules/`:

--- a/docs/features/file-editing.mdx
+++ b/docs/features/file-editing.mdx
@@ -202,7 +202,16 @@ Always use `search_files` to locate patterns before making edits. This provides 
 </Accordion>
 
 <Accordion title="Workspace Security">
-File editing operations respect workspace boundaries. Destructive operations (`edit_file`, `write_file`) require proper workspace configuration for security.
+File editing operations respect workspace boundaries. When `workspace` is omitted, `write_file` defaults to the current working directory and refuses paths that resolve outside it.
+
+Example of path that gets rejected:
+```python
+# This fails with workspace containment
+write_file("../escape.txt", "content")
+# Error: Path '../escape.txt' is outside the workspace
+```
+
+The `is_path_within_directory` check runs unconditionally against the effective workspace to prevent directory traversal attacks.
 </Accordion>
 
 <Accordion title="Verification Workflow">

--- a/docs/features/mcp-cli-tools-path-safety.mdx
+++ b/docs/features/mcp-cli-tools-path-safety.mdx
@@ -1,0 +1,202 @@
+---
+title: "MCP CLI Tools Path Safety"
+sidebarTitle: "CLI Tools Path Safety"
+description: "Workflow and deploy MCP tools accept only YAML files inside the current working directory"
+icon: "shield-check"
+---
+
+Workflow and deploy MCP tools accept only YAML files inside the current working directory for security.
+
+```mermaid
+graph LR
+    A[📄 file_path] --> B[🔍 _resolve_cwd_yaml_path]
+    B --> C{✅ Valid YAML in CWD?}
+    C -->|Yes| D[🟢 Allow]
+    C -->|No| E[🔴 ValueError]
+    
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    
+    class A input
+    class B,C process
+    class D success
+    class E error
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Valid Usage">
+```python
+# MCP tools accept bare YAML filenames
+workflow_validate("project.yaml")  # ✅ Works
+workflow_show("config.yml")        # ✅ Works
+deploy_validate("deploy.yaml")     # ✅ Works
+```
+</Step>
+
+<Step title="Rejected Usage">
+```python
+# These paths are rejected for security
+workflow_validate("../config.yaml")     # ❌ ValueError
+workflow_validate("/etc/passwd")        # ❌ ValueError
+workflow_validate("subdir/file.yaml")   # ❌ ValueError
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+Three MCP tools now enforce strict path validation:
+
+| Tool | Purpose | Path Requirement |
+|------|---------|-----------------|
+| `workflow_validate` | Validate workflow YAML | Bare filename in CWD |
+| `workflow_show` | Display workflow content | Bare filename in CWD |
+| `deploy_validate` | Validate deployment config | Bare filename in CWD |
+
+```mermaid
+sequenceDiagram
+    participant MCP as MCP Client
+    participant Tool as CLI Tool
+    participant Validator as _resolve_cwd_yaml_path
+    participant FS as File System
+    
+    MCP->>Tool: call with file_path
+    Tool->>Validator: _resolve_cwd_yaml_path(file_path)
+    Validator->>Validator: Check path rules
+    
+    alt Path valid
+        Validator->>FS: Read from CWD
+        FS-->>Validator: File content
+        Validator-->>Tool: Path object
+        Tool-->>MCP: Success result
+    else Path invalid
+        Validator-->>Tool: ValueError
+        Tool-->>MCP: Error message
+    end
+```
+
+---
+
+## What Gets Refused
+
+<Warning>
+**Breaking Change**: Absolute paths and outside-CWD paths that previously worked are now rejected.
+</Warning>
+
+| Path Pattern | Example | Error Message |
+|-------------|---------|---------------|
+| Contains `/` or `\` | `subdir/file.yaml` | `invalid file_path: 'subdir/file.yaml'` |
+| Contains NUL byte | `file\x00.yaml` | `invalid file_path: 'file\x00.yaml'` |
+| Starts with `.` | `.hidden.yaml` | `invalid file_path: '.hidden.yaml'` |
+| Not YAML extension | `config.json` | `file_path must be a .yaml or .yml file` |
+| Absolute path | `/etc/passwd` | `invalid file_path: '/etc/passwd'` |
+| Parent directory | `../config.yaml` | `invalid file_path: '../config.yaml'` |
+| Resolves outside CWD | `symlink.yaml` → `../outside.yaml` | `invalid file_path: 'symlink.yaml'` |
+
+---
+
+## Migration
+
+If you previously used these MCP tools with absolute paths or subdirectory paths:
+
+<Steps>
+<Step title="Move Files to CWD">
+```bash
+# Before (worked previously)
+workflow_validate("/home/user/project/workflows/main.yaml")
+workflow_validate("workflows/deploy.yaml")
+
+# After (required now)
+cp /home/user/project/workflows/main.yaml ./main.yaml
+cp workflows/deploy.yaml ./deploy.yaml
+workflow_validate("main.yaml")
+workflow_validate("deploy.yaml")
+```
+</Step>
+
+<Step title="Update Tool Calls">
+```python
+# Before
+deploy_validate("configs/production.yaml")
+
+# After  
+deploy_validate("production.yaml")  # file must be in CWD
+```
+</Step>
+</Steps>
+
+---
+
+## Common Patterns
+
+### Workflow Management
+
+```python
+# Validate workflow in current directory
+result = workflow_validate("workflow.yaml")
+if "valid" in result:
+    content = workflow_show("workflow.yaml")
+    print(content)
+```
+
+### Deployment Validation
+
+```python
+# Check deployment config
+result = deploy_validate("deploy.yml") 
+if "valid" in result:
+    print("Deployment config is valid")
+else:
+    print(f"Validation failed: {result}")
+```
+
+### Error Handling
+
+```python
+try:
+    content = workflow_show("../outside.yaml")
+except Exception as e:
+    print(f"Error: {e}")
+    # Error: invalid file_path: '../outside.yaml'
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Keep YAML Files in Project Root">
+Place workflow and deployment YAML files in the project root directory, not in subdirectories. This matches the MCP security model.
+</Accordion>
+
+<Accordion title="Use Descriptive Filenames">
+Since you can't use paths, use descriptive filenames like `production-deploy.yaml` instead of `deploy/production.yaml`.
+</Accordion>
+
+<Accordion title="Validate Before Use">
+Always call the validation tools before processing YAML files to catch configuration errors early.
+</Accordion>
+
+<Accordion title="Handle Errors Gracefully">
+Check for ValueError exceptions and provide helpful error messages to users when paths are rejected.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="MCP Integration" icon="plug" href="/docs/concepts/mcp">
+    Learn about MCP protocol support
+  </Card>
+  <Card title="CLI Tools" icon="terminal" href="/docs/cli/cli">
+    PraisonAI CLI command reference
+  </Card>
+</CardGroup>

--- a/docs/features/platform/auth-configuration.mdx
+++ b/docs/features/platform/auth-configuration.mdx
@@ -1,0 +1,284 @@
+---
+title: "Platform Authentication Configuration"
+sidebarTitle: "Auth Configuration"
+description: "JWT token configuration for PraisonAI Platform authentication"
+icon: "key"
+---
+
+Platform authentication requires proper JWT secret configuration for security in production environments.
+
+```mermaid
+graph LR
+    A[🔐 PLATFORM_JWT_SECRET] --> B{🌍 PLATFORM_ENV}
+    B -->|dev| C[✅ Allow Default Secret]
+    B -->|production| D{🔑 Secret Set?}
+    D -->|Yes| E[✅ Issue JWT]
+    D -->|No| F[❌ RuntimeError]
+    
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    
+    class A input
+    class B,D process
+    class C,E success
+    class F error
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Set JWT Secret for Production">
+```bash
+# Generate a secure secret
+python -c "import secrets; print(secrets.token_urlsafe(64))"
+# Example output: kV8fTqZ2Jm5nR9sQ3xW8vY1bN7pL4dF6hG0jK9sA2cE5mZ8xW...
+
+# Set the environment variable
+export PLATFORM_JWT_SECRET="your-generated-secret-here"
+```
+</Step>
+
+<Step title="Start Platform Service">
+```bash
+# With custom secret (production)
+export PLATFORM_JWT_SECRET="kV8fTqZ2Jm5nR9sQ3xW8vY1bN7pL4dF6..."
+praisonai-platform start
+
+# Or for development (allows default secret)
+export PLATFORM_ENV=dev
+praisonai-platform start
+```
+</Step>
+</Steps>
+
+---
+
+## Configuration
+
+### Required Environment Variables
+
+| Variable | Purpose | Required |
+|----------|---------|----------|
+| `PLATFORM_JWT_SECRET` | Secret for JWT token signing | **Yes** (except dev) |
+| `PLATFORM_ENV` | Environment mode (`dev` or production) | Optional (defaults to production) |
+| `PLATFORM_JWT_TTL` | Token TTL in seconds | Optional (default: 30 days) |
+
+### JWT Secret Security
+
+<Warning>
+**Breaking Change**: The platform now refuses to issue JWTs when running with the default secret outside `PLATFORM_ENV=dev`.
+</Warning>
+
+```bash
+# ✅ Valid configurations
+export PLATFORM_JWT_SECRET="your-secure-secret"  # Production with custom secret
+export PLATFORM_ENV=dev                          # Development (default secret OK)
+
+# ❌ Invalid configuration (will fail)
+# No PLATFORM_JWT_SECRET set and PLATFORM_ENV != "dev"
+```
+
+---
+
+## How It Works
+
+The `AuthService._issue_token` method enforces JWT secret validation:
+
+```python
+def _issue_token(self, user: User) -> str:
+    """Issue a JWT for a user."""
+    if JWT_SECRET == _DEFAULT_SECRET and os.environ.get("PLATFORM_ENV", "dev") != "dev":
+        raise RuntimeError(
+            "Refusing to issue JWT with default PLATFORM_JWT_SECRET outside dev"
+        )
+    # ... issue JWT
+```
+
+### Token Issuance Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant AuthService
+    participant Environment
+    
+    Client->>AuthService: login(email, password)
+    AuthService->>Environment: Check PLATFORM_JWT_SECRET
+    
+    alt Custom secret OR dev environment
+        AuthService->>AuthService: _issue_token(user)
+        AuthService-->>Client: JWT token
+    else Default secret in production
+        AuthService-->>Client: RuntimeError
+    end
+```
+
+---
+
+## Production Deployment
+
+### Docker Configuration
+
+```dockerfile
+FROM python:3.11-slim
+
+# Set JWT secret via environment
+ENV PLATFORM_JWT_SECRET="your-secure-secret-from-secrets-manager"
+
+# Install and run platform
+RUN pip install praisonai-platform
+CMD ["praisonai-platform", "start"]
+```
+
+### Kubernetes Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: platform-auth
+type: Opaque
+data:
+  jwt-secret: eW91ci1zZWN1cmUtc2VjcmV0LWJhc2U2NC1lbmNvZGVk
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: praisonai-platform
+spec:
+  template:
+    spec:
+      containers:
+      - name: platform
+        image: praisonai/platform:latest
+        env:
+        - name: PLATFORM_JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: platform-auth
+              key: jwt-secret
+```
+
+### Environment Variable Best Practices
+
+```bash
+# Use a secrets manager
+export PLATFORM_JWT_SECRET="$(aws secretsmanager get-secret-value --secret-id prod/jwt-secret --query SecretString --output text)"
+
+# Or read from file
+export PLATFORM_JWT_SECRET="$(cat /var/secrets/jwt-secret)"
+
+# Verify it's set
+echo ${PLATFORM_JWT_SECRET:0:10}...  # Show first 10 characters only
+```
+
+---
+
+## Migration
+
+### Upgrading from Previous Versions
+
+<Warning>
+If you're upgrading from a version without JWT secret validation, set `PLATFORM_JWT_SECRET` before restarting, or you'll get a RuntimeError when users try to log in.
+</Warning>
+
+<Steps>
+<Step title="Generate Secret">
+```bash
+# Generate a cryptographically secure secret
+python -c "import secrets; print('PLATFORM_JWT_SECRET=' + secrets.token_urlsafe(64))"
+```
+</Step>
+
+<Step title="Update Configuration">
+```bash
+# Add to your environment/config
+export PLATFORM_JWT_SECRET="your-generated-secret"
+
+# Or for temporary local development
+export PLATFORM_ENV=dev  # NOT for production
+```
+</Step>
+
+<Step title="Restart Platform">
+```bash
+# Restart with new configuration
+praisonai-platform restart
+```
+</Step>
+</Steps>
+
+### Error Handling
+
+When `login()` is called with misconfigured production deployment:
+
+```
+RuntimeError: Refusing to issue JWT with default PLATFORM_JWT_SECRET outside dev
+```
+
+This error occurs during token issuance, not service startup, so the platform will start successfully but fail when users attempt to authenticate.
+
+---
+
+## Development vs Production
+
+### Development Mode
+
+```bash
+# Allow default secret (insecure, development only)
+export PLATFORM_ENV=dev
+praisonai-platform start
+
+# Default secret warning will be logged but service continues
+```
+
+### Production Mode
+
+```bash
+# Require custom secret (secure, production)
+export PLATFORM_JWT_SECRET="$(python -c 'import secrets; print(secrets.token_urlsafe(64))')"
+unset PLATFORM_ENV  # Defaults to production mode
+praisonai-platform start
+```
+
+| Mode | Default Secret | Custom Secret | Notes |
+|------|----------------|---------------|-------|
+| Development (`PLATFORM_ENV=dev`) | ✅ Allowed | ✅ Allowed | For local development only |
+| Production (any other `PLATFORM_ENV`) | ❌ Rejected | ✅ Required | Enforced at token issuance |
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Use Strong Secrets">
+Generate secrets with at least 256 bits of entropy using `secrets.token_urlsafe(64)` or equivalent. Never use predictable values.
+</Accordion>
+
+<Accordion title="Rotate Secrets Regularly">
+Implement secret rotation every 90 days. When rotating, issue new tokens gradually to avoid service disruption.
+</Accordion>
+
+<Accordion title="Store Secrets Securely">
+Use dedicated secret management systems (AWS Secrets Manager, HashiCorp Vault, etc.) rather than plain environment variables.
+</Accordion>
+
+<Accordion title="Monitor Authentication Failures">
+Log and alert on RuntimeError exceptions during login to detect misconfigured deployments quickly.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="RBAC Enforcement" icon="shield-check" href="/docs/features/platform/rbac-enforcement">
+    Workspace membership and role-based access control
+  </Card>
+  <Card title="Platform SDK" icon="code" href="/docs/features/platform-python-sdk">
+    Python SDK for platform integration
+  </Card>
+</CardGroup>

--- a/docs/features/platform/members.mdx
+++ b/docs/features/platform/members.mdx
@@ -311,6 +311,8 @@ Limit the number of owners in a workspace. Having too many owners can create sec
 
 <Accordion title="Secure Token Management">
 Always use secure JWT tokens for API authentication. Store tokens securely and rotate them regularly to maintain workspace security.
+
+See [Authentication Configuration](/docs/features/platform/auth-configuration) for JWT secret setup and security requirements.
 </Accordion>
 </AccordionGroup>
 

--- a/docs/features/platform/rbac-enforcement.mdx
+++ b/docs/features/platform/rbac-enforcement.mdx
@@ -203,6 +203,8 @@ All workspace-scoped API routes now enforce membership:
 | `DELETE /workspaces/{id}` | ✅ | `owner` |
 | `GET /workspaces/{id}/members` | ✅ | `member` |
 | `POST /workspaces/{id}/members` | ✅ | `admin` |
+| `PATCH /workspaces/{id}/members/{user_id}` | ✅ | `admin` |
+| `DELETE /workspaces/{id}/members/{user_id}` | ✅ | `admin` |
 
 ### Project Management
 
@@ -231,6 +233,73 @@ All workspace-scoped API routes now enforce membership:
 | `POST /workspaces/{id}/agents/` | ✅ | `member` |
 | `PATCH /workspaces/{id}/agents/{aid}` | ✅ | `member` |
 | `DELETE /workspaces/{id}/agents/{aid}` | ✅ | `admin` |
+
+---
+
+<Warning>
+**Breaking Change**: If you have an existing client that mutates workspaces, members, agents, or issues as a non-admin member, those calls now return 403. Grant the calling user the `admin` (or `owner` where required) role first.
+</Warning>
+
+## Owner-only Sub-checks
+
+Beyond the base role requirements, certain operations require additional owner privileges:
+
+### Member Management with Owner Role
+
+| Operation | Requirement | Error Message |
+|-----------|-------------|---------------|
+| Add member with `role=owner` | Caller must be `owner` | `Only owners can add another owner` |
+| Change role to `owner` | Caller must be `owner` | `Only owners can assign the owner role` |
+| Change existing `owner` role | Caller must be `owner` | `Only owners can change an owner's role` |
+| Remove existing `owner` | Caller must be `owner` | `Only owners can remove an owner` |
+| Change your own role | Always forbidden | `Cannot change your own role` |
+| Remove yourself | Always forbidden | `Cannot remove yourself from the workspace` |
+
+### Example Owner-only Operations
+
+```python
+# These operations require the caller to be an owner:
+POST /workspaces/{id}/members {"user_id": "user-123", "role": "owner"}
+PATCH /workspaces/{id}/members/user-456 {"role": "owner"}  
+PATCH /workspaces/{id}/members/owner-789 {"role": "admin"}
+DELETE /workspaces/{id}/members/owner-789
+
+# These are always forbidden regardless of role:
+PATCH /workspaces/{id}/members/your-user-id {"role": "member"}  # Self role change
+DELETE /workspaces/{id}/members/your-user-id                   # Self removal
+```
+
+## Cross-workspace Access (IDOR)
+
+The `ensure_resource_in_workspace` function prevents cross-workspace resource access by returning **404 (not 403)** when a resource exists but belongs to a different workspace.
+
+### Protected Resources
+
+| Resource | Routes | 404 Message |
+|----------|--------|-------------|
+| Agents | `GET/PATCH/DELETE /agents/{id}` | `Agent not found` |
+| Issues | `GET/PATCH/DELETE /issues/{id}` | `Issue not found` |
+| Issue Comments | `POST/GET /issues/{id}/comments` | `Issue not found` |
+
+```mermaid
+graph TB
+    A[📨 Request /agents/agent-123] --> B[🔍 Load Agent]
+    B --> C{🏢 Same Workspace?}
+    C -->|Yes| D[✅ Allow Access]
+    C -->|No| E[❌ 404 Agent not found]
+    
+    classDef request fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    
+    class A request
+    class B,C process
+    class D success
+    class E error
+```
+
+This prevents enumeration of resource IDs across workspaces by making cross-workspace resources appear non-existent.
 
 ---
 

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -105,6 +105,56 @@ If you're upgrading from **4.6.33 or earlier**, your setup may break. See the mi
 3. **MCP rules tools reject unsafe file paths** - names like `"../../etc/passwd"` now fail
 4. **Knowledge backends validate identifiers** - collection names must be `[A-Za-z0-9_]+`
 
+## Recent Security Hardening (next release — Security Batch 10)
+
+PraisonAI's upcoming release includes **10 security advisories** worth of hardening fixes from [PR #1684](https://github.com/MervinPraison/PraisonAI/pull/1684). Several changes are **user-facing and breaking**.
+
+### Security Vulnerabilities Fixed
+
+<CardGroup cols={3}>
+  <Card title="GHSA-4mr5-g6f9-cfrh" icon="shield-x" color="#dc2626" href="https://github.com/advisories/GHSA-4mr5-g6f9-cfrh">
+    **Critical**: execute_code sandbox escapes
+  </Card>
+  <Card title="GHSA-5c6w-wwfq-7qqm" icon="shield-alert" color="#ea580c" href="https://github.com/advisories/GHSA-5c6w-wwfq-7qqm">
+    **High**: spider_tools loopback bypass
+  </Card>
+  <Card title="GHSA-9cr9-25q5-8prj" icon="shield-alert" color="#ea580c" href="https://github.com/advisories/GHSA-9cr9-25q5-8prj">
+    **High**: MCP CLI tools path traversal
+  </Card>
+  <Card title="GHSA-86qc-r5v2-v6x6" icon="shield-alert" color="#ea580c" href="https://github.com/advisories/GHSA-86qc-r5v2-v6x6">
+    **High**: Call server unauthenticated
+  </Card>
+  <Card title="GHSA-hvhp-v2gc-268q" icon="shield-alert" color="#ca8a04" href="https://github.com/advisories/GHSA-hvhp-v2gc-268q">
+    **Medium**: write_file workspace escape
+  </Card>
+  <Card title="GHSA-5cxw-77wg-jrf3" icon="shield-alert" color="#ca8a04" href="https://github.com/advisories/GHSA-5cxw-77wg-jrf3">
+    **Medium**: @url: mentions SSRF
+  </Card>
+  <Card title="GHSA-xwq8-frcg-77q8" icon="shield-check" color="#16a34a" href="https://github.com/advisories/GHSA-xwq8-frcg-77q8">
+    **Low**: Cross-workspace IDOR
+  </Card>
+  <Card title="GHSA-c2m8-4gcg-v22g" icon="shield-check" color="#16a34a" href="https://github.com/advisories/GHSA-c2m8-4gcg-v22g">
+    **Low**: Platform RBAC bypass
+  </Card>
+  <Card title="GHSA-xp85-6wwf-r67c" icon="shield-check" color="#16a34a" href="https://github.com/advisories/GHSA-xp85-6wwf-r67c">
+    **Low**: CI branch injection
+  </Card>
+  <Card title="GHSA-3qg8-5g3r-79v5" icon="shield-check" color="#16a34a" href="https://github.com/advisories/GHSA-3qg8-5g3r-79v5">
+    **Low**: Platform default JWT secret
+  </Card>
+</CardGroup>
+
+### Breaking Changes
+
+<Warning>
+**Four breaking changes** require configuration updates before upgrading:
+
+1. **`praisonai call` now requires `CALL_SERVER_TOKEN`** (or explicit opt-out) — server fails with 503 if unconfigured
+2. **MCP `workflow_show` / `workflow_validate` / `deploy_validate` no longer accept absolute or outside-cwd paths** — place files in project root
+3. **Platform member/workspace mutation endpoints now enforce `admin` / `owner` roles** — grant appropriate roles to existing clients
+4. **Platform refuses to issue JWTs when running with the default secret outside `PLATFORM_ENV=dev`** — set `PLATFORM_JWT_SECRET` in production
+</Warning>
+
 ### Migration for API Server Users
 
 For step-by-step migration instructions, see [API Server Authentication](/features/api-server-auth#migration-from--4634).

--- a/docs/tools/spider_tools.mdx
+++ b/docs/tools/spider_tools.mdx
@@ -242,6 +242,12 @@ graph LR
 |---|---|---|
 | Non-`http`/`https` schemes | `file:///etc/passwd`, `gopher://x` | Only web protocols are allowed |
 | Loopback | `http://127.0.0.1/`, `http://localhost/` | Blocks access to the local machine |
+| Trailing-dot localhost | `http://localhost.:8765/` | Some HTTP clients strip the dot and hit loopback |
+| Short-form IPv4 | `http://127.1:8765/`, `http://127.1/` | `inet_aton` expands `127.1` → `127.0.0.1` |
+| Octal IPv4 | `http://0177.0.0.1:8765/` | `0177` = `127` in octal |
+| Hex integer host | `http://0x7f000001:8765/` | `0x7f000001` = `127.0.0.1` packed |
+| Decimal integer host | `http://2130706433:8765/` | `2130706433` = `127.0.0.1` packed |
+| Internal `.localhost` suffix | `http://api.localhost/` | All `*.localhost` is loopback by RFC |
 | Private / reserved IPs | `http://10.0.0.5/`, `http://192.168.1.1/` | Blocks internal network access |
 | Link-local | `http://169.254.169.254/` | Blocks cloud metadata services |
 | Internal TLDs | `http://intranet.local/`, `http://svc.internal/` | Blocks corporate internal hosts |
@@ -251,6 +257,8 @@ graph LR
 
 <Note>
 The backslash and control-character rejections (the last two rows above) were added in PraisonAI [#1578](https://github.com/MervinPraison/PraisonAI/pull/1578) to close an SSRF bypass where `urllib.parse.urlparse` and the HTTP client (`requests` / `httpx`) disagreed on the destination host.
+
+The alternative loopback encodings (trailing-dot localhost, short-form/octal/hex IPv4, etc.) are validated by the unified `_host_is_blocked` helper, which also powers URL safety for [`@url:` mentions](/docs/cli/mentions).
 </Note>
 
 ### What it looks like to your agent


### PR DESCRIPTION
Fixes #366

This PR documents the security batch from upstream PraisonAI PR #1684, which includes 10 security advisories worth of hardening fixes. Several changes are user-facing and breaking.

## What's New

### Updated Documentation
- **docs/call.mdx**: Added authentication requirements with breaking change warning
- **docs/tools/spider_tools.mdx**: Documented new loopback URL blocking patterns
- **docs/cli/mentions.mdx**: Added URL safety section for @url mentions
- **docs/best-practices/security.mdx**: Added new sandbox blocking patterns
- **docs/features/file-editing.mdx**: Updated workspace containment documentation
- **docs/features/platform/rbac-enforcement.mdx**: Added owner-only sub-checks and IDOR protection
- **docs/security.mdx**: Added comprehensive Security Batch 10 summary

### New Documentation Pages
- **docs/features/mcp-cli-tools-path-safety.mdx**: Documents breaking path safety for MCP CLI tools
- **docs/features/platform/auth-configuration.mdx**: Documents JWT secret requirements for platform auth

## Security Advisories Documented

| GHSA | Severity | Component | Breaking |
|------|----------|-----------|----------|
| GHSA-4mr5-g6f9-cfrh | Critical | execute_code sandbox | No |
| GHSA-5c6w-wwfq-7qqm | High | spider_tools loopback | No |
| GHSA-9cr9-25q5-8prj | High | MCP CLI tools | **Yes** |
| GHSA-86qc-r5v2-v6x6 | High | Call server auth | **Yes** |
| GHSA-hvhp-v2gc-268q | Medium | write_file workspace | No |
| GHSA-5cxw-77wg-jrf3 | Medium | @url mentions | No |
| GHSA-xwq8-frcg-77q8 | Low | Cross-workspace IDOR | No |
| GHSA-c2m8-4gcg-v22g | Low | Platform RBAC | **Yes** |
| GHSA-xp85-6wwf-r67c | Low | CI branch injection | No |
| GHSA-3qg8-5g3r-79v5 | Low | Platform JWT secret | **Yes** |

## Breaking Changes

Four breaking changes require user action before upgrading:

1. **praisonai call now requires CALL_SERVER_TOKEN** (or explicit opt-out)
2. **MCP CLI tools no longer accept absolute/outside-cwd paths**
3. **Platform member/workspace endpoints now enforce admin/owner roles**
4. **Platform refuses JWT issuance with default secret in production**

Each breaking change has clear migration guidance and warning callouts in the documentation.

Generated with [Claude Code](https://claude.ai/code)