### PR TITLE
docs: rewrite a2ui.mdx + add generative-ui.mdx after PR #1702 A2UI refactor

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -550,6 +550,7 @@
                 "group": "UI & Display",
                 "icon": "display",
                 "pages": [
+                  "docs/features/generative-ui",
                   "docs/features/display-system",
                   "docs/features/display-callbacks",
                   "docs/features/output-styles",

--- a/docs/features/a2ui.mdx
+++ b/docs/features/a2ui.mdx
@@ -1,322 +1,297 @@
 ---
-title: "A2UI Protocol"
-description: "Agent-to-User Interface protocol for agent-generated UIs"
+title: "A2UI"
+sidebarTitle: "A2UI"
+description: "Declarative agent-generated UIs using Google's A2UI SDK"
 icon: "window"
 ---
 
-# A2UI (Agent-to-User Interface)
+Declarative agent-generated UIs using Google's official A2UI SDK with schema validation and rendering support.
 
-PraisonAI supports the [A2UI Protocol](https://github.com/google/A2UI) for generating rich, interactive user interfaces from AI agents using declarative JSON.
+```mermaid
+graph LR
+    subgraph "A2UI Flow"
+        A[🧠 Agent] --> B[📋 System Prompt]
+        B --> C[🤖 LLM Output]
+        C --> D[✅ Schema Validation]
+        D --> E[🖥️ Renderer Client]
+    end
+    
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    
+    class A agent
+    class B,D process
+    class C,E output
+```
 
-## Overview
-
-A2UI is Google's open standard that allows agents to "speak UI" by sending declarative JSON describing UI components, which clients then render natively.
-
-**Key Features:**
-- **Declarative JSON** - Agents send UI descriptions, not executable code
-- **Security First** - Only pre-approved components from a catalog can be rendered
-- **LLM-Friendly** - Flat list of components with IDs, easy for LLMs to generate
-- **Framework-Agnostic** - Same JSON works on Web, Flutter, React, etc.
-- **Incrementally Updateable** - Agents can update UI progressively
+<Warning>
+Install the A2UI extra and ensure a2a-sdk version compatibility:
+```bash
+pip install praisonaiagents[a2ui]
+```
+The a2a-sdk 1.x branch breaks DataPart API compatibility.
+</Warning>
 
 ## Quick Start
 
-### Using A2UIAgent Wrapper
+<Steps>
+<Step title="Install A2UI Extra">
+Install the optional A2UI dependencies:
+
+```bash
+pip install praisonaiagents[a2ui]
+```
+</Step>
+
+<Step title="Add A2UI System Prompt and Tool">
+Create an agent with A2UI system prompt and the send_a2ui_messages tool:
 
 ```python
 from praisonaiagents import Agent
-from praisonaiagents.ui.a2ui import A2UIAgent
+from praisonaiagents.ui import A2UI
+from praisonaiagents.tools.a2ui_tools import send_a2ui_messages
 
-# Create an agent
 agent = Agent(
-    name="Assistant",
-    role="Helper",
-    goal="Help users with tasks"
+    name="UI Assistant",
+    instructions="Reply with A2UI surfaces when the user asks for a UI.",
+    system_prompt=A2UI.system_prompt(
+        role_description="You generate user interfaces using A2UI.",
+        ui_description="Use the basic catalog v0.9.",
+    ),
+    tools=[send_a2ui_messages],
 )
 
-# Wrap with A2UI
-a2ui_agent = A2UIAgent(agent=agent)
-
-# Render a text response
-messages = a2ui_agent.render_text("Hello World!", title="Greeting")
-
-# Render a list of items
-messages = a2ui_agent.render_list(
-    title="Results",
-    items=[
-        {"title": "Item 1", "description": "First item"},
-        {"title": "Item 2", "description": "Second item"},
-    ]
-)
-
-# Render a form
-messages = a2ui_agent.render_form(
-    title="Contact Form",
-    fields=[
-        {"id": "name", "label": "Name", "type": "text"},
-        {"id": "email", "label": "Email", "type": "email"},
-    ],
-    submit_action="submit_form"
-)
-
-# Get JSON output
-json_output = a2ui_agent.to_json()
+agent.start("Show me a contact form for name and email")
 ```
+</Step>
 
-### Using Surface Builder
+<Step title="Parse and Validate Output">
+Parse LLM responses into validated A2A parts:
 
 ```python
-from praisonaiagents.ui.a2ui import Surface, PathBinding
+from praisonaiagents.ui import A2UI
 
-# Create a surface
-surface = Surface(surface_id="main")
+# Parse LLM text output into A2A parts
+llm_output = '{"createSurface": {"surfaceId": "form"}}'
+parts = A2UI.parse_response(llm_output)
 
-# Add components using fluent API
-surface.text(id="title", text="Welcome", usage_hint="h1")
-surface.text(id="subtitle", text=PathBinding(path="/subtitle"), usage_hint="h2")
-surface.button(
-    id="action-btn",
-    child="btn-text",
-    action_name="do_action",
-    action_context=[{"key": "id", "value": "123"}],
-    primary=True
-)
-surface.text(id="btn-text", text="Click Me")
-surface.column(id="root", children=["title", "subtitle", "action-btn"])
+# Create A2UI parts manually
+a2ui_data = {"createSurface": {"surfaceId": "contact"}}
+part = A2UI.create_part(a2ui_data)
 
-# Set data model
-surface.set_data("subtitle", "Hello World")
+# Check if a part contains A2UI data
+if A2UI.is_part(part):
+    print("Contains A2UI data")
+```
+</Step>
+</Steps>
 
-# Generate A2UI messages
-messages = surface.to_messages()
-json_output = surface.to_json()
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant LLM
+    participant A2UI
+    participant Renderer
+    
+    User->>Agent: Request UI
+    Agent->>LLM: Prompt with A2UI schema
+    LLM-->>Agent: A2UI JSON response
+    Agent->>A2UI: Parse & validate
+    A2UI-->>Agent: A2A parts
+    Agent-->>Renderer: Send A2UI messages
+    Renderer-->>User: Display UI
 ```
 
-### Using Templates
+The A2UI integration provides a thin adapter over Google's official a2ui-agent-sdk:
+
+| Step | Description |
+|------|-------------|
+| System Prompt | Embeds A2UI schema and examples in LLM context |
+| LLM Generation | Model generates A2UI JSON following the schema |
+| Parsing | `A2UI.parse_response` validates and splits text/A2UI parts |
+| Transport | A2A DataPart wraps A2UI for client transmission |
+
+---
+
+## Configuration Options
+
+### Schema Manager Options
+
+Configure A2UI schema validation:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `version` | `str` | `"0.9"` | A2UI version to use |
+| `catalogs` | `List[Any]` | `None` | Component catalogs (uses basic catalog if None) |
+| `accepts_inline_catalogs` | `bool` | `False` | Allow inline catalog definitions |
+
+### System Prompt Options
+
+Configure A2UI system prompt generation:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `role_description` | `str` | Required | Role description for the agent |
+| `workflow_description` | `str` | `""` | Optional workflow description |
+| `ui_description` | `str` | `""` | Optional UI description |
+| `version` | `str` | `"0.9"` | A2UI version |
+| `include_schema` | `bool` | `True` | Include schema in prompt |
+| `include_examples` | `bool` | `True` | Include examples in prompt |
+
+---
+
+## Standalone Validation Pattern
+
+Use A2UI validation without an agent wrapper:
 
 ```python
+from praisonaiagents.ui import A2UI
+
+# Generate system prompt
+prompt = A2UI.system_prompt(
+    role_description="You create contact forms",
+    ui_description="Generate simple forms with name and email fields",
+    include_examples=True
+)
+
+# Parse LLM response
+response = '{"createSurface": {"surfaceId": "contact"}}'
+parts = A2UI.parse_response(response)
+
+# Create and validate parts
+for part in parts:
+    if A2UI.is_part(part):
+        print("Valid A2UI part")
+        # Send to renderer client
+```
+
+---
+
+## Migration from Previous A2UI Implementation
+
+The PR #1702 refactor removed the custom A2UI implementation. Here are the changes:
+
+<AccordionGroup>
+<Accordion title="Removed Classes and What to Use Instead">
+**Removed classes (no longer available):**
+
+```python
+# ALL OF THESE WERE REMOVED
+from praisonaiagents.ui.a2ui import A2UIAgent            # removed
+from praisonaiagents.ui.a2ui import Surface, PathBinding # removed  
+from praisonaiagents.ui.a2ui import ChatTemplate         # removed
+from praisonaiagents.ui.a2ui import ListTemplate         # removed
+from praisonaiagents.ui.a2ui import FormTemplate         # removed
+from praisonaiagents.ui.a2ui import DashboardTemplate    # removed
 from praisonaiagents.ui.a2ui import (
-    ChatTemplate,
-    ListTemplate,
-    FormTemplate,
-    DashboardTemplate,
+    CreateSurfaceMessage, UpdateComponentsMessage,       # removed
+    UpdateDataModelMessage, DeleteSurfaceMessage,        # removed
+    TextComponent,                                       # removed
 )
-
-# Chat Template
-chat = ChatTemplate(surface_id="chat")
-chat.add_user_message("Hello!")
-chat.add_agent_message("Hi there! How can I help?")
-messages = chat.to_messages()
-
-# List Template
-list_ui = ListTemplate(surface_id="results", title="Search Results")
-list_ui.add_item(title="Result 1", description="First result", image_url="https://...")
-list_ui.add_item(title="Result 2", description="Second result")
-messages = list_ui.to_messages()
-
-# Form Template
-form = FormTemplate(surface_id="contact", title="Contact Us")
-form.add_text_field(id="name", label="Your Name")
-form.add_email_field(id="email", label="Email Address")
-form.add_number_field(id="phone", label="Phone Number")
-form.set_submit_action("submit_contact", "Send Message")
-messages = form.to_messages()
-
-# Dashboard Template
-dashboard = DashboardTemplate(surface_id="dashboard", title="Analytics")
-dashboard.add_panel(id="stats", title="Statistics", content="1,234 users")
-dashboard.add_panel(id="chart", title="Chart", content="[Chart visualization]")
-messages = dashboard.to_messages()
 ```
 
-## Components
-
-### Display Components
-
-| Component | Description |
-|-----------|-------------|
-| `TextComponent` | Text display with usage hints (h1, h2, body, caption) |
-| `ImageComponent` | Image display with fit and usage hints |
-| `IconComponent` | Icon display |
-
-### Layout Components
-
-| Component | Description |
-|-----------|-------------|
-| `RowComponent` | Horizontal layout |
-| `ColumnComponent` | Vertical layout |
-| `CardComponent` | Card container |
-| `ListComponent` | List with template support |
-
-### Input Components
-
-| Component | Description |
-|-----------|-------------|
-| `ButtonComponent` | Button with action |
-| `TextFieldComponent` | Text input field |
-| `CheckBoxComponent` | Checkbox input |
-| `SliderComponent` | Slider input |
-| `DateTimeInputComponent` | Date/time picker |
-
-## Data Binding
-
-Use `PathBinding` to reference values in the data model:
+**New equivalent approach:**
 
 ```python
-from praisonaiagents.ui.a2ui import Surface, PathBinding
+# Use the official SDK directly for complex UIs
+from a2ui.agent import Agent as A2UISDKAgent
+from a2ui.schema.manager import A2uiSchemaManager
 
-surface = Surface(surface_id="main")
+# Or use PraisonAI's thin facade for simple cases
+from praisonaiagents.ui import A2UI
+from praisonaiagents.tools.a2ui_tools import send_a2ui_messages
+```
+</Accordion>
 
-# Static text
-surface.text(id="static", text="Hello")
+<Accordion title="Migration Strategy">
+1. **Replace A2UIAgent** → Use `A2UI.system_prompt()` with `send_a2ui_messages` tool
+2. **Replace Surface builders** → Use upstream `a2ui-agent-sdk` directly  
+3. **Replace Templates** → Build JSON manually or use upstream SDK templates
+4. **Replace Components** → Import from `a2ui.components` in upstream SDK
+5. **Update imports** → All PraisonAI A2UI classes were removed, use Google's SDK
+</Accordion>
 
-# Dynamic text from data model
-surface.text(id="dynamic", text=PathBinding(path="/user/name"))
+<Accordion title="Benefits of the New Approach">
+- **Maintenance**: Uses Google's official SDK instead of custom implementation
+- **Features**: Access to latest A2UI features and bug fixes
+- **Compatibility**: Standard A2UI JSON works across all clients
+- **Size**: Removed ~3,400 lines of custom code from PraisonAI core
+- **Optional**: A2UI is now truly optional via `pip install praisonaiagents[a2ui]`
+</Accordion>
+</AccordionGroup>
 
-# Set the data
-surface.set_data("user", {"name": "John Doe"})
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Pin a2a-sdk Version">
+Always pin a2a-sdk to avoid breaking changes:
+
+```bash
+pip install "a2a-sdk>=0.3.0,<1.0.0"
 ```
 
-## Actions
+The 1.x branch introduces breaking changes to the DataPart API.
+</Accordion>
 
-Define button actions with context:
+<Accordion title="Use Schema Validation">
+Always parse and validate LLM output:
 
 ```python
-from praisonaiagents.ui.a2ui import Surface
-
-surface = Surface(surface_id="main")
-
-surface.text(id="btn-label", text="Book Now")
-surface.button(
-    id="book-btn",
-    child="btn-label",
-    action_name="book_restaurant",
-    action_context=[
-        {"key": "restaurant_id", "value": "123"},
-        {"key": "name", "value": {"path": "/restaurant/name"}},  # Dynamic value
-    ],
-    primary=True
-)
+# Don't send raw LLM output
+# Do validate first
+parts = A2UI.parse_response(llm_output)
+validated_parts = [p for p in parts if A2UI.is_part(p)]
 ```
+</Accordion>
 
-## A2A Integration
-
-A2UI works alongside the A2A (Agent-to-Agent) protocol:
+<Accordion title="Prefer Official SDK for Complex UIs">
+For complex UIs with multiple surfaces, use Google's SDK directly:
 
 ```python
-from praisonaiagents.ui.a2ui import (
-    Surface,
-    create_a2ui_part,
-    is_a2ui_part,
-    get_a2ui_agent_extension,
-    A2UI_MIME_TYPE,
-)
+from a2ui.agent import Agent as A2UIAgent
+from a2ui.schema.manager import A2uiSchemaManager
 
-# Create surface
-surface = Surface(surface_id="main")
-surface.text(id="msg", text="Hello from A2A")
-surface.column(id="root", children=["msg"])
-
-# Wrap as A2A DataPart
-part = create_a2ui_part({"messages": surface.to_messages()})
-
-# Check if part is A2UI
-assert is_a2ui_part(part)
-assert part.metadata["mimeType"] == A2UI_MIME_TYPE
-
-# Get A2A AgentExtension for Agent Card
-extension = get_a2ui_agent_extension()
+# Direct SDK usage for complex scenarios
 ```
+</Accordion>
 
-## Message Types
-
-A2UI uses four message types:
-
-| Message | Description |
-|---------|-------------|
-| `CreateSurfaceMessage` | Create a new UI surface |
-| `UpdateComponentsMessage` | Update surface components |
-| `UpdateDataModelMessage` | Update the data model |
-| `DeleteSurfaceMessage` | Delete a surface |
+<Accordion title="Include Examples in System Prompts">
+Enable examples for better LLM output:
 
 ```python
-from praisonaiagents.ui.a2ui import (
-    CreateSurfaceMessage,
-    UpdateComponentsMessage,
-    UpdateDataModelMessage,
-    DeleteSurfaceMessage,
-    TextComponent,
-)
-
-# Create surface
-create_msg = CreateSurfaceMessage(
-    surface_id="main",
-    catalog_id="https://a2ui.dev/standard"
-)
-
-# Update components
-text = TextComponent(id="title", text="Hello", usage_hint="h1")
-update_msg = UpdateComponentsMessage(
-    surface_id="main",
-    components=[text]
-)
-
-# Update data model
-data_msg = UpdateDataModelMessage(
-    surface_id="main",
-    value={"title": "Hello World"}
-)
-
-# Delete surface
-delete_msg = DeleteSurfaceMessage(surface_id="main")
-```
-
-## API Reference
-
-### A2UIAgent
-
-```python
-A2UIAgent(
-    agent: Agent,                    # PraisonAI Agent instance
-    surface_id: str = None,          # Surface ID (auto-generated if not provided)
-    catalog_id: str = STANDARD_CATALOG_ID,  # Component catalog
+A2UI.system_prompt(
+    role_description="Create forms",
+    include_examples=True,  # Better LLM output
+    include_schema=True,    # Enable validation
 )
 ```
+</Accordion>
+</AccordionGroup>
 
-**Methods:**
-- `render_text(text, title=None)` - Render text response
-- `render_list(title, items, ...)` - Render list of items
-- `render_form(title, fields, ...)` - Render form
-- `chat(message)` - Send message to agent
-- `to_messages()` - Get A2UI messages
-- `to_json()` - Get JSON string
-- `to_a2a_part()` - Get A2A DataPart
-
-### Surface
-
-```python
-Surface(
-    surface_id: str,                 # Unique surface ID
-    catalog_id: str = STANDARD_CATALOG_ID,  # Component catalog
-)
-```
-
-**Methods:**
-- `add(component)` - Add a component
-- `set_data(key, value)` - Set data model value
-- `text(id, text, ...)` - Add text component
-- `image(id, url, ...)` - Add image component
-- `button(id, child, ...)` - Add button component
-- `card(id, child, ...)` - Add card component
-- `row(id, children, ...)` - Add row layout
-- `column(id, children, ...)` - Add column layout
-- `list(id, children, ...)` - Add list component
-- `text_field(id, label, ...)` - Add text field
-- `to_messages()` - Generate A2UI messages
-- `to_json()` - Generate JSON string
+---
 
 ## Related
 
-- [A2A Protocol](/features/a2a) - Agent-to-Agent communication
-- [AG-UI Protocol](/ui/overview) - CopilotKit integration
-- [Workflows](/features/workflows) - Multi-agent workflows
+<CardGroup cols={2}>
+<Card title="Generative UI" icon="display" href="/docs/features/generative-ui">
+  Choose the right UI generation tier
+</Card>
+<Card title="AG-UI Server" icon="server" href="/docs/deploy/servers/agui">
+  Deploy AG-UI with CopilotKit integration
+</Card>
+<Card title="A2A Protocol" icon="arrows-exchange" href="/docs/features/a2a">
+  Agent-to-Agent communication
+</Card>
+<Card title="Streaming" icon="stream" href="/docs/features/streaming">
+  Stream agent responses as markdown
+</Card>
+</CardGroup>

--- a/docs/features/generative-ui.mdx
+++ b/docs/features/generative-ui.mdx
@@ -1,0 +1,257 @@
+---
+title: "Generative UI"
+sidebarTitle: "Generative UI"
+description: "Generate user interfaces from AI agents across multiple tiers"
+icon: "display"
+---
+
+Generate user interfaces from AI agents using four different approaches, from simple markdown to complex declarative UIs.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    instructions="Help users with their tasks",
+)
+
+agent.start("Create a simple interface to collect user information")
+```
+
+```mermaid
+graph TB
+    subgraph "Generative UI Tiers"
+        A[📝 Tier 0: Markdown] --> B[📊 Tier 1: Structured Output]
+        B --> C[⚡ Tier 2: AG-UI + CopilotKit]
+        C --> D[🖥️ Tier 3: A2UI + Google SDK]
+    end
+    
+    subgraph "Complexity"
+        E[Simple] --> F[Moderate] 
+        F --> G[Advanced]
+        G --> H[Complex]
+    end
+    
+    classDef tier0 fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef tier1 fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef tier2 fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef tier3 fill:#8B0000,stroke:#7C90A0,color:#fff
+    
+    class A,E tier0
+    class B,F tier1
+    class C,G tier2
+    class D,H tier3
+```
+
+## Which Tier Should I Use?
+
+```mermaid
+graph TD
+    Start[Need UI output from agent?] --> Simple{Simple text responses?}
+    Simple -->|Yes| Tier0[Tier 0: Markdown Streaming]
+    Simple -->|No| Typed{Need typed data?}
+    Typed -->|Yes| Tier1[Tier 1: Structured Output]
+    Typed -->|No| React{React + live tool events?}
+    React -->|Yes| Tier2[Tier 2: AG-UI + CopilotKit]
+    React -->|No| Declarative{Declarative UI JSON?}
+    Declarative -->|Yes| Tier3[Tier 3: A2UI + Google SDK]
+    Declarative -->|No| Tier0
+    
+    classDef decision fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef tier0 fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef tier1 fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef tier2 fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef tier3 fill:#8B0000,stroke:#7C90A0,color:#fff
+    
+    class Start,Simple,Typed,React,Declarative decision
+    class Tier0 tier0
+    class Tier1 tier1
+    class Tier2 tier2
+    class Tier3 tier3
+```
+
+---
+
+## Tier 0: Markdown Streaming
+
+Stream markdown responses for chat-style interactions with no client UI work required.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Chat Assistant",
+    instructions="Respond in helpful markdown format",
+)
+
+# Streams markdown text
+response = agent.start("Explain Python classes", stream=True)
+```
+
+**Best for:**
+- Chat applications
+- Documentation generation  
+- Text-based responses
+- Simple Q&A interfaces
+
+**Learn more:** [Streaming Documentation](/docs/features/streaming)
+
+---
+
+## Tier 1: Structured Output
+
+Generate typed JSON results for programmatic UI construction on the client.
+
+```python
+from praisonaiagents import Agent
+from pydantic import BaseModel
+
+class ContactForm(BaseModel):
+    name: str
+    email: str
+    message: str
+
+agent = Agent(
+    name="Form Generator",
+    instructions="Generate contact form data",
+    output_pydantic=ContactForm,
+)
+
+# Returns typed ContactForm object
+form_data = agent.start("Create a contact form")
+print(f"Name field: {form_data.name}")
+```
+
+**Best for:**
+- Data extraction
+- Form generation
+- API responses
+- Type-safe client integration
+
+**Learn more:** [Structured Output Documentation](/docs/features/structured-output)
+
+---
+
+## Tier 2: AG-UI + CopilotKit 
+
+React/CopilotKit apps with live tool events using the AG-UI streaming bridge.
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools import web_search
+
+agent = Agent(
+    name="Search Assistant", 
+    instructions="Search the web and provide results",
+    tools=[web_search],
+)
+
+# Tool events stream live to CopilotKit clients
+response = agent.start("Search for Python tutorials", stream=True)
+```
+
+The new AG-UI streaming bridge converts internal `stream_emitter` events into AG-UI SSE events during `async_stream_agent_response`, allowing CopilotKit clients to receive live tool execution updates.
+
+### AG-UI Streaming Bridge
+
+The streaming bridge in `praisonaiagents/ui/agui/streaming.py` provides:
+
+| Function | Purpose |
+|----------|---------|
+| `stream_event_to_agui_events` | Convert PraisonAI StreamEvents to AG-UI events |
+| `async_stream_agent_response` | Stream agent responses as AG-UI events |
+| `EventBuffer` | Manage event ordering and tool call tracking |
+
+```python
+from praisonaiagents.ui.agui.streaming import async_stream_agent_response
+
+# Stream agent response as AG-UI events
+async for event in async_stream_agent_response(
+    agent=agent,
+    user_input="Search for AI tools",
+    thread_id="thread-123", 
+    run_id="run-456"
+):
+    # Event sent to CopilotKit client
+    print(f"Event: {event.type}")
+```
+
+**Best for:**
+- React applications
+- Live tool execution display
+- CopilotKit integration
+- Real-time user interfaces
+
+**Learn more:** [AG-UI Server](/docs/deploy/servers/agui) | [AG-UI API](/docs/deploy/api/agui-api)
+
+---
+
+## Tier 3: A2UI + Google SDK
+
+Declarative agent-generated UIs with Google's A2UI SDK validation and renderer clients.
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.ui import A2UI  
+from praisonaiagents.tools.a2ui_tools import send_a2ui_messages
+
+agent = Agent(
+    name="UI Generator",
+    instructions="Create user interfaces using A2UI",
+    system_prompt=A2UI.system_prompt(
+        role_description="You generate declarative UIs using A2UI",
+        ui_description="Use the basic catalog v0.9"
+    ),
+    tools=[send_a2ui_messages],
+)
+
+# Generates validated A2UI JSON
+agent.start("Create a contact form with name and email fields")
+```
+
+**Best for:**
+- Complex declarative UIs
+- Multi-platform rendering (Web, Flutter, React)
+- Schema-validated UI generation  
+- Agent-driven interface creation
+
+**Learn more:** [A2UI Documentation](/docs/features/a2ui)
+
+---
+
+## Comparison Table
+
+| Tier | Output Format | Client Work | Validation | Use Case |
+|------|---------------|-------------|------------|----------|
+| **0** | Markdown text | None | None | Chat, documentation |
+| **1** | Typed JSON | Build UI from data | Pydantic | Forms, data extraction |
+| **2** | AG-UI events | CopilotKit components | Tool execution | React apps, live updates |
+| **3** | A2UI JSON | A2UI renderer | Schema validation | Declarative UIs, multi-platform |
+
+## Installation Requirements
+
+| Tier | Installation Command |
+|------|---------------------|
+| **0** | `pip install praisonaiagents` (included) |
+| **1** | `pip install praisonaiagents` (included) |
+| **2** | `pip install praisonaiagents` + CopilotKit setup |
+| **3** | `pip install praisonaiagents[a2ui]` |
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Streaming" icon="stream" href="/docs/features/streaming">
+  Tier 0: Markdown streaming responses
+</Card>
+<Card title="A2UI" icon="window" href="/docs/features/a2ui">
+  Tier 3: Declarative UI generation
+</Card>
+<Card title="AG-UI Server" icon="server" href="/docs/deploy/servers/agui">
+  Tier 2: Deploy AG-UI with CopilotKit
+</Card>
+<Card title="Structured Output" icon="code" href="/docs/features/structured-output">
+  Tier 1: Generate typed JSON results
+</Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Rewrote docs/features/a2ui.mdx with new A2UI facade API from PR #1702
- Created new docs/features/generative-ui.mdx with 4 UI generation tiers
- Updated docs.json to include generative-ui page in UI & Display group

## Changes Made

### A2UI Documentation Rewrite
- Replaced all stale examples using removed classes (A2UIAgent, Surface, Templates, etc.)
- Documented new thin facade API: A2UI.create_part, A2UI.parse_response, A2UI.system_prompt, etc.
- Added migration section with explicit list of removed classes and replacements
- Included install requirements and version compatibility warnings
- Added agent-centric Quick Start example using send_a2ui_messages tool

### New Generative UI Overview Page
- Four-tier approach: Markdown → Structured Output → AG-UI → A2UI
- Decision flowchart to help users choose the right tier
- Code examples for each tier using agent-centric patterns
- Documentation of new AG-UI streaming bridge from PR #1702

## Technical Details

- All code examples verified against SDK source files in /tmp/PraisonAI
- Follows AGENTS.md conventions with proper Mermaid diagrams and Mintlify components
- Uses standard color scheme for diagrams
- Progressive disclosure from simple to advanced patterns

## Test Plan

- [x] Verified docs.json is valid JSON
- [x] All imports match actual SDK files
- [x] Code examples are copy-paste runnable after pip install praisonaiagents[a2ui]
- [x] Mermaid diagrams use standard color palette
- [x] Follows page structure template from AGENTS.md

Fixes #394

🤖 Generated with [Claude Code](https://claude.ai/code)