### PR TITLE
docs: Update async + guardrails + reflection docs for Agent.achat unified-dispatch fix

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -526,6 +526,7 @@
                   "docs/features/activity-log",
                   "docs/features/async",
                   "docs/features/async-bridge",
+                  "docs/features/async-self-reflection",
                   "docs/features/async-scheduler",
                   "docs/features/async-jobs",
                   "docs/features/background-tasks",

--- a/docs/features/async-self-reflection.mdx
+++ b/docs/features/async-self-reflection.mdx
@@ -1,0 +1,180 @@
+---
+title: "Async Self-Reflection"
+sidebarTitle: "Async Self-Reflection"
+description: "Self-reflection now works in async agents using the unified dispatch path"
+icon: "rotate"
+---
+
+Self-reflection enables agents to evaluate and improve their responses in async execution, bringing full feature parity with sync agents.
+
+```mermaid
+graph LR
+    subgraph "Async Self-Reflection"
+        Input[📋 Async Request] --> Agent[🤖 Agent]
+        Agent --> Generate[🧠 Generate Response]
+        Generate --> Reflect[🔍 Self-Reflect]
+        Reflect -->|"Not good enough"| Generate
+        Reflect -->|"Satisfactory"| Output[✅ Final Response]
+    end
+    
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef validation fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class Input input
+    class Agent,Generate process
+    class Reflect validation
+    class Output output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Basic Async Reflection">
+Enable reflection in async agents with simple boolean flag:
+
+```python
+import asyncio
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Writer",
+    instructions="Write concise product blurbs.",
+    self_reflect=True,
+    min_reflect=1,
+    max_reflect=3,
+)
+
+async def main():
+    result = await agent.achat("Write a one-line blurb for a smart mug.")
+    print(result)
+
+asyncio.run(main())
+```
+</Step>
+
+<Step title="Custom Reflection Criteria">
+Configure reflection with custom criteria for async agents:
+
+```python
+import asyncio
+from praisonaiagents import Agent, ReflectionConfig
+
+agent = Agent(
+    name="Technical Writer",
+    instructions="Create technical documentation.",
+    self_reflect=ReflectionConfig(
+        min_reflect=2,
+        max_reflect=5,
+        criteria="Is the response clear, accurate, and complete?"
+    )
+)
+
+async def main():
+    result = await agent.achat("Explain async/await in Python.")
+    print(result)
+
+asyncio.run(main())
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+Self-reflection in async agents follows the same process as sync agents:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Reflection
+    participant LLM
+    
+    User->>Agent: await agent.achat()
+    Agent->>LLM: Generate initial response
+    LLM-->>Agent: Response
+    Agent->>Reflection: Evaluate response
+    Reflection-->>Agent: Not good enough
+    Agent->>LLM: Generate improved response
+    LLM-->>Agent: Better response
+    Agent->>Reflection: Evaluate again
+    Reflection-->>Agent: Satisfactory
+    Agent-->>User: Final response
+```
+
+| Component | Purpose | Async Behavior |
+|-----------|---------|----------------|
+| Initial Generation | Create first response | Uses `await agent.achat()` |
+| Self-Evaluation | Judge response quality | Async LLM call for evaluation |
+| Iterative Improvement | Refine based on feedback | Multiple async iterations |
+| Final Output | Deliver best response | Returns when criteria met |
+
+---
+
+## Feature Parity
+
+Prior to PR #1704, async agents had limited reflection support:
+
+<Note>
+**Before PR #1704**: Only legacy custom-LLM async branch supported reflection; the default OpenAI async path skipped it entirely.
+
+**After PR #1704**: Self-reflection works uniformly in both sync and async agents on all execution paths, including the default unified-dispatch path.
+</Note>
+
+| Feature | Sync Agents | Async Agents (Before #1704) | Async Agents (After #1704) |
+|---------|-------------|----------------------------|---------------------------|
+| Self-reflection | ✅ Full support | ❌ Limited/bypassed | ✅ Full parity |
+| Custom criteria | ✅ Supported | ❌ Not available | ✅ Supported |
+| Min/max reflect | ✅ Configurable | ❌ Not configurable | ✅ Configurable |
+| Unified dispatch | ✅ Works | ❌ Bypassed reflection | ✅ Full support |
+
+---
+
+## Configuration Options
+
+All reflection configuration options work identically in async agents:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `self_reflect` | `bool` | `False` | Enable/disable self-reflection |
+| `min_reflect` | `int` | `1` | Minimum reflection iterations |
+| `max_reflect` | `int` | `3` | Maximum reflection iterations |
+| `criteria` | `str` | Auto-generated | Custom evaluation criteria |
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Choose Appropriate Limits">
+Set reasonable `min_reflect` and `max_reflect` values to balance quality with performance. Async reflection still involves multiple LLM calls.
+</Accordion>
+
+<Accordion title="Custom Criteria">
+Provide specific evaluation criteria for better reflection quality. Generic criteria like "Is this good?" are less effective than specific requirements.
+</Accordion>
+
+<Accordion title="Monitor Performance">
+Reflection increases response time and token usage. Monitor these metrics in production async applications.
+</Accordion>
+
+<Accordion title="Error Handling">
+Wrap async reflection calls in try-catch blocks to handle potential timeout or API errors gracefully.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Async Agents" icon="clock" href="/features/async">
+  Complete guide to async agent execution
+</Card>
+<Card title="Self-Reflection Concepts" icon="rotate" href="/concepts/reflection">
+  Core concepts and architecture
+</Card>
+</CardGroup>

--- a/docs/features/async-tool-safety.mdx
+++ b/docs/features/async-tool-safety.mdx
@@ -112,6 +112,8 @@ sequenceDiagram
 | **Output truncation** | ✅ | ✅ |
 | **Error wrapping** | ✅ | ✅ |
 
+**Architecture**: The unified async dispatcher now calls `execute_tool_async` for tool invocations, so long-running tools no longer block the event loop.
+
 ---
 
 ## Safety Mechanisms

--- a/docs/features/async.mdx
+++ b/docs/features/async.mdx
@@ -555,6 +555,12 @@ See the [Async Bridge](/features/async-bridge) guide for complete documentation 
     - Upgrade to the latest release with async bridge support
     - Internal call sites now use run_coroutine_from_any_context()
   </Card>
+  <Card title="Agent Chat Hangs" icon="hourglass-half">
+    If `await agent.achat(...)` never returns (sync `agent.chat()` works fine):
+    - Upgrade to the release that includes PR #1704 (or newer)
+    - Earlier versions had a missing response-handling branch in the unified async dispatch path that caused the call to loop indefinitely
+    - No code change required after upgrade — the call returns on the first LLM round-trip
+  </Card>
 </CardGroup>
 
 ## API Reference

--- a/docs/features/guardrails.mdx
+++ b/docs/features/guardrails.mdx
@@ -46,7 +46,7 @@ Guardrails ensure task outputs meet quality and safety criteria through:
 * **Custom validation logic** for specific requirements
 
 <Note>
-**Sync vs Async Parity**: Guardrails now work uniformly in both sync (`.start()` / `.run()`) and async execution paths. Previously, async execution bypassed guardrail validation.
+**Sync vs Async Parity**: Guardrails work uniformly in both sync (`.start()` / `.run()` / `.chat()`) and async (`.astart()` / `.achat()`) execution paths, including retry-on-failure. Earlier releases bypassed validation or retries on the async path; parity is complete as of PR #1704.
 </Note>
 
 ## Quick Start
@@ -275,11 +275,9 @@ task = Task(
 
 ### How Retries Work
 
-When a guardrail validation fails:
-1. **Before PR #1514**: Async execution bypassed retry logic
-2. **After PR #1514**: Both sync and async execution paths properly retry failed validations
+When a guardrail validation fails the executor increments `task.retry_count`, sets `task.status = "in progress"`, logs the retry, and continues the execution loop. On final failure after `max_retries`, it raises an exception. When a guardrail returns a modified `TaskOutput` or string, the downstream `task.result` and any memory callbacks receive the **modified** value, not the original.
 
-The executor increments `task.retry_count`, sets `task.status = "in progress"`, logs the retry, and continues the execution loop. On final failure after `max_retries`, it raises an exception. When a guardrail returns a modified `TaskOutput` or string, the downstream `task.result` and any memory callbacks receive the **modified** value, not the original.
+This behaviour is identical in sync and async execution. Both paths apply the same retry policy and feed the same modified value forward.
 
 <Note>
 **Cached Field Clearing**: When a guardrail modifies string output, cached fields like `json_dict` and `pydantic` are automatically cleared on `TaskOutput` to prevent stale cached values from being used by structured output consumers.


### PR DESCRIPTION
Fixes #399

This PR updates the documentation to reflect the changes made in PraisonAI PR #1704, which fixed async agent chat hanging and brought async execution to full feature parity with sync.

## Changes Made

### 1. Updated docs/features/async.mdx
- Added new troubleshooting card for achat() hanging issue
- Explains the fix in PR #1704 and what users should do

### 2. Updated docs/features/guardrails.mdx  
- Updated sync/async parity note to reference PR #1704 completion
- Rewrote How Retries Work section with behavior-focused language
- Removed version-specific bullets that were tied to older PRs

### 3. Created docs/features/async-self-reflection.mdx
- New page documenting async self-reflection capabilities
- Includes agent-centric examples and feature parity table
- Added to docs.json under Async & Background group

### 4. Updated docs/features/async-tool-safety.mdx
- Added architecture note about execute_tool_async usage in unified dispatcher

### 5. Updated docs.json
- Added new async-self-reflection page to navigation
- Validated JSON structure

## Validation
- All code examples are runnable with correct imports
- Follows AGENTS.md guidelines for page structure and components
- Uses standard Mermaid color scheme and Mintlify components
- docs.json remains valid JSON

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for async agent self-reflection with code examples and best practices.
  * Enhanced async dispatcher documentation to clarify tool invocation routing behavior.
  * Added troubleshooting section addressing agent chat hang issues.
  * Clarified sync/async parity across guardrails, validation, and retry workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAIDocs/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->