### PR TITLE
docs: document new top-level praisonai.run() / arun() one-liner Python API

### DIFF
--- a/docs/developers/wrapper.mdx
+++ b/docs/developers/wrapper.mdx
@@ -6,6 +6,97 @@ icon: "box"
 
 # Include praisonai package in your project
 
+## Option 0: One-liner (simplest)
+
+```python
+import praisonai
+
+result = praisonai.run("agents.yaml")
+print(result)
+```
+
+That's it. `praisonai.run()` reuses the same framework auto-detection and LLM endpoint resolution the `praisonai` CLI uses, so anything that works on the command line works here.
+
+### What it does
+
+<Steps>
+<Step>
+  Auto-detects the first installed framework in this order: `crewai` → `praisonaiagents` → `autogen` → `ag2`. Pass `framework="..."` to override.
+</Step>
+<Step>
+  Reads `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `OPENAI_MODEL_NAME` (and the standard PraisonAI key/config files) — same as the CLI.
+</Step>
+<Step>
+  Returns the final task output as a string.
+</Step>
+</Steps>
+
+```mermaid
+graph LR
+    User[👤 User] --> Call[📞 praisonai.run]
+    Call --> Detect[🔍 Auto-detect framework]
+    Call --> Resolve[🔑 Resolve LLM endpoint]
+    Detect --> Gen[🤖 AgentsGenerator]
+    Resolve --> Gen
+    Gen --> Out[✅ Result string]
+
+    classDef user fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef out fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class User,Out user
+    class Call,Gen process
+    class Detect,Resolve config
+```
+
+### Async variant for FastAPI / Jupyter
+
+```python
+import praisonai
+
+async def handler():
+    result = await praisonai.arun("agents.yaml")
+    return result
+```
+
+`arun()` offloads the synchronous work to a thread so it never blocks the event loop.
+
+### Optional parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `agent_file` | `str` | required | Path to your `agents.yaml`. |
+| `framework` | `str \| None` | `None` (auto-detect) | One of `"crewai"`, `"praisonai"`, `"autogen"`, `"ag2"`. |
+| `tools` | `list \| None` | `None` | Optional list of tool callables passed through to `AgentsGenerator`. |
+| `agent_yaml` | `str \| None` | `None` | Inline YAML string; takes precedence over `agent_file` when both are given. |
+| `cli_config` | `dict \| None` | `None` | Advanced: override the resolved CLI config (rarely needed). |
+
+<Note>
+If no framework is installed, `run()` raises `RuntimeError("No supported framework installed. Install one of: crewai, praisonaiagents, autogen, ag2.")`. Install one with `pip install praisonaiagents` (recommended for new projects).
+</Note>
+
+### When to use `PraisonAI(...)` instead
+
+Reach for the full `PraisonAI` class (Option 1 below) when you need:
+- Streaming / approval-system integration
+- Custom backends or the gradio UI
+- The `auto="..."` natural-language-to-YAML mode
+- Repeated runs against the same generator without re-parsing YAML
+
+```mermaid
+graph TB
+    Start{Need to run an<br/>agents.yaml?} -->|Yes, just once| Simple[praisonai.run]
+    Start -->|Need streaming/<br/>approvals/auto-YAML| Full[PraisonAI class]
+    Start -->|Inside async handler| Async[praisonai.arun]
+
+    classDef question fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef choice fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Start question
+    class Simple,Full,Async choice
+```
+
 ## Option 1: Using RAW YAML
 
 ```python
@@ -40,7 +131,7 @@ print(result)
 ## Option 2: Using separate agents.yaml file
 
 
-Note: Please create agents.yaml file before hand. 
+Note: Please create agents.yaml file before hand. If you only need to run an `agents.yaml` once and want zero ceremony, see [Option 0: One-liner](#option-0-one-liner-simplest) above. 
 
 ```python
 from praisonai import PraisonAI

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -55,6 +55,11 @@ icon: "bolt"
       team.start()
       ```
     </CodeGroup>
+
+<Tip>
+For the absolute shortest Python entry point — no class instantiation — use `praisonai.run("agents.yaml")`. See [the one-liner guide](/docs/developers/wrapper#option-0-one-liner-simplest).
+</Tip>
+
       </Step>
 
       <Step title="Run Agents">


### PR DESCRIPTION
Fixes #401

Documents the new praisonai.run() and praisonai.arun() one-liner Python API functions added in PR #1708.

## Changes

### Added to docs/developers/wrapper.mdx:
- **New "Option 0: One-liner (simplest)" section** at the top with highest priority
- Agent-centric framing with 2-line zero-ceremony example
- Step-by-step explanation of auto-detection and LLM endpoint resolution  
- Hero Mermaid diagram showing the flow
- Async variant for FastAPI/Jupyter
- Complete parameters table with all options
- Decision-flow Mermaid diagram to help users choose between run() and PraisonAI(...)
- Cross-link from Option 2 to Option 0

### Added to docs/quickstart.mdx:
- Cross-link Tip pointing to the new one-liner guide

## Implementation Details

- **Framework auto-detection order**: crewai → praisonaiagents → autogen → ag2
- **LLM endpoint resolution**: Uses same env vars as CLI (OPENAI_API_KEY, OPENAI_BASE_URL, etc.)
- **Async support**: arun() uses asyncio.to_thread() to avoid blocking event loop
- **Error handling**: Proper RuntimeError when no framework installed

## Quality Checklist

✅ All code examples are copy-paste runnable
✅ Follows AGENTS.md standards (color scheme, Mintlify components, writing style)
✅ Progressive disclosure: simple first, advanced later
✅ Agent-centric framing per guidelines
✅ Verified against actual source code from merged PR #1708

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added simplified one-liner usage guide for running agents with auto-framework detection.
  * Included async usage examples and parameter documentation.
  * Added guidance on choosing between simplified and full configuration approaches.
  * Updated quickstart to highlight the shortest entry point for Python users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAIDocs/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->