### PR TITLE
docs: Add UTF-8 encoding requirements to Skills documentation (fixes #405)

### DIFF
--- a/docs/features/skills-invocation.mdx
+++ b/docs/features/skills-invocation.mdx
@@ -10,6 +10,10 @@ system-prompt listing, manually by the user via ``/skill-name`` slash
 commands, or programmatically through ``SkillManager.invoke()``.
 
 <Note>
+Skill files are read as UTF-8. If your editor saved `SKILL.md` in another encoding (common on Windows), `praisonai skills validate` will flag it. See **[File Encoding](/features/skills#file-encoding)** in the Skills page.
+</Note>
+
+<Note>
 This page covers the invocation layer added in v1.5+. For how to *author*
 skills, see **[Agent Skills](/concepts/skills)**.
 </Note>

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -99,6 +99,36 @@ This skill enables agents to process PDF documents...
 | `metadata` | Key-value pairs for custom properties |
 | `allowed-tools` | Space-delimited list of tools the skill requires |
 
+## File Encoding
+
+Skills are read as UTF-8 on every platform. You can freely use non-ASCII characters anywhere in `SKILL.md`, in files under `scripts/`, and in files under `references/` — em dashes (—), smart quotes ("..."), arrows (→), accented characters (café, résumé, naïve), emoji (🔥 📝 ✨), CJK, Cyrillic, and RTL scripts all work.
+
+```mermaid
+graph LR
+    subgraph "Encoding Flow"
+        A[📝 Editor saves SKILL.md] --> B[🔧 Loader reads UTF-8]
+        B --> C[🤖 Agent receives intact content]
+    end
+    
+    classDef editor fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef loader fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef agent fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A editor
+    class B loader
+    class C agent
+```
+
+When saving `SKILL.md`, make sure your editor uses UTF-8 (not the Windows-default cp1252 / ANSI). Most modern editors do this by default:
+- **VS Code / Cursor**: encoding shown bottom-right of the status bar — click to change to "UTF-8"
+- **Notepad++**: Encoding menu → "UTF-8" (without BOM)
+- **Windows Notepad**: "Save As" → Encoding dropdown → "UTF-8"
+
+If a skill file is saved in another encoding, `praisonai skills validate` will report:
+```
+SKILL.md is not valid UTF-8: <details>
+```
+
 ## Directory Structure
 
 ```
@@ -212,6 +242,13 @@ else:
 # Validate metadata dict
 errors = validate_metadata({"name": "test", "description": "Test skill"})
 ```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `praisonai skills validate` says `SKILL.md is not valid UTF-8: ...` | File was saved as cp1252 / ANSI / Latin-1 (common on Windows) | Re-save the file as UTF-8 in your editor (see [File Encoding](#file-encoding)) |
+| `UnicodeDecodeError` on older versions of PraisonAI when loading a skill with non-ASCII characters on Windows | Pre-#1712 PraisonAI used the platform default encoding | Upgrade `praisonaiagents` to the version that includes PR #1712 |
 
 ## Compatibility
 


### PR DESCRIPTION
Fixes #405

This PR updates the Skills documentation to cover UTF-8 encoding requirements, addressing the Windows fix from PR #1712.

## Changes Made

### docs/features/skills.mdx
- Added **File Encoding** section explaining UTF-8 support for non-ASCII characters (em dashes, smart quotes, arrows, accented characters, emoji, CJK, Cyrillic, RTL scripts)
- Included mermaid diagram showing encoding flow: editor → loader → agent  
- Added editor configuration instructions for VS Code/Cursor, Notepad++, Windows Notepad
- Added **Troubleshooting** section with validation error messages for UTF-8 issues

### docs/features/skills-invocation.mdx  
- Added callout note about UTF-8 encoding requirement
- Linked to File Encoding section in Skills documentation

### docs/features/hermes-openclaw-skills-import.mdx
- Already had adequate UTF-8 coverage in validation checklist (no changes needed)

## Style Compliance
- Follows AGENTS.md guidelines: beginner-friendly, active voice, mermaid diagram with standard colors
- Uses proper Mintlify components and formatting
- Includes user-friendly editor configuration instructions

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added file encoding documentation for skill files with UTF-8 requirements and editor configuration guidance for VS Code, Cursor, Notepad++, and Windows Notepad.
  * Added troubleshooting section covering UTF-8 validation failures from skill validation and Windows decode errors with detailed resolution steps.
  * Included visual encoding flow diagram for clarity and reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAIDocs/pull/406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->