### PR TITLE
docs: document wrapper-level tool_timeout defense-in-depth and run_sync cancellation (follow-up to PraisonAI PR #1692)

### DIFF
--- a/docs/cli/interactive-runtime.mdx
+++ b/docs/cli/interactive-runtime.mdx
@@ -217,20 +217,21 @@ roles:
 ```mermaid
 sequenceDiagram
     participant YAML as YAML Parser
-    participant Loop as Event Loop
+    participant Bridge as _async_bridge (shared loop)
     participant Runtime as InteractiveRuntime
     participant Tools as Agent Tools
     participant Team as AgentTeam
 
-    YAML->>Loop: Create scoped event loop
-    YAML->>Runtime: await runtime.start()
+    YAML->>Bridge: run_sync(runtime.start())
+    Bridge->>Runtime: start() on persistent bg loop
     Runtime->>Tools: create_agent_centric_tools(runtime)
     Tools->>YAML: Merge into tools_dict
     YAML->>Team: team.start() with merged tools
-    Team->>Team: Execute agents with runtime tools
+    Team->>Tools: tool_call → run_sync(_coro())
+    Tools->>Bridge: re-enters SAME loop
+    Bridge-->>Tools: result
     Team-->>YAML: Agent execution result
-    YAML->>Runtime: await runtime.stop() (finally block)
-    YAML->>Loop: loop.close()
+    YAML->>Bridge: run_sync(runtime.stop()) (finally block)
 ```
 
 ### YAML Configuration Details
@@ -240,7 +241,9 @@ The YAML route uses default `RuntimeConfig` values with these settings:
 - **Approval Mode**: `PRAISONAI_APPROVAL_MODE` environment variable (default: `"prompt"`)
 - **Trace Enabled**: Not explicitly set (uses RuntimeConfig default)
 
-The runtime stays alive across the entire agent execution, ensuring agent-centric tools remain accessible throughout the workflow.
+The runtime boots on the **shared `_async_bridge` background loop** (the same loop already used by ~77 wrapper-side `run_sync` callers), not on a per-run scoped loop. This is what makes ACP/LSP agent-centric tools safe — every async primitive owned by the runtime stays bound to a loop that is **still running** when tools re-enter.
+
+`run_sync()` now cancels the runtime startup/shutdown coroutine on timeout (PR #1692), so a hung LSP server or ACP backend no longer leaks.
 
 ### Full RuntimeConfig Control
 
@@ -283,6 +286,8 @@ result = asyncio.run(advanced_workflow())
 For more details on agent-centric tools and InteractiveRuntime integration, see [PraisonAI Agents Framework](/docs/framework/praisonaiagents).
 
 **As of PR #1658 (May 2026), ACP/LSP agent-centric tools work end-to-end in YAML runs. Earlier versions had a premature-teardown bug — upgrade to praisonai ≥ 0.0.58.**
+
+**PR #1692 (May 2026)** — `run_sync()` now cancels timed-out tasks on the background loop, and YAML `tool_timeout` is enforced at the wrapper boundary as well as inside the SDK. Upgrade to praisonai ≥ the release containing this PR for both behaviours.
 </Info>
 
 ## Operational Notes

--- a/docs/configuration/tool-config.mdx
+++ b/docs/configuration/tool-config.mdx
@@ -63,6 +63,62 @@ agent = Agent(
 For complete concurrency control documentation including per-agent limits and sync/async patterns, see [Concurrency](/docs/features/concurrency).
 </Note>
 
+### Wrapper-Level Tool Timeout (YAML / CLI — Defense-in-Depth)
+
+When you set `tool_timeout` in YAML (`framework: praisonai`) **or** pass `--tool-timeout` on the CLI, the wrapper now wraps every tool callable with a timeout-enforcing shim **before** handing the agent to the SDK.
+
+This means the `tool_timeout` knob is enforced even if the downstream SDK ignores it, even if the tool is a blocking C extension, and even if the tool is a subprocess that does not honour `CancelledError`.
+
+The wrapper handles **sync and async tools** differently:
+- **Sync tools** run in a daemon thread (`threading.Thread(daemon=True)`); on timeout the wrapper returns a JSON error dict and abandons the thread (daemon threads do not block process exit).
+- **Async tools** are wrapped with `asyncio.wait_for(...)`; on timeout the wrapper returns the same JSON error dict.
+
+The returned shape on wrapper-level timeout is a **JSON string** (because the wrapper boundary serialises) containing:
+```json
+{
+  "error": "tool_timeout",
+  "tool": "<function name>",
+  "timeout_seconds": 30
+}
+```
+
+If the worker thread exits without publishing a result (defensive fallback), the wrapper returns:
+```json
+{
+  "error": "tool_execution_error",
+  "tool": "<function name>",
+  "detail": "worker_exited_without_result"
+}
+```
+
+Crucially, the wrapper **also keeps passing** `tool_timeout` to the SDK Agent, so both layers are active — hence "defense in depth". The SDK's executor catches the common case; the wrapper catches the pathological one.
+
+**Example usage:**
+
+```yaml
+framework: praisonai
+topic: Fetch and summarise a slow upstream API
+
+config:
+  tool_timeout: 15  # Wrapper-level + SDK-level enforcement
+
+roles:
+  fetcher:
+    role: API Fetcher
+    goal: Pull data without wedging the crew on a slow upstream
+    backstory: Reliability-focused engineer.
+    tools:
+      - fetch_url
+    tasks:
+      fetch:
+        description: Fetch {topic}
+        expected_output: Summarised payload, or a structured timeout dict if the upstream is slow.
+```
+
+When `fetch_url` blocks for more than 15 s, the agent receives the structured JSON dict above instead of an indefinite hang, so the crew keeps moving.
+
+**Precedence note:** When both wrapper-level and SDK-level timeouts apply, the **shorter** of the two wins in practice (whichever fires first). Both currently read from the same `tool_timeout` value, so they fire at the same time; if a user later configures different values at different layers, the first-to-fire semantics still hold.
+
 ### Advanced Timeout Configuration
 
 ```python

--- a/docs/features/async-bridge.mdx
+++ b/docs/features/async-bridge.mdx
@@ -276,6 +276,8 @@ The following synchronous APIs route through `run_sync()` and therefore honour `
 
 <Warning>
 These sync wrappers now raise `RuntimeError("run_sync() cannot be called from a running event loop; await the coroutine directly instead.")` when called from inside an active asyncio loop. Previously they would silently spawn a worker thread. **If you call any of these from async code, switch to `await request_approval(...)` (or the equivalent async method) directly.** This is a deliberate fail-fast change — the silent thread spawn was masking architectural bugs in multi-agent setups.
+
+**PR #1692 — cancellation on timeout (May 2026).** When a `run_sync()` call hits its timeout (default 300 s, or whatever `PRAISONAI_RUN_SYNC_TIMEOUT` is set to), the underlying coroutine is now actively cancelled on the background loop. The bridge waits up to 1 s for cancellation to propagate before re-raising `TimeoutError`. This means slow DB queries (SurrealDB, async MySQL), HTTP calls, and subprocess waits now **release their connection / socket / pipe** instead of leaking. Cancellation also fires on `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit`.
 </Warning>
 
 ---
@@ -299,6 +301,12 @@ async def my_coroutine():
 ### asyncio.run() cannot be called from a running event loop
 
 This error used to leak from SDK internals before the async bridge was implemented. If you see this on current versions, upgrade to the latest release.
+
+| Symptom | Cause | Resolution |
+|---------|-------|-----------|
+| `TimeoutError` raised but you also see your coroutine's `finally:` block run after the exception | Expected: cancellation propagated, cleanup ran. | No action needed; this is the new PR #1692 behaviour. |
+
+**Test reference:** `praisonai/tests/unit/test_async_bridge.py::TestBridgeIntegration::test_timeout_cancels_coroutine_and_runs_finally` — quote this in the page so users can verify the behaviour locally.
 
 ### PermissionError in approval system
 

--- a/docs/features/async-tool-safety.mdx
+++ b/docs/features/async-tool-safety.mdx
@@ -176,6 +176,51 @@ await agent.achat("Use slow tool")  # Will timeout after 5 seconds
 
 ---
 
+## Wrapper-Level Timeout (YAML / framework: praisonai)
+
+When running through YAML or the CLI, the wrapper wraps every tool with a timeout-enforcing shim **before** handing the agent to the SDK. This provides defense-in-depth timeout enforcement even for pathological tools.
+
+The wrapper handles **sync and async tools** differently:
+- **Sync tools** run in a daemon thread (`threading.Thread(daemon=True)`); on timeout the wrapper returns a JSON error dict and abandons the thread (daemon threads do not block process exit).
+- **Async tools** are wrapped with `asyncio.wait_for(...)`; on timeout the wrapper returns the same JSON error dict.
+
+```mermaid
+graph LR
+    subgraph "Two-Layer Tool Timeout"
+        Call[🔄 Tool Call] --> WrapShim[🛡️ Wrapper Shim<br/>tool_timeout enforced]
+        WrapShim --> SDK[🧠 SDK Agent Executor<br/>tool_timeout enforced]
+        SDK --> Tool[🔧 Tool]
+        Tool --> Result[✅ Result]
+        WrapShim -.->|timeout| Dict1[📦 JSON: tool_timeout]
+        SDK -.->|timeout| Dict2[📦 dict: Tool timed out after Ns]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef safety fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef execution fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class Call input
+    class WrapShim,SDK safety
+    class Tool execution
+    class Result output
+    class Dict1,Dict2 error
+```
+
+**JSON return shape on wrapper-level timeout:**
+```json
+{
+  "error": "tool_timeout",
+  "tool": "<function name>",
+  "timeout_seconds": 30
+}
+```
+
+See [Tool Configuration](/configuration/tool-config#wrapper-level-tool-timeout) for full details and [Concurrency](/features/concurrency#timeout-return-shape) for shape comparison.
+
+---
+
 ## Task-Scoped Tools
 
 The `tools_override` parameter allows tasks to provide their own tool set for async execution:

--- a/docs/features/concurrency.mdx
+++ b/docs/features/concurrency.mdx
@@ -151,36 +151,39 @@ When `tool_timeout` is set, tools run in a dedicated executor with these charact
 
 ```mermaid
 graph TB
-    subgraph "Tool Execution with Timeout"
-        Call[Tool Call] --> Check{Has timeout?}
+    subgraph "Two-Layer Tool Timeout"
+        Call[Tool Call] --> WrapShim[Wrapper Shim<br/>tool_timeout enforced]
+        WrapShim --> Check{Has timeout?}
         Check -->|No| Direct[Direct execution]
         Check -->|Yes| Pool[Per-agent 2-thread pool]
         Pool --> Submit[submit(tool, timeout)]
         Submit --> Wait{Within timeout?}
         Wait -->|Yes| Result[Return result]
-        Wait -->|No| TimeoutDict[{"error": "Tool timed out after Ns", "timeout": True}]
+        WrapShim -.->|wrapper timeout| Dict1[{"error": "tool_timeout", "tool": "fn", "timeout_seconds": N}]
+        Wait -->|No| Dict2[{"error": "Tool timed out after Ns", "timeout": true}]
     end
     
     classDef call fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef safety fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef result fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef error fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
     
     class Call call
+    class WrapShim safety
     class Check,Pool,Submit process
     class Direct,Result result
-    class TimeoutDict error
+    class Dict1,Dict2 error
 ```
 
 ### Timeout Return Shape
 
-On timeout, tools return a dict (not an exception):
-```python
-{
-    "error": "Tool timed out after 30s", 
-    "timeout": True
-}
-```
+On timeout, tools return different shapes depending on which layer enforces the timeout:
+
+| Layer | Trigger | Return shape |
+|---|---|---|
+| SDK Agent executor | `Agent(tool_timeout=30)` directly in Python | `{"error": "Tool timed out after 30s", "timeout": True}` |
+| Wrapper boundary | YAML `tool_timeout: 30` or CLI `--tool-timeout 30` (`framework: praisonai`) | `{"error": "tool_timeout", "tool": <fn name>, "timeout_seconds": 30}` (returned as a JSON string from the wrapper) |
 
 ### Executor Details
 

--- a/docs/features/yaml-configuration-reference.mdx
+++ b/docs/features/yaml-configuration-reference.mdx
@@ -198,7 +198,7 @@ All recognized field names for agents in both `agents:` and `roles:` sections:
 | `system_template` | string | Custom system prompt |
 | `prompt_template` | string | Custom prompt template |
 | `response_template` | string | Custom response template |
-| `tool_timeout` | int | Tool execution timeout |
+| `tool_timeout` | int | Per-call tool execution timeout in seconds. Enforced at **two layers** when running `framework: praisonai`: (1) the wrapper wraps every tool callable in a timeout-enforcing shim that returns a structured `{"error": "tool_timeout", ...}` dict on timeout, and (2) the SDK Agent's executor pool also honours the same value. Sync tools run in a daemon thread on the wrapper layer; async tools use `asyncio.wait_for`. See [Tool Configuration](/docs/configuration/tool-config) for the full shape. |
 | `planning_tools` | array | Tools for planning |
 | `planning` | bool | Enable planning |
 | `autonomy` | string/object | Autonomy configuration |


### PR DESCRIPTION
Fixes #418

Documents the wrapper-level tool timeout defense-in-depth and run_sync cancellation features shipped in upstream PraisonAI PR #1692.

## Changes

### 1. **async-bridge.mdx**
- Added PR #1692 cancellation-on-timeout behavior documentation
- Documented that run_sync() now cancels timed-out coroutines and waits 1s for cleanup
- Added troubleshooting entry for expected cleanup behavior
- Referenced test case for verification

### 2. **tool-config.mdx** 
- Added new "Wrapper-Level Tool Timeout (YAML / CLI — Defense-in-Depth)" section
- Documented two-layer enforcement: wrapper shim + SDK executor
- Explained sync/async tool handling differences (daemon threads vs asyncio.wait_for)
- Provided YAML example with structured JSON error shapes
- Documented precedence behavior when both layers active

### 3. **concurrency.mdx**
- Updated "Timeout Return Shape" with side-by-side table showing both layers
- Updated Mermaid diagram to show two-layer timeout enforcement
- Documented different JSON shapes for SDK vs wrapper timeouts

### 4. **yaml-configuration-reference.mdx**
- Expanded tool_timeout description to explain two-layer enforcement
- Cross-referenced tool-config.mdx for complete details

### 5. **interactive-runtime.mdx**
- Updated "YAML Runtime Lifecycle" Mermaid diagram
- Replaced scoped event loop with shared _async_bridge background loop
- Updated prose to explain no-cross-loop benefits for ACP/LSP tools
- Added PR #1692 callout for cancellation behavior

### 6. **async-tool-safety.mdx**
- Added new "Wrapper-Level Timeout (YAML / framework: praisonai)" section
- Documented sync vs async wrapper handling with Mermaid diagram
- Cross-linked to tool-config.mdx and concurrency.mdx for complete details

All documentation follows AGENTS.md standards with:
- Agent-centric examples in YAML format
- Progressive disclosure from simple to advanced
- Hero-style Mermaid diagrams with standard color palette
- Copy-paste runnable code examples

🤖 Generated with [Claude Code](https://claude.ai/code)