### PR TITLE
docs(rag): document SearchResultItem support in build_context / deduplicate_chunks

### DIFF
--- a/docs/knowledge/overview.mdx
+++ b/docs/knowledge/overview.mdx
@@ -59,6 +59,10 @@ That's it! The agent can now answer questions using your documents.
 | **Updates** | Manual (re-index) | Automatic | Uses Knowledge |
 | **Best For** | Q&A, research | Chat continuity | Citations, search |
 
+<Note>
+Knowledge search returns `SearchResultItem` objects (see `praisonaiagents.knowledge.models`) that can be passed directly into RAG context utilities like `build_context` and `deduplicate_chunks`.
+</Note>
+
 ## Next Steps
 
 <CardGroup cols={2}>

--- a/docs/rag/module.mdx
+++ b/docs/rag/module.mdx
@@ -151,12 +151,16 @@ The RAG module uses protocols for extensibility.
 Custom context assembly logic.
 
 ```python
+from typing import Any, Dict, List, Union
+from praisonaiagents.knowledge.models import SearchResultItem
 from praisonaiagents.rag.protocols import ContextBuilderProtocol
+
+ResultItem = Union[Dict[str, Any], SearchResultItem]
 
 class MyContextBuilder:
     def build(
         self,
-        results: List[Dict[str, Any]],
+        results: List[ResultItem],
         max_tokens: int = 4000,
         deduplicate: bool = True,
     ) -> str:
@@ -183,24 +187,71 @@ class MyCitationFormatter:
 
 ## Context Utilities
 
-Helper functions for context building.
+Helper functions for context building that accept both dict and SearchResultItem formats.
 
+<Tabs>
+<Tab title="Dict results">
 ```python
-from praisonaiagents.rag import build_context, truncate_context, deduplicate_chunks
+from praisonaiagents.rag import build_context, deduplicate_chunks
 
-# Build context from results
+# Traditional dict format
+results = [
+    {"text": "First content", "metadata": {"filename": "a.pdf"}},
+    {"text": "Second content", "metadata": {"filename": "b.pdf"}},
+]
+
+# Build context from dict results
 context, used_results = build_context(
-    results=search_results,
+    results=results,
     max_tokens=4000,
     deduplicate=True,
+    include_source=True,
 )
-
-# Truncate long context
-truncated = truncate_context(text, max_tokens=2000)
 
 # Remove duplicate chunks
 unique = deduplicate_chunks(results)
 ```
+</Tab>
+
+<Tab title="SearchResultItem results">
+```python
+from praisonaiagents.rag import build_context, deduplicate_chunks
+from praisonaiagents.knowledge.models import SearchResultItem
+
+# SearchResultItem format
+results = [
+    SearchResultItem(text="First content", source="a.pdf", filename="a.pdf"),
+    SearchResultItem(text="Second content", source="b.pdf", filename="b.pdf"),
+]
+
+# Mixed dict + object input also works
+results.append({"text": "Third content", "metadata": {"filename": "c.pdf"}})
+
+# Build context from SearchResultItem objects
+context, used_results = build_context(
+    results=results,
+    max_tokens=2000,
+    include_source=True,
+)
+
+unique = deduplicate_chunks(results)
+```
+</Tab>
+</Tabs>
+
+<Note>
+`build_context` and `deduplicate_chunks` accept a mix of `dict` results and `SearchResultItem` objects. When `include_source=True`, the label is taken from `metadata["filename"]` / `metadata["source"]` first, falling back to the top-level `filename` / `source` attribute on the item, and finally to `Source N`.
+</Note>
+
+### Result Item Formats
+
+The context utilities support two input formats with automatic fallback for metadata lookups:
+
+| Lookup | 1st choice | 2nd choice | Fallback |
+|--------|------------|------------|----------|
+| `source` | `metadata["source"]` | `item.source` (object) / `item["source"]` (dict) | `""` |
+| `filename` | `metadata["filename"]` | `item.filename` / `item["filename"]` | `""` |
+| `text` | `item.text` / `item["text"]` | `item.memory` / `item["memory"]` | `""` (item skipped in `build_context`) |
 
 ## Integration with Knowledge
 

--- a/docs/rag/retrieval.mdx
+++ b/docs/rag/retrieval.mdx
@@ -156,6 +156,9 @@ if context_pack.citations:
     response = agent.chat(
         f"Based on this context, summarize: {context_pack.context}"
     )
+
+# Note: Each retrieved item is a SearchResultItem object (see praisonaiagents.knowledge.models)
+# that can be passed directly into build_context / deduplicate_chunks
 ```
 
 ## Multi-Agent with Shared Knowledge


### PR DESCRIPTION
## Summary
- Updated RAG documentation to reflect SearchResultItem support from PR MervinPraison/PraisonAI#1739
- Added comprehensive examples showing both dict and SearchResultItem usage
- Documented metadata fallback behavior for source/filename lookups
- Added cross-references between related documentation pages

## Changes
- **docs/rag/module.mdx**: Updated Context Utilities section with Tabs examples, added result item formats table, updated ContextBuilderProtocol signature
- **docs/rag/retrieval.mdx**: Added cross-reference note about SearchResultItem objects
- **docs/knowledge/overview.mdx**: Added Note about SearchResultItem return format

## Test Plan
- [x] All code examples use correct imports from praisonaiagents.rag and praisonaiagents.knowledge.models
- [x] Examples are copy-paste runnable
- [x] Mintlify components used appropriately (Tabs, Note)
- [x] Follows AGENTS.md style guidelines

Fixes #431

🤖 Generated with [Claude Code](https://claude.ai/code)