### PR TITLE
docs: update session-hierarchy + session-persistence for PR #1745

### DIFF
--- a/docs/features/session-hierarchy.mdx
+++ b/docs/features/session-hierarchy.mdx
@@ -1,31 +1,59 @@
 ---
-title: "Session Hierarchy Module"
-description: "Parent-child sessions, forking, snapshots, and revert capabilities"
+title: "Session Hierarchy"
+sidebarTitle: "Session Hierarchy"
+description: "Parent-child sessions, forking, snapshots, and revert capabilities with multi-process safety"
 icon: "sitemap"
 ---
 
-Advanced session management with forking, snapshots, and revert capabilities.
+Advanced session management with forking, snapshots, and revert capabilities for complex conversation flows.
 
-<Note>
-**For basic session persistence**, use the Agent's `memory` parameter:
-```python
-agent = Agent(name="Assistant", memory={"session_id": "my-session"})
+```mermaid
+graph LR
+    subgraph "Hierarchical Sessions"
+        A[📝 Parent Session] --> B[🌿 Fork]
+        A --> C[📸 Snapshot]
+        B --> D[🔀 Child Session]
+        C --> E[⏪ Revert]
+    end
+    
+    classDef session fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef operation fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A,D session
+    class B,C operation
+    class E result
 ```
-See [Session Management](/concepts/session-management) for details.
-</Note>
-
-## Features
-
-- **Parent-Child Sessions** - Create hierarchical session relationships
-- **Session Forking** - Fork sessions from any message point
-- **Snapshots** - Create labeled checkpoints within sessions
-- **Revert** - Restore sessions to previous states
-- **Export/Import** - Transfer sessions between systems
 
 ## Quick Start
 
+<Steps>
+<Step title="Agent-Centric Usage">
+Use HierarchicalSessionStore automatically when fork/snapshot operations are needed:
+
 ```python
-from praisonaiagents.session.hierarchy import HierarchicalSessionStore
+from praisonaiagents import Agent
+from praisonaiagents.session import get_hierarchical_session_store
+
+# Agent with hierarchical session support
+agent = Agent(
+    name="Assistant",
+    memory={"session_id": "project-alpha"},
+)
+
+response = agent.start("Let's plan the migration")
+
+# Later - fork the conversation to explore alternatives
+store = get_hierarchical_session_store()
+fork_id = store.fork_session("project-alpha")
+```
+</Step>
+
+<Step title="Direct Store Usage">
+For advanced control, use the store directly:
+
+```python
+from praisonaiagents.session import HierarchicalSessionStore
 
 # Create a hierarchical session store
 store = HierarchicalSessionStore(session_dir="./sessions")
@@ -46,17 +74,71 @@ store.add_message(session_id, "user", "Do something risky")
 # Revert to snapshot if needed
 store.revert_to_snapshot(session_id, snapshot_id)
 ```
+</Step>
+</Steps>
 
-## API Reference
+---
 
-### HierarchicalSessionStore
+## Multi-Process Safety
+
+`HierarchicalSessionStore` is safe under concurrent multi-process and multi-instance use, with the same guarantees as `DefaultSessionStore` plus extended-field preservation:
+
+- **File locking** — `fcntl.flock()` on Unix, `msvcrt.locking()` on Windows
+- **Atomic writes** — temp file + `os.replace()` prevents partial-write corruption
+- **Reload under lock** — every mutator (`add_message`, `update_session_metadata`, `clear_session`, `set_agent_info`, `set_gateway_info`) reloads the session from disk inside the `FileLock` before mutating, so two processes sharing the same session directory cannot drop each other's messages.
+- **Extended-field preservation** — `parent_id`, `children_ids`, `snapshots`, and `forked_from_message_id` survive across `update_session_metadata` and `clear_session` calls (fixed in PR #1745). Earlier releases could silently wipe these fields on the next save after a metadata update.
+
+<Note>
+This matters most for the PraisonAI UI host, where the UI calls `add_message` from the request thread while the agent's `auto_save` writes assistant turns from a worker thread, and `_persist_session_stats()` runs `update_session_metadata` after every turn. PR #1745 closes the last remaining race in that path.
+</Note>
+
+```mermaid
+sequenceDiagram
+    participant U as PraisonAI UI<br/>(add_message)
+    participant F as sessions/sess-1.json
+    participant A as Agent auto_save<br/>(add_message)
+
+    U->>F: FileLock acquire
+    Note over U,F: reload-under-lock<br/>(ExtendedSessionData.from_dict)
+    U->>F: append user message
+    U->>F: atomic write (preserves snapshots, children_ids)
+    U->>F: FileLock release
+
+    A->>F: FileLock acquire
+    Note over A,F: reload-under-lock<br/>sees user message ✅
+    A->>F: append assistant message
+    A->>F: atomic write
+    A->>F: FileLock release
+```
+
+---
+
+## Configuration Options
+
+<Card title="HierarchicalSessionStore API Reference" icon="code" href="/docs/sdk/reference/python/praisonaiagents.session.hierarchy">
+  Complete API documentation with all parameters and return types
+</Card>
+
+### Extended fields preserved across mutators
+
+| Field | Set by | Preserved by |
+|---|---|---|
+| `parent_id` | `create_session(parent_id=...)`, `fork_session(...)` | all mutators (PR #1745) |
+| `children_ids` | `create_session(parent_id=...)`, `fork_session(...)` | all mutators (PR #1745) |
+| `snapshots` | `create_snapshot(...)` | all mutators (PR #1745) |
+| `forked_from_message_id` | `fork_session(from_message_index=...)` | all mutators (PR #1745) |
+
+### Key Methods
 
 ```python
 class HierarchicalSessionStore(DefaultSessionStore):
     def create_session(
         self,
+        session_id: Optional[str] = None,
         title: Optional[str] = None,
-        parent_id: Optional[str] = None
+        parent_id: Optional[str] = None,
+        agent_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Create a new session, optionally as child of another."""
     
@@ -92,7 +174,9 @@ class HierarchicalSessionStore(DefaultSessionStore):
         """Import a session from exported data."""
 ```
 
-## Examples
+---
+
+## Common Patterns
 
 ### Forking Sessions
 
@@ -152,3 +236,69 @@ exported = store1.export_session(session_id)
 store2 = HierarchicalSessionStore(session_dir="./store2")
 new_id = store2.import_session(exported)
 ```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Use meaningful session titles">
+Provide descriptive titles to help identify sessions later:
+
+```python
+store.create_session(title="Project Alpha - Requirements Phase")
+store.fork_session(session_id, title="Alternative Approach")
+```
+</Accordion>
+
+<Accordion title="Create snapshots before risky operations">
+Take snapshots before potentially destructive changes:
+
+```python
+# Before making experimental changes
+snap_id = store.create_snapshot(session_id, label="Before refactor")
+# ... make changes ...
+# Revert if needed
+store.revert_to_snapshot(session_id, snap_id)
+```
+</Accordion>
+
+<Accordion title="Clean up old sessions">
+Regularly remove unused sessions to save disk space:
+
+```python
+# List all sessions
+sessions = store.list_sessions()
+for session in sessions:
+    if should_delete(session):
+        store.delete_session(session.session_id)
+```
+</Accordion>
+
+<Accordion title="Use forks for experimentation">
+Fork sessions to explore different conversation paths:
+
+```python
+# Main conversation path
+main_id = store.create_session(title="Main Discussion")
+store.add_message(main_id, "user", "Let's solve this problem")
+
+# Experimental path
+experiment_id = store.fork_session(main_id, title="Experimental Solution")
+store.add_message(experiment_id, "user", "What if we try a different approach?")
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Session Persistence" icon="floppy-disk" href="/features/session-persistence">
+  Basic session persistence with zero configuration
+</Card>
+<Card title="Session Protocol" icon="plug" href="/features/session-protocol">
+  Custom session store implementation guide
+</Card>
+</CardGroup>

--- a/docs/features/session-persistence.mdx
+++ b/docs/features/session-persistence.mdx
@@ -153,6 +153,8 @@ The session store uses file locking to ensure safe concurrent access:
 
 Multiple processes can safely read/write to the same session.
 
+The same guarantees apply to `HierarchicalSessionStore`, which adds extended-field preservation (`parent_id`, `children_ids`, `snapshots`, `forked_from_message_id`) across all mutators as of PR #1745.
+
 ## Direct Session Store Access
 
 For advanced use cases, you can access the session store directly:

--- a/docs/persistence/overview.mdx
+++ b/docs/persistence/overview.mdx
@@ -95,6 +95,8 @@ The `DbAdapter`'s lazy store initialisation is also race-free: the first thread 
 
 The session cache inside `PersistenceOrchestrator` is also thread-safe as of PR #1609. Reads return a `deepcopy` of the cached `ConversationSession`, so multiple agents sharing one orchestrator can read/update sessions concurrently without races.
 
+`HierarchicalSessionStore` inherits the JSON store's reload-under-lock guarantees and additionally preserves `parent_id`, `children_ids`, and `snapshots` across all mutators (PR #1745). UI hosts that fork sessions or take snapshots are safe to run alongside an agent's `auto_save` writer.
+
 <Note>
 These improvements were added in PraisonAI PR #1466 to ensure robust multi-threaded operation in production environments.
 </Note>


### PR DESCRIPTION
## Summary

Updates documentation to reflect the concurrency fixes in PR #1745 that resolved message loss and extended field preservation issues in `HierarchicalSessionStore`.

## Changes Made

### docs/features/session-hierarchy.mdx
- ✅ Added agent-centric Quick Start example using `Agent` with `memory` parameter
- ✅ Added comprehensive Multi-Process Safety section explaining file locking, atomic writes, and reload-under-lock
- ✅ Added user-interaction sequence diagram showing concurrent UI + agent writes
- ✅ Added extended fields preservation table documenting which fields survive mutators
- ✅ Fixed API reference signatures to match SDK source exactly
- ✅ Added Best Practices section with AccordionGroup
- ✅ Added Related section with CardGroup
- ✅ Updated hero Mermaid diagram with standard color scheme

### docs/features/session-persistence.mdx
- ✅ Extended Multi-Process Safety section to mention `HierarchicalSessionStore` guarantees

### docs/persistence/overview.mdx
- ✅ Added paragraph about `HierarchicalSessionStore` concurrency guarantees to Concurrency section

## Technical Details

The documentation now accurately reflects that PR #1745 fixed two critical bugs:

1. **Message loss in concurrent writes** - `add_message` now uses reload-under-lock instead of separate load/save operations
2. **Extended field wipe** - `update_session_metadata` and `clear_session` now preserve `parent_id`, `children_ids`, `snapshots`, and `forked_from_message_id`

All changes follow AGENTS.md standards including:
- Agent-centric examples first, SDK-focused second
- Mermaid diagrams with standard color scheme (#8B0000, #189AB4, #10B981)
- Progressive disclosure with Steps, AccordionGroup, CardGroup components
- One-sentence section introductions
- Copy-paste runnable code examples

🤖 Generated with [Claude Code](https://claude.ai/code)

Fixes #447