### PR TITLE
docs: document Telegram typing indicator renewal + default ack/done emoji

### DIFF
--- a/docs/features/messaging-bots.mdx
+++ b/docs/features/messaging-bots.mdx
@@ -169,7 +169,7 @@ from praisonaiagents import BotConfig
 config = BotConfig(
     token="your-bot-token",
     command_prefix="/",
-    typing_indicator=True,
+    typing_indicator=True,  # renews every 4s
     reply_in_thread=False,  # Inline replies
 )
 ```
@@ -468,7 +468,7 @@ config = BotConfig(
 | `webhook_url` | `str` | `None` | Webhook URL for webhook mode |
 | `command_prefix` | `str` | `"/"` | Prefix for bot commands |
 | `mention_required` | `bool` | `True` | Require @mention in channels (DMs never require mention) |
-| `typing_indicator` | `bool` | `True` | Show typing indicator |
+| `typing_indicator` | `bool` | `True` | Show typing indicator. On Telegram, the indicator is **renewed every 4 seconds** for the entire duration of the agent run so users keep seeing "typing…" even during 20–30s RAG / tool-call operations. |
 | `max_message_length` | `int` | `4096` | Max message length |
 | `allowed_users` | `list` | `[]` | Allowed user IDs |
 | `allowed_channels` | `list` | `[]` | Allowed channel IDs |
@@ -1712,9 +1712,59 @@ platforms:
 </Tabs>
 
 <Tip>
-  Set `ack_emoji: ""` (default) to disable ack reactions.
+  Onboard-generated configs enable `⏳` / `✅` by default. Set `ack_emoji: ""` to opt out.
   Currently wired for Telegram (which supports native message reactions).
 </Tip>
+
+---
+
+## Long-Running Agent Feedback
+
+RAG-enabled agents commonly take 20–30 seconds to answer (vector search + tool calls + LLM). PraisonAI Telegram bots give users continuous feedback throughout, with no extra code on your side.
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.bots import BotConfig
+from praisonai.bots import Bot
+
+agent = Agent(name="cfo", instructions="Answer finance questions using the company knowledge base.")
+
+# Defaults shown for clarity — you get all this without setting anything.
+bot = Bot("telegram", agent=agent, config=BotConfig(
+    typing_indicator=True,   # renews every 4s
+    ack_emoji="⏳",          # instant reaction at T+0
+    done_emoji="✅",         # swaps in when the reply lands
+))
+bot.run()
+```
+
+### What the user sees
+
+```mermaid
+sequenceDiagram
+    participant U as 👤 User
+    participant B as 🤖 Bot
+    participant A as 🧠 Agent
+
+    U->>B: "What is our Q1 burn rate?"
+    B->>U: React ⏳ (instant)
+    B->>U: "typing…" bubble
+    Note over B,A: agent.chat() — 20–30s
+    loop every 4s
+        B->>U: Renew "typing…"
+    end
+    A-->>B: Response
+    B->>U: Send reply
+    B->>U: Swap ⏳ → ✅
+```
+
+### Why this matters
+
+| Before | After |
+|--------|-------|
+| One `send_action("typing")` at T+0 | Renewed every 4s for the full run |
+| Bubble vanishes at T+5s | Bubble persists until the reply is sent |
+| Users assume bot is broken, send duplicates | Users see continuous activity |
 
 ---
 

--- a/docs/features/onboard.mdx
+++ b/docs/features/onboard.mdx
@@ -111,6 +111,19 @@ The onboarding process follows these phases:
 
 Agent name (`assistant`) and instructions (`"You are a helpful AI assistant."`) use sensible defaults — edit `~/.praisonai/bot.yaml` to customise. The file contains the full schema as inline documentation.
 
+### Generated bot.yaml example
+
+```yaml
+channels:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+    allowed_users: ${TELEGRAM_ALLOWED_USERS}
+    ack_emoji: "⏳"            # Show processing indicator during long agent operations
+    done_emoji: "✅"           # Replace ack_emoji when operation completes
+```
+
+Ack and done emojis are pre-populated so freshly onboarded bots give visible feedback during long agent operations from the start.
+
 <Note>
 **Upgrading?** Older `bot.yaml` files may contain a `home_channel` key (for example, `home_channel: ${TELEGRAM_HOME_CHANNEL}` or the equivalent for Discord / Slack / WhatsApp). This was never read by the gateway and is safe to delete. Re-running `praisonai onboard` and accepting the overwrite regenerates a clean file.
 </Note>


### PR DESCRIPTION
## Summary

Documents the Telegram typing indicator renewal and default ack/done emoji features shipped in PraisonAI PR #1753.

### Changes Made:

**docs/features/messaging-bots.mdx:**
- Updated typing_indicator table row to mention 4-second renewal behavior
- Updated Python example comment to show renewal behavior  
- Fixed Ack Reactions tip to reflect onboard ⏳/✅ defaults
- Added comprehensive Long-Running Agent Feedback section with sequence diagram and before/after comparison

**docs/features/onboard.mdx:**
- Added Generated bot.yaml example showing new ack_emoji and done_emoji defaults
- Added explanation that these are pre-populated for immediate feedback

### Key UX Improvement Documented:
- **Before**: Single typing action at T+0, bubble disappears after 5s
- **After**: Typing indicator renewed every 4s for full agent run duration (20-30s for RAG operations)
- Combined with default ⏳ ack reaction and ✅ done reaction for continuous user feedback

Fixes #445

🤖 Generated with Claude Code