### PR TITLE
docs: update session persistence docs for read-consistency fix

### DIFF
--- a/docs/features/persistence-json.mdx
+++ b/docs/features/persistence-json.mdx
@@ -150,6 +150,10 @@ store automatically prevents concurrent writers from corrupting session
 files — on every supported OS.
 </Note>
 
+<Note>
+Read paths (`get_chat_history`, `get_session`, `get_sessions_by_agent`) also acquire the file lock and reload from disk on every call, so multiple workers sharing a `session_dir` always observe each other's latest writes — there is no in-memory cache staleness.
+</Note>
+
 ---
 
 ## Configuration Options

--- a/docs/features/session-persistence.mdx
+++ b/docs/features/session-persistence.mdx
@@ -145,13 +145,33 @@ These fields enable cost tracking and usage analytics across sessions.
 
 ## Multi-Process Safety
 
-The session store uses file locking to ensure safe concurrent access:
+The session store uses file locking to ensure safe concurrent access on **both reads and writes**:
 
-- **Unix**: Uses `fcntl.flock()` for file locking
-- **Windows**: Uses `msvcrt.locking()` for file locking
-- **Atomic Writes**: Uses temp file + rename to prevent corruption
+- **Atomic writes**: `add_message` and friends reload under `FileLock`, mutate, then atomically write (temp file + rename) so concurrent writers can't corrupt a session file.
+- **Fresh reads**: `get_chat_history`, `get_session`, and `get_sessions_by_agent` reload from disk under `FileLock` on every call and refresh the in-process cache. Two store instances pointing at the same `session_dir` will always see each other's writes.
+- **Cross-platform locks**: `fcntl.flock` on Unix/macOS, `msvcrt.locking` on Windows.
 
-Multiple processes can safely read/write to the same session.
+<Note>
+Multiple processes (e.g. a gateway worker and a bot worker, or multiple uvicorn workers) can safely share the same `session_dir`. Each call to `get_chat_history` returns the latest committed state on disk — there is no stale-cache window.
+</Note>
+
+<Note>
+`store.invalidate_cache(session_id)` still exists for backwards compatibility, but since reads always reload from disk it is effectively a no-op on the read path. You no longer need to call it before `get_chat_history` / `get_session`.
+</Note>
+
+```mermaid
+sequenceDiagram
+    participant Reader as Store B (reader)
+    participant Disk as session-1.json
+    participant Writer as Store A (writer)
+
+    Writer->>Disk: add_user_message("first")
+    Reader->>Disk: get_chat_history()  [FileLock]
+    Disk-->>Reader: ["first"]
+    Writer->>Disk: add_user_message("second")
+    Reader->>Disk: get_chat_history()  [FileLock, fresh reload]
+    Disk-->>Reader: ["first", "second"]
+```
 
 ## Direct Session Store Access
 

--- a/docs/features/session-protocol.mdx
+++ b/docs/features/session-protocol.mdx
@@ -88,6 +88,10 @@ The protocol requires exactly **five methods**:
 The protocol uses Python's `typing.Protocol` with `@runtime_checkable`, so any class with matching method signatures automatically satisfies it — no inheritance needed.
 </Tip>
 
+<Tip>
+If your custom store backs onto shared storage (Redis, Postgres, S3, another file system), make `get_chat_history` and `get_session` read from that backing store on every call rather than caching in process memory. `DefaultSessionStore` guarantees this; downstream code (e.g. `BotSessionManager._load_history`) relies on it.
+</Tip>
+
 ## Built-in Implementations
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary
Updates session persistence documentation to reflect the read-consistency fixes from PraisonAI PR #1759.

### Changes Made:
- **session-persistence.mdx**: Extended Multi-Process Safety section to document that reads are now also disk-consistent, added sequence diagram showing fresh read behavior
- **persistence-json.mdx**: Added note about read paths acquiring file locks and reloading from disk on every call  
- **session-protocol.mdx**: Added tip for custom stores about reading fresh from backing store on every call

### Background
PraisonAI PR #1759 fixed a read-staleness bug in DefaultSessionStore where reads could return stale cached data when multiple store instances shared the same session_dir. The fix makes all read operations (`get_chat_history`, `get_session`, `get_sessions_by_agent`) reload from disk under FileLock on every call.

This ensures that multiple processes sharing a session directory always see each other's latest writes, eliminating the stale-cache window that could cause LLMs to receive truncated chat context.

Fixes #449

🤖 Generated with [Claude Code](https://claude.ai/code)