### PR TITLE
docs: Document Agent.clone_for_channel() method and multi-channel gateway isolation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -323,7 +323,8 @@
                       "docs/features/external-cli-integrations",
                       "docs/features/cli-backend-protocol",
                       "docs/features/external-agents-ui",
-                      "docs/features/resource-lifecycle"
+                      "docs/features/resource-lifecycle",
+                      "docs/features/agent-cloning"
                     ]
                   }
                 ]

--- a/docs/features/agent-cloning.mdx
+++ b/docs/features/agent-cloning.mdx
@@ -1,0 +1,189 @@
+---
+title: "Agent Cloning"
+sidebarTitle: "Agent Cloning"
+description: "Safely clone agents for multi-channel, multi-tenant, or per-session isolation"
+icon: "copy"
+---
+
+Clone agents to give each channel, tenant, or session its own isolated instance — without losing config or hitting `RLock` pickling errors.
+
+```mermaid
+graph LR
+    subgraph "Agent Cloning"
+        Base[🤖 Base Agent] --> Clone1[📱 Telegram Agent]
+        Base --> Clone2[💬 Discord Agent]
+        Base --> Clone3[📺 Slack Agent]
+    end
+    
+    classDef base fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef clone fill:#189AB4,stroke:#7C90A0,color:#fff
+    
+    class Base base
+    class Clone1,Clone2,Clone3 clone
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Single clone">
+```python
+from praisonaiagents import Agent
+
+base = Agent(
+    name="Support",
+    instructions="You are a helpful support agent",
+    llm="gpt-4o-mini",
+)
+
+# Get an isolated copy for one channel
+telegram_agent = base.clone_for_channel()
+```
+</Step>
+
+<Step title="Multiple clones for multi-channel deployment">
+```python
+from praisonaiagents import Agent
+
+base = Agent(
+    name="Support",
+    instructions="You are a helpful support agent",
+    llm="gpt-4o-mini",
+    tools=["internet_search"],
+    memory=True,
+)
+
+# Create isolated agents for each channel
+telegram_agent = base.clone_for_channel()
+discord_agent  = base.clone_for_channel()
+slack_agent    = base.clone_for_channel()
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Code
+    participant Agent
+    participant Clone
+    
+    User->>Code: agent.clone_for_channel()
+    Code->>Agent: build clone_kwargs
+    Agent->>Clone: fresh locks + interrupt controller
+    Clone-->>Code: isolated Agent
+    Code-->>User: returns isolated Agent
+```
+
+Agent cloning creates a fresh instance with the same configuration but isolated state.
+
+---
+
+## What gets cloned vs. what's reset
+
+| Attribute | Behaviour in clone |
+|---|---|
+| `name`, `role`, `goal`, `backstory`, `instructions` | Copied as-is |
+| `llm`, `base_url`, `api_key`, `auth` | Copied as-is |
+| `tools` | Shallow-copied (`list(self.tools)`) |
+| `handoffs` | Reset to `None` (channels should not share handoffs) |
+| All feature configs: `memory`, `knowledge`, `planning`, `reflection`, `guardrails`, `web`, `context`, `autonomy`, `output`, `execution`, `templates`, `caching`, `hooks`, `skills`, `approval`, `learn`, `sandbox` | Forwarded from the stored `_<name>_config` attributes |
+| `tool_timeout`, `parallel_tool_calls`, `cli_backend` | Forwarded |
+| `interrupt_controller` | **Fresh instance** (no cross-channel interference) |
+| `__cache_lock` (`threading.RLock`) | **Fresh instance** |
+| `_cost_lock` (`threading.Lock`) | **Fresh instance** |
+
+---
+
+## Common Patterns
+
+### Per-channel clone in a custom gateway
+
+```python
+from praisonaiagents import Agent
+
+def create_channel_agents(base_config):
+    base = Agent(**base_config)
+    
+    return {
+        'telegram': base.clone_for_channel(),
+        'discord': base.clone_for_channel(),
+        'slack': base.clone_for_channel()
+    }
+
+agents = create_channel_agents({
+    'name': 'Support',
+    'instructions': 'You are a helpful support agent',
+    'llm': 'gpt-4o-mini'
+})
+```
+
+### Per-tenant clone in a multi-tenant API
+
+```python
+from praisonaiagents import Agent
+
+class TenantAgentManager:
+    def __init__(self, base_agent):
+        self.base = base_agent
+        self.tenant_agents = {}
+    
+    def get_agent_for_tenant(self, tenant_id):
+        if tenant_id not in self.tenant_agents:
+            self.tenant_agents[tenant_id] = self.base.clone_for_channel()
+        return self.tenant_agents[tenant_id]
+
+base = Agent(name="Assistant", instructions="You are helpful")
+manager = TenantAgentManager(base)
+
+# Each tenant gets isolated agent
+agent_a = manager.get_agent_for_tenant("tenant_a")
+agent_b = manager.get_agent_for_tenant("tenant_b")
+```
+
+### Use with copy.deepcopy
+
+```python
+import copy
+from praisonaiagents import Agent
+
+agent = Agent(name="Test", instructions="You are a test agent")
+
+# Both methods work - agent supports deepcopy now
+clone1 = agent.clone_for_channel()  # Preferred for channels
+clone2 = copy.deepcopy(agent)       # General Python compatibility
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Prefer clone_for_channel() over copy.deepcopy() for channels">
+`clone_for_channel()` is the supported path for creating channel-safe clones. It's optimized for multi-channel scenarios and properly handles handoffs. `__deepcopy__` is provided for general Python compatibility but isn't specifically designed for channel isolation.
+</Accordion>
+
+<Accordion title="Don't share handoffs across channels">
+Clone drops `handoffs` by design. Each channel should have independent routing logic. If you need cross-channel handoffs, implement them at the gateway level rather than the agent level.
+</Accordion>
+
+<Accordion title="Tools are shallow-copied">
+If a tool holds mutable per-channel state, wrap it in a factory function or use instance-based tools. The clone shares tool instances with the original agent, which is usually fine for stateless tools.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Bot Gateway" icon="server" href="/features/bot-gateway">
+  Multi-channel gateway using agent cloning
+</Card>
+<Card title="Thread Safety" icon="shield" href="/features/thread-safety">
+  Agent thread safety and concurrency
+</Card>
+</CardGroup>

--- a/docs/features/bot-gateway.mdx
+++ b/docs/features/bot-gateway.mdx
@@ -28,6 +28,8 @@ Run all your bots from one command. The Gateway Server manages multiple bot conn
 
 **Parity with Bot()**: `praisonai gateway start` now applies the same smart defaults as `praisonai bot start`, resolving the previous "zero tools in daemon mode" issue. Both entry points produce identical behavior with safe tools auto-injected and auto-approval enabled by default.
 
+Each channel bot gets an isolated agent via `Agent.clone_for_channel()` — fresh locks, fresh interrupt controller, and no shared `handoffs` state — so configuring tools or memory on one channel never leaks into another.
+
 ## Quick Start
 
 <Steps>
@@ -279,6 +281,24 @@ gateway.get_agent("personal")    # Returns Agent instance
   ```
   
   The `push` section is only included when push notifications are enabled.
+</Accordion>
+
+<Accordion title="Advanced: Channel isolation">
+  The gateway calls `_create_bot()` to build independent clones for each channel:
+
+  ```mermaid
+  flowchart TB
+      Base[🤖 Base Agent] --> Gateway[Gateway Server]
+      Gateway --> Clone1[📱 Telegram Clone]
+      Gateway --> Clone2[💬 Discord Clone] 
+      Gateway --> Clone3[📺 Slack Clone]
+      
+      style Base fill:#8B0000,color:#fff
+      style Gateway fill:#189AB4,color:#fff
+      style Clone1,Clone2,Clone3 fill:#10B981,color:#fff
+  ```
+
+  Each clone has fresh locks and interrupt controllers, preventing cross-channel interference. Learn more about [Agent Cloning](/features/agent-cloning).
 </Accordion>
 
 <Accordion title="Advanced: Standalone Bot Mode">

--- a/docs/features/channels-gateway.mdx
+++ b/docs/features/channels-gateway.mdx
@@ -76,6 +76,10 @@ praisonai dashboard --aiui
 
 This starts Pattern B host integration with channels feature enabled.
 
+<Note>
+All configured channels now start reliably from a single gateway, resolving the previous `cannot pickle '_thread.RLock' object` error through automatic [Agent Cloning](/features/agent-cloning).
+</Note>
+
 </Step>
 </Steps>
 

--- a/docs/features/messaging-bots.mdx
+++ b/docs/features/messaging-bots.mdx
@@ -1342,6 +1342,10 @@ channels:
   #     default: "personal"
 ```
 
+<Tip>
+Behind the scenes the gateway calls `Agent.clone_for_channel()` on the configured agent for each channel, so per-channel tools or routing rules never leak between bots. See [Agent Cloning](/features/agent-cloning).
+</Tip>
+
 ```bash
 praisonai gateway --config gateway.yaml
 ```

--- a/docs/features/thread-safety.mdx
+++ b/docs/features/thread-safety.mdx
@@ -134,6 +134,10 @@ with threading.ThreadPoolExecutor(max_workers=5) as executor:
 | `RateLimiter` (sync) | `threading.Lock` | Protects `_tokens`, `_api_tokens`, and refill state from races in multi-threaded acquire calls |
 | `RateLimiter` (async) | `asyncio.Lock` | Same protection for coroutine contexts |
 
+### Deep-copy support
+
+Agent.__deepcopy__ replaces threading.RLock (__cache_lock) and threading.Lock (_cost_lock) with fresh instances during copy.deepcopy(agent), so the agent is copy-safe on every supported Python version (RLock pickling was broken on CPython < 3.13).
+
 ### Lock Usage Pattern
 
 ```python
@@ -193,6 +197,16 @@ for t in threads:
 <Note>
 Reference: PraisonAI PR #1609. The session cache uses defensive copying to prevent shared mutable state between concurrent operations.
 </Note>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Agent Cloning" icon="copy" href="/features/agent-cloning">
+  Clone agents for channel isolation
+</Card>
+</CardGroup>
 
 ## Best Practices
 


### PR DESCRIPTION
Fixes #448

## Summary
- Created new **docs/features/agent-cloning.mdx** page documenting the Agent.clone_for_channel() method
- Updated **docs/features/bot-gateway.mdx** with channel isolation explanation and accordion
- Updated **docs/features/channels-gateway.mdx** with multi-channel reliability note
- Updated **docs/features/messaging-bots.mdx** with gateway cloning tip
- Updated **docs/features/thread-safety.mdx** with deep-copy support section
- Updated **docs.json** to add the new page under Features group

## Documentation Changes
The new documentation covers:
- Quick start examples for single and multi-channel cloning
- Visual Mermaid diagrams explaining the cloning process
- Comprehensive table of what gets cloned vs reset
- Common usage patterns (per-channel, per-tenant, with deepcopy)
- Best practices with accordions
- Cross-references to related pages

## Validation
- All code examples use proper imports and are copy-paste runnable
- Mermaid diagrams follow the standard color scheme
- docs.json validated as valid JSON
- All pages follow AGENTS.md template requirements

🤖 Generated with [Claude Code](https://claude.ai/code)