### PR TITLE
docs: Document gateway port collision prevention features

### DIFF
--- a/docs/features/gateway-cli.mdx
+++ b/docs/features/gateway-cli.mdx
@@ -37,6 +37,7 @@ graph LR
 ```bash
 praisonai gateway start
 ```
+<Tip>Only one gateway can run per host:port. Stop the existing one with `praisonai gateway stop` first, or use a different port.</Tip>
 </Step>
 
 <Step title="Check Status">
@@ -61,6 +62,7 @@ curl http://127.0.0.1:8765/health
 | Command | Description | Example |
 |---------|-------------|---------|
 | `praisonai gateway start` | Start the gateway server (foreground) | `praisonai gateway start --port 9000` |
+| `praisonai gateway stop` | Stop a running gateway instance | `praisonai gateway stop --force` |
 | `praisonai gateway status` | Check gateway and daemon status | `praisonai gateway status --daemon-only` |
 | `praisonai gateway channels` | List configured channels | `praisonai gateway channels --json` |
 
@@ -90,7 +92,7 @@ praisonai gateway start [OPTIONS]
 
 Options:
   --host TEXT         Host to bind to [default: 127.0.0.1]
-  --port INTEGER      Port to listen on [default: 8765]
+  --port INTEGER      Port to listen on [default: 8765 or $GATEWAY_PORT]
   --agents TEXT       Path to agent configuration file
   --config TEXT       Path to gateway.yaml for multi-bot mode
 
@@ -98,6 +100,23 @@ Examples:
   praisonai gateway start
   praisonai gateway start --config gateway.yaml
   praisonai gateway start --agents agents.yaml --port 9000
+  GATEWAY_PORT=9000 praisonai gateway start
+```
+</Tab>
+
+<Tab title="stop">
+```bash
+praisonai gateway stop [OPTIONS]
+
+Options:
+  --host TEXT         Gateway host [default: 127.0.0.1]
+  --port INTEGER      Gateway port [default: 8765 or $GATEWAY_PORT]
+  --force             Force stop (kill process)
+
+Examples:
+  praisonai gateway stop
+  praisonai gateway stop --port 9000
+  praisonai gateway stop --force
 ```
 </Tab>
 
@@ -107,7 +126,7 @@ praisonai gateway status [OPTIONS]
 
 Options:
   --host TEXT         Gateway host [default: 127.0.0.1]
-  --port INTEGER      Gateway port [default: 8765]
+  --port INTEGER      Gateway port [default: 8765 or $GATEWAY_PORT]
   --daemon-only       Show only daemon status
 
 Examples:
@@ -131,6 +150,51 @@ Examples:
 ```
 </Tab>
 </Tabs>
+
+---
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|----------|
+| `GATEWAY_PORT` | Port for start/stop/status when --port is not passed | `8765` |
+
+<Note>
+The `GATEWAY_PORT` environment variable is used by `start`, `stop`, and `status` commands when the `--port` option is not explicitly provided. Invalid values silently fall back to `8765`.
+</Note>
+
+---
+
+## Single-Instance Enforcement
+
+PraisonAI enforces a single gateway instance per host:port combination using PID locks.
+
+```mermaid
+graph TB
+    Start[🚀 Gateway Start] --> PortCheck{🔍 Port Available?}
+    PortCheck -->|Yes| PIDLock{🔒 PID Lock?}
+    PortCheck -->|No| Error1[❌ Port Error]
+    PIDLock -->|Acquired| Success[✅ Start Gateway]
+    PIDLock -->|Conflict| Error2[❌ Instance Error]
+    Error1 --> Stop1[💡 Use Different Port]
+    Error2 --> Stop2[💡 Stop Existing Gateway]
+    
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef solution fill:#189AB4,stroke:#7C90A0,color:#fff
+    
+    class Start start
+    class PortCheck,PIDLock check
+    class Success success
+    class Error1,Error2 error
+    class Stop1,Stop2 solution
+```
+
+**Lock File Location:** `~/.praisonai/gateway-<safe_host>-<port>.pid`
+
+The `safe_host` replaces `:` and `.` with `_` (so `127.0.0.1` becomes `127_0_0_1`). Each host:port combination gets its own lock file, allowing multiple gateways on different ports.
 
 ---
 
@@ -165,6 +229,8 @@ schtasks /End /TN PraisonAIGateway && schtasks /Run /TN PraisonAIGateway
 ### Healthy Gateway
 ```bash
 $ praisonai gateway status
+Gateway PID lock: Process 12345 running (127.0.0.1:8765)
+Port 127.0.0.1:8765: In use
 Daemon service: Running (launchd)
 Process ID: 12345
 Gateway server: Reachable at http://127.0.0.1:8765/health

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -352,11 +352,53 @@ shutdown()
 
 ---
 
+## Single-Instance Enforcement
+
+PraisonAI enforces one gateway per host:port combination using PID locks to prevent conflicts and ensure reliable bot operation.
+
+```mermaid
+graph LR
+    subgraph "Gateway Instance Management"
+        Start[🚀 Start] --> Check{🔍 Port Check}
+        Check -->|Available| Lock{🔒 PID Lock}
+        Check -->|In Use| Error[❌ Port Conflict]
+        Lock -->|Acquired| Run[✅ Gateway Running]
+        Lock -->|Conflict| Stop[❌ Another Instance]
+    end
+    
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    
+    class Start start
+    class Check,Lock check
+    class Run success
+    class Error,Stop error
+```
+
+**PID Lock File:** `~/.praisonai/gateway-<host>-<port>.pid`
+
+Each lock file contains:
+- Process ID of the running gateway
+- Host and port being used
+- Timestamp of lock creation
+- Automatic cleanup of stale locks
+
+**Multiple Gateways:** Run gateways on different ports using `GATEWAY_PORT` or `--port` to avoid conflicts.
+
+---
+
 ## CLI Commands
 
 ```bash
 # Start gateway server
 praisonai gateway start --port 8765
+GATEWAY_PORT=9000 praisonai gateway start
+
+# Stop running gateway
+praisonai gateway stop
+praisonai gateway stop --force
 
 # Start with configuration file
 praisonai gateway start --config gateway.yaml
@@ -393,6 +435,10 @@ praisonai gateway channels --config gateway.yaml
   
   <Accordion title="Monitor connection limits">
     Set `max_connections` based on your server capacity. Monitor active connections to prevent resource exhaustion.
+  </Accordion>
+  
+  <Accordion title="Single instance per bot token">
+    Each Telegram/Discord/Slack bot token must be polled by exactly one process. PraisonAI enforces a PID lock at `~/.praisonai/gateway-<host>-<port>.pid` — start a second instance and you'll get a clear error pointing at the running PID. Use `GATEWAY_PORT=<other>` to run a second gateway on another port.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/guides/troubleshoot-gateway.mdx
+++ b/docs/guides/troubleshoot-gateway.mdx
@@ -35,6 +35,116 @@ graph TB
 
 ## Common Issues
 
+### Port Already In Use / Two Gateways Running
+
+**Symptom:** Gateway fails to start with a clear error message about port conflicts.
+
+```
+Error: Gateway port 8765 is already in use.
+
+  Another gateway may be running (PID 8864).
+  Stop it:  praisonai gateway stop
+  Or use a different port:  GATEWAY_PORT=8766 praisonai gateway start
+
+  Only ONE gateway process should poll each Telegram bot token.
+```
+
+<Steps>
+<Step title="Check PID lock and port status">
+```bash
+praisonai gateway status
+```
+
+Look for lines like:
+- `Gateway PID lock: Process 12345 running (127.0.0.1:8765)`
+- `Port 127.0.0.1:8765: In use`
+</Step>
+
+<Step title="Stop the existing gateway gracefully">
+```bash
+praisonai gateway stop
+```
+
+This sends SIGTERM and waits for graceful shutdown. The PID lock file will be automatically cleaned up.
+</Step>
+
+<Step title="If gateway is stuck, force stop">
+```bash
+praisonai gateway stop --force
+```
+
+This sends SIGKILL directly (SIGTERM on Windows) for immediate termination.
+</Step>
+
+<Step title="If port is used by non-gateway process">
+```bash
+# Find what's using the port
+lsof -i :8765
+# Linux alternative:
+netstat -ano | findstr :8765
+
+# Either kill that process or use a different port
+GATEWAY_PORT=8766 praisonai gateway start
+# Or:
+praisonai gateway start --port 8766
+```
+</Step>
+
+<Step title="Clean up stale lock file (if needed)">
+```bash
+# Check the PID lock file
+cat ~/.praisonai/gateway-127_0_0_1-8765.pid
+
+# Remove stale lock manually (auto-cleaned on next start)
+rm ~/.praisonai/gateway-127_0_0_1-8765.pid
+```
+
+Stale locks are automatically detected and removed, but you can clean them manually if needed.
+</Step>
+</Steps>
+
+---
+
+### Telegram Bot Goes Silent After Restart
+
+**Symptom:** Gateway `/health` endpoint returns healthy, but Telegram messages aren't received after a restart or crash.
+
+**Cause:** Two processes are polling the same Telegram bot token. Telegram delivers messages to only one poller, causing the bot to appear "silent" when the wrong process gets the messages.
+
+<Steps>
+<Step title="Stop all gateway instances">
+```bash
+praisonai gateway stop --force
+```
+
+This ensures all instances are terminated, even if PID files are corrupted.
+</Step>
+
+<Step title="Verify no processes are running">
+```bash
+praisonai gateway status
+```
+
+Should show:
+- `Gateway PID lock: No lock file found`
+- `Port 127.0.0.1:8765: Available`
+</Step>
+
+<Step title="Start a single gateway instance">
+```bash
+praisonai gateway start
+```
+
+Only start one instance to ensure exclusive bot token polling.
+</Step>
+
+<Step title="Test bot responsiveness">
+Send a message to your Telegram bot. It should respond normally now that only one process is polling the token.
+</Step>
+</Steps>
+
+---
+
 ### Daemon Running But Gateway Unreachable
 
 **Symptom:** `praisonai gateway status` shows `Daemon service: Running (launchd)` but `Gateway not reachable at http://127.0.0.1:8765/health`.
@@ -60,14 +170,16 @@ praisonai gateway logs
 Look for Python tracebacks or port binding errors.
 </Step>
 
-<Step title="Check if another process is using the port">
+<Step title="Check port and PID lock status">
 ```bash
-lsof -i :8765
-# or
-netstat -tulpn | grep :8765
+praisonai gateway status
 ```
 
-If another process is using port 8765, either stop it or change the gateway port.
+This now reports both port usage and PID lock status directly. Look for:
+- `Gateway PID lock: Process <pid> running` or `No lock file found`
+- `Port 127.0.0.1:8765: In use` or `Available`
+
+If another process is using the port, use `praisonai gateway stop` to stop an existing gateway, or choose a different port.
 </Step>
 
 <Step title="Verify PraisonAI version">
@@ -402,6 +514,13 @@ praisonai gateway status --daemon-only
 
 # Recent logs (last 50 lines)
 praisonai gateway logs -n 50
+
+# Check the PID lock file
+cat ~/.praisonai/gateway-127_0_0_1-8765.pid
+
+# Stop a running gateway
+praisonai gateway stop
+praisonai gateway stop --force
 
 # Check port usage
 lsof -i :8765


### PR DESCRIPTION
Fixes #450

This PR documents the new gateway port collision prevention features added in PraisonAI PR #1756:

## Changes Made

### docs/features/gateway-cli.mdx
- Added praisonai gateway stop command to Gateway Management table
- Added new Command Reference tab for stop with --force option
- Documented GATEWAY_PORT environment variable in new Environment Variables section
- Updated status output examples to show PID lock and port information
- Added Single-Instance Enforcement section with mermaid diagram
- Added tip about port conflicts in Quick Start

### docs/features/gateway.mdx
- Added Single-Instance Enforcement section with PID lock explanation
- Updated CLI Commands section to include stop and GATEWAY_PORT examples
- Added best practice accordion about single instance per bot token

### docs/guides/troubleshoot-gateway.mdx
- Added Port Already In Use / Two Gateways Running troubleshooting section
- Added Telegram Bot Goes Silent After Restart section covering duplicate pollers
- Updated Daemon Running But Gateway Unreachable to mention new status output
- Added PID lock file path documentation and diagnostic commands

## Technical Details Documented

- New praisonai gateway stop command with --host, --port, and --force options
- GATEWAY_PORT environment variable support for start/stop/status commands
- PID lock system at ~/.praisonai/gateway-<safe_host>-<port>.pid
- Enhanced status output with lock and port information
- User-friendly collision error messages
- Single-instance enforcement per host:port combination

Generated with [Claude Code](https://claude.ai/code)