### PR TITLE
docs: update session persistence + managed stream docs for PR #1768

### DIFF
--- a/docs/concepts/bot-os.mdx
+++ b/docs/concepts/bot-os.mdx
@@ -194,7 +194,7 @@ graph LR
 
 | Capability | CLI Flag | What It Does |
 |-----------|---------|-------------|
-| **Memory** | `--memory` | Remembers what users said in previous messages |
+| **Memory** | `--memory` | Remembers what users said in previous messages. Safe for multi-worker deployments — messages survive concurrent updates |
 | **Knowledge** | `--knowledge` | Answers from your PDF, text, or markdown files |
 | **Web Search** | `--web` | Searches the internet for up-to-date info |
 | **Thinking** | `--thinking high` | Takes more time to give better, deeper answers |

--- a/docs/concepts/managed-agents-local.mdx
+++ b/docs/concepts/managed-agents-local.mdx
@@ -202,6 +202,10 @@ ids = managed.save_ids()
 ```
 
 <Note>
+Both `agent.start(..., stream=True)` and the non-streaming path persist the user prompt, the full assistant response, and token usage to the session store. Resume the session later and the full history is available — streaming does not drop messages.
+</Note>
+
+<Note>
 `retrieve_session()` **always** returns all 4 keys (`id`, `status`, `title`, `usage`) with sensible defaults when no session exists.
 </Note>
 

--- a/docs/concepts/session-management.mdx
+++ b/docs/concepts/session-management.mdx
@@ -363,6 +363,25 @@ sessions = store.list_sessions(limit=50)
 # Delete a session
 store.delete_session("session-123")
 ```
+
+**Atomic batch replace** — when you need to rewrite the whole history under a single lock (compaction, redaction, multi-worker bot saves):
+
+```python
+from praisonaiagents.session import get_default_session_store
+
+store = get_default_session_store()
+
+store.set_chat_history(
+    "session-123",
+    [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
+    ],
+)
+```
+
+Safer than `clear_session()` + a loop of `add_message()` — there is no window where another worker can read an empty history.
+
 </Accordion>
 
 ## Best Practices

--- a/docs/persistence/session-resume.mdx
+++ b/docs/persistence/session-resume.mdx
@@ -98,6 +98,17 @@ praisonai persistence resume \
     --continue "What did we discuss?"
 ```
 
+## Concurrent Writes
+
+Multiple bot workers writing to the same `session_id` are safe — history saves use a single locked atomic write under the hood, so no worker sees an empty history mid-update.
+
+This applies to:
+- Messaging bots (`praisonai bot telegram`, `discord`, `slack`, `whatsapp`)
+- Multi-process deployments resuming the same session key
+- Managed agents streaming chunks back to the user
+
+You do not need to add a custom lock around `agent.start()`.
+
 ## Best Practices
 
 1. **Consistent session_ids** - Same ID = same conversation thread


### PR DESCRIPTION
Fixes #472

## Summary
Updates documentation for session persistence and managed stream improvements from **MervinPraison/PraisonAI#1768** (merged 2026-06-02): _"fix: session message loss in managed stream and bot history saves"_.

## Changes Made

### 1. docs/concepts/session-management.mdx
- **Added set_chat_history() API documentation** in the "Direct Session Store Access" accordion
- Shows atomic batch replace functionality with proper example code
- Explains safety benefits over clear_session() + loop pattern

### 2. docs/concepts/managed-agents-local.mdx  
- **Added streaming persistence note** in Session Management section
- Documents that both execute() and stream() paths now persist user prompts, assistant responses, and token usage
- Clarifies that session resume works for streaming-driven conversations

### 3. docs/persistence/session-resume.mdx
- **Added new "Concurrent Writes" section** explaining atomic session handling
- Documents multi-worker safety for messaging bots and managed agents
- Explains that no custom locking is needed around agent.start()

### 4. docs/concepts/bot-os.mdx
- **Enhanced Memory capability description** to mention multi-worker deployment safety
- Added note about message survival across concurrent updates

## Verification
- [x] All API signatures verified against main PraisonAI repository
- [x] Import paths match existing documentation patterns  
- [x] Code examples are copy-paste runnable
- [x] Writing follows AGENTS.md style guidelines
- [x] Changes are minimal and focused on the specific PR improvements

## API Details Confirmed
- set_chat_history(session_id: str, messages: List[Dict[str, str]]) -> bool
- Streaming persistence via _persist_message() in managed_local.py
- Atomic session writes prevent empty history visibility during updates

🤖 Generated with [Claude Code](https://claude.ai/code)