### PR TITLE
docs: Update AsyncAgentScheduler docs with new timeout and max_cost parameters

### DIFF
--- a/docs/cli/scheduler.mdx
+++ b/docs/cli/scheduler.mdx
@@ -416,6 +416,8 @@ asyncio.run(main())
 
 The canonical `AgentScheduler` from `praisonai.scheduler` exposes `from_yaml`, `start_from_yaml_config`, and `from_recipe`. For new applications, prefer `AsyncAgentScheduler` which provides better cancellation and fits naturally into async codebases.
 
+**Budget & timeout (PR #1771):** `AsyncAgentScheduler` now accepts `timeout` (per-run seconds) and `max_cost` (total USD cap) in its constructor — see [Async Agent Scheduler](/docs/features/async-agent-scheduler) for the full pattern.
+
 **MCP scheduling note:** The MCP server's `praisonai.schedule.list / .add / .remove` tools are now backed by `praisonaiagents.tools.schedule_tools`, so YAML/recipe scheduling works through MCP without needing to choose an import path.
 </Note>
 

--- a/docs/features/async-agent-scheduler.mdx
+++ b/docs/features/async-agent-scheduler.mdx
@@ -102,6 +102,35 @@ async def main():
 asyncio.run(main())
 ```
 </Step>
+
+<Step title="With Timeout & Budget Limit">
+```python
+import asyncio
+from praisonaiagents import Agent
+from praisonai.async_agent_scheduler import AsyncAgentScheduler
+
+async def main():
+    agent = Agent(
+        name="CostAwareAgent",
+        instructions="Summarise the latest tech headlines.",
+    )
+
+    scheduler = AsyncAgentScheduler(
+        agent,
+        task="Summarise tech news",
+        timeout=30,        # stop a single run after 30s
+        max_cost=1.00,     # auto-shutdown once $1.00 spent
+    )
+
+    await scheduler.start("hourly", run_immediately=True)
+    await asyncio.sleep(3600 * 4)
+    stats = await scheduler.get_stats_async()
+    print(f"Spent ${stats['total_cost_usd']}, remaining ${stats['remaining_budget']}")
+    await scheduler.stop()
+
+asyncio.run(main())
+```
+</Step>
 </Steps>
 
 ---
@@ -165,6 +194,8 @@ The scheduler's async primitives (`_stop_event`, `_cancel_event`, `_stats_lock`)
 | `config` | `Optional[Dict[str, Any]]` | `None` | Optional configuration dictionary |
 | `on_success` | `Optional[Callable[[Any], None]]` | `None` | Callback function on successful execution |
 | `on_failure` | `Optional[Callable[[Exception], None]]` | `None` | Callback function on failed execution |
+| `timeout` | `Optional[int]` | `None` | **NEW** — Maximum execution time per run in seconds. `None` means no limit. Enforced with `asyncio.wait_for()`. |
+| `max_cost` | `Optional[float]` | `1.00` | **NEW** — Maximum total cost in USD. Scheduler auto-stops when reached. Set to `None` to disable. Default `$1.00` is a safety guard. |
 
 ### start() Method Options
 
@@ -214,6 +245,8 @@ graph LR
 | `successful_executions` | `int` | Number of successful executions |
 | `failed_executions` | `int` | Number of failed executions |
 | `success_rate` | `float` | Success percentage (0-100) |
+| `total_cost_usd` | `float` | **NEW** — Running total cost in USD (4 dp) |
+| `remaining_budget` | `float \| None` | **NEW** — `max_cost - total_cost_usd`, or `None` if `max_cost` is disabled |
 
 ---
 
@@ -318,6 +351,54 @@ async def main():
 asyncio.run(main())
 ```
 
+### Budget-aware Scheduling
+
+```python
+import asyncio
+from praisonaiagents import Agent
+from praisonai.async_agent_scheduler import AsyncAgentScheduler
+
+async def main():
+    agent = Agent(name="ReportAgent", instructions="Generate hourly report")
+
+    # Hard-stop after $5 total spend, 60s per run
+    scheduler = AsyncAgentScheduler(
+        agent,
+        task="Generate report",
+        timeout=60,
+        max_cost=5.00,
+    )
+
+    await scheduler.start("hourly")
+    while scheduler.is_running:
+        await asyncio.sleep(60)
+        stats = await scheduler.get_stats_async()
+        if stats["remaining_budget"] is not None and stats["remaining_budget"] < 0.50:
+            print(f"⚠️  Budget nearly exhausted: ${stats['remaining_budget']:.4f} left")
+    print("Scheduler stopped (budget reached or manual stop)")
+
+asyncio.run(main())
+```
+
+```mermaid
+graph TB
+    Start[Execution Start] --> Check{total_cost >= max_cost?}
+    Check -->|Yes| Stop[stop_event.set] --> Halt[Scheduler Halts]
+    Check -->|No| Run[Run Agent]
+    Run --> AddCost[total_cost += ~$0.0001]
+    AddCost --> NextLoop[Wait for next interval]
+    
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef stop fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef run fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class Start start
+    class Check check
+    class Stop,Halt stop
+    class Run,AddCost,NextLoop run
+```
+
 ---
 
 ## Best Practices
@@ -385,6 +466,35 @@ from praisonai.scheduler import AgentScheduler
 scheduler = AgentScheduler(agent, task)
 scheduler.start("hourly")
 ```
+</Accordion>
+
+<Accordion title="Budget Control">
+The default `max_cost=1.00` is intentional — it caps unattended cost runaway. For long-running production deployments, raise it explicitly to the budget you've approved, or set `max_cost=None` only when an external billing system enforces limits.
+
+```python
+# Production with explicit budget
+scheduler = AsyncAgentScheduler(agent, task, max_cost=50.00)
+
+# Disable budget (only when external limits exist)
+scheduler = AsyncAgentScheduler(agent, task, max_cost=None)
+```
+
+When the budget triggers, the scheduler logs a warning and calls `stop_event.set()` internally — `stats["is_running"]` flips to `False`.
+</Accordion>
+
+<Accordion title="Timeout Configuration">
+Set `timeout` to bound the worst-case wall-clock time per run. Internally implemented with `asyncio.wait_for()`, which raises `asyncio.TimeoutError` and triggers the standard retry path.
+
+```python
+scheduler = AsyncAgentScheduler(
+    agent,
+    task,
+    timeout=30,        # individual run cannot exceed 30s
+    max_cost=1.00,
+)
+```
+
+`timeout=None` (the default) imposes no limit.
 </Accordion>
 </AccordionGroup>
 

--- a/docs/features/async-scheduler.mdx
+++ b/docs/features/async-scheduler.mdx
@@ -101,6 +101,37 @@ async def main():
 asyncio.run(main())
 ```
 </Step>
+
+<Step title="With Timeout & Budget Limit">
+Control execution time and budget with built-in enforcement.
+
+```python
+import asyncio
+from praisonaiagents import Agent
+from praisonai.async_agent_scheduler import AsyncAgentScheduler
+
+async def main():
+    agent = Agent(
+        name="CostAwareAgent",
+        instructions="Summarise the latest tech headlines."
+    )
+
+    scheduler = AsyncAgentScheduler(
+        agent,
+        task="Summarise tech news",
+        timeout=30,        # stop a single run after 30s
+        max_cost=1.00,     # auto-shutdown once $1.00 spent
+    )
+
+    await scheduler.start("hourly", run_immediately=True)
+    await asyncio.sleep(3600 * 4)
+    stats = await scheduler.get_stats_async()
+    print(f"Spent ${stats['total_cost_usd']}, remaining ${stats['remaining_budget']}")
+    await scheduler.stop()
+
+asyncio.run(main())
+```
+</Step>
 </Steps>
 
 ---
@@ -154,6 +185,8 @@ sequenceDiagram
 | `config` | `Dict[str, Any]` | `{}` | Optional configuration |
 | `on_success` | `Callable` | `None` | Success callback (sync or async) |
 | `on_failure` | `Callable` | `None` | Failure callback (sync or async) |
+| `timeout` | `Optional[int]` | `None` | **NEW** — Maximum execution time per run in seconds. `None` means no limit. Enforced with `asyncio.wait_for()`. |
+| `max_cost` | `Optional[float]` | `1.00` | **NEW** — Maximum total cost in USD. Scheduler auto-stops when reached. Set to `None` to disable. Default `$1.00` is a safety guard. |
 
 ### Start Parameters
 
@@ -162,6 +195,18 @@ sequenceDiagram
 | `schedule_expr` | `str` | Required | Schedule interval expression |
 | `max_retries` | `int` | `3` | Total attempts (1 initial + retries) |
 | `run_immediately` | `bool` | `False` | Execute immediately before scheduling |
+
+### Stats Response Format
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `is_running` | `bool` | Whether scheduler is currently running |
+| `total_executions` | `int` | Total number of execution attempts |
+| `successful_executions` | `int` | Number of successful executions |
+| `failed_executions` | `int` | Number of failed executions |
+| `success_rate` | `float` | Success percentage (0-100) |
+| `total_cost_usd` | `float` | **NEW** — Running total cost in USD (4 dp) |
+| `remaining_budget` | `float \| None` | **NEW** — `max_cost - total_cost_usd`, or `None` if `max_cost` is disabled |
 
 ---
 
@@ -209,6 +254,54 @@ async def graceful_shutdown():
         print("Scheduler cancelled")
     finally:
         await scheduler.stop()
+```
+
+### Pattern 4: Budget-aware Scheduling
+
+```python
+import asyncio
+from praisonaiagents import Agent
+from praisonai.async_agent_scheduler import AsyncAgentScheduler
+
+async def main():
+    agent = Agent(name="ReportAgent", instructions="Generate hourly report")
+
+    # Hard-stop after $5 total spend, 60s per run
+    scheduler = AsyncAgentScheduler(
+        agent,
+        task="Generate report",
+        timeout=60,
+        max_cost=5.00,
+    )
+
+    await scheduler.start("hourly")
+    while scheduler.is_running:
+        await asyncio.sleep(60)
+        stats = await scheduler.get_stats_async()
+        if stats["remaining_budget"] is not None and stats["remaining_budget"] < 0.50:
+            print(f"⚠️  Budget nearly exhausted: ${stats['remaining_budget']:.4f} left")
+    print("Scheduler stopped (budget reached or manual stop)")
+
+asyncio.run(main())
+```
+
+```mermaid
+graph TB
+    Start[Execution Start] --> Check{total_cost >= max_cost?}
+    Check -->|Yes| Stop[stop_event.set] --> Halt[Scheduler Halts]
+    Check -->|No| Run[Run Agent]
+    Run --> AddCost[total_cost += ~$0.0001]
+    AddCost --> NextLoop[Wait for next interval]
+    
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef stop fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef run fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class Start start
+    class Check check
+    class Stop,Halt stop
+    class Run,AddCost,NextLoop run
 ```
 
 ---
@@ -272,6 +365,35 @@ finally:
     await scheduler.stop()
     print(f"Final stats: {stats}")
 ```
+</Accordion>
+
+<Accordion title="Budget Control">
+The default `max_cost=1.00` is intentional — it caps unattended cost runaway. For long-running production deployments, raise it explicitly to the budget you've approved, or set `max_cost=None` only when an external billing system enforces limits.
+
+```python
+# Production with explicit budget
+scheduler = AsyncAgentScheduler(agent, task, max_cost=50.00)
+
+# Disable budget (only when external limits exist)
+scheduler = AsyncAgentScheduler(agent, task, max_cost=None)
+```
+
+When the budget triggers, the scheduler logs a warning and calls `stop_event.set()` internally — `stats["is_running"]` flips to `False`.
+</Accordion>
+
+<Accordion title="Timeout Configuration">
+Set `timeout` to bound the worst-case wall-clock time per run. Internally implemented with `asyncio.wait_for()`, which raises `asyncio.TimeoutError` and triggers the standard retry path.
+
+```python
+scheduler = AsyncAgentScheduler(
+    agent,
+    task,
+    timeout=30,        # individual run cannot exceed 30s
+    max_cost=1.00,
+)
+```
+
+`timeout=None` (the default) imposes no limit.
 </Accordion>
 </AccordionGroup>
 

--- a/docs/features/thread-safety.mdx
+++ b/docs/features/thread-safety.mdx
@@ -472,6 +472,8 @@ A transient discovery error does not lock the CLI into a broken state — the ne
 
 ### New Thread-Safe Components in PR #1673
 
+**Jobs server singleton init (PR #1771)** — `get_store()` and `get_executor()` in `praisonai/jobs/server.py` now use double-checked locking with `threading.Lock`. This eliminates a TOCTOU race where concurrent cold-start requests could create orphaned `JobStore` / `JobExecutor` instances on a fresh process.
+
 **InMemoryJobStore — locked reads and async `get_stats()`**
 
 All read methods (`get`, `get_by_idempotency_key`, `list_jobs`, `count`, `get_stats`) now hold an `asyncio.Lock` while reading internal dicts, so concurrent saves cannot tear a read.

--- a/praisonai/scheduler/async_agent_scheduler.py
+++ b/praisonai/scheduler/async_agent_scheduler.py
@@ -627,7 +627,11 @@ class AsyncAgentScheduler:
 def create_async_agent_scheduler(
     agent,
     task: str,
-    config: Optional[Dict[str, Any]] = None
+    config: Optional[Dict[str, Any]] = None,
+    on_success: Optional[Callable] = None,
+    on_failure: Optional[Callable] = None,
+    timeout: Optional[int] = None,
+    max_cost: Optional[float] = 1.00
 ) -> AsyncAgentScheduler:
     """
     Factory function to create async agent scheduler.
@@ -636,8 +640,20 @@ def create_async_agent_scheduler(
         agent: PraisonAI Agent instance
         task: Task description
         config: Optional configuration
+        on_success: Callback fired on successful execution
+        on_failure: Callback fired on failed execution
+        timeout: Per-run timeout (seconds)
+        max_cost: Budget limit (USD)
         
     Returns:
         Configured AsyncAgentScheduler instance
     """
-    return AsyncAgentScheduler(agent, task, config)
+    return AsyncAgentScheduler(
+        agent, 
+        task, 
+        config, 
+        on_success=on_success,
+        on_failure=on_failure,
+        timeout=timeout,
+        max_cost=max_cost
+    )


### PR DESCRIPTION
Fixes #479

## Summary

Updated AsyncAgentScheduler documentation to reflect new timeout and max_cost parameters from PR #1771.

## Changes

- ✅ Added new Quick Start step showing timeout & budget usage in both scheduler docs
- ✅ Updated constructor parameter tables with timeout and max_cost descriptions
- ✅ Added stats response format fields for total_cost_usd and remaining_budget
- ✅ Created budget-aware scheduling pattern with Mermaid flow diagram
- ✅ Added budget and timeout best practice accordions
- ✅ Updated factory function to accept new parameters
- ✅ Added thread-safety note for jobs server singleton init
- ✅ Updated CLI scheduler docs with reference to new features

## Files Updated

- docs/features/async-agent-scheduler.mdx
- docs/features/async-scheduler.mdx
- docs/features/thread-safety.mdx
- docs/cli/scheduler.mdx
- praisonai/scheduler/async_agent_scheduler.py

All changes follow AGENTS.md standards with agent-centric examples, proper Mermaid diagrams using the standard color scheme, and comprehensive coverage of the new budget enforcement and timeout features.

🤖 Generated with [Claude Code](https://claude.ai/code)