### PR TITLE
docs: Document smart-fallback streaming behavior for sync chat (fixes #484)

### DIFF
--- a/docs/features/streaming.mdx
+++ b/docs/features/streaming.mdx
@@ -33,7 +33,19 @@ pip install praisonaiagents
 ```
 </Step>
 
-<Step title="Stream Responses">
+<Step title="Auto-detect (Default)">
+```python
+from praisonaiagents import Agent
+
+agent = Agent(instructions="You are a helpful assistant")
+# No stream= argument — the SDK auto-detects what the provider supports
+agent.start("Write a short story")
+```
+
+By default the SDK tries streaming first and silently falls back to non-streaming if your provider's sync client doesn't support it — multi-agent workflows on providers like Deepseek now Just Work.
+</Step>
+
+<Step title="Force Streaming">
 ```python
 from praisonaiagents import Agent
 
@@ -74,7 +86,8 @@ graph TB
 
 | Method | Streams | Display | Best For |
 |--------|---------|---------|----------|
-| `start(stream=True)` | ✅ Yes | ✅ Auto | Terminal, interactive chat |
+| `start()` (auto-detect) | 🎯 Auto | ✅ Auto | **Recommended** — works everywhere |
+| `start(stream=True)` | ✅ Yes | ✅ Auto | Force streaming, interactive chat |
 | `iter_stream()` | ✅ Always | ❌ No | App integration, custom UIs |
 | `run()` | ❌ No | ❌ No | Production, batch processing |
 | `chat(stream=True)` | Configurable | Configurable | Low-level control |
@@ -333,9 +346,14 @@ TTFT is the time before the first token arrives. This is provider latency — th
 ### Streaming vs Non-Streaming
 
 | Mode | Behavior | Use Case |
-|------|----------|----------|
-| `stream=True` | Tokens appear as generated | Interactive chat, real-time display |
-| `stream=False` | Complete response at once | Batch processing, structured output |
+|------|----------|-----------|
+| `stream=None` (default) | Try streaming, fall back to non-streaming if unsupported | **Recommended** — works across all providers |
+| `stream=True` | Force streaming (errors on sync adapters that don't support it) | When you definitely want tokens |
+| `stream=False` | Force non-streaming | Batch jobs, structured output, sync providers |
+
+<Note>
+**Sync vs Async Adapters**: Async methods (`achat`, `astart`, `_execute_unified_achat_completion`) still default to `stream=True` because async adapters universally support streaming. Sync methods (`chat`, `start`, `run`) use the new smart-fallback default. Some adapters (e.g., sync OpenAI/Deepseek adapter) currently do NOT support sync streaming and will trigger the fallback.
+</Note>
 
 ---
 
@@ -354,6 +372,10 @@ praisonai chat --stream --verbose "Explain quantum computing"
 ## Best Practices
 
 <AccordionGroup>
+  <Accordion title="Let the SDK pick streaming mode">
+    Omit the `stream` argument (or pass `stream=None`) and the SDK will choose streaming where supported and silently fall back where it isn't. Only override when you have a specific reason.
+  </Accordion>
+  
   <Accordion title="Use iter_stream() for app integration">
     `iter_stream()` yields raw chunks with zero display overhead — ideal for piping into FastAPI, WebSocket, or custom UIs.
   </Accordion>
@@ -392,6 +414,10 @@ The follow-up LLM call (the one that synthesizes tool results into a final answe
 - Persistent rate limit — pair streaming with a [Rate Limiter](/docs/features/rate-limiter) at higher RPM, or back off the caller.
 - Context-length overflow — reduce conversation history or tool-result size.
 - Provider outage — include the `ref:` ID when reporting. The internal log line (`ref=..., model=..., error=...`) makes it searchable.
+
+### "Streaming is not supported in sync OpenAIAdapter" / Deepseek multi-agent crash
+
+Fixed in PraisonAI 4.6.47+ (PR #1734). Earlier versions defaulted sync chat to `stream=True`, which crashed on sync-only providers like Deepseek. Upgrade, or pass `stream=False` explicitly if you can't.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR documents the smart-fallback streaming behavior introduced in PraisonAI PR #1734 to fix Issue #1733.

## Changes

### Updated docs/features/streaming.mdx:

✅ **Quick Start leads with auto-detect example** - Shows the new default stream=None behavior  
✅ **Expanded Streaming vs Non-Streaming table** - Includes three modes: None (default), True, False  
✅ **Added Sync vs Async Adapters callout** - Explains async vs sync streaming behavior differences  
✅ **Updated Troubleshooting section** - Added entry for Streaming is not supported in sync OpenAIAdapter error  
✅ **Enhanced Best Practices** - Recommends letting SDK pick streaming mode automatically  
✅ **Updated method comparison table** - Highlights auto-detect as the recommended approach  

## Key Changes

**Smart fallback behavior (sync only)**: When stream=None (new default), the SDK tries streaming first. If the adapter raises ValueError(Streaming is not supported...), it logs debug and retries with stream=False.

**Behavior matrix**:
- stream=True (explicit): Streams or raises error  
- stream=False (explicit): Non-streaming
- stream=None (default, NEW): Auto-falls-back to non-streaming, no error
- Async path: Still defaults to stream=True (unchanged)

## References

- Fixes: #484
- Related PraisonAI PR: https://github.com/MervinPraison/PraisonAI/pull/1734  
- Related PraisonAI Issue: https://github.com/MervinPraison/PraisonAI/issues/1733

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added quick-start example for automatic streaming detection
  * Clarified streaming method recommendations and auto-detection behavior
  * Expanded guidance on streaming vs non-streaming with fallback semantics
  * Added best practices section on letting SDK pick streaming mode
  * Updated troubleshooting with version-specific fixes and upgrade guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->