### PR TITLE
docs: update session persistence file-locking docs for graceful fcntl-missing degradation

### DIFF
--- a/docs/features/persistence-json.mdx
+++ b/docs/features/persistence-json.mdx
@@ -109,18 +109,22 @@ graph LR
         A[🧠 Agent] --> B{🖥️ Platform?}
         B -->|macOS / Linux| C[🔒 fcntl lock]
         B -->|Windows| D[🔒 msvcrt lock]
+        B -->|No fcntl available| F[⚠️ Warn once, continue]
         C --> E[💾 Safe Write]
         D --> E
+        F --> E
     end
 
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef detect fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef lock fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef warn fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef write fill:#10B981,stroke:#7C90A0,color:#fff
 
     class A agent
     class B detect
     class C,D lock
+    class F warn
     class E write
 ```
 
@@ -138,16 +142,21 @@ agent = Agent(
 agent.chat("Hello! Works on macOS, Linux, and Windows.")
 ```
 
-| Platform | File Lock Mechanism | Multi-Process Safe |
-|----------|---------------------|--------------------|
-| macOS    | `fcntl.flock`       | ✅ Yes              |
-| Linux    | `fcntl.flock`       | ✅ Yes              |
-| Windows  | `msvcrt.locking`    | ✅ Yes              |
+| Platform / Environment | File Lock Mechanism | Multi-Process Safe |
+|------------------------|---------------------|--------------------|
+| macOS                  | `fcntl.flock`       | ✅ Yes              |
+| Linux                  | `fcntl.flock`       | ✅ Yes              |
+| Windows                | `msvcrt.locking`    | ✅ Yes              |
+| Other (Pyodide, WASM, embedded Python without `fcntl`) | None — degraded, warning logged once | ⚠️ Single-process only |
 
 <Note>
-If you run multiple agent processes that share the same `session_dir`, the
-store automatically prevents concurrent writers from corrupting session
-files — on every supported OS.
+On macOS, Linux, and Windows, multi-process safety is guaranteed.
+On exotic Python distributions where neither `fcntl` nor `msvcrt` is
+available, the store logs a one-time warning and continues without
+locking — single-process usage remains safe, but concurrent writers may
+corrupt session files. The exact warning text is:
+
+`File locking unavailable on this platform (fcntl not available); concurrent writers may corrupt session files.`
 </Note>
 
 ---

--- a/docs/features/session-persistence.mdx
+++ b/docs/features/session-persistence.mdx
@@ -147,11 +147,20 @@ These fields enable cost tracking and usage analytics across sessions.
 
 The session store uses file locking to ensure safe concurrent access:
 
-- **Unix**: Uses `fcntl.flock()` for file locking
+- **Unix (macOS / Linux)**: Uses `fcntl.flock()` for file locking
 - **Windows**: Uses `msvcrt.locking()` for file locking
+- **Other Python environments without `fcntl`** (Pyodide, WebAssembly, minimal embedded CPython): Locking is gracefully skipped after a one-time warning — single-process usage is still safe, but concurrent writers may corrupt session files
 - **Atomic Writes**: Uses temp file + rename to prevent corruption
 
-Multiple processes can safely read/write to the same session.
+Multiple processes can safely read/write to the same session on macOS, Linux, and Windows.
+
+<Warning>
+If `fcntl` is unavailable at import time, the store logs this warning **once** the first time `FileLock.acquire()` is called:
+
+`File locking unavailable on this platform (fcntl not available); concurrent writers may corrupt session files.`
+
+If you see this warning in your logs, you are running on an environment without native file locking. Restrict the store to a single process, or switch to a database-backed `SessionStoreProtocol` adapter for multi-writer safety.
+</Warning>
 
 ## Direct Session Store Access
 


### PR DESCRIPTION
## Summary

Updates documentation to reflect the graceful fcntl-missing degradation changes from PraisonAI PR #1792:

- **Updated Cross-Platform Support section** in docs/features/persistence-json.mdx
  - Extended Mermaid diagram to show graceful degradation path for environments without fcntl
  - Added fourth row to platform table covering Pyodide/WASM/embedded Python environments
  - Added Note callout with exact warning message text for grep-ability

- **Updated Multi-Process Safety section** in docs/features/session-persistence.mdx
  - Added bullet for environments without fcntl support
  - Added Warning callout explaining single-process-only behavior
  - Included exact warning text users will see in logs

## Key Changes

1. **Platform Support Matrix**: Now documents behavior on exotic Python distributions where fcntl is unavailable
2. **Warning Message**: Documents the exact warning text: File locking unavailable on this platform (fcntl not available); concurrent writers may corrupt session files.
3. **Graceful Degradation**: Explains that the store continues to work but without multi-process safety guarantees

## Test Plan

- [x] Verify Mermaid diagrams render correctly with standard color scheme
- [x] Confirm all warning text matches SDK implementation
- [x] Check that progressive disclosure maintains user-friendly approach
- [x] Ensure no SDK internals leak into user-facing prose

Fixes #488

Generated with [Claude Code](https://claude.ai/code)