### PR TITLE
docs: Document Telegram gateway security pipeline & fix YAML allowlist fields

### DIFF
--- a/docs/best-practices/bot-security.mdx
+++ b/docs/best-practices/bot-security.mdx
@@ -7,6 +7,10 @@ icon: "shield-keyhole"
 
 Bot security enables safe deployment of PraisonAI agents across messaging channels with built-in protection against abuse and unauthorized access.
 
+<Warning>
+**Field name is `allowed_users`, not `allowlist`.** The gateway YAML parser only recognizes `allowed_users:` and `allowed_channels:`. Examples using `allowlist:` will silently produce a bot with **no enforcement**. (Fixed in [PR #1791](https://github.com/MervinPraison/PraisonAI/pull/1791).)
+</Warning>
+
 ```mermaid
 graph LR
     subgraph "Bot Security Flow"
@@ -144,14 +148,14 @@ flowchart TD
 channels:
   telegram:
     token: ${TELEGRAM_BOT_TOKEN}
-    allowlist:
+    allowed_users:
       - "@your_username"
       - "123456789"  # User ID
     group_policy: "mention_only"  # Only respond when mentioned
 ```
 
 **Security features:**
-- ✅ User allowlist by username or ID
+- ✅ User allowlist by platform-native user ID (Telegram: numeric ID; Discord: snowflake; Slack: U...)
 - ✅ Group mention-only policy  
 - ✅ Built-in command filtering
 - ⚠️ DMs from unknown users are processed by default
@@ -165,14 +169,14 @@ channels:
 channels:
   discord:
     token: ${DISCORD_BOT_TOKEN}
-    allowlist:
+    allowed_users:
       - "your_user_id"
       - "guild:server_id"  # Specific server only
     group_policy: "mention_only"
 ```
 
 **Security features:**
-- ✅ User/guild allowlist support
+- ✅ User/guild allowlist support (user ID format: Discord snowflake)
 - ✅ Role-based restrictions
 - ✅ Thread-safe message handling
 - ⚠️ DMs from unknown users are processed by default
@@ -187,14 +191,14 @@ channels:
   slack:
     token: ${SLACK_BOT_TOKEN}
     app_token: ${SLACK_APP_TOKEN}
-    allowlist:
+    allowed_users:
       - "U0123456789"  # User ID
       - "C9876543210"  # Channel ID
     group_policy: "mention_only"
 ```
 
 **Security features:**
-- ✅ User/channel allowlist
+- ✅ User/channel allowlist (user ID format: Slack U...)
 - ✅ Enterprise Grid support
 - ✅ Socket mode security
 - ✅ Built-in DM filtering (mentions required)
@@ -207,7 +211,7 @@ channels:
 # bot.yaml
 channels:
   whatsapp:
-    allowlist:
+    allowed_users:
       - "+1234567890"    # Phone numbers
       - "group123@g.us"  # Group IDs
     blocklist:
@@ -538,13 +542,13 @@ Start with restrictive settings and gradually open access:
 # Stage 1: Internal testing
 channels:
   telegram:
-    allowlist: ["@internal_team"]
+    allowed_users: ["@internal_team"]
     group_policy: "command_only"
 
 # Stage 2: Trusted users
 channels:
   telegram:
-    allowlist: ["@internal_team", "@trusted_users"]  
+    allowed_users: ["@internal_team", "@trusted_users"]  
     group_policy: "mention_only"
 
 # Stage 3: Public (with safety nets)
@@ -560,7 +564,7 @@ channels:
 Maintain consistent allowlists across channels:
 
 ```yaml
-# Shared allowlist
+# Shared allowed users
 x-allowlist: &shared-users
   - "admin_user_1"
   - "admin_user_2"
@@ -568,11 +572,11 @@ x-allowlist: &shared-users
 
 channels:
   telegram:
-    allowlist: *shared-users
+    allowed_users: *shared-users
   discord:
-    allowlist: *shared-users  
+    allowed_users: *shared-users  
   slack:
-    allowlist: *shared-users
+    allowed_users: *shared-users
 ```
 
 ### 3. Environment-Based Security
@@ -589,13 +593,13 @@ channels:
 # staging.yaml - moderate security
 channels:
   telegram:
-    allowlist: ["@staging_team"]
+    allowed_users: ["@staging_team"]
     group_policy: "mention_only"
     
 # production.yaml - strict security  
 channels:
   telegram:
-    allowlist: ["@verified_users"]
+    allowed_users: ["@verified_users"]
     group_policy: "command_only"
     approval: true  # All tools need approval
 ```

--- a/docs/features/bot-gateway.mdx
+++ b/docs/features/bot-gateway.mdx
@@ -171,6 +171,79 @@ channels:
 Use `${ENV_VAR_NAME}` syntax in token fields. The gateway automatically reads from your environment variables.
 </Tip>
 
+### Channel Security
+
+Each channel enforces the same access-control pipeline as standalone bots.
+
+| YAML Key | Type | Default | Purpose |
+|----------|------|---------|---------|
+| `token` | `str` | required* | Bot auth token. *Optional for `whatsapp` web mode and `email`/`agentmail`. |
+| `platform` | `str` | channel name | Override channel platform (e.g. `telegram`). |
+| `routing` / `routes` | `dict` | `{"default": "default"}` | Route map: `dm`, `group`, `default` → agent id. |
+| `allowed_users` | `list[str]` \| `str` | `[]` | User-ID allowlist. Comma-separated string also accepted (env-expansion friendly). |
+| `allowed_channels` | `list[str]` \| `str` | `[]` | Channel/group-ID allowlist. Same string handling. |
+| `group_policy` | `str` | `"mention_only"` | One of `"mention_only"`, `"command_only"`, `"respond_all"`. Sets `mention_required` automatically. |
+| `auto_approve_tools` | `bool` \| `str` | `True` | Auto-approve safe tools. Strings `"1"/"true"/"yes"/"on"` are truthy. |
+| `default_tools` | `list[str]` | (BotConfig default) | Per-channel override for default safe tools. |
+
+```yaml
+channels:
+  telegram_support:
+    token: ${TELEGRAM_BOT_TOKEN}
+    allowed_users:                # User-ID allowlist (empty = anyone)
+      - "123456789"
+      - "987654321"
+    allowed_channels:             # Group/channel allowlist (empty = anywhere)
+      - "-1001234567890"
+    group_policy: "mention_only"  # mention_only | command_only | respond_all
+    auto_approve_tools: true      # Auto-approve safe tools (default true)
+    routes:
+      dm: personal
+      group: support
+      default: personal
+```
+
+```mermaid
+graph TB
+    subgraph "Inbound Security Pipeline"
+        Message[📨 Inbound Update] --> Extract[📝 Extract Text]
+        Extract --> Convert[🔄 Convert to BotMessage]
+        Convert --> Check1{🔍 Channel Allowed?}
+        Check1 -->|No| Drop1[❌ Drop Message]
+        Check1 -->|Yes| Check2{👤 User Allowed?}
+        Check2 -->|No| Pairing[🤝 Unknown User Handler]
+        Pairing -->|Denied| Drop2[❌ Drop Message]
+        Pairing -->|Approved| Check3{🏷️ Group Policy?}
+        Check2 -->|Yes| Check3
+        Check3 -->|DM| Process[✅ Process Message]
+        Check3 -->|Group + mention_only| Mention{💬 @mentioned?}
+        Check3 -->|Group + command_only| Command{⚡ Command?}
+        Check3 -->|Group + respond_all| Process
+        Mention -->|Yes| Process
+        Mention -->|No| Drop3[❌ Drop Message]
+        Command -->|Yes| Process
+        Command -->|No| Drop4[❌ Drop Message]
+    end
+    
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef drop fill:#8B0000,stroke:#7C90A0,color:#fff
+    
+    class Message,Extract,Convert input
+    class Check1,Check2,Check3,Mention,Command,Pairing check
+    class Process success
+    class Drop1,Drop2,Drop3,Drop4 drop
+```
+
+<Warning>
+Empty `allowed_users` means the bot accepts messages from **anyone** on Telegram. The gateway logs a warning at startup. For production, always set `allowed_users` or use `unknown_user_policy: pair` (see Bot Unknown-User Pairing).
+</Warning>
+
+<Note>
+As of PR #1791, gateway-mode bots enforce the same security pipeline as standalone bots (`praisonai bot start`). Previous versions silently bypassed `allowed_users`, pairing, and `group_policy` in gateway mode.
+</Note>
+
 ## CLI Commands
 
 <CodeGroup>

--- a/docs/features/bot-unknown-user-pairing.mdx
+++ b/docs/features/bot-unknown-user-pairing.mdx
@@ -86,6 +86,10 @@ sequenceDiagram
 
 The pairing system intercepts messages from users not in `allowed_users` and routes them through an approval workflow controlled by the `unknown_user_policy`, publishing a `pairing_approved` event on the default EventBus after every successful approval (CLI, inline button, or web UI).
 
+<Info>
+**Gateway mode (`praisonai gateway start`)**: As of PR #1791, the gateway polling path runs the same pairing pipeline as the standalone bot. If `pairing.enabled: true` is set in your gateway config, unknown users get the same Approve/Deny inline-button flow. No code changes needed — configure `unknown_user_policy: "pair"` and `owner_user_id` in your `channels:` YAML entry.
+</Info>
+
 ---
 
 ## Policy Options
@@ -290,6 +294,18 @@ agent = Agent(
 )
 ```
 For fully public bots. Combine with rate limiting and tool approval for safety.
+</Tab>
+
+<Tab title="Gateway YAML">
+```yaml
+channels:
+  telegram_support:
+    token: ${TELEGRAM_BOT_TOKEN}
+    allowed_users: ["123456789"]
+    unknown_user_policy: "pair"
+    owner_user_id: "123456789"
+```
+Gateway mode configuration for the pairing workflow.
 </Tab>
 </Tabs>
 

--- a/docs/features/channels-gateway.mdx
+++ b/docs/features/channels-gateway.mdx
@@ -251,6 +251,27 @@ enable_channels({
 
 ---
 
+## Channel Security
+
+All channels enforce the same access-control pipeline regardless of whether you run them via `praisonai bot start` or `praisonai gateway start`.
+
+| Feature | Standalone Bot | Gateway Mode |
+|---------|----------------|--------------|
+| User allowlist (`allowed_users`) | ✅ | ✅ |
+| Channel allowlist (`allowed_channels`) | ✅ | ✅ |
+| Unknown user pairing | ✅ | ✅ |
+| Group policy enforcement | ✅ | ✅ |
+
+<Card title="Gateway YAML Reference" icon="shield" href="/docs/features/bot-gateway#channel-security">
+  Complete YAML field documentation and pipeline diagram
+</Card>
+
+<Card title="BotConfig Reference" icon="code" href="/docs/features/messaging-bots#configuration-options">
+  Standalone bot configuration options
+</Card>
+
+---
+
 ## Platform-Specific Features
 
 ### Telegram

--- a/docs/features/messaging-bots.mdx
+++ b/docs/features/messaging-bots.mdx
@@ -495,6 +495,8 @@ config = BotConfig(
 - `mention_only` — Bot only responds when @mentioned (default, safest)
 - `respond_all` — Bot responds to every message in the group
 - `command_only` — Bot only responds to `/commands`
+
+When running via the gateway, set `group_policy` per channel in `gateway.yaml`. See [Bot Gateway → Channel Security](/docs/features/bot-gateway#channel-security).
 </Note>
 
 <Note>


### PR DESCRIPTION
Fixes #486

This PR addresses the documentation gaps identified after [PraisonAI PR #1791](https://github.com/MervinPraison/PraisonAI/pull/1791), which fixed a security vulnerability where the Telegram gateway polling path bypassed all access-control enforcement.

## Changes Made

### 📚 New Documentation Sections
- **Channel Security** subsection in bot-gateway.mdx with complete YAML reference table, security pipeline diagram, and configuration examples
- **Channel Security** section in channels-gateway.mdx showing standalone/gateway parity  
- **Gateway Mode** note in bot-unknown-user-pairing.mdx with gateway YAML configuration example

### 🐛 Critical Bug Fixes
- Fixed field name throughout bot-security.mdx: allowlist: → allowed_users:
- Added warning callout about field name requirements (examples using allowlist: silently produce bots with **no enforcement**)
- Updated user ID format comments to clarify platform-specific requirements

### 🔗 Cross-References
- Added cross-link from messaging-bots.mdx to gateway security documentation
- Linked gateway and standalone bot configuration references

### 🎨 Visual Improvements
- Added Mermaid security pipeline diagram following AGENTS.md color standards
- Included comparison tables showing feature parity between modes

## Impact
- Users can now properly configure gateway security (previously undocumented)
- Fixed critical examples that would silently break security enforcement
- Clarified that gateway mode now enforces the same security as standalone bots

Generated with [Claude Code](https://claude.ai/code)