### PR TITLE
docs: Update bot security & MCP transport docs for PR #1835

### DIFF
--- a/docs/best-practices/bot-security.mdx
+++ b/docs/best-practices/bot-security.mdx
@@ -169,7 +169,7 @@ channels:
 **Security features:**
 - ✅ User allowlist by platform-native user ID (Telegram: numeric ID; Discord: snowflake; Slack: U...)
 - ✅ Group mention-only policy  
-- ✅ Built-in command filtering
+- ✅ Built-in command filtering — /help, /status, /new and custom commands respect `allowed_users` (PR #1835)
 - ⚠️ DMs from unknown users are processed by default
 
 ### Discord
@@ -511,6 +511,7 @@ Remediation: Consider allowlists for DM security and 'mention_only' group policy
     - [ ] Unknown sender behavior defined (block/ignore/process)
     - [ ] Group policies set to `mention_only` or `command_only`
     - [ ] Blocklist configured for known spam sources
+    - [ ] Built-in commands (/help, /status, /new) verified to respect allowlist
   </Accordion>
 
   <Accordion title="✅ Gateway Pairing Active" icon="link">
@@ -732,6 +733,9 @@ def is_verified_user(user_id: str) -> bool:
 1. Check allowlist is configured (not just blocklist)
 2. Verify `group_policy` setting
 3. Check if user has alternate access path
+
+**Problem:** Unauthorized users can still invoke `/help`, `/status`, or `/new`
+**Solution:** Upgrade to the PraisonAI release that includes PR #1835. Earlier versions enforced the allowlist only on plain-text messages, not on command handlers.
 
 ---
 

--- a/docs/features/bot-commands.mdx
+++ b/docs/features/bot-commands.mdx
@@ -178,6 +178,50 @@ telegram_commands = bot.list_commands(platform="telegram")
 
 ---
 
+## Security & Allowlists
+
+Built-in commands (`/status`, `/new`, `/help`) and custom commands registered via `register_command()` go through the same security pipeline as regular text messages. If `allowed_users` is set and the sender is not in it, the command is silently dropped with no reply. If `unknown_user_policy="pair"`, unknown senders get the pairing flow before the command runs. If `group_policy="mention_only"`, commands in groups still need a mention.
+
+```python
+from praisonai.bots import TelegramBot
+from praisonaiagents.bots import BotConfig
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="Be helpful")
+bot = TelegramBot(
+    token="YOUR_TOKEN",
+    agent=agent,
+    config=BotConfig(allowed_users=["123456789"]),  # Only this user
+)
+
+# /help, /status, /new from any other user are now silently ignored
+```
+
+```mermaid
+sequenceDiagram
+    participant DisallowedUser as Disallowed User
+    participant AllowedUser as Allowed User
+    participant Bot as Bot
+    participant SecurityPipeline as Security Pipeline
+    participant Agent as Agent
+    
+    DisallowedUser->>Bot: /help
+    Bot->>SecurityPipeline: Check user
+    SecurityPipeline-->>Bot: User not allowed
+    Note right of Bot: Silently dropped (no response)
+    
+    AllowedUser->>Bot: /help
+    Bot->>SecurityPipeline: Check user
+    SecurityPipeline-->>Bot: User allowed
+    Bot->>Agent: Process command
+    Agent-->>Bot: Help response
+    Bot-->>AllowedUser: Help message
+```
+
+For full allowlist setup, see the [Bot Security](/docs/best-practices/bot-security) guide. This security hardening was implemented in [PR #1835](https://github.com/MervinPraison/PraisonAI/pull/1835).
+
+---
+
 ## Python Usage
 
 Start bots programmatically — built-in commands are always available:

--- a/docs/features/gateway-telegram-multichannel.mdx
+++ b/docs/features/gateway-telegram-multichannel.mdx
@@ -399,7 +399,7 @@ TELEGRAM_OPS_USERS=111222333,444555666      # Operations team user IDs
 TELEGRAM_CONTENT_USERS=777888999,000111222  # Content team user IDs
 ```
 
-**Security caveat:** Current gateway implementation may not enforce allowlists in polling path. Verify after PraisonAI security enhancement.
+**Security:** As of PR #1835, the gateway polling path enforces `allowed_users` for both text messages **and** built-in commands (`/help`, `/status`, `/new`). Unauthorized users are silently dropped at the security pipeline.
 
 ### Custom Knowledge Tools
 

--- a/docs/mcp/transports.mdx
+++ b/docs/mcp/transports.mdx
@@ -205,6 +205,59 @@ agent = Agent(
 )
 ```
 
+### Parallel Tool Calls
+
+MCP stdio tool calls are safe to run in parallel — each call gets its own response channel, so results never cross.
+
+```python
+from praisonaiagents import Agent, MCP
+
+agent = Agent(
+    name="Researcher",
+    instructions="Use the MCP tools in parallel when helpful.",
+    tools=MCP("npx @modelcontextprotocol/server-memory", timeout=60),
+    parallel_tool_calls=True,
+)
+
+agent.start("Look up X and Y at the same time")
+```
+
+The `timeout` parameter on `MCP()` controls the per-call wait time (default `60s`). On timeout, the tool result is the string `"Error: MCP tool call timed out after {N} seconds"` — the agent sees this as a tool error and can retry. The timeout also bounds the initial MCP handshake.
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant MCPRunner
+    participant Queue1 as Response Queue 1
+    participant Queue2 as Response Queue 2
+    participant MCPWorker as MCP Worker Thread
+    participant MCPServer as MCP Server
+    
+    Agent->>MCPRunner: call_tool("search", {"query": "X"})
+    Agent->>MCPRunner: call_tool("search", {"query": "Y"})
+    
+    MCPRunner->>Queue1: create queue.Queue(maxsize=1)
+    MCPRunner->>Queue2: create queue.Queue(maxsize=1)
+    
+    MCPRunner->>MCPWorker: submit("search", {"query": "X"}, Queue1)
+    MCPRunner->>MCPWorker: submit("search", {"query": "Y"}, Queue2)
+    
+    MCPWorker->>MCPServer: search X
+    MCPWorker->>MCPServer: search Y
+    
+    MCPServer-->>MCPWorker: result X
+    MCPServer-->>MCPWorker: result Y
+    
+    MCPWorker->>Queue1: put(result X)
+    MCPWorker->>Queue2: put(result Y)
+    
+    Queue1-->>MCPRunner: get(timeout=60) → result X
+    Queue2-->>MCPRunner: get(timeout=60) → result Y
+    
+    MCPRunner-->>Agent: return result X
+    MCPRunner-->>Agent: return result Y
+```
+
 ---
 
 ## Streamable HTTP Transport


### PR DESCRIPTION
## Summary

Updates documentation for the bot security and MCP transport improvements from [PraisonAI PR #1835](https://github.com/MervinPraison/PraisonAI/pull/1835) (merged 2026-06-03).

## Changes Made

### 1. `docs/features/bot-commands.mdx`
- Added **Security & Allowlists** section explaining that built-in commands (`/help`, `/status`, `/new`) and custom commands now go through the same security pipeline as regular text messages
- Included code example and Mermaid sequence diagram showing blocked vs allowed command execution
- Added link to bot security best practices

### 2. `docs/features/gateway-telegram-multichannel.mdx`
- Updated stale security caveat to reflect that gateway polling path now enforces `allowed_users` for both text messages and built-in commands as of PR #1835

### 3. `docs/best-practices/bot-security.mdx`
- Updated Telegram security features to note command filtering with PR reference
- Added checklist item to verify built-in commands respect allowlist
- Added troubleshooting entry for unauthorized command access issue

### 4. `docs/mcp/transports.mdx`
- Added **Parallel Tool Calls** section to stdio transport documentation
- Explained how per-request response queues prevent race conditions
- Documented timeout behavior and error handling
- Included Mermaid sequence diagram showing parallel tool call flow

## Technical Details

These changes document two critical bug fixes:

1. **Telegram Command Security**: Built-in and custom command handlers now enforce the same security pipeline as text messages, closing an auth bypass vulnerability
2. **MCP Stdio Race Fix**: Per-request response queues eliminate cross-talk between concurrent MCP tool calls when `parallel_tool_calls=True`

Fixes #496

🤖 Generated with [Claude Code](https://claude.ai/code)