### PR TITLE
docs: update + add docs for wrapper-layer fixes (native async, brace-safe templates, per-agent LLM) from PraisonAI#1794

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -261,6 +261,7 @@
                       "docs/features/onboard",
                       "docs/features/installation-extras",
                       "docs/features/llm-endpoint-config",
+                      "docs/features/yaml-template-variables",
                       "docs/features/gateway-bind-aware-auth",
                       "docs/features/test-documentation"
                     ]
@@ -273,6 +274,7 @@
                       "docs/features/reasoning-extract",
                       "docs/features/generate-reasoning",
                       "docs/features/selfreflection",
+                      "docs/features/model-router",
                       "docs/features/llm-as-judge"
                     ]
                   },

--- a/docs/features/async-crew-kickoff.mdx
+++ b/docs/features/async-crew-kickoff.mdx
@@ -1,36 +1,40 @@
 ---
 title: "Async Crew Kickoff"
 sidebarTitle: "Async Crew Kickoff"
-description: "Run a PraisonAI crew from inside a running event loop without asyncio.run()"
+description: "Run PraisonAI crews with native async execution — no thread offload required"
 icon: "play"
 ---
 
-Run a PraisonAI crew from inside a running event loop — FastAPI, Jupyter, Discord bots — without `asyncio.run()`.
+Run PraisonAI crews with native async execution from FastAPI, Jupyter, Discord bots, and other event loop contexts.
 
 ```mermaid
 graph LR
-    subgraph "Async Crew Flow"
+    subgraph "Native Async Flow"
         A[📋 Async Caller] --> B[🧠 praisonai.arun]
-        B --> C[⚡ asyncio.to_thread]
-        C --> D[✅ Result]
+        B --> C[⚡ AgentsGenerator.agenerate_crew_and_kickoff]
+        C --> D[🔧 FrameworkAdapter.arun]
+        D --> E[🚀 AgentTeam.astart]
+        E --> F[✅ Result]
     end
     
     classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
     classDef adapter fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef native fill:#10B981,stroke:#7C90A0,color:#fff
     classDef output fill:#10B981,stroke:#7C90A0,color:#fff
     
     class A input
-    class B process
-    class C adapter
-    class D output
+    class B,C process
+    class D adapter
+    class E native
+    class F output
 ```
 
 ## Quick Start
 
 <Steps>
 <Step title="FastAPI Route">
-The headline use case — running crews inside FastAPI routes without blocking the event loop:
+Native async execution — no worker threads, true cooperative multitasking:
 
 ```python
 from fastapi import FastAPI
@@ -46,7 +50,7 @@ async def run_crew():
 </Step>
 
 <Step title="Jupyter Notebook">
-Works in Jupyter cells where `asyncio.run()` would fail:
+Works directly in async cells without blocking:
 
 ```python
 import praisonai
@@ -66,19 +70,31 @@ sequenceDiagram
     participant User
     participant praisonai
     participant AgentsGenerator
+    participant FrameworkAdapter
+    participant AgentTeam
     participant Result
     
     User->>praisonai: await arun(agent_file)
-    praisonai->>AgentsGenerator: asyncio.to_thread(run)
-    AgentsGenerator-->>AgentsGenerator: generate_crew_and_kickoff()
+    praisonai->>AgentsGenerator: agenerate_crew_and_kickoff()
+    AgentsGenerator->>FrameworkAdapter: arun(config, llm_config, topic)
+    FrameworkAdapter->>AgentTeam: astart() 
+    AgentTeam-->>FrameworkAdapter: native async result
+    FrameworkAdapter-->>AgentsGenerator: result
     AgentsGenerator-->>praisonai: result
     praisonai-->>User: result
 ```
 
-| Function | Method | When Used |
-|----------|--------|-----------|
-| **Sync** | `praisonai.run()` | Plain scripts, CLI usage |
-| **Async** | `praisonai.arun()` | FastAPI, Jupyter, event loop contexts |
+### What's actually async
+
+| Adapter | Async path | Notes |
+|---------|------------|-------|
+| `praisonai` (praisonaiagents) | Native — `AgentTeam.astart()` | True cooperative async |
+| `crewai` | Thread offload (default fallback) | Until CrewAI exposes async |
+| `autogen` / `ag2` | Thread offload (default fallback) | Adapter-specific implementation |
+
+### Workflow mode
+
+YAML files with `process: workflow` also run natively async via `YAMLWorkflowParser` + `workflow.astart()` — no extra configuration needed.
 
 ---
 
@@ -91,25 +107,6 @@ sequenceDiagram
 | `tools` | `list` | `None` | Additional tools to make available |
 | `agent_yaml` | `str` | `None` | Direct YAML content as string |
 | `cli_config` | `dict` | `None` | CLI configuration overrides |
-
----
-
-## When to use which
-
-```mermaid
-graph TB
-    A{Running inside an event loop?} 
-    A -->|Yes - FastAPI, Jupyter, async framework| B[Use praisonai.arun]
-    A -->|No - Plain script, CLI| C[Use praisonai.run]
-    
-    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef async fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef sync fill:#189AB4,stroke:#7C90A0,color:#fff
-    
-    class A decision
-    class B async
-    class C sync
-```
 
 ---
 
@@ -142,7 +139,7 @@ import asyncio
 import praisonai
 
 async def run_multiple_crews():
-    # Run all crews concurrently
+    # Run all crews concurrently with true async
     results = await asyncio.gather(
         praisonai.arun(agent_file="research.yaml"),
         praisonai.arun(agent_file="analysis.yaml"),
@@ -157,18 +154,24 @@ async def run_multiple_crews():
 ## Best Practices
 
 <AccordionGroup>
-<Accordion title="Prefer async entry point over wrapping sync">
-Use `praisonai.arun()` instead of wrapping the sync version:
+<Accordion title="Cancellation and timeouts propagate">
+Under native async, `asyncio.CancelledError` and `asyncio.wait_for` now actually cancel SDK work instead of being trapped behind a worker thread:
 
 ```python
 import asyncio
 import praisonai
 
-# ✅ Good - proper async entry point
-result = await praisonai.arun(agent_file="agents.yaml")
-
-# ❌ Avoid - wrapping sync call (this won't work inside event loop)
-# result = asyncio.run(praisonai.run(agent_file="agents.yaml"))
+async def cancelable_crew():
+    try:
+        # This will properly cancel if timeout is reached
+        result = await asyncio.wait_for(
+            praisonai.arun(agent_file="agents.yaml"),
+            timeout=30.0
+        )
+        return result
+    except asyncio.TimeoutError:
+        print("Crew execution timed out and was cancelled")
+        return None
 ```
 </Accordion>
 
@@ -179,7 +182,7 @@ When running multiple crews, use `asyncio.gather` for parallel execution:
 import asyncio
 import praisonai
 
-# ✅ Concurrent execution
+# ✅ Concurrent execution with native async
 crew1_task = praisonai.arun(agent_file="crew1.yaml")
 crew2_task = praisonai.arun(agent_file="crew2.yaml")
 results = await asyncio.gather(crew1_task, crew2_task)
@@ -190,14 +193,14 @@ result2 = await praisonai.arun(agent_file="crew2.yaml")
 ```
 </Accordion>
 
-<Accordion title="Framework auto-detection works in async mode">
-All supported frameworks work transparently with async execution:
+<Accordion title="Framework detection works transparently">
+All supported frameworks work with async execution — praisonai-native uses true async, others fall back to thread offload automatically:
 
 ```python
 import praisonai
 
-# Works with any framework - auto-detected or explicit
-result = await praisonai.arun(agent_file="agents.yaml", framework="crewai")
+# Native async for praisonai, thread offload for crewai
+result = await praisonai.arun(agent_file="agents.yaml", framework="praisonai")
 ```
 </Accordion>
 
@@ -228,8 +231,8 @@ async def safe_crew_run():
 ## Related
 
 <CardGroup cols={2}>
-<Card title="Async Bridge" icon="link" href="/docs/features/async-bridge">
-  Lower-level async utilities and bridging functions
+<Card title="YAML Template Variables" icon="code" href="/docs/features/yaml-template-variables">
+  Use {topic} placeholders safely alongside JSON literals
 </Card>
 <Card title="Framework Adapter Plugins" icon="puzzle-piece" href="/docs/features/framework-adapter-plugins">
   Custom framework adapters with async support

--- a/docs/features/model-router.mdx
+++ b/docs/features/model-router.mdx
@@ -158,6 +158,32 @@ agents:
     llm: balanced  # Use specific model
 ```
 
+## Quick per-agent model (no router needed)
+
+For simple per-agent model assignment without configuring the full Model Router system, use these direct forms:
+
+```yaml
+roles:
+  researcher:
+    role: Researcher
+    goal: Research {topic}
+    llm: gpt-4o-mini            # string form
+
+  writer:
+    role: Writer  
+    goal: Write about {topic}
+    llm:
+      model: groq/llama3-70b-8192   # dict form
+```
+
+**Precedence:** per-agent `llm` > `manager_llm` (for hierarchical process) > global model resolved from `llm_config[0].model` / CLI / env.
+
+**Framework support:** Per-agent `llm` is honored by both `crewai` and the praisonai-native adapter.
+
+<Note>
+**AutoGen/AG2 limitation:** This adapter currently uses only `llm_config[0]` — per-agent LLM assignment is not yet supported.
+</Note>
+
 ### Model Configuration Fields
 
 | Field | Type | Description |
@@ -171,9 +197,9 @@ agents:
 | `supports_streaming` | bool | Whether the model supports streaming responses |
 | `strengths` | list | Model strengths: `reasoning`, `code-generation`, `analysis`, etc. |
 
-### Per-Agent LLM Configuration
+### Per-Agent LLM Configuration (Named Models)
 
-Each agent can specify its own LLM configuration:
+Each agent can specify its own LLM configuration using named models defined in the `models:` block above:
 
 ```yaml
 agents:

--- a/docs/features/yaml-template-variables.mdx
+++ b/docs/features/yaml-template-variables.mdx
@@ -1,0 +1,237 @@
+---
+title: "YAML Template Variables"
+sidebarTitle: "Template Variables"
+description: "Use {topic} and other placeholders safely in YAML — even alongside JSON or dict literals"
+icon: "code"
+---
+
+Placeholders like `{topic}` are substituted in your YAML strings; literal JSON or dicts in the same string are left alone.
+
+```mermaid
+graph LR
+    subgraph "Brace-Safe Template System"
+        A[📄 YAML String] --> B[🔍 Brace-safe substitutor]
+        B --> C[✅ Final Prompt]
+    end
+    
+    subgraph "Processing"
+        D["{topic}"] --> E["replaced with input"]
+        F["{\"key\":\"value\"}"] --> G["preserved as-is"]
+    end
+    
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef preserve fill:#189AB4,stroke:#7C90A0,color:#fff
+    
+    class A input
+    class B process
+    class C output
+    class D,F input
+    class E preserve
+    class G preserve
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Basic Template Substitution">
+Create an `agents.yaml` with a simple `{topic}` placeholder:
+
+```yaml
+roles:
+  writer:
+    role: Content writer for {topic}
+    goal: Create engaging content about {topic}
+    backstory: You are an expert writer specializing in {topic}.
+    
+    tasks:
+      write_article:
+        description: Write about {topic}
+        expected_output: A comprehensive article about {topic}
+```
+
+Run with: `praisonai "AI agents"`
+</Step>
+
+<Step title="JSON Literals + Variables Together">
+Mix JSON examples in backstory with `{topic}` placeholders safely:
+
+```yaml
+roles:
+  writer:
+    role: Technical writer for {topic}
+    backstory: |
+      You write WordPress posts about {topic}. Use blocks like
+      <!-- wp:heading {"level":2} --> and return JSON like
+      {"status":"ok"} when asked. Focus on {topic} exclusively.
+    goal: Produce an article about {topic}.
+    
+    tasks:
+      technical_post:
+        description: Write a technical post about {topic} with code examples
+        expected_output: |
+          Markdown post about {topic} including:
+          - Code blocks with {"config": "examples"}
+          - JSON snippets like {"result": true}
+          - Clear focus on {topic}
+```
+
+Both `{topic}` and the JSON literals work correctly.
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+The template system uses a precise regex pattern to identify which braces to substitute:
+
+**Pattern:** `\{([a-zA-Z_][a-zA-Z0-9_]*)\}` — only Python-identifier-shaped placeholders are touched.
+
+| Will Substitute | Won't Substitute |
+|----------------|------------------|
+| `{topic}` | `{"key":"value"}` |
+| `{user_input}` | `{1,2,3}` |
+| `{task_name}` | `{}` |
+| `{model_config}` | `{ spaced }` |
+
+```mermaid
+sequenceDiagram
+    participant YAML
+    participant TemplateEngine
+    participant Output
+    
+    YAML->>TemplateEngine: "Write about {topic} using {"level":2}"
+    TemplateEngine->>TemplateEngine: Match {topic} ✓
+    TemplateEngine->>TemplateEngine: Skip {"level":2} ✓
+    TemplateEngine->>Output: "Write about AI agents using {"level":2}"
+    
+    Note right of TemplateEngine: Only valid Python identifiers<br/>inside braces are substituted
+```
+
+## Where It Applies
+
+The brace-safe substitutor processes these YAML fields:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `role` | Agent role definition | `"Expert in {topic}"` |
+| `goal` | Agent objective | `"Research {topic} thoroughly"` |
+| `backstory` | Agent background | `"You specialize in {topic}"` |
+| `description` | Task description | `"Analyze {topic} data"` |
+| `expected_output` | Expected result | `"Report on {topic} findings"` |
+
+**Available variables:**
+- `{topic}` — main input from CLI or Python API
+- Any other keys passed via `kwargs` in the Python API
+
+---
+
+## Common Patterns
+
+### WordPress/Gutenberg Blocks
+
+```yaml
+roles:
+  content_creator:
+    backstory: |
+      You create WordPress content about {topic}. Use Gutenberg blocks:
+      <!-- wp:heading {"level":2} -->
+      <!-- wp:paragraph -->
+      Return structured data like {"publish": true, "category": "tech"}.
+```
+
+### API Response Examples
+
+```yaml
+roles:
+  api_designer:
+    goal: Design APIs for {topic}
+    backstory: |
+      You design REST APIs about {topic}. Example responses:
+      {"data": [...], "status": "success", "topic": "{topic}"}
+      Always focus on {topic}-related endpoints.
+```
+
+### Configuration Snippets
+
+```yaml
+roles:
+  devops:
+    role: DevOps engineer for {topic}
+    tasks:
+      deploy_config:
+        description: |
+          Create deployment config for {topic} service.
+          Use JSON like {"env": "prod", "replicas": 3}.
+        expected_output: |
+          YAML deployment manifest for {topic} with:
+          {"resources": {"limits": {"cpu": "500m"}}}
+```
+
+---
+
+<Note>
+**Migration note:** Before the latest release, YAML strings with literal `{...}` could silently leave `{topic}` unsubstituted. Now they work as expected — no YAML changes required.
+</Note>
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Use {topic} as the canonical input placeholder">
+Stick to `{topic}` for the main input variable — it's the standard CLI/API parameter:
+
+```yaml
+roles:
+  analyst:
+    role: Data analyst for {topic}
+    goal: Analyze {topic} comprehensively
+    # Clear, consistent naming
+```
+</Accordion>
+
+<Accordion title="Write literal JSON naturally">
+No escaping needed for JSON examples in prompts:
+
+```yaml
+roles:
+  developer:
+    backstory: |
+      You write APIs that return {"success": true, "data": [...]} 
+      and handle errors like {"error": "not found", "code": 404}.
+      Focus on {topic} implementations.
+```
+</Accordion>
+
+<Accordion title="Pass extra variables via Python API">
+For variables beyond `{topic}`, use the Python API:
+
+```python
+from praisonai import PraisonAI
+
+# Custom variables in addition to {topic}
+ai = PraisonAI(agent_file="agents.yaml")
+result = ai.run(
+    topic="machine learning",
+    style="academic",
+    deadline="next week"
+)
+```
+
+Then use `{style}` and `{deadline}` in your YAML.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Async Crew Kickoff" icon="play" href="/docs/features/async-crew-kickoff">
+  Native async execution with template substitution
+</Card>
+<Card title="Agent Configuration" icon="robot" href="/docs/concepts/agents">
+  Complete guide to agent YAML structure
+</Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

Updates documentation to reflect the three user-facing behavioral changes from PraisonAI PR #1794:

• **Native async execution path** — `praisonai.arun()` no longer thread-offloads; now drives SDK's native async API (`AgentTeam.astart()`)
• **Brace-safe template substitution** — YAML strings containing JSON/dict literals (e.g. `{"level":2}`) no longer cause silent substitution failures of `{topic}`
• **Per-agent `llm` honored** — multi-model YAML no longer silently collapses to single global model on praisonai-native path

## Changes Made

### Updated docs/features/async-crew-kickoff.mdx
- Replaced thread offload diagrams with native async flow
- Added "What's actually async" table showing adapter differences
- Updated sequence diagram to show `AgentsGenerator.agenerate_crew_and_kickoff()` → `FrameworkAdapter.arun()` → `AgentTeam.astart()`
- Added note about workflow mode using `workflow.astart()`
- Updated best practices with cancellation/timeout propagation

### Created docs/features/yaml-template-variables.mdx  
- Documents the brace-safe template substitution rule: `\{([a-zA-Z_][a-zA-Z0-9_]*)\}`
- Shows "Will substitute vs Won't substitute" examples
- Covers where substitution applies (role, goal, backstory, task description/output)
- Includes migration note about the fix
- Examples with WordPress blocks, API responses, JSON config snippets

### Updated docs/features/model-router.mdx
- Added "Quick per-agent model (no router needed)" section before existing content
- Documents string form: `llm: gpt-4o-mini` 
- Documents dict form: `llm: {model: groq/llama3-70b-8192}`
- Shows precedence ladder: per-agent `llm` > `manager_llm` > global model
- Notes framework support and AutoGen/AG2 limitation
- Updated existing section title to clarify it's for named models

### Updated docs.json
- Added `docs/features/yaml-template-variables` to "Core Agent Features" section
- Added `docs/features/model-router` to "Reasoning & Intelligence" section

## Quality Checklist

- [x] All examples copy-paste runnable with correct imports
- [x] Mermaid diagrams use standard color scheme (#8B0000, #189AB4, #10B981, #F59E0B, #6366F1)
- [x] Pages follow AGENTS.md structure template  
- [x] Added to docs.json under "Features" (never "Concepts")
- [x] JSON validated successfully
- [x] Cross-linked related pages

Fixes #500

🤖 Generated with [Claude Code](https://claude.ai/code)