### PR TITLE
docs: document typed error classification, idle-timeout circuit breaker, and unified max_iter

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -439,6 +439,7 @@
                   "docs/features/guardrails",
                   "docs/features/non-fatal-errors",
                   "docs/features/structured-llm-errors",
+                  "docs/features/llm-error-classification",
                   "docs/features/task-retry-policy",
                   "docs/features/security-environment-variables",
                   "docs/features/tool-resolver",

--- a/docs/configuration/execution-config.mdx
+++ b/docs/configuration/execution-config.mdx
@@ -101,7 +101,7 @@ config = ExecutionConfig(
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `max_iter` | `int` | `20` | Maximum tool call iterations |
+| `max_iter` | `int` | `20` | Maximum tool-calling iterations. Now propagated to the `LLM` instance, so it controls every internal loop (previously some loops were hardcoded to 5/10/20/50). LLM-level default when constructed directly is `10`; `ExecutionConfig` default is `20`. |
 | `max_rpm` | `int \| None` | `None` | Max requests per minute (rate limit) |
 | `max_execution_time` | `int \| None` | `None` | Max execution time in seconds |
 | `max_retry_limit` | `int` | `2` | Max retries on failure |
@@ -122,6 +122,45 @@ For simple budget limits, use the `Agent(max_budget=...)` convenience parameter 
 | `"balanced"` | 20 | Default, balanced approach |
 | `"thorough"` | 50 | Complex tasks, more iterations |
 | `"unlimited"` | 1000 | Long-running tasks |
+
+---
+
+## Iteration Propagation
+
+`ExecutionConfig.max_iter` is now the single source of truth for iteration limits, replacing previously hardcoded internal caps.
+
+```mermaid
+graph LR
+    subgraph "Unified Iteration Control"
+        Config[📋 ExecutionConfig.max_iter] --> Agent[🤖 Agent]
+        Agent --> LLM[⚙️ LLM]
+        LLM --> Loops[🔄 All Internal Tool Loops]
+    end
+    
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class Config config
+    class Agent,LLM process
+    class Loops output
+```
+
+**Before**: Internal LLM loops were hardcoded to different limits (5, 10, 20, 50)
+**After**: All loops respect the configured `max_iter` value
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.config import ExecutionConfig
+
+# This now controls ALL iteration loops, not just agent-level loops
+agent = Agent(
+    name="Unified Control",
+    instructions="Respect iteration limits everywhere",
+    execution=ExecutionConfig(max_iter=15)
+)
+# The agent's LLM will respect 15 iterations in all internal loops
+```
 
 ---
 
@@ -198,10 +237,16 @@ Use `max_execution_time` in production to prevent hung processes.
 ## Related
 
 <CardGroup cols={2}>
+<Card title="LLM Error Classification" icon="circle-alert" href="/features/llm-error-classification">
+  Iteration control and error handling integration
+</Card>
 <Card title="Async Execution" icon="clock" href="/docs/features/async">
   Async agent execution
 </Card>
 <Card title="Background Tasks" icon="list-check" href="/docs/features/background-tasks">
   Run agents in background
+</Card>
+<Card title="Structured LLM Errors" icon="circle-alert" href="/features/structured-llm-errors">
+  LLM error handling and retry policies
 </Card>
 </CardGroup>

--- a/docs/features/llm-error-classification.mdx
+++ b/docs/features/llm-error-classification.mdx
@@ -1,0 +1,407 @@
+---
+title: "LLM Error Classification"
+sidebarTitle: "Error Classification"
+description: "Typed error categories, failover decisions, and idle-timeout protection for LLM calls"
+icon: "circle-alert"
+---
+
+PraisonAI classifies every LLM failure into one of 11 typed categories so retries, failovers, and circuit breakers can react correctly without parsing error strings.
+
+```mermaid
+graph LR
+    subgraph "Error Classification Flow"
+        Error[❌ Exception] --> Classify[🏷️ classify_error_kind]
+        Classify --> Kind[📝 AgentErrorKind]
+        Kind --> Decision[🤔 resolve_failover_decision]
+        Decision --> Action{📋 Action}
+        Action -->|retry| Retry[🔄 Retry]
+        Action -->|rotate_profile| Profile[🔄 Switch Profile]
+        Action -->|surface_error| Fail[🛑 Surface Error]
+        Retry --> Breaker[⚡ IdleTimeoutBreaker]
+        Breaker --> Success[✅ Success]
+    end
+    
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef decision fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    
+    class Error input
+    class Classify,Decision process
+    class Kind,Action decision
+    class Retry,Profile,Success output
+    class Breaker config
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Simple Usage">
+Error classification happens automatically when using agents:
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Smart Agent",
+    instructions="Process user requests with automatic error handling"
+)
+
+# Classification happens transparently
+result = agent.start("Generate a summary")
+```
+</Step>
+
+<Step title="Read Error Category">
+Access the typed error category in error hooks:
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.errors import AgentErrorKind
+
+def handle_error(error):
+    # Access typed error category instead of parsing strings
+    if error.error_category == "billing":
+        print("💳 Quota exceeded - contact billing")
+    elif error.error_category == "rate_limit":
+        print("⏸️ Rate limited - will auto-retry")
+    elif error.error_category == "auth_permanent":
+        print("🔑 Invalid API key - check configuration")
+
+agent = Agent(
+    name="Smart Agent",
+    instructions="Handle requests with error monitoring",
+    on_error=handle_error
+)
+```
+</Step>
+
+<Step title="Custom Idle-Timeout Protection">
+Tune the idle-timeout circuit breaker for different scenarios:
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.errors import IdleTimeoutBreaker
+from praisonaiagents.llm import LLM
+
+# Custom breaker for slow self-hosted models
+breaker = IdleTimeoutBreaker(max_consecutive=5)
+
+llm = LLM(
+    model="self-hosted/slow-model",
+    idle_timeout_breaker=breaker,
+    max_iter=15
+)
+
+agent = Agent(
+    name="Patient Agent", 
+    instructions="Work with slow models",
+    llm=llm
+)
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant LLM
+    participant Classifier
+    participant Breaker
+    
+    User->>Agent: Request
+    Agent->>LLM: LLM Call
+    LLM-->>Agent: Exception
+    Agent->>Classifier: classify_error_kind(error)
+    Classifier-->>Agent: AgentErrorKind
+    Agent->>Classifier: resolve_failover_decision(error, state)
+    Classifier-->>Agent: FailoverDecision
+    
+    alt action == "retry" and kind == "idle_timeout"
+        Agent->>Breaker: record_idle_timeout()
+        Breaker-->>Agent: breaker_hit
+        alt breaker_hit == True
+            Agent-->>User: Surface Error
+        else
+            Agent->>LLM: Retry Call
+        end
+    else action == "rotate_profile"
+        Agent->>LLM: Switch Profile
+        Agent->>LLM: Retry Call
+    else action == "surface_error"
+        Agent-->>User: Final Error
+    end
+```
+
+The classification system converts every LLM exception into a structured `FailoverDecision` that tells retry logic exactly what to do.
+
+---
+
+## Error Categories
+
+All LLM failures are classified into these 11 typed categories:
+
+| Kind | Triggers (examples) | Default Action | Retryable |
+|------|-------------------|----------------|-----------|
+| `auth` | `unauthorized`, `api key`, `authentication failed` | `rotate_profile` (if failover enabled) | Yes |
+| `auth_permanent` | `invalid api key`, `incorrect api key` | `surface_error` | No |
+| `rate_limit` | `rate limit`, `429`, `resource_exhausted` | `retry` (with parsed/exponential backoff, max 60s) | Yes |
+| `overloaded` | `503`, `502`, `500`, `service unavailable` | `retry` (2s→4s→8s, capped at 30s) | Yes |
+| `context_overflow` | `maximum context length`, `context window is too long` | `surface_error` | No |
+| `idle_timeout` | `timeout`, `timed out`, `deadline exceeded` | `retry` until breaker hits 3, then `surface_error` | Yes (until breaker) |
+| `billing` | `insufficient quota`, `quota exceeded`, `payment required` | `surface_error` | No |
+| `model_not_found` | `model not found`, `unknown model` | `surface_error` | No |
+| `empty_response` | `empty response`, `json decode error` | `retry` (limited) | Limited |
+| `format_error` | `validation error`, `invalid json`, `schema error` | `surface_error` | No |
+| `unknown` | anything else | `retry` for attempt ≤ 2, then `surface_error` | Limited |
+
+## FailoverDecision Structure
+
+Every classification produces a `FailoverDecision` with these fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `action` | `"retry"` \| `"rotate_profile"` \| `"surface_error"` | What action to take |
+| `reason` | `AgentErrorKind` | The classified error type |
+| `backoff_ms` | `int` | Milliseconds to wait before retry (0 = immediate) |
+| `is_retryable` | `bool` | Whether this error is worth retrying |
+
+## Idle-Timeout Circuit Breaker
+
+The idle-timeout circuit breaker is **separate** from the [per-tool circuit breaker](/features/tool-circuit-breaker). It protects against LLM provider stalls:
+
+```mermaid
+graph TB
+    subgraph "Idle-Timeout Protection"
+        Request[📞 LLM Call] --> Timeout{⏱️ Timeout?}
+        Timeout -->|No| Success[✅ Success]
+        Timeout -->|Yes| Counter[📊 Increment Counter]
+        Counter --> Check{🔢 ≥ 3?}
+        Check -->|No| Retry[🔄 Retry]
+        Check -->|Yes| Stop[🛑 Circuit Open]
+        Success --> Reset[🔄 Reset Counter]
+    end
+    
+    classDef request fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    
+    class Request request
+    class Timeout,Counter,Check process
+    class Success,Reset,Retry success
+    class Stop error
+```
+
+- **Default**: Stops after 3 consecutive `idle_timeout` failures
+- **Auto-resets**: On any successful LLM call
+- **Only triggered by**: `idle_timeout` error kind (not other timeouts)
+
+## Choosing Between Options
+
+```mermaid
+graph TB
+    Start[Need Error Handling?] --> React{React to Errors?}
+    React -->|Yes| Hook[Use on_error hook]
+    React -->|No| Override{Custom Retry Logic?}
+    Override -->|Yes| Subclass[Subclass LLM, override resolve_failover_decision]
+    Override -->|No| Protection{Tighter Idle Protection?}
+    Protection -->|Yes| Breaker[Pass custom IdleTimeoutBreaker]
+    Protection -->|No| Default[Use Default Classification]
+    
+    Hook --> Monitor[Monitor error.error_category]
+    Subclass --> Custom[Implement custom FailoverDecision logic] 
+    Breaker --> Configure[Configure max_consecutive]
+    Default --> Auto[Automatic classification & retry]
+    
+    classDef choice fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef action fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    
+    class React,Override,Protection choice
+    class Hook,Subclass,Breaker,Default action
+    class Monitor,Custom,Configure,Auto config
+```
+
+## Common Patterns
+
+### Log Every Classified Failure
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.errors import LLMError
+
+def error_logger(error: LLMError):
+    print(f"⚠️ LLM {error.error_category}: {error.message}")
+    
+    # Route specific error types
+    if error.error_category == "billing":
+        # Alert ops team
+        send_alert("billing", error.message)
+    elif error.error_category == "auth_permanent":
+        # Alert dev team
+        send_alert("config", error.message)
+
+agent = Agent(
+    name="Monitored Agent",
+    instructions="Track all LLM failures",
+    on_error=error_logger
+)
+```
+
+### Custom Breaker for Slow Models
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.errors import IdleTimeoutBreaker
+from praisonaiagents.llm import LLM
+
+# More patient with self-hosted models
+slow_model_breaker = IdleTimeoutBreaker(max_consecutive=8)
+
+agent = Agent(
+    name="Self-Hosted Agent",
+    llm=LLM(
+        model="ollama/custom-model",
+        idle_timeout_breaker=slow_model_breaker,
+        timeout=120  # 2 minute timeout
+    )
+)
+```
+
+### Gate Alerts by Error Type
+
+```python
+from praisonaiagents import Agent
+
+def smart_alerting(error):
+    # Only alert on errors that need human intervention
+    alert_worthy = [
+        "auth_permanent", "model_not_found", 
+        "context_overflow", "billing"
+    ]
+    
+    if error.error_category in alert_worthy:
+        send_slack_alert(f"🚨 {error.error_category}: {error.message}")
+    else:
+        # Just log retryable errors
+        logger.info(f"Retryable {error.error_category} - auto-handling")
+
+agent = Agent(
+    name="Smart Alerting Agent",
+    instructions="Only alert on actionable errors",
+    on_error=smart_alerting
+)
+```
+
+## Legacy Migration
+
+<Note>
+The old `error_category` string values still work but emit a `DeprecationWarning`. Update to the new typed categories for cleaner code.
+</Note>
+
+| Old `error_category` | New `AgentErrorKind` | Migration |
+|---------------------|---------------------|-----------|
+| `"tool"` | `"unknown"` | Update error classification logic |
+| `"llm"` | `"unknown"` | More specific classification available |
+| `"budget"` | `"billing"` | Direct replacement |
+| `"validation"` | `"format_error"` | Direct replacement |
+| `"network"` | `"unknown"` | Use specific network error kinds |
+| `"handoff"` | `"unknown"` | Agent handoff errors are separate |
+
+Example migration:
+
+```python
+# OLD (deprecated - emits warning)
+if error.error_category == "budget":
+    handle_budget_error()
+
+# NEW (recommended)  
+if error.error_category == "billing":
+    handle_billing_error()
+```
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Treat Permanent Errors as Config Issues">
+Errors classified as `auth_permanent`, `model_not_found`, and `context_overflow` indicate configuration problems, not transient failures. Set up monitoring to catch these during development.
+
+```python
+permanent_errors = ["auth_permanent", "model_not_found", "format_error"]
+if error.error_category in permanent_errors:
+    # Log as config issue, not service degradation
+    config_logger.error(f"Config issue: {error.error_category}")
+```
+</Accordion>
+
+<Accordion title="Tune Circuit Breaker by Model Speed">
+Fast cloud models can use the default `max_consecutive=3`. Slow self-hosted models should increase this to avoid premature circuit breaking.
+
+```python
+# Fast cloud model (default)
+fast_breaker = IdleTimeoutBreaker()  # max_consecutive=3
+
+# Slow self-hosted model  
+slow_breaker = IdleTimeoutBreaker(max_consecutive=8)
+```
+</Accordion>
+
+<Accordion title="Use Typed Categories Over String Matching">
+Instead of parsing error messages, use the typed `error_category` field for reliable error handling.
+
+```python
+# AVOID: String parsing
+if "quota" in str(exception):
+    handle_quota()
+
+# PREFER: Typed classification
+if error.error_category == "billing":
+    handle_billing_issue()
+```
+</Accordion>
+
+<Accordion title="Pair with Model Failover for Cross-Provider Resilience">
+Combine error classification with [Model Failover](/features/model-failover) to automatically switch providers on `auth` errors.
+
+```python
+from praisonaiagents.failover import FailoverManager
+
+failover = FailoverManager([
+    AuthProfile(provider="openai", api_key="..."),
+    AuthProfile(provider="anthropic", api_key="...")
+])
+
+agent = Agent(
+    name="Resilient Agent",
+    llm={"model": "gpt-4o", "failover_manager": failover}
+)
+# Auth errors will automatically rotate to Anthropic
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Structured LLM Errors" icon="circle-alert" href="/features/structured-llm-errors">
+  Foundation error handling with LLMError structure
+</Card>
+<Card title="Model Failover" icon="arrows-rotate" href="/features/model-failover">
+  Cross-provider failover with FailoverManager
+</Card>
+<Card title="Tool Circuit Breaker" icon="plug-circle-bolt" href="/features/tool-circuit-breaker">
+  Per-tool circuit breaking for tool execution
+</Card>
+<Card title="Execution Config" icon="gear" href="/configuration/execution-config">
+  Configure max_iter and other execution parameters
+</Card>
+</CardGroup>

--- a/docs/features/model-failover.mdx
+++ b/docs/features/model-failover.mdx
@@ -7,6 +7,10 @@ icon: "rotate"
 
 Model Failover automatically switches between LLM providers when one fails, ensuring your agents remain operational even during API outages or rate limits.
 
+<Note>
+Failover now integrates with [LLM Error Classification](/features/llm-error-classification) through the new `FailoverDecision` struct, which coordinates profile rotation with typed error handling.
+</Note>
+
 ```mermaid
 graph LR
     subgraph "Failover Chain"

--- a/docs/features/structured-llm-errors.mdx
+++ b/docs/features/structured-llm-errors.mdx
@@ -7,6 +7,10 @@ icon: "circle-alert"
 
 LLM failures are now raised as structured `LLMError` exceptions instead of returning `None`, enabling proper error handling and retry policies.
 
+<Note>
+LLM errors now also carry typed `AgentErrorKind` classifications for more precise error handling. See [LLM Error Classification](/features/llm-error-classification) for the complete taxonomy and failover decision system.
+</Note>
+
 ```mermaid
 graph LR
     subgraph "LLM Error Flow"
@@ -110,20 +114,15 @@ sequenceDiagram
 
 ## Error Classification
 
-LLM errors are automatically classified as retryable or non-retryable based on error messages:
+LLM errors are automatically classified into typed `AgentErrorKind` categories for precise handling. For the complete system, see [LLM Error Classification](/features/llm-error-classification).
 
-### Retryable Errors
-- Rate limits: `429`, `rate limit`, `too many requests`
-- Network issues: `timeout`, `connection reset`, `socket error`
-- Server errors: `500`, `502`, `503`, `504`, `service unavailable`
-- DNS/Network: `dns`, `network`, `connection refused`
+### Quick Reference
+- **Retryable**: `rate_limit`, `overloaded`, `idle_timeout`, `auth`
+- **Non-retryable**: `auth_permanent`, `model_not_found`, `format_error`, `context_overflow`, `billing`
+- **Limited retry**: `unknown`, `empty_response`
 
-### Non-Retryable Errors  
-- Authentication: `401`, `403`, `unauthorized`, `invalid_api_key`
-- Client errors: Most 4xx status codes
-
-### Default Behavior
-Unknown errors default to `is_retryable=True` for resilience.
+### Legacy Support
+The simple two-bucket classification (retryable/non-retryable) remains available for backward compatibility, but typed categories provide much more control.
 
 ---
 
@@ -138,6 +137,7 @@ The `LLMError` class provides structured error information:
 | `agent_id` | `str` | Agent identifier |
 | `session_id` | `str` | Session identifier |
 | `is_retryable` | `bool` | Whether error can be retried |
+| `error_category` | `AgentErrorKind` | Typed classification — see [Error Classification](/features/llm-error-classification) |
 
 ```python
 from praisonaiagents.errors import LLMError
@@ -194,6 +194,23 @@ except LLMError as e:
     else:
         # Handle fatal error
         print(f"Fatal: {e.message}")
+```
+
+**Typed Error Categories (New):**
+```python
+from praisonaiagents.errors import LLMError
+
+try:
+    response = agent._chat_completion(messages)
+except LLMError as e:
+    # Use typed categories instead of string parsing
+    if e.error_category == "billing":
+        handle_quota_exceeded()
+    elif e.error_category == "auth_permanent":
+        handle_invalid_api_key()
+    elif e.error_category == "rate_limit":
+        # Auto-retry handles this
+        raise
 ```
 
 ---
@@ -257,10 +274,16 @@ def fallback_handler(error):
 ## Related
 
 <CardGroup cols={2}>
+<Card title="LLM Error Classification" icon="circle-alert" href="/features/llm-error-classification">
+  Typed error categories and failover decisions
+</Card>
 <Card title="Task Retry Policy" icon="rotate-ccw" href="/features/task-retry-policy">
   Configure task-level retry behavior
 </Card>
 <Card title="Hooks" icon="webhook" href="/features/hooks">
   Agent lifecycle hooks and events
+</Card>
+<Card title="Model Failover" icon="arrows-rotate" href="/features/model-failover">
+  Cross-provider failover with FailoverManager
 </Card>
 </CardGroup>

--- a/docs/features/tool-circuit-breaker.mdx
+++ b/docs/features/tool-circuit-breaker.mdx
@@ -11,6 +11,10 @@ Every tool call is automatically protected by a circuit breaker that stops repea
 **Sync and Async Parity**: Circuit breaker protection now applies uniformly to both sync and async tool execution paths. Previously, async calls bypassed circuit breaker checks.
 </Note>
 
+<Note>
+This tool-level circuit breaker is separate from the new [LLM idle-timeout circuit breaker](/features/llm-error-classification#idle-timeout-circuit-breaker), which protects against LLM provider stalls during model calls.
+</Note>
+
 ```mermaid
 graph LR
     subgraph "Circuit Breaker Flow"


### PR DESCRIPTION
Comprehensive documentation for PraisonAI PR #1853 features

## Summary

Documents three new user-facing changes from [MervinPraison/PraisonAI PR #1853](https://github.com/MervinPraison/PraisonAI/pull/1853):

### 1. Typed Error Classification (AgentErrorKind)
- Replaces freeform error strings with 11 typed categories
- Enables precise error handling without string parsing
- Provides structured failover decisions via FailoverDecision struct

### 2. Idle-Timeout Circuit Breaker
- Per-LLM instance circuit breaker for consecutive timeout failures  
- Separate from existing per-tool circuit breaker
- Configurable max_consecutive limit (default: 3)

### 3. Unified max_iter Authority
- LLM constructor now accepts max_iter parameter (default: 10)
- Agent passes ExecutionConfig.max_iter to LLM construction
- Replaces hardcoded internal iteration caps (5/10/20/50)

## Documentation Changes

### NEW: docs/features/llm-error-classification.mdx
Complete documentation following AGENTS.md standards:
- Hero Mermaid diagram with standard color scheme
- Agent-centric Quick Start with Steps component  
- All 11 AgentErrorKind categories with trigger patterns
- FailoverDecision struct reference table
- Idle-timeout breaker explanation with diagram
- Common patterns and best practices
- Legacy migration guide for deprecated string categories

### UPDATED: 5 existing pages
- **structured-llm-errors.mdx**: Cross-references to new classification system
- **execution-config.mdx**: Documents unified max_iter propagation with flow diagram
- **tool-circuit-breaker.mdx**: Distinguishes from LLM idle-timeout breaker
- **model-failover.mdx**: Notes FailoverDecision integration
- **docs.json**: Adds new page to Features group

## Technical Details

All documentation based on actual SDK source code analysis:
- Read praisonaiagents/errors.py for dataclass definitions and legacy mapping
- Read praisonaiagents/llm/llm.py for classification logic and failover decisions
- Read praisonaiagents/agent/agent.py for max_iter propagation paths

Validates AGENTS.md compliance:
- ✅ SDK-first documentation cycle followed
- ✅ Friendly imports: from praisonaiagents import Agent
- ✅ Agent-centric examples throughout
- ✅ Standard Mermaid color scheme (#8B0000, #189AB4, #10B981, etc.)
- ✅ Required Mintlify components (Steps, AccordionGroup, CardGroup)
- ✅ Placement in docs/features/ (not docs/concepts/)

Fixes #521

🤖 Generated with [Claude Code](https://claude.ai/code)