### PR TITLE
docs: add Named Toolset Groups documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -327,6 +327,7 @@
                       "docs/features/autonomy-loop",
                       "docs/features/tool-circuit-breaker",
                       "docs/features/tool-search",
+                      "docs/features/toolsets",
                       "docs/features/allowed-tools",
                       "docs/features/model-failover",
                       "docs/features/reliability",

--- a/docs/features/toolsets.mdx
+++ b/docs/features/toolsets.mdx
@@ -1,0 +1,405 @@
+---
+title: "Toolsets"
+sidebarTitle: "Toolsets"
+description: "Attach a named group of tools to an agent in one line"
+icon: "toolbox"
+---
+
+Toolsets group tools under a single name so you can give an agent a curated capability set without listing every tool.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="researcher", toolsets=["research"])
+agent.start("Summarise the latest in AI agent frameworks")
+```
+
+```mermaid
+graph LR
+    subgraph "Toolsets Flow"
+        User[👤 User Request] --> Agent[🤖 Agent]
+        Agent --> Resolver[🔍 Toolset Resolver]
+        Resolver --> Research[📊 research toolset]
+        Research --> Web[🌐 web tools]
+        Research --> Files[📁 file tools]
+        Research --> Scraping[🕷️ scraping tools]
+        Web --> Result[✅ Agent Tools]
+        Files --> Result
+        Scraping --> Result
+    end
+    
+    classDef user fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef tools fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class User user
+    class Agent agent
+    class Resolver,Research process
+    class Web,Files,Scraping tools
+    class Result result
+```
+
+```mermaid
+graph TB
+    Start[Which toolset should I use?]
+    Start --> Restricted{Restricted environment?}
+    Restricted -->|Yes| Safe[🔒 safe]
+    Restricted -->|No| Purpose{What's your purpose?}
+    
+    Purpose --> Single{Single capability?}
+    Single -->|Yes| SingleChoice[🌐 web / 📁 files / 💻 code / ⚙️ system / 🕷️ scraping]
+    Single -->|No| Workflow{Complete workflow?}
+    
+    Workflow -->|Research| Research[📊 research]
+    Workflow -->|Development| Development[🛠️ development]
+    Workflow -->|Custom| Custom[📝 register_toolset(...)]
+    
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef toolset fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef custom fill:#6366F1,stroke:#7C90A0,color:#fff
+    
+    class Start,Restricted,Purpose,Single,Workflow decision
+    class Safe,SingleChoice,Research,Development toolset
+    class Custom custom
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Pick a prebuilt toolset">
+Use one of the prebuilt toolsets for common scenarios:
+
+```python
+from praisonaiagents import Agent
+
+# Research workflow with web search and file tools
+agent = Agent(name="researcher", toolsets=["research"])
+
+# Safe environment with minimal tools
+agent = Agent(name="assistant", toolsets=["safe"])
+
+# Development with code execution and system access
+agent = Agent(name="developer", toolsets=["development"])
+```
+</Step>
+
+<Step title="Register a custom toolset">
+Create your own toolset by combining tools and other toolsets:
+
+```python
+from praisonaiagents import Agent, register_toolset
+
+register_toolset(
+    "data_analysis",
+    tools=["read_file", "write_file"],
+    includes=["safe"],
+    description="Tools for data analysis workflows"
+)
+
+agent = Agent(name="analyst", toolsets=["data_analysis"])
+```
+</Step>
+
+<Step title="YAML configuration">
+Use toolsets in YAML workflows:
+
+```yaml
+agents:
+  researcher:
+    role: Senior Research Analyst
+    goal: Research topics thoroughly
+    toolsets: [research]
+  
+  analyst:
+    role: Data Analyst
+    goal: Analyse data files
+    tools: [write_file]
+    toolsets: [safe]
+```
+</Step>
+
+<Step title="CLI usage">
+Use toolsets directly from command line:
+
+```bash
+praisonai run "Research this topic" --toolset research
+praisonai chat --toolset web,files
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Registry as ToolsetRegistry
+    participant Tools as ToolRegistry
+    
+    User->>Agent: Agent(toolsets=["research"])
+    Agent->>Registry: resolve_toolsets(["research"])
+    Registry->>Registry: resolve "research" → ["web", "files", "scraping"]
+    Registry->>Registry: resolve "web" → ["internet_search", "tavily_search", ...]
+    Registry->>Registry: resolve "files" → ["read_file", "write_file", ...]
+    Registry->>Registry: resolve "scraping" → ["scrape_page", "extract_links", ...]
+    Registry-->>Agent: flat list of tool names
+    Agent->>Tools: get tools by names (with 30s TTL cache)
+    Tools-->>Agent: tool instances
+    Agent-->>User: agent with resolved tools
+```
+
+| Component | Purpose |
+|-----------|---------|
+| **ToolsetRegistry** | Maps toolset names to tool lists with recursive resolution |
+| **Tool Resolution** | Expands toolset names to flat lists, handles cycles and includes |
+| **TTL Cache** | 30-second cache for tool availability checks to improve performance |
+| **Deduplication** | Ensures no duplicate tools when mixing explicit tools and toolsets |
+
+---
+
+## Configuration Reference
+
+<Card title="Toolsets API Reference" icon="code" href="/docs/sdk/reference/typescript/classes/ToolsetSpec">
+  TypeScript configuration options
+</Card>
+<Card title="Toolsets Rust Reference" icon="code" href="/docs/sdk/reference/rust/structs/ToolsetSpec">
+  Rust configuration options
+</Card>
+
+### Prebuilt Toolsets
+
+| Name | Direct tools | Includes | Description |
+|------|-------------|----------|-------------|
+| `web` | `internet_search`, `duckduckgo`, `searxng_search`, `tavily_search`, `exa_search` | — | Web search and crawling tools |
+| `files` | `read_file`, `write_file`, `list_files`, `get_file_info`, `copy_file`, `move_file`, `delete_file` | — | File system operations |
+| `code` | `execute_code`, `analyze_code`, `format_code`, `lint_code` | — | Python code execution and analysis |
+| `system` | `execute_command`, `list_processes`, `kill_process`, `get_system_info` | — | System administration and shell operations |
+| `scraping` | `scrape_page`, `extract_links`, `crawl`, `extract_text` | — | Web page scraping and content extraction |
+| `research` | *(none)* | `web`, `files`, `scraping` | Complete research workflow |
+| `safe` | `internet_search`, `read_file`, `tavily_search` | — | Minimal safe toolset for restricted environments |
+| `development` | *(none)* | `code`, `files`, `system` | Complete development workflow |
+
+### ToolsetSpec Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | (required) | Unique name for the toolset |
+| `tools` | `List[str]` | `[]` | Tool names included directly in this toolset |
+| `includes` | `List[str]` | `[]` | Other toolset names to include (recursive composition) |
+| `description` | `str` | `""` | Optional description of the toolset's purpose |
+
+---
+
+## Common Patterns
+
+### Mixing Explicit Tools and Toolsets
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="hybrid",
+    tools=["write_file"],  # Explicit tool
+    toolsets=["safe"],     # Toolset
+)
+# Agent gets tools from both sources with automatic deduplication
+```
+
+### Composition with Includes
+
+```python
+from praisonaiagents import register_toolset
+
+# Build up capabilities progressively
+register_toolset("basic", tools=["read_file", "write_file"])
+register_toolset("enhanced", includes=["basic"], tools=["internet_search"])
+register_toolset("complete", includes=["enhanced"], tools=["execute_code"])
+```
+
+### Environment-Specific Toolsets
+
+```python
+import os
+from praisonaiagents import Agent
+
+# Choose toolset based on environment
+if os.getenv("PRODUCTION"):
+    toolsets = ["safe"]
+else:
+    toolsets = ["development"]
+
+agent = Agent(name="assistant", toolsets=toolsets)
+```
+
+---
+
+## CLI Usage
+
+Use toolsets with `praisonai run` and `praisonai chat` commands:
+
+```bash
+# Single toolset
+praisonai run "Research renewable energy" --toolset research
+
+# Multiple toolsets (comma-separated)
+praisonai chat --toolset web,files
+
+# Safe environment
+praisonai run "Help me write a report" --toolset safe
+```
+
+---
+
+## YAML Usage
+
+Add `toolsets:` key under each agent definition:
+
+```yaml
+agents:
+  researcher:
+    role: Senior Research Analyst
+    goal: Research topics thoroughly
+    toolsets: [research]  # research = web + files + scraping
+    
+  writer:
+    role: Content Writer
+    goal: Write based on research
+    tools: [write_file]   # explicit tool
+    toolsets: [safe]      # safe toolset
+    
+  developer:
+    role: Software Developer
+    goal: Build applications
+    toolsets: [development]  # development = code + files + system
+
+tasks:
+  research_task:
+    description: Research AI frameworks
+    agent: researcher
+```
+
+---
+
+## Custom Toolsets
+
+### Register Function
+
+```python
+from praisonaiagents import register_toolset
+
+register_toolset(
+    name: str,
+    tools: Optional[List[str]] = None,
+    includes: Optional[List[str]] = None,
+    description: str = "",
+    overwrite: bool = False
+)
+```
+
+### Overwrite Behavior
+
+By default, `register_toolset` is a silent no-op if the name already exists. Set `overwrite=True` to replace:
+
+```python
+register_toolset("my_toolset", tools=["tool1"], overwrite=True)
+```
+
+### Recursive Includes
+
+Toolsets can include other toolsets with automatic cycle detection:
+
+```python
+register_toolset("base", tools=["read_file"])
+register_toolset("extended", includes=["base"], tools=["write_file"])
+register_toolset("complete", includes=["extended"], tools=["internet_search"])
+# complete resolves to: ["read_file", "write_file", "internet_search"]
+```
+
+Circular dependencies raise `ValueError`:
+```python
+register_toolset("a", includes=["b"])
+register_toolset("b", includes=["a"])  # Raises ValueError on resolution
+```
+
+---
+
+## Performance Note
+
+Tool availability is cached for 30 seconds by default. The `list_available_tools()` function uses TTL caching to avoid expensive availability checks on every agent initialization, improving performance when creating many agents.
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Pick 'safe' for production sandboxes">
+Use the `safe` toolset in production environments where you need to restrict tool capabilities. It includes only read-only operations like `internet_search` and `read_file`.
+
+```python
+# Production agent with minimal attack surface
+agent = Agent(name="prod_assistant", toolsets=["safe"])
+```
+</Accordion>
+
+<Accordion title="Compose with 'includes=' rather than copying tool lists">
+Use the `includes` parameter to build on existing toolsets instead of duplicating tool lists:
+
+```python
+# Good: Compose with includes
+register_toolset("analysis", includes=["safe"], tools=["analyze_data"])
+
+# Avoid: Copying tool lists
+register_toolset("analysis", tools=["read_file", "internet_search", "analyze_data"])
+```
+</Accordion>
+
+<Accordion title="Register custom toolsets at app boot, not per-request">
+Register toolsets once during application initialization, not in request handlers:
+
+```python
+# Good: Register once at startup
+def setup_toolsets():
+    register_toolset("custom", tools=["my_tool"])
+
+# Avoid: Registering per request
+def handle_request():
+    register_toolset("custom", tools=["my_tool"])  # Inefficient
+```
+</Accordion>
+
+<Accordion title="Mix explicit 'tools=' with 'toolsets=' when you need one extra tool">
+Use both parameters when you need a toolset plus one additional tool:
+
+```python
+agent = Agent(
+    name="researcher",
+    tools=["special_analysis_tool"],  # One extra tool
+    toolsets=["research"]             # Base capability set
+)
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Allowed Tools" icon="shield-check" href="/docs/features/allowed-tools">
+  Environment variable whitelist for tool restriction
+</Card>
+<Card title="Bot Default Tools" icon="robot" href="/docs/features/bot-default-tools">
+  Default tools for bot agents
+</Card>
+<Card title="Load MCP Tools" icon="plug" href="/docs/features/load-mcp-tools">
+  Model Context Protocol tool loading
+</Card>
+<Card title="Tools Concepts" icon="wrench" href="/docs/concepts/tools">
+  Core concepts of the tool system
+</Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the Named Toolset Groups feature introduced in PraisonAI PR #1850.

### Changes Made
- Created docs/features/toolsets.mdx with complete feature documentation
- Added navigation entry in docs.json under Features > Integration & Infrastructure  
- Verified all implementation details against SDK source code

### Documentation Coverage
- Agent-centric Quick Start examples
- Hero Mermaid diagrams showing toolset resolution flow  
- Decision tree for choosing the right toolset
- Complete prebuilt toolsets table (verified against source)
- CLI and YAML usage examples with real syntax
- Custom toolset registration with recursive includes
- Best practices and performance notes (TTL caching)
- All required Mintlify components (Steps, AccordionGroup, CardGroup)

### Quality Checklist
- Follows AGENTS.md page structure template
- Agent-centric first example using toolsets parameter
- Hero Mermaid diagram with standard color palette
- All prebuilt toolsets verified against praisonaiagents/toolsets.py
- ToolsetSpec fields match dataclass exactly
- CLI examples for both run and chat commands
- YAML usage with toolsets key
- Custom registration with overwrite behavior documented
- TTL availability cache (30s) mentioned
- JSON validation passes

Closes #528

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Toolsets documentation covering Quick Start, configuration reference, toolset resolution and selection logic, includes and deduplication features, TTL caching for performance optimization, custom toolset registration with cycle detection, and best practices for composing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->