### PR TITLE
docs: document new ContextCompactionPolicy + proactive overflow protection (fixes #530)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -523,6 +523,7 @@
                   "docs/features/rag-scoping",
                   "docs/features/platform-workspace-context",
                   "docs/features/context-compaction",
+                  "docs/features/context-compaction-policy",
                   "docs/features/context-window-management",
                   "docs/features/file-snapshot",
                   "docs/features/injected-state",

--- a/docs/configuration/execution-config.mdx
+++ b/docs/configuration/execution-config.mdx
@@ -105,6 +105,7 @@ config = ExecutionConfig(
 | `max_rpm` | `int \| None` | `None` | Max requests per minute (rate limit) |
 | `max_execution_time` | `int \| None` | `None` | Max execution time in seconds |
 | `max_retry_limit` | `int` | `2` | Max retries on failure |
+| `context_compaction` | `bool \| ContextCompactionPolicy` | `False` | Proactive context-overflow protection. `True` uses the `BALANCED_POLICY` preset. Pass a `ContextCompactionPolicy` instance for custom routing. **Default flips to `True` in the next release** — a `DeprecationWarning` is emitted today when left at `False`. See [Context Compaction Policy](/features/context-compaction-policy). |
 | `max_budget` | `float \| None` | `None` | Hard USD cap per agent run. `None` = no limit. |
 | `on_budget_exceeded` | `str \| callable` | `"stop"` | Action when limit is hit: `"stop"` raises `BudgetExceededError`, `"warn"` logs and continues, or a `callable(total_cost, max_budget)`. |
 
@@ -161,6 +162,43 @@ agent = Agent(
 )
 # The agent's LLM will respect 15 iterations in all internal loops
 ```
+
+---
+
+## Proactive Context Compaction
+
+```mermaid
+graph LR
+    subgraph "Context Protection Flow"
+        Config[📋 ExecutionConfig] --> Policy[🛡️ Policy]
+        Policy --> Routes[📊 Routes]
+        Routes --> LLM[🤖 LLM Call]
+    end
+    
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class Config config
+    class Policy,Routes process
+    class LLM output
+```
+
+Context compaction proactively prevents overflow before LLM calls instead of reacting after errors.
+
+```python
+from praisonaiagents import Agent, ExecutionConfig, BALANCED_POLICY
+
+agent = Agent(
+    name="Researcher",
+    execution=ExecutionConfig(
+        max_iter=30,
+        context_compaction=BALANCED_POLICY,  # explicit preset
+    ),
+)
+```
+
+See [Context Compaction Policy](/features/context-compaction-policy) for detailed configuration options.
 
 ---
 
@@ -237,6 +275,9 @@ Use `max_execution_time` in production to prevent hung processes.
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Context Compaction Policy" icon="shield-check" href="/features/context-compaction-policy">
+  Proactive context overflow protection
+</Card>
 <Card title="LLM Error Classification" icon="circle-alert" href="/features/llm-error-classification">
   Iteration control and error handling integration
 </Card>

--- a/docs/features/context-compaction-policy.mdx
+++ b/docs/features/context-compaction-policy.mdx
@@ -1,0 +1,375 @@
+---
+title: "Context Compaction Policy"
+sidebarTitle: "Compaction Policy"
+description: "Proactive, policy-based protection against context overflow with token-budget routing"
+icon: "shield-check"
+---
+
+Context Compaction Policy proactively routes long agent runs through token-budget checks before each LLM call, picking the right compaction strategy before context overflow happens.
+
+```mermaid
+graph LR
+    subgraph "Policy Flow"
+        A[📝 Messages] --> B{🔍 Budget Check}
+        B -->|FITS| C[✅ Direct LLM Call]
+        B -->|COMPACT_NEEDED| D[🗜️ Apply Strategy]
+        B -->|TRUNCATE_TOOLS| E[✂️ Truncate Tools]
+        B -->|COMPACT_THEN_TRUNCATE| F[🗜️✂️ Both Actions]
+        D --> C
+        E --> C
+        F --> C
+    end
+    
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A input
+    class B decision
+    class D,E,F process
+    class C success
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Enable with defaults (one line)">
+```python
+from praisonaiagents import Agent, ExecutionConfig
+
+agent = Agent(
+    name="LongRunner",
+    instructions="Handle long multi-turn research sessions.",
+    execution=ExecutionConfig(context_compaction=True),
+)
+
+agent.start("Research the entire history of large language models...")
+```
+</Step>
+
+<Step title="Pick a preset">
+<Tabs>
+<Tab title="Conservative">
+```python
+from praisonaiagents import Agent, ExecutionConfig, CONSERVATIVE_POLICY
+
+agent = Agent(
+    name="CautiousAgent",
+    execution=ExecutionConfig(context_compaction=CONSERVATIVE_POLICY),
+)
+```
+</Tab>
+
+<Tab title="Balanced (Default)">
+```python
+from praisonaiagents import Agent, ExecutionConfig, BALANCED_POLICY
+
+agent = Agent(
+    name="StandardAgent",
+    execution=ExecutionConfig(context_compaction=BALANCED_POLICY),
+)
+```
+</Tab>
+
+<Tab title="Aggressive">
+```python
+from praisonaiagents import Agent, ExecutionConfig, AGGRESSIVE_POLICY
+
+agent = Agent(
+    name="ToolHeavyAgent",
+    execution=ExecutionConfig(context_compaction=AGGRESSIVE_POLICY),
+)
+```
+</Tab>
+</Tabs>
+</Step>
+
+<Step title="Custom policy">
+```python
+from praisonaiagents import Agent, ExecutionConfig, ContextCompactionPolicy
+
+agent = Agent(
+    name="CustomAgent",
+    execution=ExecutionConfig(
+        context_compaction=ContextCompactionPolicy(
+            trigger_at=0.85,
+            strategy="summarise",
+            preserve_last_n_turns=8,
+            target_utilization=0.65,
+        )
+    ),
+)
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Policy
+    participant Compactor
+    participant LLM
+    
+    User->>Agent: Long conversation turn
+    Agent->>Policy: compute_context_budget(messages, model)
+    Policy-->>Agent: ContextBudgetResult(route=COMPACT_NEEDED)
+    Agent->>Compactor: Apply DROP_OLDEST_TOOLS strategy
+    Compactor-->>Agent: Compacted messages (utilization now 0.70)
+    Agent->>LLM: Call with compacted history
+    LLM-->>Agent: Response
+    Agent-->>User: Response (no overflow, no silent failure)
+```
+
+| Phase | Trigger | What happens |
+|-------|---------|--------------|
+| `FITS` | utilization < `trigger_at` | No action; messages pass through |
+| `COMPACT_NEEDED` | utilization ≥ `trigger_at` | Strategy runs against history |
+| `TRUNCATE_TOOLS` | Any tool output > 1000 chars + `aggressive_tool_truncation=True` | Tool outputs truncated head 300 / tail 200 with marker |
+| `COMPACT_THEN_TRUNCATE` | utilization ≥ 0.95 | Both compaction and tool truncation |
+
+---
+
+## Choose Your Policy
+
+```mermaid
+graph TB
+    A[What type of agent?] --> B[Short conversations<br/>Cheap models]
+    A --> C[Most agents<br/>Standard use cases]
+    A --> D[Long tool-heavy loops<br/>Token-limited models]
+    A --> E[Need fine control<br/>Custom requirements]
+    
+    B --> F[CONSERVATIVE<br/>trigger_at: 0.80<br/>preserve: 8 turns]
+    C --> G[BALANCED<br/>trigger_at: 0.90<br/>preserve: 5 turns]
+    D --> H[AGGRESSIVE<br/>trigger_at: 0.95<br/>summarize strategy]
+    E --> I[Custom<br/>ContextCompactionPolicy]
+    
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef policy fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef custom fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A decision
+    class F,G,H policy
+    class I custom
+```
+
+---
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `trigger_at` | `float` | `0.90` | Context utilization fraction that triggers compaction. Range `[0.1, 0.99]`. Must be > `target_utilization`. |
+| `strategy` | `str` \| `CompactionStrategy` | `"drop_oldest_tools"` | One of `"truncate"`, `"summarise"`, `"drop_oldest_tools"`, `"sliding_window"`. |
+| `preserve_last_n_turns` | `int` | `5` | Conversation turns at the tail that compaction never touches. |
+| `max_compaction_attempts` | `int` | `2` | Maximum compaction passes per LLM call. |
+| `target_utilization` | `float` | `0.70` | Post-compaction utilization target. Range `[0.1, 0.95]`. |
+| `aggressive_tool_truncation` | `bool` | `True` | When `True`, tool outputs > 1000 chars get truncated to head 300 / tail 200. |
+| `model_overrides` | `dict[str, dict]` \| `None` | `None` | Per-model overrides (e.g. `{"gpt-4o-mini": {"trigger_at": 0.75}}`). |
+
+---
+
+## Presets
+
+### CONSERVATIVE_POLICY
+```python
+CONSERVATIVE_POLICY = ContextCompactionPolicyAdapter(
+    trigger_at=0.80,
+    strategy=CompactionStrategy.DROP_OLDEST_TOOLS,
+    preserve_last_n_turns=8,
+    target_utilization=0.60,
+)
+```
+**When to use**: Short conversations, cheap models where early compaction doesn't impact cost significantly.
+
+### BALANCED_POLICY (Default)
+```python
+BALANCED_POLICY = ContextCompactionPolicyAdapter(
+    trigger_at=0.90,
+    strategy=CompactionStrategy.DROP_OLDEST_TOOLS,
+    preserve_last_n_turns=5,
+    target_utilization=0.70,
+)
+```
+**When to use**: Most agents and standard use cases.
+
+### AGGRESSIVE_POLICY
+```python
+AGGRESSIVE_POLICY = ContextCompactionPolicyAdapter(
+    trigger_at=0.95,
+    strategy=CompactionStrategy.SUMMARISE,
+    preserve_last_n_turns=3,
+    target_utilization=0.75,
+    aggressive_tool_truncation=True,
+)
+```
+**When to use**: Long tool-heavy loops or token-limited models where maximum context utilization is critical.
+
+---
+
+## Routes (`CompactionRoute` enum)
+
+| Route | Value | Action |
+|-------|-------|--------|
+| `FITS` | `"fits"` | No action — context within budget |
+| `COMPACT_NEEDED` | `"compact_needed"` | Run strategy on history |
+| `TRUNCATE_TOOLS` | `"truncate_tools"` | Shrink tool outputs only |
+| `COMPACT_THEN_TRUNCATE` | `"compact_then_truncate"` | Both — last-resort recovery |
+
+---
+
+## Strategies (`CompactionStrategy` enum)
+
+| Strategy | Value | Description | Maps to Legacy |
+|----------|-------|-------------|----------------|
+| `TRUNCATE` | `"truncate"` | Remove oldest messages | `TRUNCATE` |
+| `SUMMARISE` | `"summarise"` | LLM-based summarization of old messages | `SUMMARIZE` |
+| `DROP_OLDEST_TOOLS` | `"drop_oldest_tools"` | Remove old tool outputs first | `PRUNE` |
+| `SLIDING_WINDOW` | `"sliding_window"` | Keep recent messages only | `SLIDING` |
+
+---
+
+## Tool Output Truncation
+
+When `aggressive_tool_truncation=True` and any tool message content exceeds 1000 characters:
+
+- **Threshold**: 1000 chars
+- **Keep**: Head 300 chars + tail 200 chars  
+- **Marker**: `...[truncated N chars for context budget]...`
+
+Set `aggressive_tool_truncation=False` to disable this behavior.
+
+---
+
+## Model Overrides
+
+Use `model_overrides` to apply different settings per model:
+
+```python
+ContextCompactionPolicy(
+    trigger_at=0.90,
+    model_overrides={
+        "gpt-4o-mini": {"trigger_at": 0.80, "target_utilization": 0.60},
+        "claude-haiku-4-5": {"trigger_at": 0.85},
+    },
+)
+```
+
+The override values take precedence over the base configuration for the specified models.
+
+---
+
+## YAML / dict configuration
+
+Policies serialize via `to_dict()` / `from_dict()` for CLI/YAML support:
+
+```yaml
+execution:
+  context_compaction:
+    trigger_at: 0.85
+    strategy: drop_oldest_tools
+    preserve_last_n_turns: 5
+    target_utilization: 0.65
+    aggressive_tool_truncation: true
+```
+
+Strategy accepts a plain string in dict/YAML form.
+
+---
+
+## Deprecation Notice
+
+<Warning>
+**ExecutionConfig.context_compaction will default to True in the next release for proactive context overflow protection. To disable, explicitly set context_compaction=False. To use the new default early, set context_compaction=True.**
+
+**Today the default is `False`** — set it to `True` (or pass a policy) to opt in early.
+</Warning>
+
+---
+
+## Common Patterns
+
+### Use BALANCED for most agents
+```python
+from praisonaiagents import Agent, ExecutionConfig
+
+agent = Agent(
+    name="StandardAgent",
+    execution=ExecutionConfig(context_compaction=True),  # Uses BALANCED_POLICY
+)
+```
+
+### Use AGGRESSIVE for token-tight models
+```python
+from praisonaiagents import Agent, ExecutionConfig, AGGRESSIVE_POLICY
+
+agent = Agent(
+    name="TokenTightAgent", 
+    llm="gpt-4o-mini",
+    execution=ExecutionConfig(context_compaction=AGGRESSIVE_POLICY),
+)
+```
+
+### Per-model overrides for multi-model agents
+```python
+from praisonaiagents import Agent, ExecutionConfig, ContextCompactionPolicy
+
+policy = ContextCompactionPolicy(
+    trigger_at=0.90,
+    model_overrides={
+        "gpt-4o-mini": {"trigger_at": 0.75},
+        "gpt-4o": {"trigger_at": 0.95},
+    }
+)
+
+agent = Agent(
+    name="MultiModelAgent",
+    execution=ExecutionConfig(context_compaction=policy),
+)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Set trigger_at lower than your model's hard limit ratio">
+The default 0.90 is fine for 128k models. For smaller context windows, consider lowering to 0.80-0.85 to ensure sufficient headroom.
+</Accordion>
+
+<Accordion title="Keep preserve_last_n_turns >= 3">
+This ensures the agent doesn't lose the active sub-task or recent conversation context that's critical for coherent responses.
+</Accordion>
+
+<Accordion title="Use model_overrides for mixed-model workflows">
+If your agent swaps between cheap and large models, set different thresholds to optimize token usage for each model type.
+</Accordion>
+
+<Accordion title="aggressive_tool_truncation=True is the right default">
+For tool-heavy agents (code execution, web search, RAG), large tool outputs often contain redundant information. Truncation preserves the essential parts.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Context Compaction" icon="compress" href="/features/context-compaction">
+  The reactive CompactionConfig system
+</Card>
+<Card title="Execution Config" icon="play" href="/configuration/execution-config">
+  Agent execution configuration options
+</Card>
+<Card title="LLM Context Compression" icon="brain" href="/features/llm-context-compression">
+  LLM-driven message-history compression
+</Card>
+<Card title="Intelligent Conversation Compaction" icon="comments" href="/features/intelligent-conversation-compaction">
+  Smart conversation summarization
+</Card>
+</CardGroup>

--- a/docs/features/context-compaction.mdx
+++ b/docs/features/context-compaction.mdx
@@ -5,6 +5,8 @@ description: "Automatic context window management with anti-injection framing fo
 icon: "compress"
 ---
 
+<Note>Looking for the proactive policy-based system added in PR #1828? See [Context Compaction Policy](/features/context-compaction-policy). This page documents the reactive `CompactionConfig` system used inside `Agent(context=...)`.</Note>
+
 Context compaction automatically manages context window size while preventing models from treating summarized history as active instructions.
 
 ```mermaid
@@ -410,6 +412,31 @@ print(f"Structured template: {config_info['structured_template']}")
 - Test topic changes to verify anti-injection works
 </Accordion>
 </AccordionGroup>
+
+---
+
+## Policy vs. CompactionConfig — which should I use?
+
+```mermaid
+graph TB
+    A[What do you need?] --> B[Overflow prevention<br/>before LLM calls]
+    A --> C[Message-history compaction<br/>after overflow]
+    A --> D[Both systems together]
+    
+    B --> E[ContextCompactionPolicy<br/>via execution=...]
+    C --> F[CompactionConfig<br/>via Agent context=...]
+    D --> G[Both compatible<br/>Execution → Context]
+    
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef policy fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef both fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A decision
+    class E,F policy
+    class G both
+```
+
+**ContextCompactionPolicy** is the proactive gate that runs before LLM calls. **CompactionConfig** runs after when compaction is actually needed. Both are compatible — `execution.context_compaction` is the proactive gate, `Agent(context=...)` runs after.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the new **ContextCompactionPolicy** system introduced in [MervinPraison/PraisonAI#1828](https://github.com/MervinPraison/PraisonAI/pull/1828). The new system provides proactive, policy-based protection against context overflow with token-budget routing.

### Changes Made

- **NEW**: `docs/features/context-compaction-policy.mdx` — Primary documentation page for the new policy system
- **UPDATED**: `docs/features/context-compaction.mdx` — Added cross-references and decision diagram  
- **UPDATED**: `docs/configuration/execution-config.mdx` — Documented new `context_compaction` Union field
- **UPDATED**: `docs.json` — Added new page to State & Sessions group navigation

### Key Features Documented

- **Policy-based routing**: Four routes (FITS, COMPACT_NEEDED, TRUNCATE_TOOLS, COMPACT_THEN_TRUNCATE)
- **Three presets**: CONSERVATIVE_POLICY, BALANCED_POLICY, AGGRESSIVE_POLICY
- **Custom configuration**: Full ContextCompactionPolicy API with model overrides
- **Deprecation handling**: Documents default change from False → True with warning
- **Tool truncation**: Explains proactive tool output truncation (1000 char threshold)
- **YAML/dict support**: Shows serialization for CLI/config files

### Standards Compliance

- ✅ Follows AGENTS.md page structure template exactly
- ✅ Uses standard Mermaid color scheme (#6366F1, #189AB4, #10B981, #F59E0B)
- ✅ Includes required Mintlify components (Steps, AccordionGroup, CardGroup)
- ✅ All code examples use friendly imports (`from praisonaiagents import ...`)
- ✅ Agent-centric Quick Start examples
- ✅ Comprehensive decision diagrams and flow charts
- ✅ Cross-links between related pages

## Test plan

- [x] Verify docs.json is valid JSON
- [x] All file paths and cross-references are correct
- [x] Code examples use proper imports and syntax
- [x] Mermaid diagrams render correctly
- [x] Related section links work properly

🤖 Generated with [Claude Code](https://claude.ai/code)