### PR TITLE
docs: document new ConversationOptimizer class and protocol rename

### DIFF
--- a/docs/features/context-optimizer.mdx
+++ b/docs/features/context-optimizer.mdx
@@ -144,6 +144,81 @@ result, stats = optimizer.optimize(messages, target_tokens=10000)
 
 **Best for**: Long conversations where context continuity matters.
 
+### Conversation
+
+Conversation-aware compaction that preserves topic, goals, decisions, and action items across long sessions.
+
+```python
+from praisonaiagents import Agent, ManagerConfig
+
+agent = Agent(
+    name="Planner",
+    instructions="Help plan products over multi-hour sessions.",
+    context=ManagerConfig(
+        auto_compact=True,
+        strategy="conversation",
+        conversation_compaction=True,
+        conversation_analyzer_strategy="hybrid",
+        conversation_min_compaction_ratio=0.3,
+    ),
+)
+```
+
+**Low-level class usage:**
+
+```python
+from praisonaiagents import ConversationOptimizer
+
+optimizer = ConversationOptimizer(
+    analyzer_strategy="hybrid",
+    preserve_recent=5,
+    min_compaction_ratio=0.3,
+)
+result, stats = optimizer.optimize(messages, target_tokens=4000)
+```
+
+**Configuration Options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `llm_analyze_fn` | `Optional[callable]` | `None` | LLM function for conversation analysis. If `None`, falls back to rule-based analysis. |
+| `min_compaction_ratio` | `float` | `0.3` | Minimum compression ratio to attempt compaction. Below this, falls back to `SmartOptimizer`. |
+| `analyzer_strategy` | `str` | `"hybrid"` | One of `"hybrid"`, `"rule_based"`, `"keyword"`. |
+| `preserve_recent` | `int` | `5` | Number of recent messages to keep intact. |
+| `llm_summarize_fn` | `Optional[callable]` | `None` | LLM function for summarization. |
+
+```mermaid
+graph LR
+    subgraph "Conversation Optimizer"
+        A[📨 Messages] --> B{Compaction Ratio Meaningful?}
+        B -->|No| F[🤖 SmartOptimizer Fallback]
+        B -->|Yes| C[🧠 HybridAnalyzer]
+        C --> D[📝 ConversationContext]
+        D --> E[✅ Compacted Messages]
+        C -.error.-> F
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef fallback fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class A input
+    class B decision
+    class C,D process
+    class E output
+    class F fallback
+```
+
+<Note>
+ConversationOptimizer automatically falls back to `SmartOptimizer` when the compaction ratio is not meaningful (`target_tokens / original_tokens > (1 - min_compaction_ratio)`) or when internal errors occur during compaction. This ensures safe operation while preserving advanced conversation analysis when beneficial.
+</Note>
+
+**Best for**: Multi-hour planning, iterative development, long support sessions where topic/goal continuity matters more than literal message history.
+
+See [Intelligent Conversation Compaction](/features/intelligent-conversation-compaction) for the full conceptual deep-dive.
+
 ### LLM Context Compressor
 
 Advanced LLM-driven compression with session lineage and head/tail protection.

--- a/docs/features/context-strategies.mdx
+++ b/docs/features/context-strategies.mdx
@@ -93,7 +93,7 @@ agents = AgentTeam(
 - **`sliding_window`**: Long conversations where recent context matters most
 - **`prune_tools`**: Tool-heavy agents with large outputs
 - **`summarize`**: When historical context is critical
-- **`conversation`**: Multi-hour planning sessions, iterative development
+- **`conversation`**: Multi-hour planning sessions, iterative development — automatically falls back to `smart` when compaction ratio isn't meaningful, making it safe as a default for long-running agents
 - **`smart`** (recommended): Production use, balances all concerns
 
 ## Overflow Handling

--- a/docs/features/intelligent-conversation-compaction.mdx
+++ b/docs/features/intelligent-conversation-compaction.mdx
@@ -51,6 +51,19 @@ agent.start("Let's design a new product over the next few hours...")
 ```
 </Step>
 
+<Step title="Low-Level Class">
+```python
+from praisonaiagents import ConversationOptimizer
+
+optimizer = ConversationOptimizer(
+    analyzer_strategy="hybrid",
+    preserve_recent=5,
+    min_compaction_ratio=0.3,
+)
+compacted_messages, stats = optimizer.optimize(messages, target_tokens=4000)
+```
+</Step>
+
 <Step title="Direct API for full control">
 ```python
 from praisonaiagents import (
@@ -81,14 +94,14 @@ sequenceDiagram
     participant Agent
     participant ContextManager
     participant HybridAnalyzer
-    participant ConversationCompactor
+    participant ConversationCompactorProtocol
 
     User->>Agent: multi-hour conversation
     Agent->>ContextManager: needs compaction?
     ContextManager->>HybridAnalyzer: analyze_conversation(messages)
     HybridAnalyzer-->>ContextManager: ConversationContext
-    ContextManager->>ConversationCompactor: compact_conversation(messages, context)
-    ConversationCompactor-->>Agent: structured summary + recent messages
+    ContextManager->>ConversationCompactorProtocol: compact_conversation(messages, context)
+    ConversationCompactorProtocol-->>Agent: structured summary + recent messages
     Agent->>User: continues with preserved continuity
 ```
 
@@ -135,6 +148,10 @@ graph TB
 | `original_message_count` | `int` | Messages before compaction |
 | `compacted_message_count` | `int` | Messages after compaction |
 | `compaction_timestamp` | `float` | When compaction occurred |
+
+<Note>
+The protocol classes were renamed in PR #1899 to `ConversationAnalyzerProtocol` and `ConversationCompactorProtocol`. The old unsuffixed names (`ConversationAnalyzer`, `ConversationCompactor`) remain as deprecated backward-compatible aliases.
+</Note>
 
 **`.to_summary_message()` example output:**
 ```


### PR DESCRIPTION
## Summary

This PR implements documentation updates for the restored ConversationOptimizer class and protocol renames from upstream PR #1899. The changes include:

- **New Conversation section in context-optimizer.mdx** with complete parameter table, agent-centric and low-level examples, mermaid diagram, and fallback behavior explanation
- **Low-Level Class step added to intelligent-conversation-compaction.mdx** Quick Start showing direct ConversationOptimizer usage
- **Protocol name updates** throughout to use the new `ConversationAnalyzerProtocol`/`ConversationCompactorProtocol` names with note about backward-compatible aliases
- **Fallback behavior documentation** in context-strategies.mdx explaining automatic fallback to `SmartOptimizer`

## Changes

### docs/features/context-optimizer.mdx
- Added comprehensive `### Conversation` section under "Strategy Reference"
- Includes agent-centric example using ManagerConfig
- Includes low-level class example with ConversationOptimizer
- Complete parameter table with all 5 configuration options
- Mermaid diagram showing optimization flow with fallback behavior
- Note explaining automatic fallback to SmartOptimizer
- Cross-link to intelligent-conversation-compaction.mdx

### docs/features/intelligent-conversation-compaction.mdx
- Added "Low-Level Class" step to Quick Start showing direct ConversationOptimizer usage
- Updated sequence diagram to reference `ConversationCompactorProtocol`
- Added note about protocol rename with backward-compatibility aliases

### docs/features/context-strategies.mdx
- Updated "When to Use Each" section to note conversation strategy's automatic fallback behavior

## Acceptance Criteria

- ✅ `docs/features/context-optimizer.mdx` has a `### Conversation` section under "Strategy Reference"
- ✅ `docs/features/intelligent-conversation-compaction.mdx` Quick Start includes ConversationOptimizer step
- ✅ Protocol references updated to use `*Protocol` names with backward-compat note
- ✅ `docs/features/context-strategies.mdx` notes the automatic fallback behavior
- ✅ All code examples use simple `from praisonaiagents import ...` form
- ✅ Parameter types and defaults match SDK specifications from issue
- ✅ No edits to `docs/concepts/` - all updates are in `docs/features/`

Fixes #534

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for conversation-aware context optimization, including configuration options, usage examples, and workflow visualization.
  * Documented automatic fallback behavior for conversation strategy to ensure safe defaults in long-running agents.
  * Updated low-level integration documentation with new Quick Start examples and compatibility notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->