### PR TITLE
docs: update for PR #1898 — LLM max_iter default 10→20, billing now non-retryable, classify-order fix, legacy method deprecation

### DIFF
--- a/docs/configuration/execution-config.mdx
+++ b/docs/configuration/execution-config.mdx
@@ -101,7 +101,7 @@ config = ExecutionConfig(
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `max_iter` | `int` | `20` | Maximum tool-calling iterations. Now propagated to the `LLM` instance, so it controls every internal loop (previously some loops were hardcoded to 5/10/20/50). LLM-level default when constructed directly is `10`; `ExecutionConfig` default is `20`. |
+| `max_iter` | `int` | `20` | Maximum tool-calling iterations. Now propagated to the `LLM` instance, so it controls every internal loop (previously some loops were hardcoded to 5/10/20/50). Both the `ExecutionConfig` default and the `LLM`-direct-construction default are `20` (aligned as of PR #1898). |
 | `max_rpm` | `int \| None` | `None` | Max requests per minute (rate limit) |
 | `max_execution_time` | `int \| None` | `None` | Max execution time in seconds |
 | `max_retry_limit` | `int` | `2` | Max retries on failure |

--- a/docs/features/llm-error-classification.mdx
+++ b/docs/features/llm-error-classification.mdx
@@ -161,6 +161,12 @@ All LLM failures are classified into these 11 typed categories:
 | `format_error` | `validation error`, `invalid json`, `schema error` | `surface_error` | No |
 | `unknown` | anything else | `retry` for attempt ≤ 2, then `surface_error` | Limited |
 
+As of PR #1898, billing errors are explicitly added to the non-retryable list and are classified **before** rate-limit (so `quota exceeded` no longer double-matches as a rate-limit error). This means a quota-exhausted call now surfaces immediately instead of retrying with backoff.
+
+## Classification Ordering
+
+The order of checks in `classify_error_kind` matters: billing is checked before rate-limit so phrases like `quota exceeded` route to `billing` (non-retryable) instead of `rate_limit` (retryable). Auth is checked before billing so `auth_permanent` takes precedence on invalid API keys.
+
 ## FailoverDecision Structure
 
 Every classification produces a `FailoverDecision` with these fields:
@@ -325,6 +331,30 @@ if error.error_category == "budget":
 # NEW (recommended)  
 if error.error_category == "billing":
     handle_billing_error()
+```
+
+### Migrating from `_classify_error_and_should_retry`
+
+If you previously subclassed `LLM` to override `_classify_error_and_should_retry`, that method now emits a `DeprecationWarning` and delegates to `resolve_failover_decision`. Override `resolve_failover_decision` directly instead — it returns a typed `FailoverDecision` instead of a `(category, retry, delay)` tuple.
+
+```python
+# OLD (deprecated)
+from praisonaiagents import LLM
+
+class MyLLM(LLM):
+    def _classify_error_and_should_retry(self, error, attempt=1):
+        return "rate_limit", True, 5.0
+
+# NEW
+from praisonaiagents import LLM
+from praisonaiagents.errors import FailoverDecision
+
+class MyLLM(LLM):
+    def resolve_failover_decision(self, error, attempt_state):
+        return FailoverDecision(
+            action="retry", reason="rate_limit",
+            backoff_ms=5000, is_retryable=True,
+        )
 ```
 
 ## Best Practices

--- a/docs/sdk/praisonaiagents/config/index.mdx
+++ b/docs/sdk/praisonaiagents/config/index.mdx
@@ -161,7 +161,7 @@ agent = Agent(instructions="...", execution="thorough")
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `max_iter` | `int` | `10` | Maximum iterations |
+| `max_iter` | `int` | `20` | Maximum iterations |
 | `max_retry_limit` | `int` | `3` | Maximum retries on failure |
 | `timeout` | `int` | `None` | Execution timeout in seconds |
 | `code_execution` | `bool` | `False` | Enable code execution |
@@ -174,7 +174,7 @@ agent = Agent(instructions="...", execution="thorough")
 | Preset | Description |
 |--------|-------------|
 | `"fast"` | Quick execution (max_iter=5) |
-| `"balanced"` | Balanced (max_iter=10) |
+| `"balanced"` | Balanced (max_iter=20) |
 | `"thorough"` | Thorough (max_iter=25) |
 
 ---


### PR DESCRIPTION
## Summary

Updates documentation to reflect the four user-facing behavior changes shipped in PR #1898:

1. **LLM.max_iter default changed from 10 → 20** to align with ExecutionConfig default
2. **Billing errors are now non-retryable** in resolve_failover_decision  
3. **classify_error_kind checks billing before rate_limit** so quota exceeded routes correctly
4. **_classify_error_and_should_retry is deprecated** in favor of resolve_failover_decision

## Changes Made

- **docs/configuration/execution-config.mdx**: Updated max_iter description to reflect both ExecutionConfig and LLM defaults are now 20 (aligned as of PR #1898)
- **docs/features/llm-error-classification.mdx**: Added billing classification ordering explanation and migration guide for deprecated method
- **docs/sdk/praisonaiagents/config/index.mdx**: Updated max_iter default from 10→20 and balanced preset description

## Testing

- [x] All documentation follows AGENTS.md standards
- [x] Code examples use friendly import style
- [x] No files modified under docs/concepts/ (human-approved only)
- [x] Examples are copy-paste runnable with correct imports

Fixes #537

🤖 Generated with [Claude Code](https://claude.ai/code)