### PR TITLE
docs: document ToolResolver.resolve(instantiate=True) and cache-hit fix from PR #1858

### DIFF
--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -239,6 +239,8 @@ graph TB
     class A1,A2,A3 answer
 ```
 
+If you need to resolve class tools by name (e.g. from a YAML `tools:` list), call `resolver.resolve("ToolClassName", instantiate=True)` — see [Common Patterns → Resolving Class Tools](#common-patterns) below.
+
 **Example tools.py with functions:**
 ```python
 # tools.py - Plain functions
@@ -276,9 +278,10 @@ class WeatherTool(BaseTool):
 
 ## Configuration Options
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `tools_py_path` | `Optional[str]` | `"tools.py"` | Path to tools.py file to load |
+| Parameter | Where | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `tools_py_path` | `ToolResolver(...)` constructor | `Optional[str]` | `"tools.py"` | Path to the `tools.py` file to load (resolved eagerly against the current working directory). |
+| `instantiate` | `resolver.resolve(name, ...)` | `bool` | `False` | When `True`, class tools (BaseTool subclasses, `langchain_community.tools.*` classes) are instantiated before being returned. Plain function tools are returned as-is. Safe with cache warm-up via `has_tool()` (since [PR #1858](https://github.com/MervinPraison/PraisonAI/pull/1858)). |
 
 ```python
 # Load from non-default path
@@ -333,6 +336,25 @@ tools = resolver.get_local_tool_classes_from_dir("./tools")
 
 print(f"Found {len(tools)} tools from directory")
 print(f"Tool names: {list(tools.keys())}")
+```
+</Tab>
+
+<Tab title="Resolving Class Tools">
+```python
+from praisonaiagents import Agent
+from praisonai.tool_resolver import ToolResolver
+
+# tools.py exports a BaseTool subclass (e.g. CalculatorTool)
+resolver = ToolResolver()
+calc = resolver.resolve("CalculatorTool", instantiate=True)
+
+agent = Agent(
+    name="Math Helper",
+    instructions="Use the calculator to answer math questions",
+    tools=[calc],
+)
+
+agent.start("What is 21 * 2?")
 ```
 </Tab>
 </Tabs>
@@ -419,6 +441,20 @@ tool2 = resolver.resolve("tavily_search")  # Uses cache
 # Clear both caches
 resolver.clear_cache()
 tool3 = resolver.resolve("tavily_search")  # Loads from source again
+```
+
+**Class tools and the cache:** When `tools.py` exports `BaseTool` subclasses (rather than plain functions), pass `instantiate=True` to get a ready-to-use instance back. The cache returns the same instantiation path whether or not `has_tool()` or `validate_yaml_tools()` warmed the cache first — so YAML validation flows that check tools exist before resolving them no longer return uninstantiated classes (fixed in [PR #1858](https://github.com/MervinPraison/PraisonAI/pull/1858)).
+
+```python
+from praisonai.tool_resolver import ToolResolver
+
+resolver = ToolResolver()
+
+# Warming the cache via has_tool() first is safe — the next resolve(instantiate=True)
+# will still hand back an instance, not the raw class.
+if resolver.has_tool("CalculatorTool"):
+    calc = resolver.resolve("CalculatorTool", instantiate=True)
+    # calc is an instance of CalculatorTool, ready to run
 ```
 
 ### Resetting the Default Resolver

--- a/docs/tools/yaml-tools.mdx
+++ b/docs/tools/yaml-tools.mdx
@@ -480,7 +480,7 @@ graph TD
 
 | Method | Description | Thread Safe |
 |--------|-------------|-------------|
-| `resolve(name)` | Resolve single tool name | ✅ |
+| `resolve(name, instantiate=False)` | Resolve single tool name. Pass `instantiate=True` to get an instance of class tools (BaseTool / langchain) instead of the raw class. | ✅ |
 | `resolve_many(names)` | Resolve multiple tool names | ✅ |
 | `list_available()` | List available tools | ✅ |
 | `has_tool(name)` | Check if tool exists | ✅ |


### PR DESCRIPTION
## Summary

Documents the previously undocumented `instantiate=True` parameter on `ToolResolver.resolve()` and the cache fix from [PR #1858](https://github.com/MervinPraison/PraisonAI/pull/1858).

## Changes

### docs/features/tool-resolver.mdx
- **Caching Behaviour section**: Added documentation for class tools with cache, explaining that `has_tool()` followed by `resolve(..., instantiate=True)` now works correctly
- **Common Patterns tabs**: Added new "Resolving Class Tools" tab with agent-centric example
- **Configuration Options**: Updated table to include both constructor and method parameters, documenting `instantiate` parameter
- **Two Flavours section**: Added pointer to the new tab for users needing to resolve class tools by name

### docs/tools/yaml-tools.mdx  
- **ToolResolver Class table**: Updated `resolve(name)` method signature to `resolve(name, instantiate=False)` with description

## Technical Details

The `instantiate=True` parameter allows users to get ready-to-use instances of BaseTool subclasses instead of raw classes. PR #1858 fixed a bug where the cache fast-path would return uninstantiated classes even when `instantiate=True` was specified, if `has_tool()` had warmed the cache first.

## Testing

All code examples follow the agent-centric approach and use correct import paths. Examples are minimal and copy-paste runnable.

Fixes #543

Generated with [Claude Code](https://claude.ai/code)