### PR TITLE
docs: cover wrapper-layer architectural fixes from PraisonAI PR #1891

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -637,6 +637,7 @@
                   "docs/features/registry-dependency-injection",
                   "docs/features/persistence-backend-plugins",
                   "docs/features/integration-registry",
+                  "docs/features/endpoint-provider-registry",
                   "docs/features/observability-hooks",
                   "docs/features/agent-server",
                   "docs/features/agent-profiles",

--- a/docs/deploy/scheduler-deploy.mdx
+++ b/docs/deploy/scheduler-deploy.mdx
@@ -96,6 +96,98 @@ scheduler.set_deployer(MyCustomDeployer())
 scheduler.stop()
 ```
 
+---
+
+## Async API
+
+Use async methods for non-blocking daemon shutdown and retry-with-backoff deployment from async contexts like FastAPI routes or MCP tools.
+
+```mermaid
+graph TB
+    Start{Calling from…} -->|Sync code / CLI| Sync[stop_daemon / deploy_with_retry]
+    Start -->|async function / FastAPI route / MCP tool| Async[astop_daemon / adeploy_with_retry]
+
+    Sync --> S1[Blocks current thread]
+    Async --> A1[Cooperative — event loop stays free]
+
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef sync fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef async fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Start start
+    class Sync,S1 sync
+    class Async,A1 async
+```
+
+### DaemonManager.astop_daemon()
+
+**Signature:** `async def astop_daemon(pid, timeout=10) -> bool`
+
+Async variant of `stop_daemon`. Uses `asyncio.sleep` (cooperative) instead of `time.sleep` (blocking). Same SIGTERM → wait → SIGKILL escalation, with `timeout` seconds between SIGTERM and SIGKILL.
+
+### DeploymentScheduler.adeploy_with_retry()
+
+**Signature:** `async def adeploy_with_retry(max_retries=3) -> bool`
+
+Async variant of the retry-with-backoff path. Runs each blocking `deployer.deploy()` call via `asyncio.to_thread(...)` so it never blocks the event loop, and sleeps 30s between retries via `asyncio.sleep`.
+
+### Quick Start Example
+
+```python
+import asyncio
+from praisonai.scheduler.daemon_manager import DaemonManager
+from praisonai.scheduler.deployment import DeploymentScheduler
+
+async def main():
+    # Stop a daemon without blocking the event loop
+    manager = DaemonManager()
+    stopped = await manager.astop_daemon(pid=12345, timeout=10)
+
+    # Deploy with cooperative retries
+    scheduler = DeploymentScheduler()
+    deployed = await scheduler.adeploy_with_retry(max_retries=3)
+
+asyncio.run(main())
+```
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant Caller as Async caller
+    participant DM as DaemonManager
+    participant OS
+
+    Caller->>DM: await astop_daemon(pid, timeout=10)
+    DM->>OS: SIGTERM pid
+    loop up to timeout*10 ticks
+        DM->>OS: kill -0 pid
+        OS-->>DM: alive
+        DM->>DM: await asyncio.sleep(0.1)
+    end
+    DM->>OS: SIGKILL pid
+    DM->>DM: await asyncio.sleep(0.2)
+    DM-->>Caller: True
+```
+
+### Best Practices
+
+<AccordionGroup>
+<Accordion title="In any async def context, prefer a* variants">
+Sync versions will block the event loop for up to `timeout` seconds. Use async variants to keep the event loop responsive.
+</Accordion>
+
+<Accordion title="Don't mix">
+Calling `stop_daemon` from inside `asyncio.run(...)` freezes the loop; calling `astop_daemon` from sync code requires `asyncio.run(...)` wrapper.
+</Accordion>
+
+<Accordion title="CLI path stays sync">
+`praisonai schedule stop` continues to use the sync method, unchanged for backward compatibility.
+</Accordion>
+</AccordionGroup>
+
+---
+
 **Sequence Diagram:**
 
 ```mermaid

--- a/docs/features/endpoint-provider-registry.mdx
+++ b/docs/features/endpoint-provider-registry.mdx
@@ -1,0 +1,250 @@
+---
+title: "Endpoint Provider Registry"
+sidebarTitle: "Endpoint Providers"
+description: "Plug custom endpoint providers (A2A, MCP, recipe, agents-api…) into PraisonAI via Python entry points"
+icon: "plug"
+---
+
+Endpoint Provider Registry lets you add custom server-side endpoint providers (recipe, agents-api, MCP, tools-MCP, A2A, A2U, or your own) to PraisonAI through entry points — no fork required.
+
+```mermaid
+graph LR
+    A[📦 Your pip package] --> B[🔌 Entry Point\npraisonai.endpoint_providers]
+    B --> C[📝 ProviderRegistry]
+    C --> D[🚀 praisonai serve / discovery]
+
+    classDef package fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef entrypoint fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef registry fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef serve fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A package
+    class B entrypoint
+    class C registry
+    class D serve
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Use a built-in provider">
+Minimal usage with a built-in provider:
+
+```python
+from praisonai.endpoints.registry import get_provider
+
+provider = get_provider("recipe", base_url="http://localhost:8765")
+```
+</Step>
+
+<Step title="Register at runtime">
+Register a custom provider without creating a pip package:
+
+```python
+from praisonai.endpoints.registry import register_provider
+from praisonai.endpoints.providers.base import BaseProvider
+
+class MyCustomProvider(BaseProvider):
+    def __init__(self, base_url, api_key=None, **kwargs):
+        self.base_url = base_url
+        self.api_key = api_key
+
+register_provider("my-custom", MyCustomProvider)
+```
+</Step>
+
+<Step title="Distribute as a pip plugin">
+The recommended approach for distributable packages:
+
+```toml
+# pyproject.toml of your package
+[project.entry-points."praisonai.endpoint_providers"]
+my-custom = "mypkg.endpoints:MyCustomProvider"
+```
+
+```bash
+pip install my-praisonai-endpoint
+```
+
+```python
+# Now anyone with your package installed gets:
+from praisonai.endpoints.registry import get_provider
+provider = get_provider("my-custom", base_url="http://localhost:8765")
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant API as get_provider("my-custom", …)
+    participant Reg as ProviderRegistry
+    participant EP as importlib.metadata entry_points
+    participant Cls as MyCustomProvider
+
+    User->>API: get_provider("my-custom", base_url, api_key, **kw)
+    API->>Reg: resolve("my-custom")
+    Reg->>EP: load praisonai.endpoint_providers
+    EP-->>Reg: MyCustomProvider class
+    Reg-->>API: class
+    API->>Cls: __init__(base_url=…, api_key=…, **kw)
+    Cls-->>User: provider instance
+```
+
+The registry is thread-safe and loads plugins lazily. Built-ins are discovered on first access, entry points are loaded when needed, and aliases are case-insensitive. The singleton registry is obtained via `get_default_registry()`.
+
+---
+
+## Configuration / API
+
+### Functions
+
+| Function / Method | Signature | Description |
+|---|---|---|
+| `register_provider(type, cls)` | `(str, Type[BaseProvider]) -> None` | Backwards-compat module function; delegates to `get_default_registry().register(...)` |
+| `get_provider(type, base_url, api_key, **kw)` | `(str, str, Optional[str], **Any) -> Optional[BaseProvider]` | Resolve + instantiate; returns `None` for unknown type; raises if loader fails |
+| `list_provider_types()` | `() -> List[str]` | List registered + entry-point + built-in types |
+| `get_provider_class(type)` | `(str) -> Optional[Type[BaseProvider]]` | Returns the class without instantiating |
+| `get_default_registry()` | `() -> ProviderRegistry` | Thread-safe singleton accessor |
+
+### ProviderRegistry Class
+
+| Method | Signature | Description |
+|---|---|---|
+| `ProviderRegistry.get(type, base_url, api_key, **kw)` | identical to `get_provider` | OOP-style interface |
+| `ProviderRegistry.list_types()` | `() -> List[str]` | Back-compat alias for `list_names()` |
+| `ProviderRegistry.get_class(type)` | `(str) -> Optional[Type]` | Back-compat alias for `resolve()` |
+
+### Built-in Provider Types
+
+| Type | Loaded From | Purpose |
+|---|---|---|
+| `recipe` | `endpoints/providers/recipe.py` | Recipe runner endpoint |
+| `agents-api` | `endpoints/providers/agents_api.py` | OpenAI Agents-API compatible endpoint |
+| `mcp` | `endpoints/providers/mcp.py` | MCP server endpoint |
+| `tools-mcp` | `endpoints/providers/tools_mcp.py` | MCP tools-only endpoint |
+| `a2a` | `endpoints/providers/a2a.py` | A2A protocol endpoint |
+| `a2u` | `endpoints/providers/a2u.py` | A2U protocol endpoint |
+
+---
+
+## Common Patterns
+
+<AccordionGroup>
+<Accordion title="Override a Built-in">
+Last-write-wins behavior lets you replace built-in providers:
+
+```python
+from praisonai.endpoints.registry import register_provider
+from praisonai.endpoints.providers.base import BaseProvider
+
+class MyRecipeProvider(BaseProvider):
+    def __init__(self, base_url, api_key=None, **kwargs):
+        # Custom implementation
+        pass
+
+# Override built-in recipe provider
+register_provider("recipe", MyRecipeProvider)
+```
+</Accordion>
+
+<Accordion title="Multiple Aliases">
+Use the underlying PluginRegistry for alias support:
+
+```python
+from praisonai.endpoints.registry import get_default_registry
+
+registry = get_default_registry()
+registry.register_lazy("my-provider", lambda: MyProvider, aliases=["mp", "custom"])
+```
+</Accordion>
+
+<Accordion title="Per-tenant Isolation">
+Instantiate `ProviderRegistry` directly for isolation:
+
+```python
+from praisonai.endpoints.registry import ProviderRegistry
+
+# Tenant-specific registry
+tenant_registry = ProviderRegistry()
+tenant_registry.register("custom", TenantProvider)
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Always provide a _loader() function">
+Never import your provider class at module top-level — defeats lazy loading and breaks the no-heavy-deps-at-import-time guarantee:
+
+```python
+# Good - lazy loader
+def _load_my_provider():
+    from .heavy_dependency import MyProvider
+    return MyProvider
+
+# Bad - top-level import
+from .heavy_dependency import MyProvider  # Loaded immediately!
+```
+</Accordion>
+
+<Accordion title="Subclass BaseProvider">
+Required for type compatibility and consistent API:
+
+```python
+from praisonai.endpoints.providers.base import BaseProvider
+
+class MyProvider(BaseProvider):
+    def __init__(self, base_url, api_key=None, **kwargs):
+        super().__init__(base_url, api_key, **kwargs)
+```
+</Accordion>
+
+<Accordion title="Distinguish missing vs import failure">
+`get_provider("unknown")` returns `None`, but import failures propagate:
+
+```python
+provider = get_provider("unknown")
+if provider is None:
+    print("Provider type not registered")
+    
+try:
+    provider = get_provider("registered-but-missing-deps")
+except ValueError as e:
+    print(f"Provider exists but dependencies missing: {e}")
+```
+</Accordion>
+
+<Accordion title="Prefer entry points for distributable packages">
+Use `pyproject.toml` entry points instead of `register_provider()` calls:
+
+```toml
+# Preferred - discoverable via pip install
+[project.entry-points."praisonai.endpoint_providers"]
+my-provider = "my_package.providers:MyProvider"
+
+# Avoid - requires explicit registration
+# register_provider("my-provider", MyProvider)
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Integration Registry" icon="puzzle-piece" href="/docs/features/integration-registry">
+  The sibling plugin registry for CLI tools / managed agents
+</Card>
+<Card title="Framework Adapter Plugins" icon="code" href="/docs/features/framework-adapter-plugins">
+  Third sibling plugin registry, for framework adapters
+</Card>
+</CardGroup>

--- a/docs/features/lazy-imports.mdx
+++ b/docs/features/lazy-imports.mdx
@@ -38,6 +38,34 @@ The following dependencies are NOT loaded at import time:
 - **chromadb** - Only loaded when vector stores are used
 - **mem0** - Only loaded when memory features are used
 
+### Training & Vision Module Lazy Loading
+
+Modules affected: `praisonai.train.llm.trainer` (the `TrainModel` class) and `praisonai.upload_vision` (the `UploadVisionModel` class) now use lazy loading to defer heavy ML dependencies.
+
+These modules use a `_lazy_import_*_deps()` helper called from `__init__`, mirroring `train.py` / `train_vision.py` patterns.
+
+**Dependencies deferred:**
+- **torch** - CUDA/GPU computation framework
+- **transformers** (`TextStreamer`, `TrainingArguments`) - Hugging Face transformers
+- **unsloth** (`FastLanguageModel`, `FastVisionModel`, `is_bfloat16_supported`, `standardize_sharegpt`, `get_chat_template`) - Fast training optimization
+- **trl** (`SFTTrainer`) - Transformer Reinforcement Learning
+- **datasets** (`load_dataset`, `concatenate_datasets`) - Dataset loading utilities
+- **psutil** (`virtual_memory`) - System memory monitoring
+
+**Impact:** Importing `praisonai.upload_vision` or `praisonai.train.llm.trainer` is now near-instant; CUDA / ~2 GB of ML libs only load when you instantiate `UploadVisionModel(...)` or `TrainModel(...)`.
+
+```python
+# Fast — no torch/unsloth load
+from praisonai.upload_vision import UploadVisionModel
+
+# Heavy deps load here, not at import time
+uploader = UploadVisionModel(config_path="config.yaml")
+```
+
+ImportError messages now include install hints:
+- Vision upload: `pip install torch unsloth`
+- Training: `pip install torch transformers unsloth datasets trl psutil`
+
 ## Verifying Lazy Imports
 
 You can verify lazy imports are working:
@@ -52,6 +80,11 @@ import praisonaiagents
 assert 'litellm' not in sys.modules
 assert 'requests' not in sys.modules
 assert 'chromadb' not in sys.modules
+
+# Check training/vision modules are lazy loaded
+from praisonai.upload_vision import UploadVisionModel  # noqa
+assert "torch" not in sys.modules
+assert "unsloth" not in sys.modules
 
 print("✓ All heavy dependencies are lazy loaded")
 ```


### PR DESCRIPTION
Fixes #541

This PR documents the wrapper-layer architectural fixes from PraisonAI PR #1891:

## Changes

### 1. Created docs/features/endpoint-provider-registry.mdx
- Documents the new entry-point-based endpoint provider registry
- Explains how to register custom endpoint providers via pip packages
- Follows AGENTS.md structure with hero Mermaid diagram, Quick Start steps, API documentation
- Includes common patterns and best practices for plugin development

### 2. Updated docs/features/lazy-imports.mdx
- Added Training & Vision Module Lazy Loading section
- Documents lazy loading in praisonai.train.llm.trainer and praisonai.upload_vision
- Lists deferred dependencies (torch, transformers, unsloth, trl, datasets, psutil)
- Includes verification examples for the new lazy imports

### 3. Updated docs/deploy/scheduler-deploy.mdx
- Added Async API section with new async methods
- Documents DaemonManager.astop_daemon() and DeploymentScheduler.adeploy_with_retry()
- Includes decision diagram, sequence diagrams, and best practices
- Provides runnable async code examples

### 4. Updated docs.json
- Added endpoint-provider-registry page to Features group
- Validated JSON syntax

All documentation follows AGENTS.md standards with proper Mermaid diagrams using the specified color scheme, Mintlify components, and agent-centric examples.

Generated with Claude Code