### PR TITLE
docs: Update for PR #1857 — wrapper layer cleanup (unified tool resolution, scheduler parity, framework adapter dedup)

### DIFF
--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -288,6 +288,8 @@ praisonai
 | `praisonai chat` / `-i` | flag | Interactive TUI mode |
 | `praisonai chat` | flag | Single prompt chat mode |
 
+**Note on `--tools`:** Comma-separated tool names (e.g., `--tools tavily_search,my_tool`) are now resolved via the unified [ToolResolver](/docs/features/tool-resolver), so any tool reachable from YAML is also reachable from the CLI.
+
 ## SDK Module Reference
 
 ### praisonaiagents (Core SDK)

--- a/docs/cli/scheduler.mdx
+++ b/docs/cli/scheduler.mdx
@@ -127,6 +127,7 @@ praisonai schedule delete news-bot
 praisonai schedule describe <name>
 
 # Shows: PID, status, uptime, executions, cost, config, logs path
+# Note: Async daemons (schedule start) now correctly persist executions and cost to disk (PR #1857)
 ```
 
 ## Legacy Foreground Mode
@@ -491,20 +492,23 @@ scheduler = AgentScheduler(
 
 **Python API (AsyncAgentScheduler):**
 ```python
-stats = await scheduler.get_stats()
+stats = await scheduler.get_stats_async()
 # Returns:
 {
     "is_running": True,
-    "execution_count": 10,
-    "success_count": 9,
-    "failure_count": 1,
-    "agent_name": "NewsChecker",
-    "task": "Check the latest AI news"
+    "total_executions": 10,
+    "successful_executions": 9,
+    "failed_executions": 1,
+    "success_rate": 90.0,
+    "total_cost_usd": 0.0234,
+    "remaining_budget": 0.9766,
+    "runtime_seconds": 3601.5,
+    "cost_per_execution": 0.0023,
 }
 ```
 
 <Note>
-**API Change:** The AsyncAgentScheduler uses simplified stats keys (`execution_count`, `success_count`, `failure_count`) and does not track cost or runtime metrics directly. Cost and runtime tracking may be handled by other system layers.
+**Stats parity (PR #1857):** Both `AgentScheduler` and `AsyncAgentScheduler` now return the same stats shape via a shared `_BaseAgentScheduler._build_stats()` helper. Keys: `is_running`, `total_executions`, `successful_executions`, `failed_executions`, `success_rate`, `total_cost_usd`, `remaining_budget`, `runtime_seconds`, `cost_per_execution`. Use `await scheduler.get_stats_async()` in async code, `scheduler.get_stats()` in sync code.
 </Note>
 # On stop (Ctrl+C)
 🛑 Stopping scheduler...

--- a/docs/cli/tools-resolve.mdx
+++ b/docs/cli/tools-resolve.mdx
@@ -42,4 +42,6 @@ tools = resolve_tools(["my_custom_tool"], registry=registry)
 
 <Note>
 **Alternative Tool Resolution:** For YAML-based tool resolution with per-agent isolation, see [YAML Tools - Tool Resolver](/docs/tools/yaml-tools#per-agent-tool-resolution) which uses the `praisonai.tool_resolver` module. The API documented on this page uses `praisonai.templates.tool_override` for template-based tool overrides.
+
+**CLI flag (`--tools name1,name2`)** also now goes through `praisonai.tool_resolver.ToolResolver` (PR #1857). See [Tool Resolver](/docs/features/tool-resolver) for the canonical 5-source chain.
 </Note>

--- a/docs/features/async-agent-scheduler.mdx
+++ b/docs/features/async-agent-scheduler.mdx
@@ -104,34 +104,20 @@ asyncio.run(main())
 ```
 </Step>
 
-<<<<<<< HEAD
 <Step title="With Timeout & Budget Limit">
 ```python
 import asyncio
 from praisonaiagents import Agent
-from praisonai.async_agent_scheduler import AsyncAgentScheduler
+from praisonai.scheduler import AsyncAgentScheduler
 
 async def main():
     agent = Agent(
         name="CostAwareAgent",
         instructions="Summarise the latest tech headlines.",
-=======
-<Step title="With Custom Configuration">
-```python
-import asyncio
-from praisonaiagents import Agent
-from praisonai.scheduler.async_agent_scheduler import AsyncAgentScheduler
-
-async def main():
-    agent = Agent(
-        name="DataProcessor",
-        instructions="Process and analyze market data efficiently.",
->>>>>>> origin/main
     )
 
     scheduler = AsyncAgentScheduler(
         agent,
-<<<<<<< HEAD
         task="Summarise tech news",
         timeout=30,        # stop a single run after 30s
         max_cost=1.00,     # auto-shutdown once $1.00 spent
@@ -142,21 +128,6 @@ async def main():
     stats = await scheduler.get_stats_async()
     print(f"Spent ${stats['total_cost_usd']}, remaining ${stats['remaining_budget']}")
     await scheduler.stop()
-=======
-        task="Check the latest AI news",
-        config={"retry_backoff": True},
-        on_success=lambda result: print(f"Success: {result}"),
-        on_failure=lambda error: print(f"Failed: {error}"),
-    )
-    await scheduler.start("hourly", max_retries=3, run_immediately=True)
-
-    # ... run your app ...
-
-    await scheduler.stop()
-    stats = await scheduler.get_stats()
-    print(f"Total executions: {stats['total_executions']}")
-    print(f"Success rate: {stats['success_rate']:.1f}%")
->>>>>>> origin/main
 
 asyncio.run(main())
 ```
@@ -274,8 +245,12 @@ Statistics can be read in both sync and async contexts with different guarantees
 | `successful_executions` | `int` | Number of successful executions |
 | `failed_executions` | `int` | Number of failed executions |
 | `success_rate` | `float` | Success percentage (0-100) |
-| `total_cost_usd` | `float` | **NEW** — Running total cost in USD (4 dp) |
-| `remaining_budget` | `float \| None` | **NEW** — `max_cost - total_cost_usd`, or `None` if `max_cost` is disabled |
+| `total_cost_usd` | `float` | Running total cost in USD (4 dp) |
+| `remaining_budget` | `float \| None` | `max_cost - total_cost_usd`, or `None` if `max_cost` is disabled |
+| `runtime_seconds` | `float` | **NEW (PR #1857)** — Seconds since `start()` was called. `0` when scheduler hasn't started. |
+| `cost_per_execution` | `float` | **NEW (PR #1857)** — `total_cost_usd / total_executions`, rounded to 4 dp. `0` when no executions yet. |
+
+Since [PR #1857](https://github.com/MervinPraison/PraisonAI/pull/1857), `AsyncAgentScheduler` shares its stats builder with the sync `AgentScheduler` via the internal `_BaseAgentScheduler` mixin — the schema is now identical across sync and async.
 
 ---
 
@@ -385,7 +360,7 @@ asyncio.run(main())
 ```python
 import asyncio
 from praisonaiagents import Agent
-from praisonai.async_agent_scheduler import AsyncAgentScheduler
+from praisonai.scheduler import AsyncAgentScheduler
 
 async def main():
     agent = Agent(name="ReportAgent", instructions="Generate hourly report")
@@ -427,6 +402,12 @@ graph TB
     class Stop,Halt stop
     class Run,AddCost,NextLoop run
 ```
+
+---
+
+### Daemon state persistence
+
+When `AsyncAgentScheduler` runs as a daemon (started via `praisonai schedule start <name> ...`), it now updates `~/.praisonai/schedulers/<name>.json` after every execution with the current `executions` count and `cost`. The file I/O is offloaded with `asyncio.to_thread()` so the event loop is never blocked. Previously these writes were a TODO and async daemons silently reported stale numbers. See [PR #1857](https://github.com/MervinPraison/PraisonAI/pull/1857).
 
 ---
 
@@ -533,7 +514,7 @@ scheduler = AsyncAgentScheduler(
 **Import paths (updated in PR #1723):**
 - **Canonical (recommended):** `from praisonai.scheduler import AsyncAgentScheduler`
 - **Explicit module path:** `from praisonai.scheduler.async_agent_scheduler import AsyncAgentScheduler`
-- **Deprecated** (still works, emits `DeprecationWarning`): `from praisonai.async_agent_scheduler import AsyncAgentScheduler`
+- **Deprecated** (still works, emits `DeprecationWarning`): `from praisonai.scheduler import AsyncAgentScheduler`
 
 The sync `AgentScheduler` is unchanged: `from praisonai.scheduler import AgentScheduler`.
 </Note>

--- a/docs/features/async-scheduler.mdx
+++ b/docs/features/async-scheduler.mdx
@@ -36,10 +36,7 @@ Create and start an async scheduler with basic configuration.
 ```python
 import asyncio
 from praisonaiagents import Agent
-from praisonai.async_agent_scheduler import AsyncAgentScheduler
-
-# Migration note: this import will move to praisonai.scheduler.async_agent_scheduler
-# See import paths section below
+from praisonai.scheduler import AsyncAgentScheduler
 
 async def main():
     agent = Agent(
@@ -68,7 +65,7 @@ Add success/failure callbacks and custom configuration.
 ```python
 import asyncio
 from praisonaiagents import Agent
-from praisonai.async_agent_scheduler import AsyncAgentScheduler
+from praisonai.scheduler import AsyncAgentScheduler
 
 def success_callback(result):
     print(f"✅ Success: {result}")
@@ -108,7 +105,7 @@ Control execution time and budget with built-in enforcement.
 ```python
 import asyncio
 from praisonaiagents import Agent
-from praisonai.async_agent_scheduler import AsyncAgentScheduler
+from praisonai.scheduler import AsyncAgentScheduler
 
 async def main():
     agent = Agent(
@@ -205,8 +202,10 @@ sequenceDiagram
 | `successful_executions` | `int` | Number of successful executions |
 | `failed_executions` | `int` | Number of failed executions |
 | `success_rate` | `float` | Success percentage (0-100) |
-| `total_cost_usd` | `float` | **NEW** — Running total cost in USD (4 dp) |
-| `remaining_budget` | `float \| None` | **NEW** — `max_cost - total_cost_usd`, or `None` if `max_cost` is disabled |
+| `total_cost_usd` | `float` | Running total cost in USD (4 dp) |
+| `remaining_budget` | `float \| None` | `max_cost - total_cost_usd`, or `None` if `max_cost` is disabled |
+| `runtime_seconds` | `float` | **NEW (PR #1857)** — Seconds since `start()` was called. `0` when scheduler hasn't started. |
+| `cost_per_execution` | `float` | **NEW (PR #1857)** — `total_cost_usd / total_executions`, rounded to 4 dp. `0` when no executions yet. |
 
 ---
 
@@ -261,7 +260,7 @@ async def graceful_shutdown():
 ```python
 import asyncio
 from praisonaiagents import Agent
-from praisonai.async_agent_scheduler import AsyncAgentScheduler
+from praisonai.scheduler import AsyncAgentScheduler
 
 async def main():
     agent = Agent(name="ReportAgent", instructions="Generate hourly report")
@@ -403,7 +402,7 @@ scheduler = AsyncAgentScheduler(
 
 <Note>
 **Import paths (PR #1552):**
-- **Pending deprecation** (still works, emits `PendingDeprecationWarning` — will move to `praisonai.scheduler.async_agent_scheduler` in a future release): `from praisonai.async_agent_scheduler import AsyncAgentScheduler`
+- **Pending deprecation** (still works, emits `PendingDeprecationWarning` — will move to `praisonai.scheduler.async_agent_scheduler` in a future release): `from praisonai.scheduler import AsyncAgentScheduler`
 - **Canonical:** `from praisonai.scheduler import AgentScheduler` (sync scheduler)
 - **Deprecated** (still works, emits `DeprecationWarning`): `from praisonai.agent_scheduler import AgentScheduler`
 

--- a/docs/features/framework-adapter-plugins.mdx
+++ b/docs/features/framework-adapter-plugins.mdx
@@ -151,6 +151,8 @@ Framework adapters must implement the `FrameworkAdapter` protocol:
 | `run(config, llm_config, topic)` | ✅ | Execute framework logic |
 | `cleanup()` | ✅ | Clean up resources |
 
+**Single authoritative `arun()` (PR #1857):** The Protocol declares `arun()` once; `BaseFrameworkAdapter` provides a single default that offloads `run()` to a worker thread via `asyncio.to_thread`. Sync-only adapters (crewai, autogen v0.2) inherit this and need do nothing. Native-async adapters override `arun()`. Earlier revisions of the codebase declared `arun()` twice on both the Protocol and the base class; those duplicate declarations have been removed and there is now exactly one default to override.
+
 ### Optional Adapter Hooks
 
 After the existing "Adapter protocol" section, two new optional methods were added in PR #1763:

--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -94,6 +94,8 @@ graph TB
     class NotFound notfound
 ```
 
+CLI, YAML, and Python all share this resolution chain. See [CLI Reference](/docs/cli/cli-reference) for `--tools` usage.
+
 ---
 
 ## Registering Tools at Runtime
@@ -161,6 +163,10 @@ The resolver delegates to `_safe_loader.load_user_module` for consistent environ
 The wrapper now invokes `resolve()` once per YAML-referenced tool name, with results cached via the resolve cache to avoid repeated lookups.
 
 Directory mode iterates each `.py` file and unions the results using the same security gates and extraction logic.
+
+### CLI uses the same resolver (PR #1857)
+
+`praisonai --tools tavily_search,my_tool "..."` now goes through `ToolResolver.resolve(name, instantiate=True)`, identical to the YAML path. The CLI `_load_tools()` helper used to call `getattr(praisonaiagents.tools, name)` directly, which skipped the wrapper `ToolRegistry`, the optional `praisonai-tools` package, and core SDK plugin sources. Those sources are now reachable from the CLI.
 
 ---
 


### PR DESCRIPTION
Updates documentation to reflect changes from PraisonAI PR [#1857](https://github.com/MervinPraison/PraisonAI/pull/1857) which implemented wrapper layer cleanup.

## Changes Made

### Git Merge Conflict Resolution
- Fixed production merge conflicts in `docs/features/async-agent-scheduler.mdx`
- Kept HEAD side (timeout & budget example) as instructed
- Updated import to canonical `from praisonai.scheduler import AsyncAgentScheduler`

### Stats Schema Updates
- Added new fields `runtime_seconds` and `cost_per_execution` to async scheduler documentation
- Removed factually incorrect note about AsyncAgentScheduler having "simplified stats keys"
- Updated Python API examples to show unified 9-field stats schema
- Added note about shared `_BaseAgentScheduler` mixin providing parity

### CLI Tool Resolution
- Documented that `--tools` flag now uses unified `ToolResolver`
- Added notes that CLI, YAML, and Python share the same 5-source resolution chain
- Updated CLI reference with link to Tool Resolver documentation

### Framework Adapter Changes
- Added paragraph explaining single authoritative `arun()` method
- Clarified sync-only vs native-async adapter override patterns

### Daemon State Persistence
- Added section documenting async daemon state persistence fixes
- Noted that `asyncio.to_thread` prevents event loop blocking

### Import Updates
- Updated all deprecated `from praisonai.async_agent_scheduler` imports to canonical `from praisonai.scheduler`

## Files Modified
- `docs/features/async-agent-scheduler.mdx` - Conflict resolution, stats schema, daemon section
- `docs/cli/scheduler.mdx` - Corrected stats schema and example
- `docs/features/async-scheduler.mdx` - Stats schema and canonical imports
- `docs/features/tool-resolver.mdx` - CLI usage documentation
- `docs/cli/cli-reference.mdx` - `--tools` flag clarification
- `docs/cli/tools-resolve.mdx` - CLI resolver cross-reference
- `docs/features/framework-adapter-plugins.mdx` - `arun()` method clarification

Closes #538

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: Mervin Praison <MervinPraison@users.noreply.github.com>