### PR TITLE
docs: clarify YAML llm/function_calling_llm accept string + dict forms across all framework adapters

### DIFF
--- a/docs/features/yaml-configuration-reference.mdx
+++ b/docs/features/yaml-configuration-reference.mdx
@@ -187,8 +187,8 @@ All recognized field names for agents in both `agents:` and `roles:` sections:
 | `backstory` | string | Personality/background context |
 | `tools` | array | List of tool names |
 | `tasks` | object | Nested task definitions (legacy) |
-| `llm` | string | Model to use |
-| `function_calling_llm` | string | Model for tool calls |
+| `llm` | string \| dict | Model to use |
+| `function_calling_llm` | string \| dict | Model for tool calls |
 | `allow_delegation` | bool | Allow task delegation |
 | `max_iter` | int | Maximum iterations |
 | `max_rpm` | int | Max requests per minute |
@@ -440,14 +440,45 @@ graph LR
   </Accordion>
 
   <Accordion title="LLM Configuration" icon="brain">
-    | Field | Default | Description |
-    |-------|---------|-------------|
-    | `llm` | `gpt-4o-mini` | Model to use |
-    | `function_calling_llm` | Same as `llm` | Model for tool calls |
-    | `reflect_llm` | Same as `llm` | Model for self-reflection |
-    | `system_template` | - | Custom system prompt |
-    | `prompt_template` | - | Custom prompt template |
-    | `response_template` | - | Custom response template |
+    | Field | Type | Default | Description |
+    |-------|------|---------|-------------|
+    | `llm` | string \| dict | `gpt-4o-mini` | Model to use |
+    | `function_calling_llm` | string \| dict | Same as `llm` | Model for tool calls |
+    | `reflect_llm` | string \| dict | Same as `llm` | Model for self-reflection |
+    | `system_template` | string | - | Custom system prompt |
+    | `prompt_template` | string | - | Custom prompt template |
+    | `response_template` | string | - | Custom response template |
+
+Both `llm` and `function_calling_llm` accept a model name as a **string**, or a **dict** when you also need to override `base_url` / `api_key`. Both shapes work identically across every supported framework (`praisonai`, `crewai`, `autogen`, `autogen_v4`).
+
+<Tabs>
+<Tab title="String form (simplest)">
+```yaml
+agents:
+  writer:
+    role: Writer
+    llm: gpt-4o-mini
+    function_calling_llm: gpt-4o-mini
+```
+</Tab>
+<Tab title="Dict form (when overriding endpoint / key)">
+```yaml
+agents:
+  writer:
+    role: Writer
+    llm:
+      model: gpt-4o-mini
+      base_url: https://my-proxy.example.com/v1
+      api_key: sk-...
+    function_calling_llm:
+      model: gpt-4o-mini
+```
+</Tab>
+</Tabs>
+
+<Note>
+If `llm` is omitted, PraisonAI falls back to the `MODEL_NAME` environment variable, then to `openai/gpt-4o-mini`. This fallback is shared by every framework adapter.
+</Note>
   </Accordion>
 
   <Accordion title="Rate Limiting & Execution" icon="clock">
@@ -807,6 +838,10 @@ What works where:
 <Check>
 **Full Feature Parity!** Both file formats support all features. The only difference is naming conventions.
 </Check>
+
+<Note>
+**Framework LLM Configuration Parity:** The `llm` and `function_calling_llm` configuration shapes (string and dict forms) work identically across all supported frameworks (`praisonai`, `crewai`, `autogen`, `autogen_v4`). You can switch between frameworks without changing your LLM configuration syntax.
+</Note>
 
 ---
 


### PR DESCRIPTION
Fixes #554

## Summary

Updates docs/features/yaml-configuration-reference.mdx to document that both llm and function_calling_llm fields now accept string and dict forms consistently across all framework adapters (praisonai, crewai, autogen, autogen_v4).

## Changes Made

- **Updated type columns** in both "Recognized Fields" and "LLM Configuration" tables from string to string | dict
- **Added tabbed examples** showing both string form (llm: gpt-4o-mini) and dict form (llm: {model: gpt-4o-mini, base_url: ..., api_key: ...})
- **Added fallback note** documenting the MODEL_NAME → openai/gpt-4o-mini fallback chain
- **Added cross-framework parity note** in Feature Compatibility Matrix section explaining that LLM configuration shapes work identically across all supported frameworks

## Context

This documentation update addresses the user-facing changes from MervinPraison/PraisonAI PR #1884 which fixed adapter inconsistency where CrewAI adapter previously crashed with string form LLM configs while PraisonAI adapter accepted both forms. Now all framework adapters behave consistently.

🤖 Generated with [Claude Code](https://claude.ai/code)