### PR TITLE
docs: update persistence docs for PR #1829 — AsyncConversationStore protocol, MySQL backend, schema versioning

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -974,6 +974,8 @@
               "docs/persistence/overview",
               "docs/persistence/quickstart",
               "docs/persistence/session-resume",
+              "docs/features/async-conversation-store",
+              "docs/features/persistence-conversation-mysql",
               "docs/features/async-db-hooks"
             ]
           },

--- a/docs/features/async-conversation-store.mdx
+++ b/docs/features/async-conversation-store.mdx
@@ -1,0 +1,250 @@
+---
+title: "Async Conversation Store"
+sidebarTitle: "Async Conversation Store"
+description: "Implement non-blocking conversation persistence with the AsyncConversationStore protocol"
+icon: "database"
+---
+
+Async conversation stores provide non-blocking persistence for conversation sessions and messages, enabling high-performance multi-agent systems.
+
+```mermaid
+graph LR
+    subgraph "Async Conversation Flow"
+        A[🤖 Agent] --> B[🔄 Orchestrator]
+        B --> C{📊 instanceof?}
+        C -->|AsyncConversationStore| D[⚡ await store.get_session]
+        C -->|ConversationStore| E[🔄 asyncio.to_thread]
+        D --> F[💾 Database]
+        E --> F
+    end
+    
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef orchestrator fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef async fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef sync fill:#6366F1,stroke:#7C90A0,color:#fff
+    
+    class A agent
+    class B orchestrator
+    class C,D async
+    class E sync
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Use Built-in Async Store">
+Use a built-in async conversation store with automatic resource management:
+
+```python
+from praisonaiagents import Agent
+from praisonai.persistence.conversation import AsyncPostgresConversationStore
+
+async def main():
+    async with AsyncPostgresConversationStore(
+        url="postgresql://user:pass@localhost/db"
+    ) as store:
+        agent = Agent(
+            name="Assistant",
+            instructions="Help users with their tasks",
+            conversation_store=store
+        )
+        
+        result = await agent.start("Hello, how are you?")
+        print(result)
+
+# Run the async agent
+import asyncio
+asyncio.run(main())
+```
+</Step>
+
+<Step title="Implement Custom Async Store">
+Create a custom async store by inheriting from `AsyncConversationStore`:
+
+```python
+from praisonai.persistence.conversation import AsyncConversationStore, ConversationSession, ConversationMessage
+from typing import List, Optional
+
+class CustomAsyncStore(AsyncConversationStore):
+    async def create_session(self, session: ConversationSession) -> ConversationSession:
+        # Your async implementation
+        return session
+    
+    async def get_session(self, session_id: str) -> Optional[ConversationSession]:
+        # Your async implementation
+        return None
+    
+    async def add_message(self, session_id: str, message: ConversationMessage) -> ConversationMessage:
+        # Your async implementation
+        return message
+    
+    # ... implement other required methods
+    
+    async def close(self) -> None:
+        # Clean up async resources
+        pass
+
+# Use your custom store
+store = CustomAsyncStore()
+agent = Agent(name="Assistant", conversation_store=store)
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Orchestrator
+    participant AsyncStore as AsyncConversationStore
+    participant Database
+    
+    Agent->>Orchestrator: start("Hello")
+    Orchestrator->>Orchestrator: isinstance(store, AsyncConversationStore)?
+    Orchestrator->>AsyncStore: await store.get_session(session_id)
+    AsyncStore->>Database: SELECT * FROM sessions
+    Database-->>AsyncStore: session data
+    AsyncStore-->>Orchestrator: ConversationSession
+    Orchestrator-->>Agent: Response
+```
+
+| Component | Role |
+|-----------|------|
+| **Agent** | Initiates conversation requests |
+| **Orchestrator** | Routes requests based on store type using `isinstance()` |
+| **AsyncConversationStore** | Handles async persistence operations |
+| **Database** | Stores session and message data |
+
+---
+
+## Configuration Options
+
+<Card title="AsyncConversationStore API Reference" icon="code" href="/docs/sdk/praisonai/persistence">
+  Complete method signatures and configuration options
+</Card>
+
+---
+
+## Common Patterns
+
+### Context Manager Usage
+
+Always use `async with` for automatic resource management:
+
+```python
+async with AsyncPostgresConversationStore(url="postgresql://...") as store:
+    session = await store.get_session("session_123")
+    if session:
+        message = ConversationMessage(
+            session_id="session_123",
+            role="user",
+            content="Hello"
+        )
+        await store.add_message("session_123", message)
+```
+
+### Upsert Session Helper
+
+Use the built-in `upsert_session()` method for create-or-update operations:
+
+```python
+session = ConversationSession(session_id="new_session", user_id="user_123")
+updated_session = await store.upsert_session(session)  # Creates or updates
+```
+
+### Custom Async Store Implementation
+
+When implementing a custom async store, inherit from `AsyncConversationStore`:
+
+```python
+from praisonai.persistence.conversation import AsyncConversationStore
+
+class MyAsyncStore(AsyncConversationStore):
+    # MUST inherit AsyncConversationStore for proper orchestrator dispatch
+    async def create_session(self, session: ConversationSession) -> ConversationSession:
+        # Implementation here
+        pass
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Always Use async with Context Manager">
+The async context manager ensures proper resource cleanup:
+
+```python
+# ✅ Good - automatic cleanup
+async with store:
+    await store.get_session("id")
+
+# ❌ Bad - manual cleanup required  
+try:
+    await store.get_session("id")
+finally:
+    await store.close()
+```
+</Accordion>
+
+<Accordion title="Inherit AsyncConversationStore for Custom Stores">
+The orchestrator uses `isinstance()` checks to dispatch correctly:
+
+```python
+# ✅ Good - proper inheritance
+class MyStore(AsyncConversationStore):
+    pass
+
+# ❌ Bad - will be wrapped in asyncio.to_thread()
+class MyStore(ConversationStore):
+    async def get_session(self):  # This won't work as expected
+        pass
+```
+</Accordion>
+
+<Accordion title="Don't Mix Sync and Async APIs">
+Use either sync or async consistently:
+
+```python
+# ✅ Good - pure async
+async with AsyncPostgresConversationStore() as store:
+    session = await store.get_session("id")
+
+# ❌ Bad - mixing patterns
+store = AsyncPostgresConversationStore()
+session = store.get_session("id")  # This is not the async method
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+<Warning>
+**Breaking Change in PR #1829**: The `async_*` prefixed methods have been removed from async stores:
+
+```python
+# Before (removed)
+session = await store.async_get_session(session_id)
+
+# After (current)
+session = await store.get_session(session_id)
+```
+
+Update your code to use the non-prefixed async methods.
+</Warning>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Async DB Hooks" icon="webhook" href="/docs/features/async-db-hooks">
+  Event-driven persistence hooks for async stores
+</Card>
+<Card title="Persistence Overview" icon="database" href="/docs/persistence/overview">
+  Architecture and backend options
+</Card>
+</CardGroup>

--- a/docs/features/async-db-hooks.mdx
+++ b/docs/features/async-db-hooks.mdx
@@ -1,5 +1,3 @@
-from datetime import datetime, timezone
-
 ---
 title: "Async DB Hooks"
 sidebarTitle: "Async DB Hooks"
@@ -8,6 +6,18 @@ icon: "database"
 ---
 
 Async DB hooks enable non-blocking database operations in async agents through automatic async/sync detection and `asyncio.to_thread` fallback.
+
+<Warning>
+**Breaking Change in PR #1829**: The `async_*` prefixed methods have been removed from async stores. The orchestrator now uses `isinstance(store, AsyncConversationStore)` for dispatch instead of runtime method introspection.
+
+```python
+# Before (removed)
+session = await store.async_get_session(session_id)
+
+# After (current)
+session = await store.get_session(session_id)
+```
+</Warning>
 
 ```mermaid
 graph LR
@@ -89,12 +99,12 @@ sequenceDiagram
     participant Store as Storage Backend
     
     Agent->>Adapter: aon_user_message()
-    Adapter->>Adapter: Check for async_add_message()
+    Adapter->>Adapter: isinstance(store, AsyncConversationStore)
     alt Native async support
-        Adapter->>Store: await async_add_message()
+        Adapter->>Store: await store.add_message()
         Store-->>Adapter: Result
     else Sync fallback
-        Adapter->>Store: asyncio.to_thread(add_message)
+        Adapter->>Store: asyncio.to_thread(store.add_message)
         Store-->>Adapter: Result
     end
     Adapter-->>Agent: Success
@@ -102,11 +112,11 @@ sequenceDiagram
 
 | Method | Purpose | Async Detection |
 |--------|---------|----------------|
-| `aon_agent_start` | Agent session start | Checks `async_set_agent_state` |
-| `aon_user_message` | User message logging | Checks `async_add_message` |
-| `aon_agent_message` | Agent response logging | Checks `async_add_message` |
-| `aon_tool_call` | Tool execution logging | Checks `async_add_tool_call` |
-| `aon_agent_end` | Agent session end | Checks `async_set_agent_state` |
+| `aon_agent_start` | Agent session start | Dispatches via isinstance(store, AsyncConversationStore) |
+| `aon_user_message` | User message logging | Dispatches via isinstance(store, AsyncConversationStore) |
+| `aon_agent_message` | Agent response logging | Dispatches via isinstance(store, AsyncConversationStore) |
+| `aon_tool_call` | Tool execution logging | Dispatches via isinstance(store, AsyncConversationStore) |
+| `aon_agent_end` | Agent session end | Dispatches via isinstance(store, AsyncConversationStore) |
 
 ---
 

--- a/docs/features/persistence-backend-plugins.mdx
+++ b/docs/features/persistence-backend-plugins.mdx
@@ -100,6 +100,7 @@ Each `StoreRegistry` provides a thread-safe API for backend management:
 | `create` | `create(name: str, **kwargs) -> Any` | Create a store instance by name or alias |
 | `list_registered` | `() -> list[str]` | Get all registered backend names (sorted) |
 | `list_aliases` | `() -> dict[str, str]` | Get alias → canonical name mappings |
+| `default` | `@classmethod default(cls) -> "PluginRegistry[T]"` | **New in PR #1829**: Process-default registry instance (thread-safe, per-subclass) |
 
 ---
 
@@ -107,7 +108,11 @@ Each `StoreRegistry` provides a thread-safe API for backend management:
 
 ### Conversation Stores
 
-**Primary backends:** `postgres`, `async_postgres`, `mysql`, `async_mysql`, `sqlite`, `sync_sqlite`, `async_sqlite`, `json`, `singlestore`, `supabase`, `surrealdb`, `turso`
+**Primary backends:** `postgres`, `async_postgres`, `mysql`, `async_mysql`, `MySQLConversationStore`, `sqlite`, `sync_sqlite`, `async_sqlite`, `json`, `singlestore`, `supabase`, `surrealdb`, `turso`
+
+<Note>
+**New in PR #1829**: `MySQLConversationStore` is available from `praisonai.persistence.conversation.mysql_new` but not re-exported from the main package. It inherits the unified schema from `_SQLConversationStoreBase`.
+</Note>
 
 **Aliases available:**
 - `neon`, `cockroachdb`, `crdb`, `cockroach`, `xata` → `postgres`
@@ -137,6 +142,78 @@ Each `StoreRegistry` provides a thread-safe API for backend management:
 
 **Aliases available:**
 - `motor`, `mongodb_async` → `async_mongodb`
+
+---
+
+## Extending SQL Backends
+
+For building new SQL conversation stores, inherit from `_SQLConversationStoreBase` to get unified schema and retry logic:
+
+```python
+from praisonai.persistence.conversation._sql_base import _SQLConversationStoreBase
+
+class MyDBConversationStore(_SQLConversationStoreBase):
+    # Constants for this dialect
+    SCHEMA_VERSION = "1.0.0"  # Inherited from base
+    _id_type = "UUID"
+    _json_type = "JSONB"
+    _float_type = "DOUBLE PRECISION"
+    _serverless_hosts = (".mydb.cloud",)
+    
+    # Required dialect hooks
+    def _param(self, n: int) -> str:
+        return f"${n}"  # PostgreSQL-style parameters
+    
+    async def _connect(self, **kwargs):
+        # Return connection for this dialect
+        pass
+    
+    def _get_conn(self):
+        # Get connection from pool
+        pass
+    
+    def _put_conn(self, conn):
+        # Return connection to pool  
+        pass
+    
+    async def _execute(self, conn, query: str, *args):
+        # Execute query with this dialect
+        pass
+    
+    # ... implement other dialect hooks
+```
+
+The base class provides:
+- Unified table schema with `SCHEMA_VERSION = "1.0.0"`
+- Retry logic with configurable `max_retries` and `retry_delay`  
+- Serverless detection and exponential backoff
+- Standard CRUD operations for sessions and messages
+
+---
+
+## Process-Default Registry
+
+Use `PluginRegistry.default()` for thread-safe per-subclass singleton registries:
+
+```python
+from praisonai._registry import PluginRegistry
+
+class MyRegistry(PluginRegistry["MyThing"]):
+    pass
+
+# Thread-safe, per-subclass lazy initialization
+reg = MyRegistry.default()
+
+# Alternative registries are independent
+class OtherRegistry(PluginRegistry["OtherThing"]):
+    pass
+
+other_reg = OtherRegistry.default()  # Different instance
+```
+
+This replaces the manual singleton pattern used in previous versions. Both `LLMProviderRegistry.default()` and `FrameworkAdapterRegistry.default()` now use this unified approach.
+
+The legacy module-level functions (`get_default_registry()`, `get_default_llm_registry()`) remain for backward compatibility and delegate to the respective `cls.default()` methods.
 
 ---
 

--- a/docs/features/persistence-conversation-mysql.mdx
+++ b/docs/features/persistence-conversation-mysql.mdx
@@ -1,0 +1,272 @@
+---
+title: "MySQL Conversation Store"
+sidebarTitle: "MySQL Conversation Store"
+description: "Direct MySQL conversation persistence with PlanetScale auto-retry support"
+icon: "database"
+---
+
+MySQL conversation store provides direct persistence for conversation sessions and messages with built-in serverless database optimization and retry logic.
+
+```mermaid
+graph LR
+    subgraph "MySQL Conversation Store"
+        A[🤖 Agent] --> B[🗃️ MySQLConversationStore]
+        B --> C{🌐 PlanetScale?}
+        C -->|Yes| D[⚡ Auto-retry]
+        C -->|No| E[🔄 Standard]
+        D --> F[🐬 MySQL DB]
+        E --> F
+    end
+    
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef store fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef serverless fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef database fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A agent
+    class B store
+    class C,D serverless
+    class E,F database
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Install Dependencies">
+Install the required MySQL driver:
+
+```bash
+pip install mysql-connector-python
+```
+</Step>
+
+<Step title="Basic Usage">
+Use MySQL conversation store with URL connection:
+
+```python
+from praisonaiagents import Agent
+from praisonai.persistence.conversation.mysql_new import MySQLConversationStore
+
+agent = Agent(
+    name="MySQL Agent",
+    instructions="Store conversations in MySQL",
+    conversation_store=MySQLConversationStore(
+        url="mysql://user:password@localhost:3306/praisonai"
+    )
+)
+
+result = agent.start("Hello, store this conversation!")
+```
+</Step>
+
+<Step title="With Configuration">
+Configure MySQL with all available options:
+
+```python
+from praisonai.persistence.conversation.mysql_new import MySQLConversationStore
+
+store = MySQLConversationStore(
+    host="localhost",
+    port=3306,
+    database="praisonai", 
+    user="root",
+    password="secret",
+    table_prefix="praison_",
+    auto_create_tables=True,
+    pool_size=5,
+    max_retries=3,
+    retry_delay=0.5
+)
+
+agent = Agent(
+    name="Configured Agent",
+    conversation_store=store
+)
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Store as MySQLConversationStore
+    participant MySQL
+    
+    Agent->>Store: create_session(session)
+    Store->>Store: Detect serverless (.psdb.cloud)
+    Store->>MySQL: CREATE TABLE IF NOT EXISTS
+    Store->>MySQL: INSERT INTO sessions
+    MySQL-->>Store: session_id
+    Store-->>Agent: ConversationSession
+    
+    Note over Store,MySQL: Auto-retry for serverless
+    Agent->>Store: add_message(message)
+    Store->>MySQL: INSERT INTO messages (retry if needed)
+    MySQL-->>Store: message_id
+    Store-->>Agent: ConversationMessage
+```
+
+| Feature | Description |
+|---------|-------------|
+| **Auto-retry** | Exponential backoff for `.psdb.cloud` hosts |
+| **Schema Management** | Automatic table creation with `SCHEMA_VERSION = "1.0.0"` |
+| **Connection Pooling** | Configurable pool size for high concurrency |
+| **SQL Base** | Inherits unified schema from `_SQLConversationStoreBase` |
+
+---
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `url` | `str` | `None` | Complete MySQL URL (overrides individual options) |
+| `host` | `str` | `"localhost"` | MySQL server hostname |
+| `port` | `int` | `3306` | MySQL server port |
+| `database` | `str` | `"praisonai"` | Database name |
+| `user` | `str` | `"root"` | Database username |
+| `password` | `str` | `""` | Database password |
+| `table_prefix` | `str` | `"praison_"` | Prefix for table names |
+| `auto_create_tables` | `bool` | `True` | Create tables automatically |
+| `pool_size` | `int` | `5` | Connection pool size |
+| `max_retries` | `int` | `3` | Maximum retry attempts for failed operations |
+| `retry_delay` | `float` | `0.5` | Base delay between retries (seconds) |
+
+<Note>
+**Import Path**: Due to current implementation, you must import from the submodule:
+```python
+from praisonai.persistence.conversation.mysql_new import MySQLConversationStore
+```
+This will be improved in a future release to be available from the main package.
+</Note>
+
+---
+
+## Common Patterns
+
+### PlanetScale Configuration
+
+For PlanetScale serverless MySQL, use optimized retry settings:
+
+```python
+store = MySQLConversationStore(
+    url="mysql://user:pass@gateway.psdb.cloud:3306/mydb",
+    max_retries=5,      # Higher retries for cold starts
+    retry_delay=1.0,    # Longer initial delay
+    pool_size=3         # Smaller pool for serverless
+)
+```
+
+### Connection URL Formats
+
+Support for various MySQL URL formats:
+
+```python
+# Standard MySQL
+url="mysql://user:pass@localhost:3306/dbname"
+
+# PlanetScale (auto-detected for retry behavior)
+url="mysql://user:pass@gateway.psdb.cloud:3306/dbname"
+
+# MySQL with SSL
+url="mysql://user:pass@host:3306/db?ssl_mode=REQUIRED"
+```
+
+### Async Context Manager
+
+Use with async context manager for resource management:
+
+```python
+from praisonai.persistence.conversation.mysql_new import MySQLConversationStore
+
+async def main():
+    async with MySQLConversationStore(
+        url="mysql://user:pass@localhost/db"
+    ) as store:
+        # Store will be automatically closed
+        session = await store.create_session(session_obj)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Tune Retries for Serverless">
+Serverless MySQL databases benefit from higher retry counts:
+
+```python
+# For PlanetScale, Neon, or other serverless
+store = MySQLConversationStore(
+    max_retries=5,
+    retry_delay=1.0,  # Exponential backoff: 1s, 2s, 4s, 8s, 16s
+)
+```
+</Accordion>
+
+<Accordion title="Use Connection Pooling">
+Configure appropriate pool size for your workload:
+
+```python
+# High concurrency workload
+store = MySQLConversationStore(pool_size=10)
+
+# Serverless or low traffic  
+store = MySQLConversationStore(pool_size=2)
+```
+</Accordion>
+
+<Accordion title="Table Prefix for Multi-tenancy">
+Use table prefixes to isolate different applications:
+
+```python
+# Production app
+prod_store = MySQLConversationStore(table_prefix="prod_")
+
+# Staging app  
+staging_store = MySQLConversationStore(table_prefix="staging_")
+```
+</Accordion>
+
+<Accordion title="Monitor Schema Version">
+The store uses `SCHEMA_VERSION = "1.0.0"` for migration tracking:
+
+```python
+# Check current schema version
+store = MySQLConversationStore()
+print(store.SCHEMA_VERSION)  # "1.0.0"
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Error Handling
+
+The store automatically handles common MySQL errors:
+
+```python
+try:
+    store = MySQLConversationStore(url="mysql://invalid")
+    session = store.create_session(session_obj)
+except Exception as e:
+    print(f"Connection failed: {e}")
+```
+
+For PlanetScale hosts (`.psdb.cloud`), transient errors trigger exponential backoff retry automatically.
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Async Conversation Store" icon="database" href="/docs/features/async-conversation-store">
+  Async conversation persistence protocol
+</Card>
+<Card title="Persistence Backend Plugins" icon="puzzle-piece" href="/docs/features/persistence-backend-plugins">
+  Extending SQL backends with _SQLConversationStoreBase
+</Card>
+</CardGroup>

--- a/docs/persistence/overview.mdx
+++ b/docs/persistence/overview.mdx
@@ -36,7 +36,7 @@ pip install "praisonaiagents[tools]"
 
 | Category | Backends | Count |
 |----------|----------|-------|
-| **Conversation** | PostgreSQL, MySQL, SQLite, SingleStore, Supabase, SurrealDB, Turso | 7 |
+| **Conversation** | PostgreSQL, MySQL (including MySQLConversationStore), SQLite, SingleStore, Supabase, SurrealDB, Turso | 7+ |
 | **Knowledge** | Qdrant, ChromaDB, Pinecone, Weaviate, LanceDB, Milvus, PGVector, Redis, Cassandra, ClickHouse, MongoDB Vector, Couchbase, SingleStore Vector, SurrealDB Vector, Upstash Vector, LightRAG, LangChain, LlamaIndex, CosmosDB | 19 |
 | **State** | Redis, MongoDB, DynamoDB, Firestore, Upstash, Memory, GCS | 7 |
 
@@ -92,6 +92,8 @@ The persistence registry provides user-friendly aliases for common databases:
 
 Persistence sync wrappers (`get_session`, `add_message`, `get`, `set`, `delete`, `list_keys`, `clear`, `close`, …) are safe to call from any context — plain sync scripts, worker threads, or code running inside a live event loop (FastAPI, Streamlit, background tasks). They route through a canonical async bridge, so you will not see `RuntimeError: This event loop is already running` anymore.
 
+**Async hooks offloading (PR #1829)**: Sync conversation stores plugged into async hooks are now automatically offloaded via `asyncio.to_thread()` rather than blocking the event loop. The orchestrator uses `isinstance(store, AsyncConversationStore)` to determine whether to await the store directly or wrap it in thread execution.
+
 As of PR #1763, you can also opt into the dedicated `sync_sqlite` backend (`mode="sync"`) — it provides per-call connection locking (`threading.RLock`) for multi-agent scenarios where you'd rather not depend on the legacy sync wrappers.
 
 The `DbAdapter`'s lazy store initialisation is also race-free: the first thread to touch the adapter constructs the stores, and subsequent threads see the ready instance.
@@ -111,6 +113,19 @@ These improvements were added in PraisonAI PR #1466, #1609, #1709, #1724, and #1
 </Note>
 
 The JSON session store (`DefaultSessionStore`) reloads from disk under `FileLock` for every mutator as of PR #1709 (metadata), PR #1724 (agent info, gateway info, clear), and PR #1727 (`LocalManagedAgent._persist_state`). PRs #1759 and #1764 extended the same `FileLock`-guarded reload to the read path (`get_chat_history`, `get_session`, `get_sessions_by_agent`), so two processes pointed at the same `~/.praisonai/sessions/` directory observe each other's writes without any stale-cache window.
+
+## Schema Versioning (PR #1829)
+
+**New unified schema system**: All SQL conversation stores now inherit from `_SQLConversationStoreBase` with consistent `SCHEMA_VERSION = "1.0.0"`. This applies to PostgreSQL, MySQL (new), and all existing SQL backends uniformly.
+
+The base class provides:
+- Standardized table schemas for sessions and messages
+- Dialect-specific type mappings (`_id_type`, `_json_type`, `_float_type`)
+- Unified retry logic with `max_retries` and `retry_delay` parameters
+- Automatic serverless database detection and exponential backoff
+- Consistent `table_prefix` handling across all SQL stores
+
+**MySQL backend**: The new `MySQLConversationStore` (from `praisonai.persistence.conversation.mysql_new`) includes PlanetScale auto-retry with exponential backoff for serverless cold-starts.
 
 ## Schema Migration (PR #1597)
 
@@ -164,5 +179,6 @@ The `register_store()` method is the canonical API. The `register()` method is p
 
 - [Quickstart](/docs/persistence/quickstart) - Get started in 5 minutes
 - [Session Resume](/docs/persistence/session-resume) - Continue conversations
+- [Async Conversation Store](/docs/features/async-conversation-store) - AsyncConversationStore protocol for non-blocking persistence
 - [CLI Reference](/docs/cli/persistence) - Command-line usage
 - [Backend Plugins](/docs/features/persistence-backend-plugins) - Custom storage backends

--- a/docs/persistence/quickstart.mdx
+++ b/docs/persistence/quickstart.mdx
@@ -121,8 +121,44 @@ praisonai persistence run \
     "Hello, my name is Bob"
 ```
 
+## Serverless Database Tuning
+
+For serverless databases that may experience cold starts, tune the retry parameters:
+
+```python
+from praisonaiagents import Agent
+
+# PlanetScale MySQL 
+agent = Agent(
+    name="Assistant",
+    memory={
+        "db": "mysql://user:pass@gateway.psdb.cloud:3306/mydb",
+        "max_retries": 5,      # Higher retries for cold starts
+        "retry_delay": 1.0     # Longer initial delay
+    }
+)
+
+# Neon PostgreSQL
+agent = Agent(
+    name="Assistant", 
+    memory={
+        "db": "postgresql://user:pass@host.neon.tech/db",
+        "max_retries": 3,
+        "retry_delay": 0.5
+    }
+)
+```
+
+Supported serverless platforms with auto-retry:
+- **PlanetScale**: `.psdb.cloud` hosts (exponential backoff)
+- **Neon**: `.neon.tech` hosts
+- **CockroachDB**: `.cockroachlabs.cloud`, `.cockroachlabs.com`
+- **Supabase**: `.supabase.com`, `.supabase.co`
+- **Xata**: `.xata.sh`
+
 ## Next Steps
 
 - [Session Resume](/docs/persistence/session-resume) - Continue conversations
+- [Async Conversation Store](/docs/features/async-conversation-store) - Non-blocking persistence
 - [PostgreSQL](/docs/databases/postgres) - Production setup
 - [CLI Reference](/docs/cli/persistence) - Full CLI documentation


### PR DESCRIPTION
## Summary

Updates documentation for persistence layer changes introduced in PraisonAI PR #1829, including:

- New AsyncConversationStore protocol for non-blocking conversation persistence
- MySQLConversationStore backend with PlanetScale auto-retry support  
- _SQLConversationStoreBase unified SQL backend extension point
- PluginRegistry.default() thread-safe singleton pattern
- Breaking change fixes for removed async_* method prefixes

## Documentation Changes

### New Pages Created
- docs/features/async-conversation-store.mdx - AsyncConversationStore protocol documentation with inheritance requirements and context manager usage
- docs/features/persistence-conversation-mysql.mdx - MySQLConversationStore backend with serverless optimization

### Updated Pages  
- docs/features/async-db-hooks.mdx - Fixed references to removed async_* methods, added migration warning
- docs/features/persistence-backend-plugins.mdx - Added _SQLConversationStoreBase and PluginRegistry.default() documentation
- docs/persistence/overview.mdx - Added schema versioning section and asyncio.to_thread offloading notes
- docs/persistence/quickstart.mdx - Added serverless database tuning section with retry parameters
- docs.json - Added new pages to Persistence navigation group

Fixes #555

🤖 Generated with [Claude Code](https://claude.ai/code)