### PR TITLE
docs: update for PraisonAI SDK default framework change

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -251,6 +251,7 @@
                     "icon": "cpu",
                     "pages": [
                       "docs/features/openai-quickstart",
+                      "docs/features/framework-default-change",
                       "docs/features/chat",
                       "docs/features/streaming",
                       "docs/features/streaming-tool-events",

--- a/docs/cli/cli.mdx
+++ b/docs/cli/cli.mdx
@@ -92,7 +92,7 @@ praisonai "What is 2+2?"
 ### Other Examples
 
 ```bash
-# Run agents from YAML
+# Run agents from YAML - uses praisonai framework by default
 praisonai agents.yaml
 
 # Interactive mode with slash commands
@@ -295,7 +295,7 @@ praisonai "List files here" -v
 
 | Flag | Description | Example |
 |------|-------------|---------|
-| `--framework` | Specify framework (crewai, autogen, praisonai) | `praisonai agents.yaml --framework crewai` |
+| `--framework` | Specify framework (crewai, autogen, praisonai). Defaults to `praisonai` when neither CLI flag nor YAML `framework:` is set. | `praisonai agents.yaml --framework crewai` |
 | `--ui` | UI mode (chainlit, gradio) | `praisonai --ui chainlit` |
 | `--llm` | Specify LLM model | `praisonai "task" --llm gpt-4o` |
 | `--model` | Model name | `praisonai "task" --model gpt-4o` |

--- a/docs/features/framework-default-change.mdx
+++ b/docs/features/framework-default-change.mdx
@@ -1,0 +1,132 @@
+---
+title: "Default Framework Change (v1.0.0+)"
+sidebarTitle: "Framework Default Change"
+description: "Default framework changed from crewai to praisonai when running YAML files without an explicit framework flag"
+icon: "arrows-rotate"
+---
+
+The default framework changed from `crewai` to `praisonai` when running YAML files without specifying an explicit framework.
+
+```mermaid
+graph LR
+    subgraph "New Default Framework Flow"
+        User[👤 User] --> CLI[💻 praisonai agents.yaml]
+        CLI --> YAML[📄 Read YAML]
+        YAML --> Check{🔍 Framework specified?}
+        Check -->|No| Default[⚙️ Default: praisonai]
+        Check -->|Yes| UseSpecified[⚙️ Use specified framework]
+        Default --> Run[🚀 Run agents]
+        UseSpecified --> Run
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef middle fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class User input
+    class CLI,YAML,Check,Default,UseSpecified middle
+    class Run output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Before (v0.x)">
+Running `praisonai agents.yaml` would fail with error:
+```
+ValueError: Unknown praisonai.framework_adapters plugin: ''.
+Available: ['ag2', 'autogen', 'autogen_v4', 'crewai', 'praisonai']
+```
+</Step>
+
+<Step title="After (v1.0.0+)">
+Running `praisonai agents.yaml` works out of the box using the `praisonai` framework:
+```bash
+praisonai agents.yaml  # ✅ Uses praisonai framework by default
+```
+</Step>
+</Steps>
+
+---
+
+## Agent-Centric Example
+
+```python
+from praisonai import PraisonAI
+
+# No framework= argument — uses 'praisonai' by default
+praison = PraisonAI(agent_file="agents.yaml")
+result = praison.run()
+```
+
+Equivalent CLI command:
+```bash
+praisonai agents.yaml
+```
+
+Both produce the same result with no `--framework` flag required.
+
+---
+
+## Framework Precedence
+
+PraisonAI resolves the framework in this order:
+
+| Priority | Source | Example |
+|----------|--------|---------|
+| 1 | CLI flag | `--framework crewai` |
+| 2 | YAML key | `framework: crewai` |
+| 3 | Default | `praisonai` |
+
+---
+
+## How to Keep CrewAI as Default
+
+If you want to continue using CrewAI as your default framework, you have two options:
+
+### Option 1: YAML Configuration
+```yaml
+framework: crewai
+topic: Your task description
+roles:
+  # Your agents here
+```
+
+### Option 2: CLI Flag
+```bash
+praisonai --framework crewai agents.yaml
+```
+
+---
+
+## User Interaction Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant AgentsGenerator
+    participant FrameworkAdapter
+
+    User->>CLI: praisonai agents.yaml
+    CLI->>AgentsGenerator: initialize()
+    AgentsGenerator->>AgentsGenerator: defer adapter creation
+    AgentsGenerator->>AgentsGenerator: load YAML file
+    AgentsGenerator->>AgentsGenerator: resolve framework (YAML → default)
+    AgentsGenerator->>FrameworkAdapter: create adapter (praisonai)
+    FrameworkAdapter-->>CLI: execution result
+    CLI-->>User: agent output
+```
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="CrewAI Framework" icon="users" href="/docs/framework/crewai">
+    CrewAI framework integration guide
+  </Card>
+  <Card title="PraisonAI Agents" icon="users-gear" href="/docs/framework/praisonaiagents">
+    PraisonAI native agents framework
+  </Card>
+</CardGroup>

--- a/docs/framework/crewai.mdx
+++ b/docs/framework/crewai.mdx
@@ -60,6 +60,10 @@ roles:
 export OPENAI_API_KEY=your-key
 praisonai agents.yaml --framework crewai
 ```
+
+<Note>
+CrewAI is no longer the default framework. You must either pass `--framework crewai` or set `framework: crewai` in your YAML to use CrewAI.
+</Note>
 </Step>
 
 </Steps>

--- a/docs/framework/praisonaiagents.mdx
+++ b/docs/framework/praisonaiagents.mdx
@@ -7,6 +7,10 @@ icon: "users-gear"
 A lightweight package dedicated to creating and managing AI agents with advanced capabilities.
 
 <Note>
+This is now the default framework. Running `praisonai agents.yaml` without any framework flag uses this adapter.
+</Note>
+
+<Note>
 Need a framework that isn't listed here? See [Framework Adapter Plugins](/docs/features/framework-adapter-plugins) to register your own via Python entry points.
 </Note>
 

--- a/docs/nocode/tldr.mdx
+++ b/docs/nocode/tldr.mdx
@@ -27,6 +27,13 @@ python -m praisonai
 python -m praisonai "What is machine learning?"
 ```
 
+## Default Framework
+
+```bash
+# No flag needed — uses praisonai (default)
+praisonai agents.yaml
+```
+
 ## With Different Frameworks
 
 ```bash

--- a/docs/sdk/praisonai/cli.mdx
+++ b/docs/sdk/praisonai/cli.mdx
@@ -30,7 +30,7 @@ result = praison.run()
 ```python
 PraisonAI(
     agent_file: str = "agents.yaml",
-    framework: str = "praisonaiagents",
+    framework: str = "praisonai",
     auto: bool = False,
     agent_yaml: str = None,
     tools: list = None
@@ -40,10 +40,14 @@ PraisonAI(
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `agent_file` | str | `"agents.yaml"` | Path to YAML agent definition |
-| `framework` | str | `"praisonaiagents"` | Framework: `praisonaiagents`, `crewai`, `autogen` |
+| `framework` | str | `"praisonai"` | Framework: `praisonai`, `crewai`, `autogen` (precedence: CLI flag → YAML `framework:` → default) |
 | `auto` | bool | `False` | Enable auto mode for agent generation |
 | `agent_yaml` | str | `None` | YAML content as string (alternative to file) |
 | `tools` | list | `None` | List of tools to make available |
+
+<Note>
+If neither `--framework` CLI flag nor YAML `framework:` key is set, PraisonAI defaults to the `praisonai` adapter.
+</Note>
 
 ### Methods
 


### PR DESCRIPTION
Fixes #564

Updates documentation to reflect the framework default change from crewai to praisonai after PraisonAI SDK PR #1881.

## Changes
- Updated CLI constructor table default from crewai to praisonai
- Added notices to framework pages about the default change
- Created new migration page with examples and upgrade path
- Updated CLI reference with new default behavior
- Added navigation entry for migration page

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation to reflect that PraisonAI is now the default framework when running YAML files without explicit framework specification.
  * Added comprehensive guide explaining the framework selection precedence and how to override defaults using CLI flags or YAML configuration.
  * Added clarifications across CLI, framework, and SDK documentation noting that CrewAI requires explicit specification to use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->