### PR TITLE
docs: clarify auto_save + memory="history" persistence semantics and Session.save_state() idempotency (fixes #566)

### DIFF
--- a/docs/features/history-injection.mdx
+++ b/docs/features/history-injection.mdx
@@ -202,6 +202,10 @@ agent = Agent(
   </Step>
 </Steps>
 
+<Note>
+**Per-turn persistence is exact.** When `memory="history"` (or `MemoryConfig(history=True)`) is combined with `auto_save`, each agent turn persists exactly the user message and the assistant response — no duplicates, even on repeated `save_state()` calls. Fixed in PraisonAI PR #1897.
+</Note>
+
 ## Best Practices
 
 <CardGroup cols={2}>
@@ -212,7 +216,7 @@ agent = Agent(
     Always use meaningful session IDs like `user-{user_id}` for multi-user apps via `auto_save`.
   </Card>
   <Card title="Combine with auto_save" icon="floppy-disk">
-    Use `auto_save` to persist conversations and `memory="history"` to reload them.
+    Use `auto_save` to persist conversations and `memory="history"` to reload them. Repeated turns persist incrementally; the auto-save bookkeeping stays in sync with per-turn writes (PR #1897).
   </Card>
   <Card title="Test Token Usage" icon="coins">
     Monitor token usage when enabling history to ensure costs stay reasonable.

--- a/docs/features/session-persistence.mdx
+++ b/docs/features/session-persistence.mdx
@@ -9,6 +9,10 @@ icon: "floppy-disk"
 PraisonAI Agents provides automatic session persistence with zero configuration. Simply provide a `session_id` to your Agent and conversation history is automatically saved and restored.
 
 <Info>
+**Released in PR #1897** — Earlier versions wrote duplicate messages when `memory="history"` was combined with `auto_save` (one turn produced 4 messages instead of 2), and `Session.save_state()` re-appended full history on every call. Both paths are now exact and idempotent.
+</Info>
+
+<Info>
 **Released in PR #1709** — Earlier versions could silently drop the latest messages when `update_session_metadata()` ran concurrently with `add_message()` across processes or store instances. Upgrade to pick up the fix.
 </Info>
 
@@ -162,6 +166,15 @@ store.update_session_metadata(
     total_tokens=125,
 )
 ```
+
+## Idempotent saves
+
+`Session._save_agent_chat_histories()` uses `set_chat_history(session_id, messages)` to atomically replace the persisted history rather than appending. This means:
+
+- Repeated `session.save_state()` calls do not duplicate messages.
+- The per-turn `_persist_message()` path and the `_auto_save_session()` flush share `_auto_save_last_index`, so each message is written exactly once.
+
+Custom session stores that do not implement `set_chat_history` fall back to `add_message()` with a logged warning — those stores may produce duplicates on repeated `save_state()` calls until they add `set_chat_history`.
 
 ## Multi-Process Safety
 

--- a/docs/features/session-protocol.mdx
+++ b/docs/features/session-protocol.mdx
@@ -83,6 +83,7 @@ The protocol requires exactly **five methods**:
 | `clear_session(session_id)` | `bool` | Remove all messages (keep metadata) |
 | `delete_session(session_id)` | `bool` | Delete session completely |
 | `session_exists(session_id)` | `bool` | Check if a session exists |
+| `set_chat_history(session_id, messages)` | `bool` | **Recommended.** Atomically replace chat history for idempotent saves |
 | `update_session_metadata(session_id, **fields)` | `bool` | Merge metadata fields without touching messages |
 
 <Note>
@@ -92,6 +93,28 @@ For **persistent backends (DB / JSON)**, `clear_session()` and `delete_session()
 <Tip>
 The protocol uses Python's `typing.Protocol` with `@runtime_checkable`, so any class with matching method signatures automatically satisfies it — no inheritance needed.
 </Tip>
+
+### set_chat_history (Recommended)
+
+**`set_chat_history(session_id, messages)` (recommended).** Atomically replaces the chat history for a session. If your store omits this method, `Session.save_state()` falls back to `add_message()` per message and may produce duplicates when called repeatedly. The built-in `DefaultSessionStore` implements this with reload-under-lock atomic-write semantics.
+
+```python
+class MyStore:
+    def set_chat_history(self, session_id: str, messages: list[dict]) -> bool:
+        """Replace the chat history for a session atomically.
+        
+        Args:
+            session_id: Session identifier
+            messages: list of {"role": str, "content": str}
+            
+        Returns:
+            True if successful
+        """
+        with self._lock:
+            self._data[session_id] = list(messages)
+            self._flush()
+        return True
+```
 
 <Tip>
 If your custom store backs onto shared storage (Redis, Postgres, S3, another file system), make `get_chat_history`, `get_session`, and `get_sessions_by_agent` read from that backing store on every call rather than caching in process memory. `DefaultSessionStore` guarantees this; downstream code such as `BotSessionManager._load_history` relies on it.

--- a/docs/features/sessions.mdx
+++ b/docs/features/sessions.mdx
@@ -532,6 +532,10 @@ agent.start("Remember that I prefer dark mode")
 ```
 
 <Note>
+**Idempotent saves.** `Session.save_state()` is idempotent against the underlying session store: calling it repeatedly does not duplicate chat history. The session store must implement `set_chat_history(session_id, messages)`; the built-in `DefaultSessionStore` does. Custom stores that only implement `add_message()` will log a warning and may produce duplicates on repeated saves. (PraisonAI PR #1897)
+</Note>
+
+<Note>
 The standalone `auto_save` parameter on `Agent(...)` is **deprecated**. Use `memory=MemoryConfig(auto_save="name")` instead.
 </Note>
 
@@ -539,8 +543,8 @@ The standalone `auto_save` parameter on `Agent(...)` is **deprecated**. Use `mem
 
 | Approach | Code | When to Use |
 |----------|------|-------------|
-| `auto_save` | `MemoryConfig(auto_save="name")` | Most applications — zero boilerplate |
-| Manual | `session.save_state()` | When you need save-point control |
+| `auto_save` | `MemoryConfig(auto_save="name")` | Most applications — zero boilerplate, per-turn persistence stays in sync |
+| Manual | `session.save_state()` | Save-point control; **idempotent** as of PR #1897 |
 | History injection | `MemoryConfig(history=True)` | Auto-inject past messages into context |
 
 ## Next Steps

--- a/docs/sdk/reference/praisonaiagents/functions/Session-save_state.mdx
+++ b/docs/sdk/reference/praisonaiagents/functions/Session-save_state.mdx
@@ -15,6 +15,8 @@ icon: "function"
 
 Save session state data to memory.
 
+Calling `save_state()` repeatedly is safe and idempotent — it does not duplicate chat history. Requires the session store to implement `set_chat_history`; built-in stores do.
+
 ## Signature
 
 ```python


### PR DESCRIPTION
## Summary

Updates documentation to reflect upstream bug fixes from PraisonAI PR #1897 that resolved:
- Duplicate messages when `memory="history"` was combined with `auto_save` (one turn produced 4 messages instead of 2)
- Non-idempotent `Session.save_state()` re-appending full history on every call

## Changes

### 1. `docs/features/history-injection.mdx`
- Added Note about per-turn persistence being exact
- Updated Best Practices card about auto-save bookkeeping staying in sync

### 2. `docs/features/sessions.mdx`
- Added idempotency note in Auto-Save Sessions section
- Updated Auto-Save vs Manual Save table with idempotency info

### 3. `docs/features/session-persistence.mdx`
- Added PR #1897 Info block 
- Added new "Idempotent saves" section explaining atomic replacement semantics

### 4. `docs/features/session-protocol.mdx`
- Added `set_chat_history` as recommended method to the protocol methods table
- Added detailed description and code example for implementing atomic replacement

### 5. `docs/sdk/reference/praisonaiagents/functions/Session-save_state.mdx`
- Added idempotency guarantee in the description

## Test plan

- [x] All code examples remain valid and copy-paste runnable
- [x] Follows AGENTS.md page structure and standards
- [x] Uses correct Mintlify components (Note, Info, etc.)
- [x] No new files created - only existing files updated
- [x] Changes accurately reflect upstream SDK behavior

Fixes #566

🤖 Generated with [Claude Code](https://claude.ai/code)