### PR TITLE
docs: Update doctor pages for Windows ASCII status symbol fallback

### DIFF
--- a/docs/cli/doctor-cli.mdx
+++ b/docs/cli/doctor-cli.mdx
@@ -278,23 +278,61 @@ praisonai doctor --only python_version,openai_api_key
 praisonai doctor --skip network_dns,network_https
 ```
 
+## Status Symbols
+
+The text formatter automatically picks symbols that match your terminal encoding.
+
+| Status | UTF-8 terminals | Non-UTF-8 terminals (e.g. Windows cp1252) |
+|--------|-----------------|-------------------------------------------|
+| Pass    | `✓` | `[OK]` |
+| Warn    | `⚠` | `[!]`  |
+| Fail    | `✗` | `[X]`  |
+| Skip    | `○` | `[-]`  |
+| Error   | `✗` | `[X]`  |
+
+<Note>
+Detection runs once when the formatter starts. UTF-8 terminals always
+use the Unicode symbols. Anything else (Windows default consoles,
+legacy `cp1252`/`cp437`, etc.) automatically falls back to ASCII so
+`praisonai doctor` never crashes with `UnicodeEncodeError`.
+</Note>
+
+Use `--json` for machine-readable output that does not depend on terminal encoding.
+
 ## Output Examples
 
 ### Text Output
 
+<Tabs>
+<Tab title="UTF-8 terminals">
 ```
 PraisonAI Doctor v1.0.0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ✓ Python Version: Python 3.11.0 (>= 3.9 required)
-✓ PraisonAI Package: praisonai 2.7.0 installed
 ✓ OpenAI API Key: OPENAI_API_KEY configured (***configured***)
 ⚠ Virtual Environment: Not running in a virtual environment
 ✗ Docker: Docker not found
 ○ ChromaDB: ChromaDB not installed (optional)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-6 checks: 3 passed, 1 warnings, 1 failed, 1 skipped
+5 checks: 2 passed, 1 warnings, 1 failed, 1 skipped
 Completed in 15ms
 ```
+</Tab>
+<Tab title="Windows cp1252">
+```
+PraisonAI Doctor v1.0.0
+----------------------------------------------------------------------
+[OK] Python Version: Python 3.13.2 (>= 3.9 required)
+[OK] OpenAI API Key: OPENAI_API_KEY configured (***configured***)
+[!]  Virtual Environment: Not running in a virtual environment
+[X]  Docker: Docker not found
+[-]  ChromaDB: ChromaDB not installed (optional)
+----------------------------------------------------------------------
+5 checks: 2 passed, 1 warnings, 1 failed, 1 skipped
+Completed in 15ms
+```
+</Tab>
+</Tabs>
 
 ### JSON Output
 
@@ -415,3 +453,19 @@ praisonai doctor network --deep
 # Verify database connectivity
 praisonai doctor db --deep --dsn "$DATABASE_URL"
 ```
+
+### Windows Unicode / encoding errors
+
+As of v4.x, `praisonai doctor` auto-detects your terminal encoding and falls
+back to ASCII status symbols (`[OK] [!] [X] [-]`) on non-UTF-8 consoles, so
+the historical `UnicodeEncodeError: 'charmap' codec` crash on Windows
+`cmd.exe` / PowerShell no longer happens. If you prefer Unicode output on
+Windows, run one of:
+
+```powershell
+$env:PYTHONIOENCODING="utf-8"
+praisonai doctor env
+```
+
+Or use Windows Terminal / a UTF-8 capable shell. For machine-readable
+output that does not depend on terminal encoding, use `--json`.

--- a/docs/cli/doctor.mdx
+++ b/docs/cli/doctor.mdx
@@ -195,6 +195,47 @@ praisonai doctor --skip network_dns,network_https
 praisonai doctor env --only openai_api_key,anthropic_api_key
 ```
 
+## Status Symbols
+
+The text formatter automatically picks symbols that match your terminal encoding.
+
+| Status | UTF-8 terminals | Non-UTF-8 terminals (e.g. Windows cp1252) |
+|--------|-----------------|-------------------------------------------|
+| Pass    | `✓` | `[OK]` |
+| Warn    | `⚠` | `[!]`  |
+| Fail    | `✗` | `[X]`  |
+| Skip    | `○` | `[-]`  |
+| Error   | `✗` | `[X]`  |
+
+<Note>
+Detection runs once when the formatter starts. UTF-8 terminals always
+use the Unicode symbols. Anything else (Windows default consoles,
+legacy `cp1252`/`cp437`, etc.) automatically falls back to ASCII so
+`praisonai doctor` never crashes with `UnicodeEncodeError`.
+</Note>
+
+Use `--json` for machine-readable output that does not depend on terminal encoding.
+
+```mermaid
+graph LR
+    Start[praisonai doctor] --> Detect{stdout<br/>encoding?}
+    Detect -->|UTF-8| Unicode[✓ ⚠ ✗ ○]
+    Detect -->|cp1252 / ascii / other| Ascii[OK ! X -]
+    Unicode --> Print[Render report]
+    Ascii --> Print
+
+    classDef cmd fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef decide fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef warn fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class Start cmd
+    class Detect decide
+    class Unicode ok
+    class Ascii warn
+    class Print cmd
+```
+
 ## JSON Output Format
 
 ```json


### PR DESCRIPTION
Closes #574

## Summary

Documents the Windows ASCII status symbol fallback feature for `praisonai doctor` text output, based on PraisonAI PR #1904 that added automatic terminal encoding detection.

## Changes

### Both Files (doctor.mdx and doctor-cli.mdx)
- **Status Symbols section**: Documents UTF-8 vs ASCII symbol mappings
- **Auto-detection explanation**: Terminal encoding detection happens at formatter init
- **No crash behavior**: Historical `UnicodeEncodeError` on Windows cp1252 consoles now resolved

### doctor.mdx
- Added Mermaid flow diagram showing encoding detection process
- Uses standard PraisonAIDocs color scheme (#8B0000, #F59E0B, #10B981, #6366F1)

### doctor-cli.mdx  
- **Updated text output examples**: Now shows both UTF-8 and ASCII variants using Tabs
- **Windows troubleshooting section**: Documents `PYTHONIOENCODING=utf-8` workaround for Unicode preference
- **Historical context**: Mentions the fix for `charmap` codec crashes

## Status Symbol Mappings

| Status | UTF-8 | ASCII |
|--------|-------|-------|
| Pass   | ✓     | [OK]  |
| Warn   | ⚠     | [!]   |
| Fail   | ✗     | [X]   |
| Skip   | ○     | [-]   |

## Testing

- [x] Both pages document UTF-8 and ASCII symbol sets
- [x] Auto-detection behavior explained
- [x] Windows troubleshooting included
- [x] Mintlify components used (Tabs, Note)
- [x] Mermaid diagram follows color standards
- [x] No changes to docs.json (existing pages)

🤖 Generated with [Claude Code](https://claude.ai/code)