### PR TITLE
docs: add Tool Parameter Types page for Optional/Union/Literal/Enum support

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1627,6 +1627,7 @@
               "docs/tools/tools_class",
               "docs/tools/reliability",
               "docs/features/tool-schema-validation",
+              "docs/features/tool-parameter-types",
               "docs/tools/single-file-plugins",
               {
                 "group": "Search Tools",

--- a/docs/features/dynamic-tool-schemas.mdx
+++ b/docs/features/dynamic-tool-schemas.mdx
@@ -324,8 +324,14 @@ class ComplexTool(BaseTool):
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Tool Parameter Types" icon="shapes" href="/docs/features/tool-parameter-types">
+  Use Optional, Union, Literal, Enum in tool parameters
+</Card>
 <Card title="Tools Overview" icon="wrench" href="/docs/tools">
   Learn about PraisonAI's tool system and how to create custom tools
+</Card>
+<Card title="Tool Schema Validation" icon="shield-check" href="/docs/features/tool-schema-validation">
+  Validate tool schemas for OpenAI compatibility
 </Card>
 <Card title="Agents Guide" icon="robot" href="/docs/concepts/agents">
   Understand how agents use tools and manage their capabilities

--- a/docs/features/tool-parameter-types.mdx
+++ b/docs/features/tool-parameter-types.mdx
@@ -1,0 +1,295 @@
+---
+title: "Tool Parameter Types"
+sidebarTitle: "Parameter Types"
+description: "Use Optional, Union, Literal, Enum, List and Dict in tool signatures and the agent sees the right schema"
+icon: "shapes"
+---
+
+Use expressive Python type annotations in tool signatures and agents understand exactly what parameters they can pass.
+
+```mermaid
+graph LR
+    subgraph "Tool Parameter Type System"
+        A[📝 Python Annotation] --> B[🔄 annotation_to_json_schema] 
+        B --> C[📋 JSON Schema]
+        C --> D[🤖 LLM Tool Schema]
+    end
+    
+    classDef annotation fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef schema fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A annotation
+    class B process
+    class C schema
+    class D output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Optional Parameter">
+Create a tool where parameters can be omitted by the agent:
+
+```python
+from typing import Optional
+from praisonaiagents import Agent, tool
+
+@tool
+def search(query: str, max_results: Optional[int] = None) -> str:
+    """Search the web. Leave max_results blank to use the default."""
+    limit = max_results or 10
+    return f"Searched '{query}' (limit={limit})"
+
+agent = Agent(
+    instructions="You search the web for information",
+    tools=[search]
+)
+
+agent.start("Find AI news")
+```
+</Step>
+
+<Step title="Literal for Fixed Choices">
+Restrict parameter values to specific literal options:
+
+```python
+from typing import Literal
+from praisonaiagents import Agent, tool
+
+@tool
+def analyze(text: str, mode: Literal["fast", "deep"] = "fast") -> str:
+    """Analyze text with different modes."""
+    if mode == "deep":
+        return f"Deep analysis of: {text}"
+    return f"Quick analysis of: {text}"
+
+agent = Agent(
+    instructions="You analyze text content",
+    tools=[analyze]
+)
+
+agent.start("Analyze this document in deep mode")
+```
+</Step>
+
+<Step title="Enum for Choices">
+Use Enum classes for reusable choice sets across tools:
+
+```python
+from enum import Enum
+from praisonaiagents import Agent, tool
+
+class Priority(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+@tool
+def create_task(title: str, priority: Priority = Priority.MEDIUM) -> str:
+    """Create a new task with specified priority."""
+    return f"Created task '{title}' with priority: {priority.value}"
+
+agent = Agent(
+    instructions="You manage tasks",
+    tools=[create_task]
+)
+
+agent.start("Create a high priority task for the meeting")
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+The agent understands your type annotations through this process:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Schema
+    participant LLM
+    
+    User->>Agent: "Create task with high priority"
+    Agent->>Schema: annotation_to_json_schema(Priority)
+    Schema-->>Agent: {"type": "string", "enum": ["low", "medium", "high"]}
+    Agent->>LLM: Tool schema with enum constraint
+    LLM-->>Agent: create_task(title="meeting", priority="high")
+    Agent-->>User: "Created task 'meeting' with priority: high"
+```
+
+| Python Annotation | JSON Schema Output |
+|---|---|
+| `str`, `int`, `float`, `bool` | `{"type": "string" | "integer" | "number" | "boolean"}` |
+| `Optional[int]` | `{"anyOf": [{"type": "integer"}, {"type": "null"}]}` |
+| `Union[str, int]` | `{"anyOf": [{"type": "string"}, {"type": "integer"}]}` |
+| `Literal["fast", "deep"]` | `{"type": "string", "enum": ["fast", "deep"]}` |
+| `Literal[1, 2, 3]` | `{"type": "integer", "enum": [1, 2, 3]}` |
+| Enum subclass (str-valued) | `{"type": "string", "enum": ["...", ...]}` |
+| `List[int]` | `{"type": "array", "items": {"type": "integer"}}` |
+| `Dict[str, int]` | `{"type": "object", "additionalProperties": {"type": "integer"}}` |
+
+---
+
+## Choosing the Right Type
+
+```mermaid
+graph TD
+    A[Need parameter?] --> B{Can be omitted?}
+    B -->|Yes| C[Optional[T]]
+    B -->|No| D{Fixed set of values?}
+    D -->|Yes| E{Reused across tools?}
+    E -->|Yes| F[Enum]
+    E -->|No| G[Literal]
+    D -->|No| H{Multiple types?}
+    H -->|Yes| I[Union[T1, T2]]
+    H -->|No| J[Simple type: str, int, etc.]
+    
+    classDef optional fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef choice fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef simple fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class C optional
+    class F,G choice
+    class I,J simple
+```
+
+---
+
+## Common Patterns
+
+### Mode Flags with Defaults
+```python
+@tool
+def process_data(data: str, mode: Literal["fast", "thorough"] = "fast") -> str:
+    """Process data with different thoroughness levels."""
+    if mode == "thorough":
+        return f"Thoroughly processed: {data}"
+    return f"Quick processing: {data}"
+```
+
+### Shared Choice Sets
+```python
+class Format(str, Enum):
+    JSON = "json"
+    CSV = "csv"
+    XML = "xml"
+
+@tool
+def export_data(data: str, format: Format) -> str:
+    """Export data in specified format."""
+    return f"Exported as {format.value}: {data}"
+
+@tool
+def import_data(file_path: str, format: Format) -> str:
+    """Import data from specified format."""
+    return f"Imported {format.value} file: {file_path}"
+```
+
+### Structured Collections
+```python
+from typing import List, Dict
+
+@tool
+def batch_process(items: List[str], config: Dict[str, str]) -> str:
+    """Process multiple items with configuration."""
+    return f"Processed {len(items)} items with config: {config}"
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Prefer Optional[T] over bare parameters">
+Use `Optional[int]` with a default of `None` instead of leaving parameters untyped. This tells the agent the parameter can be omitted and what type to use when provided.
+
+```python
+# Good
+def search(query: str, limit: Optional[int] = None) -> str:
+    pass
+
+# Avoid
+def search(query: str, limit=None) -> str:
+    pass
+```
+</Accordion>
+
+<Accordion title="Use Literal for small fixed sets, Enum for reusable choices">
+Choose `Literal[...]` when values are unique to one tool. Use `Enum` when the same choices appear across multiple tools.
+
+```python
+# Literal for one-off choices
+def analyze(text: str, depth: Literal["surface", "deep"] = "surface"):
+    pass
+
+# Enum for shared choices
+class Priority(str, Enum):
+    LOW = "low"
+    HIGH = "high"
+
+def create_task(title: str, priority: Priority):
+    pass
+
+def update_task(id: str, priority: Priority):
+    pass
+```
+</Accordion>
+
+<Accordion title="Avoid Union for unrelated types">
+Don't use `Union[str, dict]` for "either a string or a dict" - the LLM struggles with such choices. Create separate tools instead.
+
+```python
+# Avoid
+def process(input: Union[str, Dict[str, str]]):
+    pass
+
+# Prefer
+def process_text(text: str):
+    pass
+
+def process_data(data: Dict[str, str]):
+    pass
+```
+</Accordion>
+
+<Accordion title="Parameterize your collections">
+Write `List[str]` instead of bare `list` so the agent knows what elements to include.
+
+```python
+# Good - agent knows to pass strings
+def process_items(items: List[str]) -> str:
+    pass
+
+# Avoid - agent doesn't know element type
+def process_items(items: list) -> str:
+    pass
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Tool Schema Validation" icon="check-circle" href="/docs/features/tool-schema-validation">
+Validate tool schemas and catch type errors
+</Card>
+
+<Card title="Custom Tools Guide" icon="wrench" href="/docs/guides/tools/create-custom-tools">
+Complete guide to creating custom tools
+</Card>
+
+<Card title="Dynamic Tool Schemas" icon="refresh" href="/docs/features/dynamic-tool-schemas">
+Generate schemas dynamically at runtime
+</Card>
+
+<Card title="Different Ways to Create Tools" icon="code" href="/docs/guides/tools/different-ways-to-create-tools">
+Explore all methods for tool creation
+</Card>
+</CardGroup>

--- a/docs/features/tool-schema-validation.mdx
+++ b/docs/features/tool-schema-validation.mdx
@@ -113,6 +113,7 @@ sequenceDiagram
 | JSON round-trip preserves structure | Non-serializable values (functions, sets, etc.) |
 | `required` is a list when present | Common typo (string instead of list) |
 | Unique names across a list | Duplicate registration |
+| Complex type annotations | Optional, Union, Literal, Enum, parameterized List/Dict translated to proper JSON Schema |
 
 ---
 
@@ -265,10 +266,16 @@ This early detection helps you fix schema issues during development instead of d
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Tool Parameter Types" icon="shapes" href="/docs/features/tool-parameter-types">
+  Use Optional, Union, Literal, Enum in tool parameters
+</Card>
 <Card title="Custom Tools" icon="wrench" href="/docs/tools/custom">
   Learn to create custom BaseTool and @tool implementations
 </Card>
 <Card title="Tool Reliability" icon="shield" href="/docs/tools/reliability">
   Runtime error handling and tool safety patterns
+</Card>
+<Card title="Dynamic Tool Schemas" icon="refresh" href="/docs/features/dynamic-tool-schemas">
+  Generate schemas dynamically at runtime
 </Card>
 </CardGroup>

--- a/docs/guides/tools/create-custom-tools.mdx
+++ b/docs/guides/tools/create-custom-tools.mdx
@@ -170,11 +170,50 @@ icon: "plus"
   </Step>
 </Steps>
 
+## How to Use Optional, Literal, and Enum Parameters
+
+<Steps>
+<Step title="Create Tool with Choice Parameters">
+```python
+from typing import Optional, Literal
+from enum import Enum
+from praisonaiagents import Agent, tool
+
+class Priority(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+@tool
+def create_task(
+    title: str,
+    priority: Priority = Priority.MEDIUM,
+    deadline: Optional[str] = None,
+    mode: Literal["draft", "active"] = "draft"
+) -> str:
+    """Create a task with flexible parameters."""
+    result = f"Task '{title}' created with priority: {priority.value}, mode: {mode}"
+    if deadline:
+        result += f", deadline: {deadline}"
+    return result
+
+agent = Agent(
+    instructions="You manage tasks",
+    tools=[create_task]
+)
+
+agent.start("Create a high priority task with deadline tomorrow")
+```
+</Step>
+</Steps>
+
+See the [Tool Parameter Types](/docs/features/tool-parameter-types) page for complete reference on using Optional, Union, Literal, Enum, List, and Dict types.
+
 ## Tool Function Requirements
 
 | Requirement | Description |
 |-------------|-------------|
-| Type hints | All parameters must have type hints |
+| Type hints | All parameters must have type hints. Supports Optional, Union, Literal, Enum, List[T] and Dict[K, V] with proper JSON Schema translation |
 | Docstring | Must include description and Args section |
 | Return type | Must specify return type |
 | Serializable | Return value must be JSON-serializable |

--- a/docs/guides/tools/different-ways-to-create-tools.mdx
+++ b/docs/guides/tools/different-ways-to-create-tools.mdx
@@ -245,6 +245,36 @@ icon: "layer-group"
   </Step>
 </Steps>
 
+## How to Create Tools with Choice Parameters
+
+<Steps>
+<Step title="Use Literal for Fixed Options">
+```python
+from typing import Literal
+from praisonaiagents import Agent, tool
+
+@tool
+def format_text(text: str, style: Literal["bold", "italic", "underline"]) -> str:
+    """Format text with specified style."""
+    if style == "bold":
+        return f"**{text}**"
+    elif style == "italic":
+        return f"*{text}*"
+    else:
+        return f"__{text}__"
+
+agent = Agent(
+    instructions="You format text",
+    tools=[format_text]
+)
+
+agent.start("Make this text bold")
+```
+</Step>
+</Steps>
+
+See the [Tool Parameter Types](/docs/features/tool-parameter-types) page for complete guide on using Optional, Union, Literal, Enum, List, and Dict types.
+
 ## Tool Creation Methods Comparison
 
 | Method | Best For | Complexity |

--- a/docs/tools/custom.mdx
+++ b/docs/tools/custom.mdx
@@ -196,6 +196,35 @@ agent = Agent(
 agent.start("What's the weather in Paris?")
 ```
 
+## Expressive Parameter Types
+
+Create tools with rich type annotations for better schema generation:
+
+```python
+from typing import Optional, Literal
+from praisonaiagents import Agent, tool
+
+@tool
+def configure_service(
+    name: str,
+    port: Optional[int] = None,
+    mode: Literal["production", "development"] = "development"
+) -> str:
+    """Configure a service with optional port and mode."""
+    config = f"Service '{name}' configured in {mode} mode"
+    if port:
+        config += f" on port {port}"
+    return config
+
+agent = Agent(
+    instructions="You configure services",
+    tools=[configure_service]
+)
+agent.start("Configure webapp in production mode with port 8080")
+```
+
+See the [Tool Parameter Types](/docs/features/tool-parameter-types) page for complete guide.
+
 ## Creating a Pip-Installable Tool Package
 
 Create tools that auto-register when installed:


### PR DESCRIPTION
Fixes #577

This PR adds comprehensive documentation for the new tool parameter types functionality from PR #1907, which allows complex Python type annotations in tool signatures.

## Changes

### 🆕 New Documentation Page
- Created `docs/features/tool-parameter-types.mdx` with complete guide on using Optional, Union, Literal, Enum, List and Dict types
- Includes Quick Start examples, How It Works section, decision diagram, common patterns, and best practices
- Follows AGENTS.md standards with hero Mermaid diagram, Steps component, AccordionGroup, and CardGroup

### ✨ Updated Existing Documentation
- `docs/guides/tools/create-custom-tools.mdx`: Added new section with choice parameters example and cross-link
- `docs/guides/tools/different-ways-to-create-tools.mdx`: Added section showing Literal usage
- `docs/tools/custom.mdx`: Added expressive parameter types section with practical example
- `docs/features/tool-schema-validation.mdx`: Updated validation table and added cross-link
- `docs/features/dynamic-tool-schemas.mdx`: Added cross-link in Related section

### 🔗 Navigation
- Added new page to `docs.json` under Features group, positioned next to other tool schema pages

## Features Documented

- **Optional[T]** parameters that can be omitted by agents
- **Literal["choice1", "choice2"]** for fixed value sets
- **Enum classes** for reusable choices across tools  
- **Union types** for multiple allowed types
- **Parameterized List[T] and Dict[K,V]** collections
- **Proper JSON Schema generation** for all complex types

## Quality Checklist

- ✅ Frontmatter complete (title, sidebarTitle, description, icon)
- ✅ Hero Mermaid diagram with standard color scheme
- ✅ Quick Start uses Steps component
- ✅ Best Practices uses AccordionGroup  
- ✅ Related section uses CardGroup
- ✅ All code examples use friendly imports
- ✅ docs.json is valid JSON
- ✅ Cross-links added to related pages

Generated with [Claude Code](https://claude.ai/code)