### PR TITLE
docs: document wrapper-layer convergence (sync/async parity + workflow YAML routing) and kanban dispatcher operational behavior

### DIFF
--- a/docs/features/execution-systems.mdx
+++ b/docs/features/execution-systems.mdx
@@ -38,6 +38,8 @@ Ordered step execution mixing deterministic automation and AI agent steps.
 
 **Discriminator**: `type: job` in YAML | **Engine**: `JobWorkflowExecutor`
 
+**Routing**: Honored by both the CLI (`praisonai workflow run ...`) and the programmatic wrapper (`AgentsGenerator.generate_crew_and_kickoff()` / `.agenerate_crew_and_kickoff()`)
+
 **Deterministic steps**: `run:` (shell), `python:` (script), `script:` (inline Python), `action:` (custom/built-in)
 
 **Agent-centric steps**: `agent:` (AI agent), `judge:` (quality gate), `approve:` (approval gate)
@@ -107,6 +109,8 @@ praisonai workflow run research.yaml
 Combines job workflow steps (deterministic + agent) with multi-agent collaboration steps.
 
 **Discriminator**: `type: hybrid` in YAML | **Engine**: `HybridWorkflowExecutor`
+
+**Routing**: Honored by both the CLI (`praisonai workflow run ...`) and the programmatic wrapper (`AgentsGenerator.generate_crew_and_kickoff()` / `.agenerate_crew_and_kickoff()`)
 
 Supports all job workflow step types **plus**:
 - `workflow:` — execute a named agent from the `agents:` block

--- a/docs/features/hybrid-workflows.mdx
+++ b/docs/features/hybrid-workflows.mdx
@@ -48,6 +48,20 @@ praisonai workflow run pipeline.yaml
 praisonai workflow run pipeline.yaml --dry-run
 ```
 
+```python Run programmatically
+from praisonai.agents_generator import AgentsGenerator
+
+# Hybrid workflow YAML
+gen = AgentsGenerator(agent_file="pipeline.yaml")
+gen.generate_crew_and_kickoff()
+
+# Or async
+import asyncio
+asyncio.run(AgentsGenerator(agent_file="pipeline.yaml").agenerate_crew_and_kickoff())
+```
+
+**No extra flag needed** — the wrapper detects `type: hybrid` and routes automatically. Previously only the `praisonai workflow run` CLI did this; the programmatic API now matches.
+
 ---
 
 ## How It Works

--- a/docs/features/job-workflows.mdx
+++ b/docs/features/job-workflows.mdx
@@ -30,8 +30,22 @@ praisonai workflow run deploy.yaml
 praisonai workflow run deploy.yaml --dry-run
 ```
 
+```python Run programmatically
+from praisonai.agents_generator import AgentsGenerator
+
+# Job workflow YAML
+gen = AgentsGenerator(agent_file="deploy.yaml")
+gen.generate_crew_and_kickoff()
+
+# Or async
+import asyncio
+asyncio.run(AgentsGenerator(agent_file="deploy.yaml").agenerate_crew_and_kickoff())
+```
+
 > [!TIP]
 > A YAML file is a job workflow when it has **`type: job`** at the root. Without it, PraisonAI treats it as an agent workflow.
+
+**No extra flag needed** — the wrapper detects `type: job` and routes automatically. Previously only the `praisonai workflow run` CLI did this; the programmatic API now matches.
 
 ---
 

--- a/docs/features/yaml-workflows.mdx
+++ b/docs/features/yaml-workflows.mdx
@@ -185,7 +185,42 @@ result = manager.execute_yaml(
     variables={"topic": "Machine Learning"}
 )
 ```
+
+```python Programmatic Usage
+# Option 3: AgentsGenerator (auto-detects workflow YAML)
+from praisonai.agents_generator import AgentsGenerator
+
+# Sync path
+gen = AgentsGenerator(agent_file="research.yaml")
+result = gen.generate_crew_and_kickoff()
+
+# Async path (works the same as sync)
+import asyncio
+async def main():
+    gen = AgentsGenerator(agent_file="research.yaml")
+    return await gen.agenerate_crew_and_kickoff()
+
+result = asyncio.run(main())
+```
 </CodeGroup>
+
+<Note>
+**Programmatic Routing**: The `AgentsGenerator` wrapper auto-detects workflow YAML and routes to the appropriate engine:
+
+| Discriminator in YAML  | Routed to             |
+|------------------------|-----------------------|
+| `process: workflow`    | `YAMLWorkflowParser`  |
+| `steps:` + `workflow:` | `YAMLWorkflowParser`  |
+| `type: job`            | `YAMLWorkflowParser`  |
+| `type: hybrid`         | `YAMLWorkflowParser`  |
+| *(none of the above)*  | Framework adapter     |
+
+This means calling `AgentsGenerator(agent_file="release.yaml").generate_crew_and_kickoff()` with a job/hybrid YAML now routes correctly to the workflow runner instead of falling through to the framework adapter.
+</Note>
+
+<Note>
+**Async parity:** `agenerate_crew_and_kickoff()` now initializes observability and adapter setup the same way `generate_crew_and_kickoff()` does — Langfuse / AgentOps traces are wired on both paths.
+</Note>
 
 ## Complete workflow.yaml Reference
 

--- a/docs/gateway.mdx
+++ b/docs/gateway.mdx
@@ -261,6 +261,12 @@ The `get_exec_approval_manager()` function is preserved as a backward-compatible
 
 ---
 
+## Kanban Dispatcher
+
+**Kanban dispatcher (v4.6.x):** Worker file descriptors are now released as soon as the subprocess starts (fixes a slow leak under sustained dispatch). `release_claim` failures are logged with full stack traces instead of being silently swallowed — orphaned `claimed` tasks now leave a clear log trail for triage. `KeyboardInterrupt` / `SystemExit` / asyncio cancellation propagate cleanly through dispatcher shutdown.
+
+---
+
 ## Common Patterns
 
 ### Single Gateway Deployment


### PR DESCRIPTION
## Summary

Documents the changes from PR MervinPraison/PraisonAI#1908 that introduced sync/async parity and improved kanban dispatcher operational behavior.

### Changes Made

- **yaml-workflows.mdx**: Added programmatic usage section showing `AgentsGenerator` with both sync and async examples, routing rules table, and async parity note
- **job-workflows.mdx**: Added "Run programmatically" section with `AgentsGenerator` examples and automatic `type: job` detection
- **hybrid-workflows.mdx**: Added "Run programmatically" section with `AgentsGenerator` examples and automatic `type: hybrid` detection  
- **execution-systems.mdx**: Added routing notes mentioning both CLI and programmatic wrapper honor discriminators
- **gateway.mdx**: Added "Kanban Dispatcher" section with operational improvements notes

### Key Documentation Updates

- `AgentsGenerator._is_workflow_yaml()` now detects `type: job` and `type: hybrid` in addition to existing patterns
- Both sync (`generate_crew_and_kickoff()`) and async (`agenerate_crew_and_kickoff()`) paths now share preparation logic
- CLI config overrides now apply consistently on both sync and async paths
- Observability hooks and adapter setup now fire on both sync and async paths
- Kanban dispatcher improvements: fixed file descriptor leaks, better error logging, cleaner shutdown

## Test Plan

- [x] Verify all documentation pages build correctly
- [x] Check that code examples follow AGENTS.md standards
- [x] Ensure routing table accurately reflects source code behavior
- [x] Validate async parity notes match implementation

🤖 Generated with [Claude Code](https://claude.ai/code)