### PR TITLE
docs: Document auto-injection of project instruction files + --no-rul…

### DIFF
--- a/docs/cli/chat.mdx
+++ b/docs/cli/chat.mdx
@@ -37,6 +37,7 @@ praisonai chat [OPTIONS] [PROMPT]
 | `--no-color` | | Disable colors | `false` |
 | `--theme` | | UI theme: `default`, `dark`, `light`, `minimal` | `default` |
 | `--compact` | | Compact output mode | `false` |
+| `--no-rules` | | Disable auto-injection of project instruction files | `false` |
 
 ## Examples
 
@@ -87,6 +88,14 @@ praisonai chat --json "Summarize this text"
 ```bash
 praisonai chat --ui-backend mg
 ```
+
+### Chat without auto-loaded instructions
+
+```bash
+praisonai chat --no-rules "Hello, ignore project rules"
+```
+
+The chat session normally inherits `AGENTS.md`/`CLAUDE.md`/`PRAISON.md` from the working directory. `--no-rules` runs the assistant with only its built-in instructions.
 
 ## UI Backends
 

--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -278,6 +278,7 @@ praisonai
 | `--auto-save` | str | Auto-save name |
 | `--history` | int | History size |
 | `--include-rules` | str | Include rules |
+| `--no-rules` | flag | Disable auto-injection of project instruction files (AGENTS.md, CLAUDE.md, etc.) |
 | `--checkpoint` | str | Checkpoint ID |
 | `--thinking` | str | Thinking budget |
 | `--compaction` | str | Compaction strategy |

--- a/docs/cli/cli.mdx
+++ b/docs/cli/cli.mdx
@@ -364,6 +364,7 @@ praisonai "List files here" -v
 | `--expand-prompt` | Expand short prompt to detailed | `praisonai "task" --expand-prompt` |
 | `--expand-tools` | Tools for prompt expansion | `praisonai "task" --expand-prompt --expand-tools tools.py` |
 | `--include-rules` | Include rules file | `praisonai "task" --include-rules rules.md` |
+| `--no-rules` | Disable auto-loading of project instruction files | `praisonai "task" --no-rules` |
 | `--max-tokens` | Maximum tokens for response | `praisonai "task" --max-tokens 4000` |
 
 ### Monitoring & Display

--- a/docs/cli/config.mdx
+++ b/docs/cli/config.mdx
@@ -69,6 +69,45 @@ Configuration can also be set via environment variables:
 | `PRAISONAI_MODEL` | Default model |
 | `PRAISONAI_VERBOSE` | Enable verbose mode |
 
+## TOML Configuration
+
+The CLI also reads a structured TOML config from `~/.praisonai/config.toml` (or `.praisonai/config.toml` in your project). This is separate from the SDK's `[defaults.*]` config — it controls **CLI behaviour** like auto-injection of project instructions.
+
+```toml
+# ~/.praisonai/config.toml
+
+[rules]
+# Auto-inject project instruction files (AGENTS.md, CLAUDE.md, PRAISON.md, etc.)
+# into prompts run via `praisonai run` and `praisonai chat`.
+auto = true              # Default: true
+max_chars = 32000        # Total character cap across all rules. Default: 32000.
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `auto` | `bool` | `true` | Auto-inject project instruction files into CLI prompts. Set to `false` to disable globally. |
+| `max_chars` | `int` | `32000` | Maximum total characters loaded from rules. Per-file cap is fixed at 12000. |
+
+### Disable rules globally
+
+```toml
+[rules]
+auto = false
+```
+
+You can still load rules on-demand with `praisonai run "task" --include-rules security`.
+
+### Other CLI config sections
+
+| Section | Purpose |
+|---------|---------|
+| `[output]` | Output preset, verbose, stream, metrics |
+| `[traces]` | Telemetry providers |
+| `[mcp]` | MCP server registrations |
+| `[model]` | Default model and provider settings |
+| `[session]` | Auto-save, history limit |
+| `[rules]` | **New** — auto-injection of project instructions |
+
 ## See Also
 
 - [Profile](/docs/cli/profile) - Performance profiling

--- a/docs/cli/rules.mdx
+++ b/docs/cli/rules.mdx
@@ -18,6 +18,66 @@ praisonai rules list
   <img src="./rules-list-auto-discovered-rules.gif" alt="List auto-discovered rules example" />
 </Frame>
 
+## CLI Auto-Injection
+
+`praisonai run` and `praisonai chat` automatically load project instruction files from the current directory (and walk up to the git root). Zero config required — drop an `AGENTS.md` into your project and every CLI run sees it.
+
+```mermaid
+graph LR
+    subgraph "CLI Auto-Injection Flow"
+        CLI[💻 praisonai run / chat] --> CHECK{🔍 --no-rules?}
+        CHECK -->|No| DISCOVER[📄 Auto-discover<br/>AGENTS.md, CLAUDE.md,<br/>PRAISON.md, etc.]
+        CHECK -->|Yes| SKIP[⏭️ Skip]
+        DISCOVER --> INJECT[💉 Prepend to prompt]
+        INJECT --> LLM[🤖 LLM]
+        SKIP --> LLM
+    end
+
+    classDef cli fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef decide fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef load fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class CLI cli
+    class CHECK decide
+    class DISCOVER,INJECT load
+    class SKIP,LLM result
+```
+
+### Opt-out
+
+| Goal | How |
+|------|-----|
+| Disable for a single run | `praisonai run "task" --no-rules` |
+| Disable globally | Set `[rules] auto = false` in `~/.praisonai/config.toml` |
+| Override the size cap | Set `[rules] max_chars = 16000` in `config.toml` |
+| Still load a specific manual rule | `praisonai run "task" --include-rules security` |
+
+### Precedence
+
+1. `--no-rules` (always wins)
+2. `--include-rules <names>` (manual list or `auto`)
+3. `[rules] auto` in `config.toml`
+4. Default: auto-loading **on**
+
+### Size caps
+
+| Cap | Default | Where to change |
+|-----|---------|-----------------|
+| Per file | 12 KB (12000 chars) | Hard-coded in `RulesManager.MAX_RULE_CHARS` |
+| Total | 32 KB (32000 chars) | `[rules] max_chars` in `config.toml` |
+
+Files over the per-file cap are truncated with a warning. Total context stops at `max_chars`.
+
+### Verbose output
+
+```bash
+praisonai run "Refactor the auth module" --verbose
+# Loaded project instructions: AGENTS.md, CLAUDE.md
+```
+
+Only **root-priority** files (`AGENTS.md`, `CLAUDE.md`, `PRAISON.md`, `GEMINI.md`, `.cursorrules`, `.windsurfrules`) are listed — modular rules under `.praison/rules/` and globals are loaded silently.
+
 ## Usage
 
 ![Manage Auto-Discovered Rules](./rules-manage-auto-discovered-rules.gif)
@@ -66,6 +126,7 @@ praisonai rules stats
 
 ```bash
 praisonai "Task" --include-rules security,testing
+praisonai "Task" --no-rules
 ```
 
 ## Auto-Discovered Files

--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -32,6 +32,7 @@ praisonai run [OPTIONS] [TARGET]
 | `--memory` | | Enable memory | `false` |
 | `--tools` | `-t` | Tools file path | |
 | `--max-tokens` | | Maximum output tokens | `16000` |
+| `--no-rules` | | Disable auto-injection of project instruction files (AGENTS.md, CLAUDE.md, etc.) | `false` |
 
 ## Examples
 
@@ -75,6 +76,21 @@ praisonai run agents.yaml --verbose
 
 ```bash
 praisonai run agents.yaml --tools tools.py
+```
+
+### Run without project instruction files
+
+By default, `praisonai run` auto-loads `AGENTS.md`, `CLAUDE.md`, `PRAISON.md`, etc. from the project root. Use `--no-rules` to opt out:
+
+```bash
+praisonai run "Quick one-off task" --no-rules
+```
+
+Use `--verbose` to see which instruction files were loaded:
+
+```bash
+praisonai run "What does this codebase do?" --verbose
+# > Loaded project instructions: AGENTS.md, CLAUDE.md
 ```
 
 ## Agent File Format

--- a/docs/features/rules.mdx
+++ b/docs/features/rules.mdx
@@ -398,6 +398,57 @@ context = agent.get_rules_context(
 print(context)
 ```
 
+## CLI Integration
+
+Project instruction files are auto-injected into `praisonai run`, `praisonai chat`, and `praisonai code` runs — no Python required.
+
+```mermaid
+sequenceDiagram
+    participant U as 👤 User
+    participant CLI as 💻 praisonai run
+    participant RM as 📚 RulesManager
+    participant LLM as 🤖 Agent
+
+    U->>CLI: praisonai run "Fix the auth bug"
+    CLI->>RM: build_rules_context()
+    RM->>RM: Discover AGENTS.md, CLAUDE.md
+    RM-->>CLI: rules_context (≤32 KB)
+    CLI->>LLM: rules_context + "\n# Task:\nFix the auth bug"
+    LLM-->>U: Response respecting project rules
+```
+
+### Quick start
+
+```bash
+# 1. Create an instruction file in your project
+echo "Always use type hints" > AGENTS.md
+
+# 2. Run any CLI command — instructions are loaded automatically
+praisonai run "Write a sort function"
+```
+
+### CLI flags
+
+| Flag | Effect |
+|------|--------|
+| _(default)_ | Auto-inject all discovered instruction files |
+| `--no-rules` | Skip auto-injection for this run |
+| `--include-rules <names>` | Force-include named rules (comma-separated) |
+| `--include-rules auto` | Explicitly enable auto (same as default) |
+| `--verbose` | Print loaded files: `Loaded project instructions: AGENTS.md, CLAUDE.md` |
+
+### Configuration
+
+Global opt-out via `~/.praisonai/config.toml`:
+
+```toml
+[rules]
+auto = false        # Disable everywhere
+max_chars = 16000   # Or shrink the budget
+```
+
+See [CLI Config](/cli/config) for the full TOML reference.
+
 ## Cross-Tool Compatibility
 
 PraisonAI rules are compatible with other AI coding assistants:


### PR DESCRIPTION
…es flag (fixes #597)

- Add --no-rules flag documentation to run.mdx, chat.mdx, cli-reference.mdx, cli.mdx
- Add CLI Auto-Injection section to rules.mdx with flow diagram and opt-out options
- Add TOML Configuration section to config.mdx documenting new [rules] section
- Add CLI Integration section to features/rules.mdx with sequence diagram
- Document precedence: --no-rules > --include-rules > [rules].auto > default
- Document size caps: 12KB per file, 32KB total (configurable)
- Show verbose output example: 'Loaded project instructions: AGENTS.md, CLAUDE.md'