### PR TITLE
docs: CLI session continuity for praisonai run command

### DIFF
--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -24,7 +24,7 @@ praisonai run [OPTIONS] [TARGET]
 |--------|-------|-------------|---------|
 | `--model` | `-m` | LLM model to use | `gpt-4o-mini` |
 | `--framework` | `-f` | Framework: praisonai, crewai, autogen | `praisonai` |
-| `praisonai chat` | `-i` | Enable interactive mode | `false` |
+| `--interactive` | `-i` | Enable interactive mode | `false` |
 | `--verbose` | `-v` | Verbose output | `false` |
 | `--stream` | | Stream output | `true` |
 | `--no-stream` | | Disable streaming | |
@@ -32,6 +32,10 @@ praisonai run [OPTIONS] [TARGET]
 | `--memory` | | Enable memory | `false` |
 | `--tools` | `-t` | Tools file path | |
 | `--max-tokens` | | Maximum output tokens | `16000` |
+| `--continue` | `-c` | Continue the most recent session for this project | `false` |
+| `--session` | `-s` | Resume a specific session ID | |
+| `--fork` | | Fork from the specified session (requires `--session`) | `false` |
+| `--no-save` | | Don't auto-save the session after execution | `false` |
 | `--no-rules` | | Disable auto-injection of project instruction files (AGENTS.md, CLAUDE.md, etc.) | `false` |
 
 ## Examples
@@ -78,6 +82,32 @@ praisonai run agents.yaml --verbose
 praisonai run agents.yaml --tools tools.py
 ```
 
+### Resume a previous session
+
+Continue where you left off in your current project:
+
+```bash
+praisonai run "now add tests" --continue
+```
+
+Resume a specific session by ID:
+
+```bash
+praisonai run "what were we working on?" --session abc12345
+```
+
+Fork from a session to try a different approach:
+
+```bash
+praisonai run "try a different approach" --fork --session abc12345
+```
+
+Run without saving the session:
+
+```bash
+praisonai run "one-off question" --no-save
+```
+
 ### Run without project instruction files
 
 By default, `praisonai run` auto-loads `AGENTS.md`, `CLAUDE.md`, `PRAISON.md`, etc. from the project root. Use `--no-rules` to opt out:
@@ -111,8 +141,17 @@ roles:
         expected_output: Comprehensive research summary
 ```
 
+## Session Management
+
+Sessions are scoped to the **current project** (git root, or current directory if not a git repository). Each run auto-saves to a generated `session-<uuid8>` unless `--no-save` is set.
+
+<Note>
+Use `praisonai session list` to view saved sessions for the current project, or `praisonai session list --all` to see sessions across all projects.
+</Note>
+
 ## See Also
 
+- [Session](/docs/cli/session) - Session management commands
 - [Agents](/docs/cli/agents) - Agent management
 - [Workflow](/docs/cli/workflow) - Workflow execution
 - [Interactive TUI](/docs/cli/interactive-tui) - Interactive terminal interface

--- a/docs/cli/session.mdx
+++ b/docs/cli/session.mdx
@@ -10,8 +10,11 @@ The `session` command manages conversation sessions, allowing you to save, resum
 ## Quick Start
 
 ```bash
-# List all sessions
+# List sessions for current project
 praisonai session list
+
+# List sessions across all projects
+praisonai session list --all
 ```
 
 <Frame>
@@ -57,18 +60,34 @@ praisonai session list
 
 **Expected Output:**
 ```
+Project: MyApp (ID: a1b2c3d4)
+
 📋 Available Sessions:
 
 ┌────┬─────────────────┬─────────────────────┬──────────┬──────────┐
 │ #  │ Session ID      │ Last Active         │ Messages │ Status   │
 ├────┼─────────────────┼─────────────────────┼──────────┼──────────┤
-│ 1  │ my-project      │ 2024-12-16 15:45    │ 12       │ active   │
-│ 2  │ research-task   │ 2024-12-16 14:20    │ 8        │ paused   │
-│ 3  │ code-review     │ 2024-12-15 10:30    │ 25       │ paused   │
-│ 4  │ documentation   │ 2024-12-14 09:15    │ 5        │ archived │
+│ 1  │ session-abc123  │ 2024-12-16 15:45    │ 12       │ active   │
+│ 2  │ session-def456  │ 2024-12-16 14:20    │ 8        │ paused   │
 └────┴─────────────────┴─────────────────────┴──────────┴──────────┘
 
-Total: 4 sessions
+Total: 2 sessions (current project only)
+```
+
+<Note>
+**Behavior Change:** Since PR #1929, `session list` now shows only the current project's sessions by default. Use `--all` to see sessions across all projects.
+</Note>
+
+**List sessions across all projects:**
+
+```bash
+praisonai session list --all
+```
+
+**List sessions for a specific project:**
+
+```bash
+praisonai session list --project a1b2c3d4
 ```
 
 ### Resume a Session
@@ -334,19 +353,54 @@ manager.delete_checkpoint("deploy-v1")
     └── build-v2.json
 ```
 
+## Project-Scoped Sessions
+
+Sessions are automatically scoped to your current project. PraisonAI detects your project by finding the git repository root, or uses the current working directory as a fallback.
+
+```mermaid
+flowchart TB
+    subgraph "Project Detection"
+        CWD[📁 Current Directory] --> Git{🔍 Git Root?}
+        Git -->|Found| GitRoot[📂 Git Repository Root]
+        Git -->|Not Found| UseCWD[📂 Use Current Directory]
+        GitRoot --> Hash[🔑 SHA256 Hash]
+        UseCWD --> Hash
+        Hash --> ProjectID[🆔 Project ID<br/>abc12345]
+    end
+    
+    ProjectID --> SessionDir[💾 Session Directory<br/>~/.praisonai/sessions/projects/abc12345/]
+    
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class CWD input
+    class Git,Hash process
+    class ProjectID,SessionDir output
+```
+
+**Project identification:**
+- **Project ID:** First 8 characters of SHA256 hash of project root path
+- **Git detection:** Uses `git rev-parse --show-toplevel` with 5-second timeout
+- **Fallback:** Current working directory if not in a git repository
+
+**Storage structure:**
+```
+~/.praisonai/sessions/
+├── projects/
+│   ├── abc12345/          # Project sessions
+│   │   ├── session-def789.json
+│   │   └── session-ghi012.json
+│   └── xyz98765/          # Another project
+│       └── session-jkl345.json
+└── global/                # Legacy global sessions
+    ├── old-session.json
+    └── another.json
+```
+
 ## Session Storage
 
-Sessions are stored locally in `~/.praisonai/memory/{user_id}/sessions/`:
-
-```
-~/.praisonai/
-└── memory/
-    └── praison/
-        └── sessions/
-            ├── my-project.json
-            ├── research-task.json
-            └── code-review.json
-```
+With project-scoped sessions, your sessions are organized by project automatically. Legacy sessions remain accessible via `--all` flag.
 
 ### Storage Backend Options
 
@@ -513,6 +567,11 @@ Long sessions accumulate tokens. Consider starting fresh sessions for unrelated 
 
 ## Related
 
-- [Session Management](/concepts/session-management)
-- [Memory CLI](/docs/cli/auto-memory)
-- [Sessions Feature](/features/sessions)
+<CardGroup cols={2}>
+  <Card title="Run Command" icon="play" href="/docs/cli/run">
+    Session flags for `praisonai run`
+  </Card>
+  <Card title="Session Persistence" icon="database" href="/docs/features/session-persistence">
+    SDK-level session management
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Fixes #602

## Summary

Adds documentation for CLI session continuity features added in PraisonAI PR #1929:

- **New session flags for \`praisonai run\`**: \`--continue\`, \`--session\`, \`--fork\`, \`--no-save\`
- **Project-scoped session management**: Sessions are now automatically scoped to the current project (git root or cwd)
- **Updated \`praisonai session list\`**: Now defaults to current project only, with \`--all\` and \`--project\` flags for cross-project access

## Changes

### \`docs/cli/run.mdx\`
- ✅ Added new session flags to Options table with correct types and defaults
- ✅ Fixed \`--interactive\` flag display (was incorrectly showing 'praisonai chat')
- ✅ Added "Resume a previous session" section with examples for each new flag
- ✅ Added session management section explaining project-scoped behavior
- ✅ Added cross-link to session documentation

### \`docs/cli/session.mdx\`
- ✅ Updated Quick Start to show both project-scoped and all-projects listing
- ✅ Modified List Sessions section to show new project-scoped default output
- ✅ Added Note about behavior change from PR #1929
- ✅ Added examples for \`--all\` and \`--project\` flags
- ✅ Added Project-Scoped Sessions section with Mermaid diagram showing git root detection flow
- ✅ Updated storage structure documentation
- ✅ Updated Related section with CardGroup links

## Validation

- ✅ All code examples match source code implementation from PraisonAI PR #1929
- ✅ Follows AGENTS.md documentation standards (Mermaid color scheme, Mintlify components)
- ✅ All examples are copy-paste runnable
- ✅ docs.json remains valid JSON
- ✅ No modifications to docs/concepts/ folder per guidelines

🤖 Generated with [Claude Code](https://claude.ai/code)