### PR TITLE
docs: Document praisonai run session continuity flags (--continue, --session, --fork, --no-save) and project-scoped session listing

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -523,6 +523,7 @@
                 "icon": "database",
                 "pages": [
                   "docs/features/sessions",
+                  "docs/features/project-sessions",
                   "docs/features/session-persistence",
                   "docs/features/session-protocol",
                   "docs/features/session-hierarchy",

--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -33,6 +33,10 @@ praisonai run [OPTIONS] [TARGET]
 | `--tools` | `-t` | Tools file path | |
 | `--max-tokens` | | Maximum output tokens | `16000` |
 | `--no-rules` | | Disable auto-injection of project instruction files (AGENTS.md, CLAUDE.md, etc.) | `false` |
+| `--continue` | `-c` | Continue the most recent session for the current project | `false` |
+| `--session` | `-s` | Resume a specific session ID | |
+| `--fork` | | Fork from the specified session (requires `--session`) | `false` |
+| `--no-save` | | Don't auto-save session after execution | `false` |
 
 ## Examples
 
@@ -93,6 +97,122 @@ praisonai run "What does this codebase do?" --verbose
 # > Loaded project instructions: AGENTS.md, CLAUDE.md
 ```
 
+---
+
+## Session Continuity
+
+Pick up where you left off — `praisonai run` remembers per-project conversations.
+
+```mermaid
+graph LR
+    subgraph "Session Flow"
+        A[📋 Run 1] --> B[💾 Session stored per project]
+        B --> C[🔄 Run 2 --continue]
+        C --> D[📈 Conversation continues]
+    end
+    
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A input
+    class B,C process
+    class D output
+```
+
+<Steps>
+<Step title="Continue the last run">
+Continue the most recent session for your current project:
+
+```bash
+praisonai run --continue "now add tests"
+```
+
+If no previous session exists, a warning is shown and a new session starts.
+</Step>
+
+<Step title="Resume a specific session">
+Resume a specific session by ID (find IDs with `praisonai session list`):
+
+```bash
+praisonai run --session abc123 "what were we working on?"
+```
+
+Errors out if the session ID does not exist in the current project.
+</Step>
+
+<Step title="Try a different approach without losing history">
+Fork from an existing session to try alternatives:
+
+```bash
+praisonai run --fork --session abc123 "try Postgres instead of SQLite"
+```
+
+Creates a new session ID copied from the source. Both sessions evolve independently.
+</Step>
+</Steps>
+
+### Choosing between the flags
+
+```mermaid
+graph TB
+    Start(["Need session continuity?"])
+    Continue["Just keep going?"] 
+    SpecificSession["Have a specific session ID?"]
+    Branch["Want to branch without affecting original?"]
+    NoSave["Don't want this run remembered?"]
+    
+    Start --> Continue
+    Start --> SpecificSession
+    Start --> Branch
+    Start --> NoSave
+    
+    Continue --> ContinueFlag["--continue"]
+    SpecificSession --> SessionFlag["--session <id>"]
+    Branch --> ForkFlag["--fork --session <id>"]
+    NoSave --> NoSaveFlag["--no-save"]
+    
+    classDef question fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef answer fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class Start,Continue,SpecificSession,Branch,NoSave question
+    class ContinueFlag,SessionFlag,ForkFlag,NoSaveFlag answer
+```
+
+<Tabs>
+<Tab title="Prompt mode">
+```bash
+# First run
+praisonai run "Build a FastAPI todo app"
+
+# Continue tomorrow
+praisonai run --continue "now add tests"
+
+# Continue with specific session
+praisonai run --session abc123 "deploy it to Fly.io"
+```
+</Tab>
+
+<Tab title="YAML mode">
+```bash
+# First run
+praisonai run agents.yaml
+
+# Continue with YAML file
+praisonai run agents.yaml --continue
+
+# Continue with specific session
+praisonai run agents.yaml --session abc123
+```
+</Tab>
+</Tabs>
+
+<Info>
+Sessions are scoped to the current project — detected from the git root, or the current directory if you're not in a repo. Two projects never see each other's sessions.
+</Info>
+
+---
+
 ## Agent File Format
 
 Create an `agents.yaml` file:
@@ -113,6 +233,8 @@ roles:
 
 ## See Also
 
+- [Session](/docs/cli/session) - Session management
+- [Project-Scoped Sessions](/docs/features/project-sessions) - How project sessions work
 - [Agents](/docs/cli/agents) - Agent management
 - [Workflow](/docs/cli/workflow) - Workflow execution
 - [Interactive TUI](/docs/cli/interactive-tui) - Interactive terminal interface

--- a/docs/cli/session.mdx
+++ b/docs/cli/session.mdx
@@ -57,6 +57,7 @@ praisonai session list
 
 **Expected Output:**
 ```
+Project: my-repo (ID: 4f3a91c2)
 📋 Available Sessions:
 
 ┌────┬─────────────────┬─────────────────────┬──────────┬──────────┐
@@ -65,11 +66,17 @@ praisonai session list
 │ 1  │ my-project      │ 2024-12-16 15:45    │ 12       │ active   │
 │ 2  │ research-task   │ 2024-12-16 14:20    │ 8        │ paused   │
 │ 3  │ code-review     │ 2024-12-15 10:30    │ 25       │ paused   │
-│ 4  │ documentation   │ 2024-12-14 09:15    │ 5        │ archived │
 └────┴─────────────────┴─────────────────────┴──────────┴──────────┘
 
-Total: 4 sessions
+Total: 3 sessions
 ```
+
+By default, only this project's sessions are listed. Use `--all` to see everything.
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Show sessions from all projects |
+| `--project <id>` | Show sessions for a specific project ID |
 
 ### Resume a Session
 
@@ -163,6 +170,16 @@ Session Commands:
 Using Sessions with Prompts:
   praisonai "prompt" --session <name>   - Run with session context
 ```
+
+## Working with `praisonai run`
+
+The same project-scoped store powers `--continue` and `--session` on `praisonai run`:
+
+```bash
+praisonai run --continue "Add tests for the new endpoint"
+```
+
+See [Run](/docs/cli/run) for complete session continuity documentation.
 
 ## Using Sessions with Prompts
 
@@ -336,7 +353,14 @@ manager.delete_checkpoint("deploy-v1")
 
 ## Session Storage
 
-Sessions are stored locally in `~/.praisonai/memory/{user_id}/sessions/`:
+Sessions are stored in a project-scoped layout when using the default behavior:
+
+```
+~/.praisonai/sessions/projects/{project_id}/
+└── {session_id}.json
+```
+
+For backward compatibility with global/legacy sessions:
 
 ```
 ~/.praisonai/

--- a/docs/features/project-sessions.mdx
+++ b/docs/features/project-sessions.mdx
@@ -1,0 +1,188 @@
+---
+title: "Project-Scoped Sessions"
+sidebarTitle: "Project Sessions"
+description: "Sessions are remembered per project, so different repos never see each other's history"
+icon: "folder-tree"
+---
+
+Every project gets its own conversation history, automatically.
+
+```mermaid
+graph LR
+    subgraph "Project Session Flow"
+        A[📁 Project A] --> B[🗂️ Sessions A]
+        C[📁 Project B] --> D[🗂️ Sessions B]
+        B --> E[🔄 praisonai run --continue]
+        D --> F[🔄 praisonai run --continue]
+        E --> G[📊 Project A history only]
+        F --> H[📊 Project B history only]
+    end
+    
+    classDef project fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef sessions fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef operation fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class A,C project
+    class B,D sessions
+    class E,F operation
+    class G,H result
+```
+
+## Quick Start
+
+<Steps>
+<Step title="From your project root">
+Start working in any project directory:
+
+```bash
+cd ~/code/my-app && praisonai run "Build a TODO app"
+```
+
+Project context is automatically detected from the git root or current directory.
+</Step>
+
+<Step title="Continue tomorrow, from the same folder">
+Return to the same project to pick up where you left off:
+
+```bash
+praisonai run --continue "Add a delete endpoint"
+```
+
+Session continuity works seamlessly across days and terminal sessions.
+</Step>
+
+<Step title="List this project's sessions">
+See all sessions for the current project:
+
+```bash
+praisonai session list
+```
+
+Only sessions from this project are shown by default.
+</Step>
+</Steps>
+
+## How project detection works
+
+| Where you are | Project ID derived from |
+|---|---|
+| Inside a git repo | `git rev-parse --show-toplevel` (the repo root) |
+| Outside a git repo | The current working directory |
+| The hash itself | First 8 chars of `sha256(absolute_path)` |
+
+The project ID ensures consistent session scoping regardless of your current subdirectory within the project.
+
+## How `--continue` finds your session
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Detector as Project detector
+    participant Store as Project session store
+    participant Agent
+    
+    User->>CLI: praisonai run --continue "..."
+    CLI->>Detector: resolve git root / cwd
+    Detector-->>CLI: /path/to/project
+    CLI->>Store: find_last_session(project_id)
+    Store-->>CLI: most-recent session ID (or none)
+    CLI->>Agent: resume with that session, run new prompt
+    Agent-->>User: response with context from previous runs
+    
+    classDef user fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef cli fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef system fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    
+    class User user
+    class CLI cli
+    class Detector,Store system
+    class Agent result
+```
+
+If no previous session exists, a warning is shown and a new session starts automatically.
+
+## Common Patterns
+
+### Resume after lunch
+Pick up exactly where you left off:
+
+```bash
+praisonai run --continue "Now let's add error handling"
+```
+
+### Branch a session to try something risky
+Experiment without affecting the original conversation:
+
+```bash
+praisonai run --fork --session abc123 "What if we used GraphQL instead?"
+```
+
+Both the original and forked sessions evolve independently.
+
+### One-off question I don't want remembered
+Ask quick questions without cluttering project history:
+
+```bash
+praisonai run --no-save "What's the capital of France?"
+```
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Run from the project root">
+Always start `praisonai run` from your project's root directory so the git root is detected correctly. This ensures consistent project identification regardless of your current subdirectory.
+
+```bash
+# Good: from project root
+cd ~/code/my-app
+praisonai run --continue "Add tests"
+
+# Still works: from subdirectory (same project detected)
+cd ~/code/my-app/src
+praisonai run --continue "Add tests"
+```
+</Accordion>
+
+<Accordion title="Use `--fork` instead of mid-conversation branching">
+When exploring alternatives, fork the session rather than continuing in the main conversation thread:
+
+```bash
+# Fork to try different approach
+praisonai run --fork --session abc123 "try Redis instead of PostgreSQL"
+
+# Original session remains intact
+praisonai run --session abc123 "continue with PostgreSQL implementation"
+```
+</Accordion>
+
+<Accordion title="Use `--no-save` for throwaway/PII-sensitive prompts">
+For quick questions or sensitive information that shouldn't be stored:
+
+```bash
+praisonai run --no-save "How do I hash this password: secretPassword123"
+```
+</Accordion>
+
+<Accordion title="Use `praisonai session list --all` to clean up across projects">
+Periodically review and delete old sessions from all projects:
+
+```bash
+praisonai session list --all
+praisonai session delete old-session-id
+```
+</Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Run Command" icon="play" href="/docs/cli/run">
+    Complete `praisonai run` documentation with session flags
+  </Card>
+  <Card title="Session Management" icon="clock-rotate-left" href="/docs/cli/session">
+    Session commands and storage backends
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Fixes #603

## Summary

This PR documents the new session continuity features for `praisonai run` command that were added in upstream PR #1929. The changes include:

- **New session continuity flags** for `praisonai run`:
  - `--continue/-c` - Continue the most recent session for current project
  - `--session/-s` - Resume a specific session ID
  - `--fork` - Fork from specified session (requires `--session`)
  - `--no-save` - Don't auto-save session after execution

- **Project-scoped session behavior** for `praisonai session list`:
  - By default shows only current project's sessions
  - New `--all` flag to show sessions from all projects
  - New `--project <id>` flag to show sessions for specific project

## Changes Made

### Updated `docs/cli/run.mdx`
- Added new session continuity flags to Options table
- Added comprehensive "Session Continuity" section with:
  - Hero mermaid diagram showing session flow
  - Step-by-step usage guide
  - Decision flow diagram for choosing between flags
  - Tabs showing both prompt and YAML mode examples
  - Project scoping info callout
- Updated examples to include session flags
- Added cross-links to session documentation

### Updated `docs/cli/session.mdx`
- Updated List Sessions section to show new project-scoped output format
- Added documentation for `--all` and `--project` flags
- Added "Working with praisonai run" section linking to run command
- Updated Session Storage section to show new project-scoped layout
- Maintained backward compatibility documentation for global sessions

### Created `docs/features/project-sessions.mdx`
- New feature page explaining project session scoping concept
- Follows AGENTS.md structure with hero diagram and components
- Includes project detection table and sequence diagram
- Common patterns and best practices sections
- Related cards linking to CLI documentation

### Updated `docs.json`
- Added new page to Features > State & Sessions group
- Maintains proper navigation order

## Implementation Notes

All documentation was created by reading the actual SDK source code from PR #1929 to ensure accuracy:
- `src/praisonai/praisonai/cli/commands/run.py` - New session flags
- `src/praisonai/praisonai/cli/commands/session.py` - Project-scoped listing  
- `src/praisonai/praisonai/cli/utils/project.py` - Project detection logic
- `src/praisonai/praisonai/cli/state/project_sessions.py` - Session store implementation

Documentation follows AGENTS.md guidelines:
- Agent-centric examples throughout
- Beginner-friendly tone with "is it really this easy?" feel
- Mintlify components: Steps, AccordionGroup, CardGroup, Tabs, Info callouts
- Mermaid diagrams using standard color scheme (#8B0000, #189AB4, #10B981, etc.)
- User-friendly imports only (no internal SDK paths)
- Copy-paste runnable code examples

## Validation

- ✅ JSON syntax validated in docs.json
- ✅ All new flags documented with correct types and defaults
- ✅ Mermaid diagrams use standard PraisonAI color scheme
- ✅ Cross-references between pages added
- ✅ Examples are copy-paste runnable
- ✅ Follows AGENTS.md structure template exactly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new documentation page for project-scoped sessions with usage patterns, project ID derivation, and best-practice command examples with diagrams.
  * Enhanced session CLI documentation with previously undocumented session listing flags and clarified session storage structure.
  * Expanded run command guide with session continuity behavior, flow diagrams, and step-by-step tabbed examples for different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->