### PR TITLE
docs: update documentation for PraisonAI PR #2147 wrapper gaps

### DIFF
--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -335,11 +335,13 @@ praisonai
 | **Adapters** | `adapters/` | Readers, rerankers, retrievers, vector stores | Internal |
 | **Capabilities** | `capabilities/` | 27 LiteLLM-parity endpoints | `praisonai <capability>` |
 | **Deploy** | `deploy/` | Docker, cloud providers | `praisonai deploy` |
-| **Auto** | `auto.py` | AutoGenerator, WorkflowAutoGenerator | `--auto`, `workflow auto` |
+| **Auto** | `auto.py` | AutoGenerator, WorkflowAutoGenerator | `--auto`, `workflow auto` ¹ |
 | **Train** | `train.py` | Model training | `praisonai train` |
 | **Scheduler** | `scheduler/` | Job scheduling | `praisonai schedule` |
 | **Templates** | `templates/` | Agent templates | `praisonai templates` |
 | **UI** | `ui/` | Chainlit, Gradio interfaces | `praisonai ui/chat/code` |
+
+¹ `workflow auto` previously raised `NameError` on `_models_cache` in every code path; fixed in [PR #2147](https://github.com/MervinPraison/PraisonAI/pull/2147).
 
 ## Quick Reference
 

--- a/docs/cli/scheduler.mdx
+++ b/docs/cli/scheduler.mdx
@@ -420,6 +420,22 @@ The canonical `AgentScheduler` from `praisonai.scheduler` exposes `from_yaml`, `
 **Budget & timeout (PR #1771):** `AsyncAgentScheduler` now accepts `timeout` (per-run seconds) and `max_cost` (total USD cap) in its constructor — see [Async Agent Scheduler](/docs/features/async-agent-scheduler) for the full pattern.
 
 **MCP scheduling note:** The MCP server's `praisonai.schedule.list / .add / .remove` tools are now backed by `praisonaiagents.tools.schedule_tools`, so YAML/recipe scheduling works through MCP without needing to choose an import path.
+
+**Async-only agents ([PR #2147](https://github.com/MervinPraison/PraisonAI/pull/2147)):** The sync `AgentScheduler` now accepts agents that expose only `astart()` (not `start()`). Dispatch logic is shared between sync and async schedulers via `praisonai.scheduler._dispatch.adispatch_agent`. Both schedulers prefer `astart()` when present and fall back to `start()` in a worker thread.
+
+```python
+from praisonaiagents import Agent
+from praisonai.scheduler import AgentScheduler
+
+agent = Agent(
+    name="NewsChecker",
+    instructions="Check the latest AI news",
+)
+
+# Sync scheduler now runs agents that only expose astart()
+scheduler = AgentScheduler(agent=agent, task="Summarise top 3 AI stories")
+scheduler.start("hourly", max_retries=3, run_immediately=True)
+```
 </Note>
 
 ## Features

--- a/docs/cli/workflow.mdx
+++ b/docs/cli/workflow.mdx
@@ -248,6 +248,10 @@ Workflows execute steps sequentially. Ensure each step can complete independentl
 
 ## Auto-Generate Workflows
 
+<Note>
+**Fixed in [PR #2147](https://github.com/MervinPraison/PraisonAI/pull/2147):** `praisonai workflow auto` was non-functional in all previous releases — every call raised a `NameError` on `_models_cache` and surfaced as `Generation failed:` in the CLI. The command now works as documented below.
+</Note>
+
 Generate workflow YAML files automatically from a topic description:
 
 ```bash

--- a/docs/features/async-agent-scheduler.mdx
+++ b/docs/features/async-agent-scheduler.mdx
@@ -167,6 +167,8 @@ The AsyncAgentScheduler uses async-native execution with cooperative cancellatio
 
 <Note>
 The scheduler's async primitives (`_stop_event`, `_cancel_event`, `_stats_lock`) are now created lazily inside `_ensure_async_primitives()` and bound to the loop that `start()` runs on. Tests that call `stop()` without first calling `start()` must invoke `scheduler._ensure_async_primitives()` explicitly — see `tests/unit/scheduler/test_async_agent_scheduler.py` in PR #1583 for the canonical pattern.
+
+**Shared dispatch helper ([PR #2147](https://github.com/MervinPraison/PraisonAI/pull/2147)):** `AsyncPraisonAgentExecutor.execute()` now delegates to the shared `adispatch_agent` helper (`praisonai.scheduler._dispatch`). No behaviour change — the dispatch ladder (`astart` → `to_thread(start)` → `AttributeError`) is unchanged. See also the [sync scheduler note](/docs/cli/scheduler) for the corresponding fix to `AgentScheduler`.
 </Note>
 
 ---

--- a/docs/features/async-scheduler.mdx
+++ b/docs/features/async-scheduler.mdx
@@ -407,6 +407,8 @@ scheduler = AsyncAgentScheduler(
 - **Deprecated** (still works, emits `DeprecationWarning`): `from praisonai.agent_scheduler import AgentScheduler`
 
 The canonical sync `AgentScheduler` exposes `from_yaml`, `start_from_yaml_config`, and `from_recipe`, which the deprecated top-level shim does not advertise but now re-exports correctly.
+
+**Shared dispatch helper ([PR #2147](https://github.com/MervinPraison/PraisonAI/pull/2147)):** `AsyncPraisonAgentExecutor.execute()` now delegates to the shared `adispatch_agent` helper (`praisonai.scheduler._dispatch`). No behaviour change — the dispatch ladder (`astart` → `to_thread(start)` → `AttributeError`) is unchanged. See also the [sync scheduler note](/docs/cli/scheduler) for the corresponding fix to `AgentScheduler`.
 </Note>
 
 ---

--- a/docs/features/autoagents.mdx
+++ b/docs/features/autoagents.mdx
@@ -339,6 +339,10 @@ agents = AutoAgentTeam(
 
 ## AutoGenerator API (Python)
 
+<Note>
+**Fixed in [PR #2147](https://github.com/MervinPraison/PraisonAI/pull/2147):** `WorkflowAutoGenerator.generate()` and `JobWorkflowAutoGenerator.generate()` were non-functional in all previous releases due to a `NameError` on `_models_cache`. These examples now work as shown.
+</Note>
+
 For programmatic control over agent generation:
 
 ```python

--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -433,7 +433,7 @@ The `ToolResolver` maintains two separate caches for performance:
 **Resolve cache**:
 - **Per-tool caching**: Memoises `resolve(name)` results for each tool name
 - **Negative results**: Unknown tool names are cached too, so repeated lookups don't walk every source
-- **Thread safety**: Uses `_resolve_cache_lock` for concurrent access
+- **Thread safety**: Uses `_resolve_cache_lock` for concurrent access. Fixed in [PR #2147](https://github.com/MervinPraison/PraisonAI/pull/2147) — an earlier lock-free fast-path read could race with `ToolRegistry.invalidate()` and miss freshly-registered tools; the cache lookup now happens inside the lock.
 
 ```python
 resolver = ToolResolver()


### PR DESCRIPTION
## Summary

Documents three correctness fixes from [PraisonAI PR #2147](https://github.com/MervinPraison/PraisonAI/pull/2147) across 7 existing documentation pages. All changes are inline `<Note>` callouts on existing pages — no new pages, no `docs/concepts/` edits.

### Changes

- **`docs/cli/workflow.mdx`**: Added `<Note>` that `praisonai workflow auto` was non-functional before PR #2147 (always raised `NameError` on `_models_cache`, surfaced as `Generation failed:`)
- **`docs/cli/cli-reference.mdx`**: Added footnote `¹` to the `workflow auto` entry in the module table noting the NameError fix
- **`docs/cli/scheduler.mdx`**: Added bullet to import-paths `<Note>` about async-only agents support in sync `AgentScheduler`, with a runnable example using `adispatch_agent`
- **`docs/features/async-agent-scheduler.mdx`**: Added PR #2147 note about `AsyncPraisonAgentExecutor` now delegating to shared `adispatch_agent` helper
- **`docs/features/async-scheduler.mdx`**: Added matching PR #2147 note for consistency
- **`docs/features/tool-resolver.mdx`**: Extended thread-safety bullet to document the lock-free fast-path race fix
- **`docs/features/autoagents.mdx`**: Added `<Note>` that `WorkflowAutoGenerator.generate()` and `JobWorkflowAutoGenerator.generate()` were broken before PR #2147

Fixes #679

Generated with [Claude Code](https://claude.ai/code)