### PR TITLE
docs: Gateway flow control documentation (max_inbox, max_buffered_bytes)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -332,6 +332,7 @@
                       "docs/features/gateway-channel-supervision",
                       "docs/features/l3-dashboard-pages",
                       "docs/features/gateway-error-handling",
+                      "docs/features/gateway-flow-control",
                       "docs/features/autonomy-loop",
                       "docs/features/tool-circuit-breaker",
                       "docs/features/prompt-injection-protection",
@@ -488,7 +489,7 @@
                   "docs/features/cloud-databases",
                   "docs/features/neon",
                   "docs/features/supabase",
-                  "docs/features/turso", 
+                  "docs/features/turso",
                   "docs/features/cockroachdb",
                   "docs/features/xata"
                 ]
@@ -594,7 +595,6 @@
                   "docs/features/middleware"
                 ]
               },
-
               {
                 "group": "LLM & Models",
                 "icon": "microchip",
@@ -628,7 +628,7 @@
                   "docs/features/langchain",
                   "docs/integrations/langflow",
                   "docs/features/load-mcp-tools",
-                  "docs/features/mcp-tool-filtering", 
+                  "docs/features/mcp-tool-filtering",
                   "docs/features/mcp-client-protocol",
                   "docs/features/mcp-yaml-config",
                   "docs/features/n8n-integration",

--- a/docs/features/gateway-flow-control.mdx
+++ b/docs/features/gateway-flow-control.mdx
@@ -1,0 +1,230 @@
+---
+title: "Gateway Flow Control"
+sidebarTitle: "Flow Control"
+description: "Bounded inboxes and slow-consumer disconnect keep one misbehaving client from degrading the gateway"
+icon: "gauge-high"
+---
+
+Flow control bounds per-session inboxes and disconnects slow consumers so a single misbehaving client can't degrade the whole gateway.
+
+```mermaid
+graph LR
+    subgraph "Gateway Flow Control"
+        Client[👤 Client] --> Inbox{📥 Inbox Full?}
+        Inbox -->|No| Queue[✅ Queue Message]
+        Inbox -->|Yes| Reject[⚠️ inbox_full error]
+        Queue --> Agent[🤖 Agent]
+        Agent --> Buffer{📤 Buffer Full?}
+        Buffer -->|No| Send[✅ Send to Client]
+        Buffer -->|Yes, droppable| Drop[💧 Drop Event]
+        Buffer -->|Yes, critical| Close[🔌 Close 1013]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class Client,Agent input
+    class Inbox,Buffer decision
+    class Queue,Send success
+    class Reject,Drop,Close error
+```
+
+## Quick Start
+
+<Steps>
+
+<Step title="Defaults work out of the box">
+Flow control is enabled by default — no configuration needed. Every session gets a 256-message inbox and the gateway disconnects clients whose transport buffer exceeds 1 MB.
+
+```python
+from praisonaiagents import Agent, GatewayConfig
+
+agent = Agent(
+    name="assistant",
+    instructions="You help users with tasks"
+)
+```
+</Step>
+
+<Step title="Tune the limits">
+Adjust thresholds to match your workload.
+
+```python
+from praisonaiagents import Agent, GatewayConfig, SessionConfig
+
+config = GatewayConfig(
+    max_buffered_bytes=4 * 1024 * 1024,
+    session_config=SessionConfig(
+        max_inbox=512,
+    )
+)
+
+agent = Agent(
+    name="assistant",
+    instructions="You help users with tasks"
+)
+```
+</Step>
+
+</Steps>
+
+---
+
+## How It Works
+
+Two checks protect the gateway from overload:
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Gateway
+    participant Agent
+
+    Client->>Gateway: Send message
+    alt Inbox not full
+        Gateway->>Agent: Route message
+        Agent->>Gateway: Response
+        alt Buffer not full
+            Gateway-->>Client: Deliver response
+        else Droppable event (presence/typing/status)
+            Gateway->>Gateway: Silently drop
+        else Critical event
+            Gateway-->>Client: Close 1013 "slow consumer"
+        end
+    else Inbox full
+        Gateway-->>Client: Error — inbox_full
+    end
+```
+
+| Event type | When buffer is full |
+|------------|---------------------|
+| `presence` | Silently dropped |
+| `typing` | Silently dropped |
+| `status` | Silently dropped |
+| All other types | Connection closed with code `1013` |
+
+---
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `max_inbox` | `int` | `256` | Maximum queued messages per session. `0` = unlimited. Negative values raise `ValueError`. |
+| `max_buffered_bytes` | `int` | `1048576` | Maximum buffered bytes before a slow consumer is disconnected. `0` = disable slow-consumer checks. Negative values raise `ValueError`. |
+
+`max_inbox` is set on `SessionConfig`; `max_buffered_bytes` is set on `GatewayConfig`.
+
+```python
+from praisonaiagents import GatewayConfig, SessionConfig
+
+config = GatewayConfig(
+    max_buffered_bytes=1024 * 1024,
+    session_config=SessionConfig(
+        max_inbox=256,
+    )
+)
+```
+
+These options are also available in `gateway.yaml`:
+
+```yaml
+gateway:
+  max_buffered_bytes: 1048576
+  session_config:
+    max_inbox: 256
+```
+
+---
+
+## Client-Side Error Contract
+
+When the inbox is full, the gateway sends this JSON frame before rejecting the message:
+
+```json
+{
+  "type": "error",
+  "code": "inbox_full",
+  "message": "Message queue is full. Please wait for current messages to be processed."
+}
+```
+
+When the transport buffer exceeds `max_buffered_bytes` for a critical event, the gateway closes the WebSocket with:
+
+- **Code:** `1013` (Try Again Later)
+- **Reason:** `slow consumer`
+
+Clients should reconnect and resume from the last known message.
+
+---
+
+## Common Patterns
+
+**Chat-heavy workloads** — Tighten the inbox to shed load early and fail fast:
+
+```python
+from praisonaiagents import GatewayConfig, SessionConfig
+
+config = GatewayConfig(
+    max_buffered_bytes=512 * 1024,
+    session_config=SessionConfig(max_inbox=64)
+)
+```
+
+**Long-running tools** — Loosen both limits to avoid spurious disconnections during slow AI responses:
+
+```python
+from praisonaiagents import GatewayConfig, SessionConfig
+
+config = GatewayConfig(
+    max_buffered_bytes=8 * 1024 * 1024,
+    session_config=SessionConfig(max_inbox=1024)
+)
+```
+
+**Local development** — Disable slow-consumer checks so network hiccups don't interrupt debugging:
+
+```python
+from praisonaiagents import GatewayConfig, SessionConfig
+
+config = GatewayConfig(
+    max_buffered_bytes=0,
+    session_config=SessionConfig(max_inbox=0)
+)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Never set max_inbox=0 in production">
+    An unlimited inbox (`max_inbox=0`) lets a slow or malicious client queue messages indefinitely, eventually exhausting gateway memory. Reserve it for local testing only.
+  </Accordion>
+
+  <Accordion title="Size max_buffered_bytes against your payload">
+    A typical chat message is a few kilobytes. Set `max_buffered_bytes` to at least 10× your largest expected event payload. For file-transfer or streaming use cases, increase to 4–8 MB.
+  </Accordion>
+
+  <Accordion title="Handle inbox_full on the client side">
+    When your client receives `{"code": "inbox_full"}`, pause new sends and retry with exponential backoff (e.g., 1 s → 2 s → 4 s). Do not flood the gateway with immediate retries.
+  </Accordion>
+
+  <Accordion title="React to a 1013 slow-consumer close">
+    On receiving WebSocket close code `1013`, reconnect after a short delay and replay any messages that were in-flight. The gateway preserves session state during the `resume_window` (default 24 h), so conversation context is not lost.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Gateway" icon="tower-broadcast" href="/features/gateway">
+    Full gateway configuration and YAML reference
+  </Card>
+  <Card title="Gateway Error Handling" icon="triangle-alert" href="/features/gateway-error-handling">
+    Error handling patterns for the gateway
+  </Card>
+</CardGroup>

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -97,17 +97,21 @@ sequenceDiagram
 from praisonaiagents import GatewayConfig, SessionConfig
 
 config = GatewayConfig(
-    host="127.0.0.1",           # Bind address
-    port=8765,                   # WebSocket port
-    auth_token="secret",         # Authentication token
-    max_connections=1000,        # Max concurrent connections
-    heartbeat_interval=30,       # Heartbeat in seconds
+    host="127.0.0.1",
+    port=8765,
+    auth_token="secret",
+    max_connections=1000,
+    heartbeat_interval=30,
+    max_buffered_bytes=1024 * 1024,
     session_config=SessionConfig(
-        timeout=3600,            # Session timeout (1 hour)
-        max_messages=1000,       # Message history limit
+        timeout=3600,
+        max_messages=1000,
+        max_inbox=256,
     )
 )
 ```
+
+### GatewayConfig Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -117,9 +121,21 @@ config = GatewayConfig(
 | `max_connections` | `int` | `1000` | Maximum concurrent connections |
 | `heartbeat_interval` | `int` | `30` | Heartbeat interval in seconds |
 | `reconnect_timeout` | `int` | `60` | Reconnection timeout |
+| `max_buffered_bytes` | `int` | `1048576` | Slow-consumer disconnect threshold in bytes (`0` to disable) |
 | `ssl_cert` | `str` | `None` | SSL certificate path |
 | `ssl_key` | `str` | `None` | SSL key path |
 | `push` | `PushConfig` | `PushConfig()` | Push notification service configuration (disabled by default) |
+
+### SessionConfig Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `timeout` | `int` | `3600` | Session timeout in seconds (`0` = no timeout) |
+| `max_messages` | `int` | `1000` | Maximum messages to keep in history (`0` = unlimited) |
+| `max_inbox` | `int` | `256` | Per-session inbox bound — queued messages before rejection (`0` = unlimited) |
+| `persist` | `bool` | `False` | Whether to persist session state |
+| `persist_path` | `str` | `None` | Filesystem path for session persistence |
+| `resume_window` | `int` | `86400` | Resume window after disconnect in seconds |
 
 ---
 
@@ -146,6 +162,15 @@ config = GatewayConfig(
 Configure the gateway with a `gateway.yaml` file for multi-platform deployment:
 
 ```yaml
+gateway:
+  host: "127.0.0.1"
+  port: 8765
+  max_buffered_bytes: 1048576       # 1 MB — slow-consumer disconnect threshold
+  session_config:
+    timeout: 3600
+    max_messages: 1000
+    max_inbox: 256                  # per-session message queue bound
+
 agents:
   support:
     instructions: "You are a support agent"
@@ -458,6 +483,10 @@ praisonai gateway channels --config gateway.yaml
     Set `max_connections` based on your server capacity. Monitor active connections to prevent resource exhaustion.
   </Accordion>
   
+  <Accordion title="Tune flow control for your workload">
+    `max_buffered_bytes` (default 1 MB) disconnects slow consumers before they degrade the gateway. `session_config.max_inbox` (default 256) caps the per-session message queue. See [Gateway Flow Control](/features/gateway-flow-control) for tuning guidance.
+  </Accordion>
+  
   <Accordion title="Single instance per bot token">
     Each Telegram/Discord/Slack bot token must be polled by exactly one process. PraisonAI enforces a PID lock at `~/.praisonai/gateway-<host>-<port>.pid` — start a second instance and you'll get a clear error pointing at the running PID. Use `GATEWAY_PORT=<other>` to run a second gateway on another port.
   </Accordion>
@@ -473,5 +502,11 @@ praisonai gateway channels --config gateway.yaml
   </Card>
   <Card title="Sessions" icon="clock" href="/concepts/sessions">
     Manage conversation state
+  </Card>
+  <Card title="Gateway Flow Control" icon="gauge-high" href="/features/gateway-flow-control">
+    Bounded inboxes and slow-consumer disconnect
+  </Card>
+  <Card title="Gateway Error Handling" icon="triangle-alert" href="/features/gateway-error-handling">
+    Error handling patterns for the gateway
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

Documents the two new public config fields added in MervinPraison/PraisonAI#2156:
- `SessionConfig.max_inbox: int = 256` — bounded per-session message queue
- `GatewayConfig.max_buffered_bytes: int = 1048576` — slow-consumer disconnect threshold

## Changes

### Updated `docs/features/gateway.mdx`
- Added `max_buffered_bytes` row to `GatewayConfig` table
- Promoted `SessionConfig` to a full options table including `max_inbox`
- Updated Python config example and `gateway.yaml` block to show both new fields
- Added flow control cross-link in Best Practices accordion and Related cards

### Created `docs/features/gateway-flow-control.mdx`
- New feature page with hero Mermaid diagram (AGENTS.md color scheme)
- Quick Start with two Steps (defaults + tuning)
- How It Works with sequence diagram and event-type table
- Configuration Options table for both fields
- Client-side error contract: `inbox_full` JSON and `1013 slow consumer` close
- Common Patterns for chat-heavy, long-running, and local-dev scenarios
- Best Practices AccordionGroup (4 items)
- Related CardGroup linking to gateway and gateway-error-handling

### Updated `docs.json`
- Added `docs/features/gateway-flow-control` under Features → Integration & Infrastructure, adjacent to `gateway-error-handling`

Fixes #682

Generated with [Claude Code](https://claude.ai/code)