### PR TITLE
docs: add OpenAI-compatible server documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -263,6 +263,7 @@
                       "docs/features/onboard",
                       "docs/features/installation-extras",
                       "docs/features/llm-endpoint-config",
+                      "docs/features/openai-compatible-server",
                       "docs/features/yaml-template-variables",
                       "docs/features/gateway-bind-aware-auth",
                       "docs/features/test-documentation"

--- a/docs/cli/serve.mdx
+++ b/docs/cli/serve.mdx
@@ -26,6 +26,7 @@ The `praisonai serve` command launches various PraisonAI server types with unifi
 | `praisonai serve a2a` | JSON-RPC | 8001 | Agent-to-Agent protocol |
 | `praisonai serve a2u` | SSE | 8002 | Agent-to-User event stream |
 | `praisonai serve unified` | HTTP/SSE | 8765 | All providers combined |
+| `praisonai serve openai` | HTTP/SSE | 8765 | OpenAI API compatibility layer |
 
 ### Bot Servers (Messaging Platforms)
 

--- a/docs/deploy/api/index.mdx
+++ b/docs/deploy/api/index.mdx
@@ -73,6 +73,7 @@ All examples use `http://127.0.0.1:8765` as the base URL. Change the port if you
 | Tools | `praisonai serve tools` | 8081 | Tools as MCP server |
 | A2A | `praisonai serve a2a` | 8082 | Agent-to-Agent protocol |
 | A2U | `praisonai serve a2u` | 8083 | Agent-to-User events |
+| OpenAI | `praisonai serve openai` | 8765 | OpenAI-compatible API |
 
 ## Discovery Endpoint
 

--- a/docs/deploy/index.mdx
+++ b/docs/deploy/index.mdx
@@ -164,6 +164,7 @@ Use `praisonai serve <type>` to start any server. All options in one place:
 | `praisonai serve a2a` | JSON-RPC | 8001 | Agent-to-Agent protocol |
 | `praisonai serve a2u` | SSE | 8002 | Agent-to-User event stream |
 | `praisonai serve unified` | HTTP/SSE | 8765 | All providers combined |
+| `praisonai serve openai` | HTTP/SSE | 8765 | OpenAI API compatibility layer |
 
 <Card title="Unified Serve Reference" icon="server" href="./servers/serve">
   Complete guide to all `praisonai serve` commands and options

--- a/docs/deploy/servers/serve.mdx
+++ b/docs/deploy/servers/serve.mdx
@@ -80,6 +80,7 @@ Run `praisonai serve` to see all available options with descriptions.
 | `praisonai serve a2a` | JSON-RPC | 8001 | Agent-to-Agent protocol |
 | `praisonai serve a2u` | SSE | 8002 | Agent-to-User event stream |
 | `praisonai serve unified` | HTTP/SSE | 8765 | All providers combined |
+| `praisonai serve openai` | HTTP/SSE | 8765 | OpenAI API compatibility layer |
 
 ---
 

--- a/docs/features/openai-compatible-server.mdx
+++ b/docs/features/openai-compatible-server.mdx
@@ -1,0 +1,285 @@
+---
+title: "OpenAI-Compatible Server"
+sidebarTitle: "OpenAI Server"
+description: "Drop-in OpenAI API replacement powered by PraisonAI agents"
+icon: "plug"
+---
+
+`praisonai serve openai` starts a FastAPI server that exposes OpenAI-compatible HTTP endpoints — point any existing OpenAI SDK code at it and it works as a drop-in replacement.
+
+```mermaid
+graph LR
+    subgraph "OpenAI-Compatible Server"
+        Client[📱 OpenAI SDK] --> Server[🔌 /v1/chat/completions]
+        Server --> Agent[🤖 PraisonAI Agent]
+        Agent --> LLM[🧠 LLM]
+        LLM --> Response[✅ OpenAI-shaped Response]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Client input
+    class Server process
+    class Agent,LLM agent
+    class Response output
+```
+
+## Quick Start
+
+<Steps>
+
+<Step title="Start the server">
+```bash
+praisonai serve openai
+```
+
+The server starts on `http://localhost:8765` by default.
+</Step>
+
+<Step title="Use from any OpenAI client">
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8765/v1", api_key="anything")
+
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+print(response.choices[0].message.content)
+```
+</Step>
+
+<Step title="Expose a PraisonAI agent">
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    instructions="You are a helpful assistant"
+)
+# 1. Start the agents API: praisonai serve agents agents.yaml
+# 2. Start the OpenAI compat layer: praisonai serve openai --agents-url http://localhost:8000
+```
+</Step>
+
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Client as OpenAI SDK
+    participant Server as serve openai
+    participant Agent as PraisonAI Agent
+    participant LLM as LLM
+
+    Client->>Server: POST /v1/chat/completions
+    Server->>Agent: Forward request
+    Agent->>LLM: Process with tools
+    LLM-->>Agent: Completion
+    Agent-->>Server: Result
+    Server-->>Client: OpenAI-shaped response
+```
+
+---
+
+## Endpoints
+
+All endpoints follow the OpenAI REST specification.
+
+| Method | Path | Description | Streaming |
+|--------|------|-------------|-----------|
+| `POST` | `/v1/chat/completions` | Chat completions | SSE (`stream: true`) with `[DONE]` sentinel |
+| `POST` | `/v1/completions` | Legacy text completions | No |
+| `GET` | `/v1/models` | List available models | No |
+| `POST` | `/v1/tools/invoke` | PraisonAI extension — invoke an agent tool | No |
+| `GET` | `/__praisonai__/discovery` | Provider discovery | No |
+| `GET` | `/health` | Health check | No |
+
+---
+
+## Streaming
+
+Set `stream=True` to receive tokens via Server-Sent Events:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8765/v1", api_key="anything")
+
+stream = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Write a haiku about agents"}],
+    stream=True
+)
+
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="", flush=True)
+```
+
+The stream ends with a `data: [DONE]` sentinel. Errors during streaming are also sent as SSE events:
+
+```
+data: {"error": {"message": "...", "type": "stream_error"}}
+
+data: [DONE]
+```
+
+---
+
+## Tool Invocation
+
+`/v1/tools/invoke` is a PraisonAI extension that calls an agent tool by name. It requires `--agents-url` to point to a running agents server.
+
+```bash
+curl -X POST http://localhost:8765/v1/tools/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"tool": "search", "arguments": {"query": "PraisonAI features"}}'
+```
+
+Start the agents server first:
+
+```bash
+# Terminal 1 — agents API
+praisonai serve agents --file agents.yaml --port 8000
+
+# Terminal 2 — OpenAI compat layer
+praisonai serve openai --agents-url http://localhost:8000
+```
+
+---
+
+## Authentication
+
+Pass `--api-key` to require authentication:
+
+```bash
+praisonai serve openai --api-key my-secret-key
+```
+
+Clients must include the key as the `Authorization` header:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8765/v1",
+    api_key="my-secret-key"
+)
+```
+
+---
+
+## CLI Reference
+
+```bash
+praisonai serve openai [OPTIONS]
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--host`, `-h` | `str` | `"127.0.0.1"` | Host to bind to |
+| `--port`, `-p` | `int` | `8765` | Port to bind to |
+| `--agents-url` | `str` | `"http://127.0.0.1:8000"` | URL of the running Agents API server |
+| `--api-key` | `str` | `None` | Optional API key for authentication |
+| `--reload` | `bool` | `False` | Enable auto-reload (dev) |
+
+---
+
+## Choosing Between `serve openai` and `serve rag --openai-compat`
+
+```mermaid
+graph TB
+    Q{Need OpenAI-compatible API?}
+    Q -->|Yes, full chat + tools + models| A[praisonai serve openai]
+    Q -->|Yes, but only for RAG queries| B[praisonai serve rag --openai-compat]
+    Q -->|Multiple providers in one server| C[praisonai serve unified]
+
+    classDef question fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef option fill:#10B981,stroke:#7C90A0,color:#fff
+    class Q question
+    class A,B,C option
+```
+
+| Surface | Command | Scope |
+|---------|---------|-------|
+| **OpenAI server** | `praisonai serve openai` | Standalone — chat, completions, models, tool invocation |
+| **RAG compat flag** | `praisonai serve rag --openai-compat` | RAG microservice only, chat endpoint only |
+| **Unified** | `praisonai serve unified` | All providers in a single server |
+
+<Note>
+For OpenAI-compatible RAG queries, use `praisonai serve rag --openai-compat` instead. See [RAG CLI](/docs/cli/rag) for details.
+</Note>
+
+---
+
+## Error Shape
+
+All errors follow the OpenAI error format:
+
+```json
+{
+  "error": {
+    "message": "Model not found",
+    "type": "api_error"
+  }
+}
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Set an API key for production">
+Always pass `--api-key` when running on a public or shared network. The default configuration accepts unauthenticated requests.
+
+```bash
+praisonai serve openai --api-key $PRAISONAI_API_KEY --host 0.0.0.0
+```
+</Accordion>
+
+<Accordion title="Bind to 0.0.0.0 for external access">
+The default `127.0.0.1` only accepts local connections. Use `--host 0.0.0.0` to accept connections from other machines — always pair with `--api-key`.
+
+```bash
+praisonai serve openai --host 0.0.0.0 --port 8765 --api-key $SECRET
+```
+</Accordion>
+
+<Accordion title="Route model names with LiteLLM">
+The server passes `model` directly to the underlying LLM. Use LiteLLM-style model names (`ollama/llama3`, `anthropic/claude-3-5-sonnet-20241022`) to route to any provider.
+</Accordion>
+
+<Accordion title="When to use the unified server instead">
+Use `praisonai serve unified` when you need multiple protocol surfaces (MCP, A2A, agents) alongside the OpenAI-compat layer. Use `serve openai` for a lightweight standalone deployment that only exposes OpenAI endpoints.
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Serve Commands" icon="server" href="/docs/cli/serve">
+    All praisonai serve subcommands
+  </Card>
+  <Card title="Gateway" icon="gateway" href="/docs/gateway">
+    Unified gateway and control plane
+  </Card>
+  <Card title="RAG OpenAI Compat" icon="database" href="/docs/cli/rag">
+    OpenAI-compatible RAG server
+  </Card>
+  <Card title="LLM Endpoint Config" icon="plug" href="/docs/features/llm-endpoint-config">
+    Configure LLM provider endpoints
+  </Card>
+</CardGroup>

--- a/docs/gateway.mdx
+++ b/docs/gateway.mdx
@@ -132,6 +132,7 @@ graph LR
 | **mcp** | 8080 | HTTP/SSE | Tool protocols |
 | **a2a** | 8001 | JSON-RPC | Agent communication |
 | **a2u** | 8002 | SSE | Event streams |
+| **openai** | 8765 | HTTP + SSE | OpenAI API compatibility |
 
 ---
 

--- a/docs/sdk/reference/praisonai/modules/endpoints.mdx
+++ b/docs/sdk/reference/praisonai/modules/endpoints.mdx
@@ -21,6 +21,7 @@ Provider Types:
 - tools-mcp: Tools exposed as MCP server
 - a2a: Agent-to-agent protocol
 - a2u: Agent-to-user event stream
+- openai-compat: OpenAI API compatibility layer
 
 Architecture:
 - Discovery schema is versioned and consistent across all providers


### PR DESCRIPTION
## Summary

- Creates `docs/features/openai-compatible-server.mdx` — new standalone documentation page for `praisonai serve openai`
- Updates 6 existing pages to include the `openai` subcommand row
- Registers the new page in `docs.json` under Features > Core Agent Features

## Changes

- **NEW** `docs/features/openai-compatible-server.mdx` — hero Mermaid diagram, Quick Start with Steps, endpoints table, streaming example, tool invocation, authentication, CLI reference, decision diagram comparing `serve openai` vs `serve rag --openai-compat` vs `serve unified`, Best Practices AccordionGroup, Related CardGroup
- **UPDATE** `docs/cli/serve.mdx` — add `openai` row to subcommand table
- **UPDATE** `docs/deploy/servers/serve.mdx` — add `openai` row to subcommand table
- **UPDATE** `docs/deploy/index.mdx` — add `openai` row to All Serve Commands table
- **UPDATE** `docs/deploy/api/index.mdx` — add OpenAI row to server types table
- **UPDATE** `docs/gateway.mdx` — add `openai` row to gateway comparison table
- **UPDATE** `docs/sdk/reference/praisonai/modules/endpoints.mdx` — add `openai-compat` provider
- **UPDATE** `docs.json` — register new page in navigation

Fixes #687

Generated with [Claude Code](https://claude.ai/code)