### PR TITLE
docs: add Fast CLI Startup page for lazy command dispatch

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -488,7 +488,7 @@
                   "docs/features/cloud-databases",
                   "docs/features/neon",
                   "docs/features/supabase",
-                  "docs/features/turso", 
+                  "docs/features/turso",
                   "docs/features/cockroachdb",
                   "docs/features/xata"
                 ]
@@ -594,7 +594,6 @@
                   "docs/features/middleware"
                 ]
               },
-
               {
                 "group": "LLM & Models",
                 "icon": "microchip",
@@ -628,7 +627,7 @@
                   "docs/features/langchain",
                   "docs/integrations/langflow",
                   "docs/features/load-mcp-tools",
-                  "docs/features/mcp-tool-filtering", 
+                  "docs/features/mcp-tool-filtering",
                   "docs/features/mcp-client-protocol",
                   "docs/features/mcp-yaml-config",
                   "docs/features/n8n-integration",
@@ -790,6 +789,7 @@
                 "icon": "bolt",
                 "pages": [
                   "docs/features/lazy-imports",
+                  "docs/features/cli-command-lazy-dispatch",
                   "docs/features/lite-package",
                   "docs/features/logging-configuration",
                   "docs/features/mcp-lifecycle",

--- a/docs/features/cli-command-lazy-dispatch.mdx
+++ b/docs/features/cli-command-lazy-dispatch.mdx
@@ -1,0 +1,140 @@
+---
+title: "Fast CLI Startup"
+sidebarTitle: "Fast CLI Startup"
+description: "Sub-commands load only when you run them — every CLI invocation starts fast"
+icon: "bolt"
+---
+
+Sub-commands load on demand — only the module you actually use is imported, so every `praisonai` invocation starts in milliseconds regardless of how many commands exist.
+
+```mermaid
+graph LR
+    A[📝 You run<br/>praisonai chat] --> B{🔍 Sub-command?}
+    B -->|Yes| C[🧠 Load only<br/>chat module]
+    B -->|No| D[⚡ Skip to<br/>prompt/YAML path]
+    C --> E[✅ Run]
+    D --> E
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef load fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef skip fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A input
+    class B decision
+    class C load
+    class D skip
+    class E result
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Run a prompt directly">
+No sub-command is needed — and no sub-command modules load:
+
+```python
+from praisonaiagents import Agent
+
+Agent(
+    name="Assistant",
+    instructions="You are a helpful assistant",
+).start("Summarise the latest sales report")
+```
+
+The CLI equivalent is identical in startup cost:
+
+```bash
+praisonai "Summarise the latest sales report"
+```
+</Step>
+
+<Step title="Run a sub-command">
+Only the matching module loads — the other ~77 commands stay unloaded:
+
+```bash
+praisonai chat
+```
+</Step>
+
+<Step title="List all available commands">
+```bash
+praisonai --help
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+PraisonAI keeps a static map of command names (`_COMMAND_GROUPS` in `praisonai/cli/app.py`). When you run `praisonai chat`, the CLI checks that map and imports only the `chat` module. All other ~77 modules are never touched.
+
+```mermaid
+graph TB
+    subgraph "CLI Startup"
+        A[praisonai chat] --> B[Check _COMMAND_GROUPS]
+        B --> C{Match found?}
+        C -->|Yes| D[Import chat module only]
+        C -->|No| E[Treat as prompt or YAML]
+        D --> F[Run chat]
+        E --> G[Run prompt/YAML]
+    end
+
+    classDef entry fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef decision fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef load fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef run fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A entry
+    class B check
+    class C decision
+    class D,E load
+    class F,G run
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="You don't have to opt in">
+Lazy command dispatch is always on — no flag, no environment variable. Every `praisonai` invocation benefits automatically.
+</Accordion>
+
+<Accordion title="Adding a new sub-command">
+Add an entry to `_COMMAND_GROUPS` in `praisonai/cli/app.py`:
+
+```python
+_COMMAND_GROUPS = {
+    # existing entries ...
+    "mycommand": ".commands.mycommand",
+}
+```
+
+Without this entry, `praisonai --help` won't list your command and dispatch won't reach it.
+</Accordion>
+
+<Accordion title="When things go wrong">
+Run the built-in diagnostic to check your CLI setup:
+
+```bash
+praisonai doctor
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Lazy Imports & Fast Startup" icon="bolt" href="/docs/features/lazy-imports">
+  SDK-side lazy imports for litellm, chromadb, and mem0 — a different but complementary optimization
+</Card>
+<Card title="Performance Benchmarks" icon="chart-line" href="/docs/features/performance-benchmarks">
+  Measured startup times and memory usage across PraisonAI versions
+</Card>
+</CardGroup>


### PR DESCRIPTION
Fixes #694. Creates docs/features/cli-command-lazy-dispatch.mdx explaining the _COMMAND_GROUPS lazy dispatch mechanism from PraisonAI PR #2068. Adds page to Performance and Optimization group in docs.json. Follows AGENTS.md template with agent-centric example, hero Mermaid diagram, Steps Quick Start, AccordionGroup Best Practices, CardGroup Related. Generated with Claude Code.