### PR TITLE
docs: document --host CLI flag and safer default bind for praisonai call

### DIFF
--- a/docs/call.mdx
+++ b/docs/call.mdx
@@ -98,6 +98,48 @@ When `CALL_SERVER_TOKEN` is not configured and the environment is not developmen
 CALL_SERVER_TOKEN is not configured. Set CALL_SERVER_TOKEN or PRAISONAI_CALL_AUTH=disabled to run without authentication.
 ```
 
+## Binding & Network Access
+
+The call server binds to `127.0.0.1` by default, so it is only reachable from the same machine.
+
+```mermaid
+graph TB
+    Start([Where will clients connect from?]) --> Local{Same machine only?}
+    Local -->|Yes| Localhost["✅ Default<br/>praisonai call"]
+    Local -->|No| LAN{Local network?}
+    LAN -->|Yes| LANbind["⚠️ praisonai call --host 0.0.0.0<br/>or bind to a specific NIC<br/>--host 192.168.1.x"]
+    LAN -->|No| Public["🌐 praisonai call --public<br/>(uses ngrok)"]
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef branch fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef safe fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef warn fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class Start input
+    class Local,LAN branch
+    class Localhost,Public safe
+    class LANbind warn
+```
+
+```bash
+# Local development (default — same machine only)
+praisonai call
+
+# Specific port, still localhost-only
+praisonai call --port 8090
+
+# Expose on LAN (warning will be printed)
+praisonai call --host 0.0.0.0 --port 8090
+
+# Expose publicly via ngrok
+export NGROK_AUTH_TOKEN="your-ngrok-auth-token"
+praisonai call --public
+```
+
+<Warning>
+**Breaking change (earlier versions → this release):** Earlier versions of `praisonai call` bound to `0.0.0.0` unconditionally, exposing the server to your entire LAN. Starting in this release, the default is `127.0.0.1`. Production deployments that previously relied on the LAN-exposed default must add `--host 0.0.0.0` (or a specific NIC) and ensure `CALL_SERVER_TOKEN` is set.
+</Warning>
+
 ## Features
 
 - Make and receive phone calls with AI agents
@@ -190,6 +232,7 @@ RUN pip install --no-cache-dir --upgrade "praisonai[call]"
 # Expose the port the app runs on
 EXPOSE 8090
 
-# Run the application
-CMD ["praisonai", "call"]
+# Bind to all container interfaces — the container boundary is the security boundary.
+# Pair with CALL_SERVER_TOKEN for any externally-published port.
+CMD ["praisonai", "call", "--host", "0.0.0.0"]
 ```

--- a/docs/cli/call.mdx
+++ b/docs/cli/call.mdx
@@ -4,42 +4,55 @@ description: "Voice and call interaction mode"
 icon: "phone"
 ---
 
-The `call` command enables voice/call interaction with AI agents.
+The `call` command starts the PraisonAI Call server for voice-based AI interactions over phone calls.
 
 ## Usage
 
 ```bash
-praisonai call [OPTIONS] [PROMPT]
+praisonai call [OPTIONS]
 ```
-
-## Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `PROMPT` | Initial prompt for the call session |
 
 ## Options
 
-| Option | Short | Description | Default |
-|--------|-------|-------------|---------|
-| `--model` | `-m` | LLM model to use | `gpt-4o-mini` |
-| `--verbose` | `-v` | Verbose output | `false` |
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--port` | Port to run the server on | `8090` (or `PORT` env var) |
+| `--host` | Host to bind the server to | `127.0.0.1` |
+| `--public` | Expose the server via an ngrok tunnel | `false` |
+
+<Note>
+`praisonai call` binds to `127.0.0.1` by default — local machine access only. To expose on your LAN, pass `--host 0.0.0.0` (a warning will print). To expose publicly, use `--public` (requires `NGROK_AUTH_TOKEN`).
+</Note>
 
 ## Examples
 
-### Start a call session
+### Start locally (default)
 
 ```bash
 praisonai call
 ```
 
-### Call with initial prompt
+### Custom port
 
 ```bash
-praisonai call "Help me with customer support"
+praisonai call --port 8090
+```
+
+### Expose publicly via ngrok
+
+```bash
+export NGROK_AUTH_TOKEN="your-ngrok-auth-token"
+praisonai call --public
+```
+
+### Expose on LAN
+
+```bash
+praisonai call --host 0.0.0.0 --port 8090
 ```
 
 ## See Also
 
+- [PraisonAI Call](/docs/call) - Full setup guide with Docker, tools, and deployment
+- [Voice Call API](/docs/deploy/api/voice-call/endpoints) - HTTP endpoints reference
 - [Realtime](/docs/cli/realtime) - Realtime interaction mode
-- [Chat](/docs/cli/chat) - Text chat mode

--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -16,6 +16,7 @@ praisonai
 ├── chat                         # Chainlit chat UI (port 8084)
 ├── code                         # Chainlit code UI (port 8086)
 ├── call                         # PraisonAI Call server
+│   └── --port --host --public
 ├── realtime                     # Realtime voice UI (port 8088)
 ├── train                        # Model training
 ├── ui                           # Gradio/Chainlit UI (port 8082)

--- a/docs/deploy/api/voice-call/endpoints.mdx
+++ b/docs/deploy/api/voice-call/endpoints.mdx
@@ -9,6 +9,15 @@ api: "GET /status"
 
 The Voice Call API provides Twilio voice integration with OpenAI's Realtime API for voice-based AI interactions.
 
+## Binding
+
+`praisonai call` binds to `127.0.0.1:8090` by default. Inside a container or VM, use `--host 0.0.0.0` so the server is reachable from outside the container boundary — see [Binding & Network Access](/docs/call#binding-network-access) for details. Always pair an exposed port with `CALL_SERVER_TOKEN`.
+
+```bash
+# Inside a container / pod (the container IS the isolation boundary)
+praisonai call --host 0.0.0.0 --port 8090
+```
+
 ## Base URL
 
 ```
@@ -160,8 +169,14 @@ python -m praisonai.api.call --port 9000
 ```python
 from praisonai.api.call import run_server
 
-# Start the server
+# Start the server (local only, default)
+run_server(port=8090)
+
+# Start with public ngrok tunnel
 run_server(port=8090, use_public=True)
+
+# Start bound to all interfaces (e.g. inside a container)
+run_server(port=8090, host="0.0.0.0")
 ```
 
 ## Session Configuration

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -155,6 +155,8 @@ PraisonAI's upcoming release includes **10 security advisories** worth of harden
 4. **Platform refuses to issue JWTs when running with the default secret outside `PLATFORM_ENV=dev`** — set `PLATFORM_JWT_SECRET` in production
 </Warning>
 
+**Call server bind hardening ([PR #2085](https://github.com/MervinPraison/PraisonAI/pull/2085), fixes [#1602](https://github.com/MervinPraison/PraisonAI/issues/1602)):** `praisonai call` now binds to `127.0.0.1` by default and exposes a `--host` flag for explicit override. Previously bound to `0.0.0.0` unconditionally while printing a misleading `http://localhost:{port}` log line. If `--host 0.0.0.0` is used without `--public`, a `WARNING` is printed at startup. Related advisory: [GHSA-86qc-r5v2-v6x6](https://github.com/advisories/GHSA-86qc-r5v2-v6x6).
+
 ### Migration for API Server Users
 
 For step-by-step migration instructions, see [API Server Authentication](/features/api-server-auth#migration-from--4634).


### PR DESCRIPTION
## Summary

Documents the new --host CLI flag and security default change (0.0.0.0 -> 127.0.0.1) for praisonai call (upstream PR MervinPraison/PraisonAI#2085).

### Changes

- docs/cli/call.mdx: Replace incorrect --model/--verbose options table with actual flags (--port, --host, --public); remove bogus [PROMPT] argument; add Security note.
- docs/call.mdx: Add Binding and Network Access section with Mermaid decision diagram, four runnable examples, Warning callout for breaking change, and fix Docker CMD to use --host 0.0.0.0.
- docs/security.mdx: Add call server bind hardening bullet under Security Batch 10 Breaking Changes, referencing PR 2085, issue 1602, and GHSA-86qc-r5v2-v6x6.
- docs/cli/cli-reference.mdx: Update call entry in ASCII tree to show --port --host --public flags.
- docs/deploy/api/voice-call/endpoints.mdx: Add Binding section, update Python usage example with host parameter, add container deployment example.

Fixes #699

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated call server binding and network access guidance, including breaking change: default binding changed to `127.0.0.1` (previously `0.0.0.0`). Existing LAN deployments require explicit `--host 0.0.0.0` configuration and `CALL_SERVER_TOKEN`.
  * Documented new CLI options (`--port`, `--host`, `--public`) with examples for local, ngrok, and LAN exposure scenarios.
  * Expanded Python server start examples for different binding and exposure configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->