### PR TITLE
docs: document auth-aware first-run onboarding

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -261,6 +261,7 @@
                       "docs/features/mini",
                       "docs/features/autoagents",
                       "docs/features/onboard",
+                      "docs/features/first-run-onboarding",
                       "docs/features/installation-extras",
                       "docs/features/llm-endpoint-config",
                       "docs/features/yaml-template-variables",
@@ -1196,6 +1197,7 @@
                 "icon": "play",
                 "pages": [
                   "docs/cli/run",
+                  "docs/cli/setup",
                   "docs/cli/chat",
                   "docs/cli/code",
                   "docs/cli/retrieval",

--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -4,6 +4,34 @@ description: "Complete command tree and flag reference for PraisonAI CLI"
 icon: "terminal"
 ---
 
+## First-run Credential Check
+
+Both `praisonai` (bare) and `praisonai run` verify credentials before executing agent work.
+
+```mermaid
+graph TB
+    Start[🚀 praisonai / praisonai run] --> Auth{Credentials<br/>configured?}
+    Auth -->|Yes| Run[✅ Execute normally]
+    Auth -->|No, TTY| Wizard[🧙 Offer setup wizard]
+    Auth -->|No, non-TTY| Err[❌ stderr + exit 1]
+
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef wizard fill:#189AB4,stroke:#7C90A0,color:#fff
+
+    class Start start
+    class Auth check
+    class Run success
+    class Err error
+    class Wizard wizard
+```
+
+Detected env vars (any one satisfies the check): `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`, `COHERE_API_KEY`. Stored credentials from `praisonai setup` are also accepted. See [First-run Onboarding](/docs/features/first-run-onboarding) for details.
+
+---
+
 ## Command Tree
 
 ```

--- a/docs/cli/cli.mdx
+++ b/docs/cli/cli.mdx
@@ -22,7 +22,13 @@ PraisonAI uses a unified CLI entry point with Typer as the primary dispatcher:
 graph TB
     Start[🚀 praisonai command] --> Version{--version?}
     Version -->|Yes| PrintVersion[📄 Print version & exit]
-    Version -->|No| LegacyCheck{Bare prompt/YAML?}
+    Version -->|No| Auth{Credentials<br/>configured?}
+    Auth -->|No, TTY| Wizard[🧙 Offer setup wizard]
+    Auth -->|No, non-TTY| Err[❌ stderr + exit 1]
+    Auth -->|Yes| LegacyCheck{Bare prompt/YAML?}
+    Wizard -->|User accepts| SetupRun[⚙️ praisonai setup]
+    Wizard -->|User declines| Exit0[💡 Exit 0 with hint]
+    SetupRun --> LegacyCheck
     LegacyCheck -->|Yes| Legacy[🔄 Legacy shim]
     LegacyCheck -->|No| Typer[⚡ Typer dispatcher]
     
@@ -33,13 +39,20 @@ graph TB
     FileCheck -->|No| Typer
     
     classDef version fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef legacy fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef auth fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef legacy fill:#189AB4,stroke:#7C90A0,color:#fff
     classDef typer fill:#10B981,stroke:#7C90A0,color:#fff
     
     class PrintVersion version
+    class Auth auth
+    class Wizard,SetupRun,Exit0 auth
+    class Err error
     class Legacy,FreeText,YAMLFile legacy
     class Typer typer
 ```
+
+When no credentials are configured, both `praisonai` (bare) and `praisonai run` check before doing any agent work. In a TTY, the user is offered the setup wizard. In CI or `--output json` mode, the command exits `1` with a clear error on `stderr`. See [First-run Onboarding](/docs/features/first-run-onboarding) for the full behaviour matrix.
 
 <Note>
 PraisonAI now fails loud on CLI registration errors. If you see a new ImportError after upgrading, a Typer subcommand or one of its dependencies failed to import — fix the import rather than ignoring the error.

--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -125,6 +125,34 @@ praisonai run "What does this codebase do?" --verbose
 
 ---
 
+## First-run Credential Check
+
+`praisonai run` verifies credentials are configured before doing any work.
+
+If no API key is found in environment variables or stored credentials, you'll see:
+
+**Interactive (TTY):**
+```
+No API key configured.
+Would you like to run the setup wizard now? [Y/n]:
+```
+
+**CI / non-interactive:**
+```
+Error: No API key configured. Run: praisonai auth login
+```
+
+Exit code is `1` in CI mode. Set any supported env var to bypass the check entirely:
+
+```bash
+export OPENAI_API_KEY=sk-...
+praisonai run "hello"
+```
+
+See [First-run Onboarding](/docs/features/first-run-onboarding) for the full behaviour matrix and CI examples.
+
+---
+
 ## Session Continuity
 
 Pick up where you left off — `praisonai run` remembers per-project conversations.

--- a/docs/cli/setup.mdx
+++ b/docs/cli/setup.mdx
@@ -1,0 +1,183 @@
+---
+title: "Setup"
+sidebarTitle: "Setup"
+description: "Interactive wizard for configuring LLM provider credentials"
+icon: "key"
+---
+
+Interactive wizard that stores your LLM provider API key so every subsequent `praisonai` command works without extra configuration.
+
+```mermaid
+graph TB
+    A[🚀 praisonai setup] --> B[Choose provider]
+    B --> C[Enter API key]
+    C --> D[Choose default model]
+    D --> E[Telemetry consent]
+    E --> F[💾 Save to ~/.praisonai/]
+    F --> G[✅ Ready to use]
+
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef step fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef save fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef done fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A start
+    class B,C,D,E step
+    class F save
+    class G done
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Run the setup wizard">
+```bash
+praisonai setup
+```
+
+The interactive wizard walks you through provider selection and key entry.
+</Step>
+
+<Step title="Choose a provider">
+```
+🚀 PraisonAI Setup Wizard
+
+1. Choose your LLM provider:
+  1) OpenAI (GPT-4o, GPT-4, GPT-3.5)
+  2) Anthropic (Claude)
+  3) Google (Gemini)
+  4) Ollama (Local models)
+  5) Custom provider
+
+Select provider [1]:
+```
+</Step>
+
+<Step title="Enter your API key">
+```
+2. Enter your OpenAI API key:
+Enter API key (hidden):
+```
+
+The key is stored securely in `~/.praisonai/.env` with permissions `0600`.
+</Step>
+
+<Step title="Verify it works">
+```bash
+praisonai "Say hello in one sentence"
+```
+</Step>
+</Steps>
+
+---
+
+## CLI Flags
+
+```bash
+praisonai setup [OPTIONS] [COMMAND]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--non-interactive` | Run without prompts (requires `--provider` and `--api-key`) |
+| `--provider TEXT` | Provider: `openai`, `anthropic`, `google`, `ollama`, `custom` |
+| `--api-key TEXT` | API key for the provider |
+| `--model TEXT` | Default model to use |
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `setup wizard` | Explicitly run the interactive wizard |
+| `setup config --show` | Show current configuration (API keys masked) |
+| `setup config --edit` | Open configuration in `$EDITOR` |
+| `setup reset` | Remove stored credentials |
+| `setup reset --force` | Remove without confirmation |
+
+---
+
+## Non-interactive Mode
+
+For CI/CD or scripted setup:
+
+```bash
+praisonai setup --non-interactive \
+  --provider openai \
+  --api-key "$OPENAI_API_KEY" \
+  --model gpt-4o-mini
+```
+
+Supported providers and their required env vars:
+
+| Provider | `--provider` value | Env var written |
+|----------|--------------------|-----------------|
+| OpenAI | `openai` | `OPENAI_API_KEY` |
+| Anthropic | `anthropic` | `ANTHROPIC_API_KEY` |
+| Google | `google` | `GEMINI_API_KEY` |
+| Ollama | `ollama` | *(no key needed)* |
+| Custom | `custom` | *(user-defined)* |
+
+---
+
+## Where Credentials Are Stored
+
+`praisonai setup` writes two files:
+
+| File | Purpose | Permissions |
+|------|---------|-------------|
+| `~/.praisonai/.env` | API keys as `KEY=value` lines | `0600` |
+| `~/.praisonai/config.yaml` | Provider name, default model, telemetry flag | `0600` |
+
+The credential store (`CredentialStore`) reads `~/.praison/credentials.json` as an additional fallback path consulted by `resolve_llm_endpoint_with_credentials()`.
+
+<Note>
+All sensitive files are written with `chmod 600` and are never included in any telemetry data.
+</Note>
+
+---
+
+## When Does Setup Run Automatically?
+
+If you skip setup at install time (or run `--no-prompt`), the first `praisonai` or `praisonai run` command detects the missing credentials and offers to launch this wizard for you. See [First-run Onboarding](/docs/features/first-run-onboarding) for the full flow.
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Re-run setup to change provider or rotate keys">
+`praisonai setup` is idempotent — running it again overwrites the previous configuration. Use it whenever you switch providers or need to rotate an API key.
+</Accordion>
+
+<Accordion title="Use env vars in CI, stored credentials on workstations">
+In CI environments set `OPENAI_API_KEY` (or the provider-specific key) as a secret. On developer workstations use `praisonai setup` so you don't have to set env vars in every shell session.
+</Accordion>
+
+<Accordion title="Inspect what is stored without exposing keys">
+```bash
+praisonai setup config --show
+# Output: OPENAI_API_KEY=***
+```
+
+API keys are masked in the output. Only non-sensitive settings (provider, model) appear in plaintext.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="First-run Onboarding" icon="key-round" href="/docs/features/first-run-onboarding">
+    Auto-detects missing credentials at first invocation
+  </Card>
+  <Card title="Run Command" icon="play" href="/docs/cli/run">
+    Run agents from files or prompts
+  </Card>
+  <Card title="CLI Reference" icon="terminal" href="/docs/cli/cli-reference">
+    Complete command tree and flag reference
+  </Card>
+  <Card title="Installer Internals" icon="gear" href="/docs/install/installer">
+    How the installer sets up credentials at install time
+  </Card>
+</CardGroup>

--- a/docs/features/first-run-onboarding.mdx
+++ b/docs/features/first-run-onboarding.mdx
@@ -1,0 +1,199 @@
+---
+title: "First-run Onboarding"
+sidebarTitle: "First-run Onboarding"
+description: "Auto-detects missing credentials and routes new users into the setup wizard"
+icon: "key-round"
+---
+
+When you run PraisonAI for the first time without API keys, it detects the unconfigured environment and offers to launch the setup wizard instead of failing on the first LLM call.
+
+```mermaid
+graph LR
+    A[🚀 praisonai / praisonai run] --> B{Credentials<br/>configured?}
+    B -->|Yes| C[✅ Run normally]
+    B -->|No, TTY| D[🧙 Offer setup wizard]
+    B -->|No, non-TTY| E[❌ stderr + exit 1]
+    D -->|User says Yes| F[⚙️ praisonai setup]
+    D -->|User says No| G[💡 Exit 0 with hint]
+    F --> H[✅ Run continues]
+
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef wizard fill:#189AB4,stroke:#7C90A0,color:#fff
+
+    class A start
+    class B check
+    class C,H success
+    class E error
+    class D,F wizard
+    class G wizard
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Run praisonai without any setup">
+```bash
+praisonai
+```
+
+If no credentials are configured, you'll see:
+
+```
+No API key configured.
+Would you like to run the setup wizard now? [Y/n]:
+```
+
+Type `Y` (or press Enter) to launch the setup wizard.
+</Step>
+
+<Step title="Complete setup once">
+The setup wizard asks for your provider and API key, then stores the credential securely:
+
+```bash
+praisonai setup
+# Choose: 1) OpenAI  2) Anthropic  3) Google  4) Ollama  5) Custom
+# Enter your API key when prompted
+```
+
+Credentials are stored in `~/.praison/credentials.json` (permissions `0600`).
+</Step>
+
+<Step title="Re-run — no prompts after the first time">
+```bash
+praisonai "What is 2+2?"
+# Runs immediately — no credential prompt
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+Both `praisonai` (bare) and `praisonai run` perform a credential check before doing any work.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant CredCheck as Credential Check
+    participant Store as CredentialStore
+    participant Wizard as Setup Wizard
+
+    User->>CLI: praisonai run "hello"
+    CLI->>CredCheck: is_configured()?
+    CredCheck->>CredCheck: Check env vars
+    CredCheck->>Store: Check ~/.praison/credentials.json
+    Store-->>CredCheck: Not found
+    CredCheck-->>CLI: False
+    CLI->>CLI: Is TTY?
+    alt TTY — interactive
+        CLI->>User: "No API key configured. Run setup wizard? [Y/n]"
+        User->>CLI: Y
+        CLI->>Wizard: praisonai setup
+        Wizard-->>CLI: Credentials stored
+        CLI->>User: Continues with run
+    else non-TTY / --quiet / --output json
+        CLI->>User: stderr: "No API key configured. Run: praisonai auth login"
+        CLI->>CLI: exit 1
+    end
+```
+
+### Credential detection order
+
+| Step | What is checked | Example |
+|------|----------------|---------|
+| 1. Env vars (fast path) | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`, `COHERE_API_KEY` | `export OPENAI_API_KEY=sk-...` |
+| 2. Credential store | `~/.praison/credentials.json` written by `praisonai setup` | `praisonai setup` |
+| 3. LLM resolution | `resolve_llm_endpoint_with_credentials()` — final fallback | Stored OpenAI base URL |
+
+---
+
+## Behaviour by Mode
+
+| Scenario | Old behaviour | New behaviour |
+|----------|--------------|--------------|
+| Configured user (env var or stored credential) | Works normally | Works — **no extra prompts, no added latency** |
+| New TTY user, no credentials, `praisonai` | Launched TUI, failed on first LLM call | Prints prompt, offers setup wizard |
+| New TTY user, no credentials, `praisonai run "hi"` | Ran agent, failed on first LLM call | Same prompt as above; on success continues the run |
+| CI / piped stdin / `--output json` | Cryptic LLM failure | Writes error to `stderr`, exits `1` |
+
+---
+
+## CI / Scripting
+
+In non-interactive environments, PraisonAI exits with code `1` and writes to `stderr`:
+
+```
+No API key configured. Run: praisonai auth login
+```
+
+**Non-interactive detection:** `not sys.stdin.isatty()` or `--output json` mode.
+
+### GitHub Actions example
+
+```yaml
+- name: Run PraisonAI agent
+  run: praisonai run "Summarize the changelog"
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+Setting any of the 6 detected env vars silences the check completely — no code changes needed.
+
+---
+
+## Skipping the Prompt
+
+Three ways to avoid the setup prompt:
+
+| Method | Command / Action |
+|--------|-----------------|
+| Set an env var | `export OPENAI_API_KEY=sk-...` |
+| Run setup ahead of time | `praisonai setup` |
+| Answer "No" at the prompt | Type `n` → exits `0` with a hint to run `praisonai auth login` |
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="In CI, set credentials before invoking">
+Set `OPENAI_API_KEY` (or the provider key for your model) as a repository secret, then reference it in your workflow env block. This is the recommended approach — no credential files in your repo, no interactive prompts:
+
+```yaml
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+</Accordion>
+
+<Accordion title="Prefer stored credentials over env vars for shared machines">
+On shared developer machines, stored credentials (`praisonai setup`) are scoped to the user's home directory and avoid environment variable leakage between sessions. Run `praisonai setup config --show` to verify what is stored.
+</Accordion>
+
+<Accordion title="Test your setup with a quick prompt before piping through automation">
+Run `praisonai run "ping"` manually before wiring the command into a pipeline or CI job. A successful response confirms credentials are configured and the model is reachable.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Setup Wizard" icon="key" href="/docs/cli/setup">
+    Interactive wizard for configuring LLM provider credentials
+  </Card>
+  <Card title="Run Command" icon="play" href="/docs/cli/run">
+    Run agents from files or prompts
+  </Card>
+  <Card title="CLI Reference" icon="terminal" href="/docs/cli/cli-reference">
+    Complete command tree and flag reference
+  </Card>
+  <Card title="Installer Internals" icon="gear" href="/docs/install/installer">
+    How the installer scripts work including post-install flow
+  </Card>
+</CardGroup>

--- a/docs/features/onboard.mdx
+++ b/docs/features/onboard.mdx
@@ -256,6 +256,10 @@ graph TB
 
 Both are called automatically by the installer, but can be run independently.
 
+<Note>
+**"First-run onboarding" and "bot onboarding" are two distinct flows.** First-run onboarding (`praisonai setup`) sets up LLM credentials and is triggered automatically when you first invoke `praisonai` or `praisonai run` without API keys. Bot onboarding (`praisonai onboard`, this page) is an optional step for configuring Telegram/Discord/Slack/WhatsApp bots. See [First-run Onboarding](/docs/features/first-run-onboarding) for the credential setup flow.
+</Note>
+
 ---
 
 ## Common Patterns

--- a/docs/install/installer.mdx
+++ b/docs/install/installer.mdx
@@ -163,6 +163,10 @@ After successful installation and verification, the installer runs an interactiv
 PR #1486 ensures only one summary appears - never both. The onboard wizard's ✅ Done panel is the canonical final summary when onboarding completes.
 </Note>
 
+<Note>
+If you skip the setup wizard during install (for example with `--no-prompt`), the next `praisonai` or `praisonai run` invocation will detect the missing credentials and offer to launch the wizard for you (or exit with a clear error in CI). See [First-run Onboarding](/docs/features/first-run-onboarding) for details.
+</Note>
+
 ## CI/CD Usage
 
 <Tabs>


### PR DESCRIPTION
## Summary

- **New** `docs/features/first-run-onboarding.mdx` — user-facing page covering the credential check flow, TTY vs non-TTY behaviour matrix, CI usage with GitHub Actions example, and best practices
- **New** `docs/cli/setup.mdx` — dedicated reference page for `praisonai setup` wizard including non-interactive flags, credential store location, and subcommands
- **Updated** `docs/cli/run.mdx` — added "First-run Credential Check" section with verbatim error strings and link to the new feature page
- **Updated** `docs/cli/cli.mdx` — extended dispatch diagram with auth branch before TUI launch
- **Updated** `docs/cli/cli-reference.mdx` — added credential check diagram and env var list
- **Updated** `docs/install/installer.mdx` — added callout for users who skip setup at install time
- **Updated** `docs/features/onboard.mdx` — disambiguated bot onboarding from LLM credential onboarding with cross-link
- **Updated** `docs.json` — added both new pages under Features (Core Agent Features) and CLI (Core Commands) groups; JSON validated

Fixes #698

Generated with [Claude Code](https://claude.ai/code)