### PR TITLE
docs: update sandbox CLI docs for fail-loud behavior + modal fix

### DIFF
--- a/docs/cli/sandbox.mdx
+++ b/docs/cli/sandbox.mdx
@@ -27,6 +27,8 @@ praisonai sandbox <command> [OPTIONS]
 
 | Command | Description |
 |---------|-------------|
+| `run` | Execute code in a registered sandbox backend |
+| `shell` | Open an interactive shell inside a registered sandbox backend |
 | `status` | Check sandbox container status |
 | `explain` | Explain sandbox configuration |
 | `list` | List all sandbox containers |
@@ -153,6 +155,44 @@ praisonai sandbox recreate --all --force
 
 ---
 
+## Run
+
+Execute code in a registered sandbox backend using `--type` to select the backend.
+
+```bash
+praisonai sandbox run --code "print('hello')" --type subprocess
+```
+
+```bash
+praisonai sandbox run --code "print('hello')" --type docker --image python:3.11-slim
+```
+
+<Tip>
+If the requested backend isn't installed, the CLI exits with code 2 and prints an install hint. Install optional backends with `pip install "praisonai[docker]"` (or `modal`, `ssh`, `e2b`, `daytona`). See [Installing Optional Backends](/features/sandbox-backends#installing-optional-backends) for the full matrix.
+</Tip>
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--code`, `-c` | — | Inline code to execute |
+| `--file`, `-f` | — | Path to a Python file to execute |
+| `--type`, `-t` | `subprocess` | Sandbox backend name |
+| `--image` | `python:3.11-slim` | Docker image (docker backend only) |
+| `--timeout` | `60` | Execution timeout in seconds |
+
+---
+
+## Shell
+
+Open an interactive shell inside a registered sandbox backend.
+
+```bash
+praisonai sandbox shell --type subprocess
+```
+
+Type `exit` or press Ctrl+D to quit the shell. If the backend isn't installed, the CLI exits with code 2 and prints a fix-it hint.
+
+---
+
 ## Sandbox Modes
 
 | Mode | Description |
@@ -228,5 +268,8 @@ Sandbox mode provides an additional layer of security but should not be consider
   </Card>
   <Card title="Browser CLI" icon="globe" href="/cli/browser">
     Browser automation
+  </Card>
+  <Card title="Sandbox Backends" icon="shield" href="/features/sandbox-backends">
+    All seven built-in backends, install commands, and backend selection guide
   </Card>
 </CardGroup>

--- a/docs/features/sandbox-backends.mdx
+++ b/docs/features/sandbox-backends.mdx
@@ -128,6 +128,7 @@ PR #2003 exposes all seven sandboxes through `SandboxRegistry` — selectable by
 <Tab title="CLI">
 ```bash
 # Run code in any registered backend
+praisonai sandbox run --code "print('hello')" --type subprocess
 praisonai sandbox run --code "print('hello')" --type e2b
 praisonai sandbox run --file script.py --type modal
 praisonai sandbox run --code "ls" --type docker --image python:3.11-slim
@@ -147,6 +148,53 @@ sandbox = sandbox_cls()
 ```
 </Tab>
 </Tabs>
+
+### Installing Optional Backends
+
+Only `subprocess` and `sandlock` ship in the base install — every other backend requires an optional extra.
+
+| Backend | Install command |
+|---------|-----------------|
+| `subprocess` | Built in — no extra required |
+| `sandlock` | Built in — no extra required |
+| `docker` | `pip install "praisonai[docker]"` |
+| `ssh` | `pip install "praisonai[ssh]"` |
+| `modal` | `pip install "praisonai[modal]"` |
+| `daytona` | `pip install "praisonai[daytona]"` |
+| `e2b` | `pip install "praisonai[e2b]"` |
+
+Selecting an uninstalled backend exits with code 2 and prints a fix-it hint — no silent downgrade to subprocess:
+
+```bash
+$ praisonai sandbox run --code "print('hi')" --type modal
+Error: sandbox 'modal' is unavailable: <reason>
+Available: ['subprocess', 'sandlock']
+To install the optional backend:  pip install "praisonai[modal]"
+Or explicitly choose another sandbox:  --sandbox-type subprocess
+$ echo $?
+2
+```
+
+```mermaid
+graph LR
+    A[--sandbox-type X] --> B{Registry}
+    B -->|installed| C[✅ Run]
+    B -->|missing| D[❌ Error + hint\nexit code 2]
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef registry fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class A input
+    class B registry
+    class C success
+    class D error
+```
+
+<Note>
+You'll never get an unexpected backend — if `--sandbox-type X` isn't available, the CLI tells you exactly what to install.
+</Note>
 
 ### Third-Party Sandbox Plugins
 
@@ -392,6 +440,25 @@ Choose the sandbox backend based on your isolation requirements:
 - **Remote**: `SSHSandbox` for network-isolated execution
 - **High Security**: Always use Docker or SSH backends with `shell=False`
 </Accordion>
+
+<Accordion title="Handle missing backends explicitly in scripts and CI">
+Catch exit code 2 from `praisonai sandbox run --type <X>` and either install the extra or fall back to `--sandbox-type subprocess`:
+
+```bash
+praisonai sandbox run --code "print('hello')" --type docker
+if [ $? -eq 2 ]; then
+  echo "Docker not available, falling back to subprocess"
+  praisonai sandbox run --code "print('hello')" --type subprocess
+fi
+```
+
+In CI pipelines, install the required extra before running:
+
+```bash
+pip install "praisonai[docker]"
+praisonai sandbox run --code "print('hello')" --type docker
+```
+</Accordion>
 </AccordionGroup>
 
 ---
@@ -404,5 +471,8 @@ Choose the sandbox backend based on your isolation requirements:
 </Card>
 <Card title="Thread Safety" icon="lock" href="/docs/features/thread-safety">
   Understanding thread-safe operations across PraisonAI components
+</Card>
+<Card title="Sandbox CLI" icon="terminal" href="/cli/sandbox">
+  CLI reference for `praisonai sandbox run` and `praisonai sandbox shell`
 </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

Updates documentation for the fail-loud behavior introduced in PraisonAI PR #2095.

### Changes

**`docs/features/sandbox-backends.mdx`**
- Added **Installing Optional Backends** section (between "Select by Name" and "Third-Party Sandbox Plugins") with:
  - Install matrix for all 7 built-in backends
  - Terminal block showing exit code 2 + fix-it hint
  - Mermaid `graph LR` diagram (`--sandbox-type X → registry → installed? → run | error+hint`)
  - `<Note>` callout explaining the fail-loud behavior
- Added explicit `--type subprocess` example to the CLI "Select by Name" tab (safe default)
- Added new `<Accordion>` to Best Practices: "Handle missing backends explicitly in scripts and CI"
- Added cross-link `<Card>` to `/cli/sandbox` in the Related section

**`docs/cli/sandbox.mdx`**
- Added `run` and `shell` rows to the Sandbox Commands table
- Added `## Run` section with examples, flags table, and `<Tip>` linking to Installing Optional Backends
- Added `## Shell` section with minimal example
- Added cross-link `<Card>` to `/features/sandbox-backends` in Related section

Fixes #711

Generated with [Claude Code](https://claude.ai/code)