### PR TITLE
docs: AutoGen v0.4/AG2 stubs, family router, autogen_v2 alias, resolve_alias(), conditional tool registration

### DIFF
--- a/docs/features/framework-adapter-plugins.mdx
+++ b/docs/features/framework-adapter-plugins.mdx
@@ -147,11 +147,94 @@ Framework adapters must implement the `FrameworkAdapter` protocol:
 | `name` | ✅ | Unique framework identifier |
 | `is_available()` | ✅ | Check framework dependencies |
 | `resolve()` | ❌ | Pick the concrete adapter variant (default returns `self`) |
+| `resolve_alias()` | ❌ | Return the concrete adapter name to dispatch to (string). Default returns `self.name`. Override when your adapter is a router that picks a sibling adapter at runtime by name. |
 | `setup(*, framework_tag)` | ❌ | Framework-specific pre-run hooks (default no-op) |
 | `run(config, llm_config, topic)` | ✅ | Execute framework logic |
 | `cleanup()` | ✅ | Clean up resources |
 
+<Note>
+`resolve_alias()` (added in PR #2086) and `resolve_variant(config, registry)` (added in PR #1988) are **both** present on the Protocol. Use `resolve_variant` when your family decision depends on YAML config keys; use `resolve_alias` when it depends on environment / runtime state. They are not mutually exclusive — `AutoGenFamilyAdapter` uses `resolve_alias` internally inside its own `resolve(config=...)` override.
+</Note>
+
 **Single authoritative `arun()` (PR #1857):** The Protocol declares `arun()` once; `BaseFrameworkAdapter` provides a single default that offloads `run()` to a worker thread via `asyncio.to_thread`. Sync-only adapters (crewai, autogen v0.2) inherit this and need do nothing. Native-async adapters override `arun()`. Earlier revisions of the codebase declared `arun()` twice on both the Protocol and the base class; those duplicate declarations have been removed and there is now exactly one default to override.
+
+### Family Router Pattern — `AutoGenFamilyAdapter` as Canonical Example
+
+A family adapter routes to a concrete sibling adapter based on environment or config. It overrides `resolve_alias()` to return an adapter name, then `resolve()` uses that name to look up and return the concrete instance.
+
+```python
+import os
+import logging
+from typing import Dict, Any, Optional
+from praisonai.framework_adapters.base import BaseFrameworkAdapter
+
+logger = logging.getLogger(__name__)
+
+class AutoGenFamilyAdapter(BaseFrameworkAdapter):
+    """Router adapter for AutoGen family (v0.2, v0.4, AG2)."""
+
+    name = "autogen"
+
+    def is_available(self) -> bool:
+        v2 = AutoGenAdapter()
+        v4 = AutoGenV4Adapter()
+        ag2 = AG2Adapter()
+        return v2.is_available() or v4.is_available() or ag2.is_available()
+
+    def resolve_alias(self) -> str:
+        """Pick adapter name from AUTOGEN_VERSION env var."""
+        requested = os.getenv("AUTOGEN_VERSION", "auto").lower()
+        v2_available = AutoGenAdapter().is_available()
+        v4_available = AutoGenV4Adapter().is_available()
+        ag2_available = AG2Adapter().is_available()
+
+        if requested == "v0.2":
+            if not v2_available:
+                logger.warning("AUTOGEN_VERSION=v0.2 requested but autogen (v0.2) is not installed")
+            return "autogen_v2"
+        if requested == "v0.4":
+            if not v4_available:
+                logger.warning("AUTOGEN_VERSION=v0.4 requested but autogen_agentchat (v0.4) is not installed")
+            return "autogen_v4"
+        if requested == "ag2":
+            if not ag2_available:
+                logger.warning("AUTOGEN_VERSION=ag2 requested but AG2 is not installed")
+            return "ag2"
+
+        # auto: prefer v0.2 (v0.4 and ag2 are stubs)
+        if v2_available:
+            return "autogen_v2"
+        elif v4_available:
+            logger.warning("AutoGen v0.4 is installed but not yet implemented, falling back.")
+            return "autogen_v4"
+        elif ag2_available:
+            return "ag2"
+
+        raise ImportError(
+            "No AutoGen variant is available. Install with:\n"
+            "  pip install 'praisonai[autogen]' for v0.2\n"
+            "  pip install 'praisonai[autogen-v4]' for v0.4\n"
+            "  pip install 'praisonai[ag2]' for AG2"
+        )
+
+    def resolve(self, *, config: Optional[Dict[str, Any]] = None) -> "BaseFrameworkAdapter":
+        adapter_name = self.resolve_alias()
+        from praisonai.framework_adapters.registry import get_default_registry
+        return get_default_registry().create(adapter_name)
+
+    def run(self, config, llm_config, topic) -> str:
+        raise RuntimeError(
+            "AutoGenFamilyAdapter.run() should not be called directly. "
+            "The resolve() method should have been called first to get the concrete adapter."
+        )
+```
+
+Key points:
+- `resolve_alias()` returns a **string name** (env-var based routing)
+- `resolve()` uses that name to fetch the concrete adapter from the registry
+- `run()` raises `RuntimeError` — the orchestrator calls `resolve()` first, then calls `run()` on the returned concrete adapter
+
+---
 
 ### Optional Adapter Hooks
 
@@ -183,7 +266,7 @@ def setup(self, *, framework_tag: str) -> None:
     pass
 ```
 
-### Orchestrator Pipeline (Post-#1763)
+### Orchestrator Pipeline (Post-#1763, updated for #2086)
 
 The orchestrator (`AgentsGenerator.generate_crew_and_kickoff`) now follows this sequence:
 
@@ -192,11 +275,13 @@ sequenceDiagram
     participant Gen as AgentsGenerator
     participant Reg as Registry
     participant Adapter
+    participant FamilyAdapter as FamilyAdapter (router)
     participant Obs as init_observability
 
     Gen->>Reg: resolve(framework)
     Reg-->>Gen: initial_adapter
     Gen->>Adapter: resolve()
+    Note over Adapter,FamilyAdapter: For family adapters, resolve() calls<br/>resolve_alias() internally to pick name,<br/>then returns concrete adapter from registry
     Adapter-->>Gen: concrete_adapter
     Gen->>Gen: assert_framework_available(adapter.name)
     Gen->>Obs: init_observability(adapter.name)

--- a/docs/features/framework-availability.mdx
+++ b/docs/features/framework-availability.mdx
@@ -69,6 +69,37 @@ The following framework names are supported:
 | `litellm` | `import litellm` | LiteLLM package |
 | `openai` | `import openai` | OpenAI Python client |
 
+<Note>
+`autogen_v2` is an **adapter name** registered in `FrameworkAdapterRegistry`, not a probe name in `_framework_availability`. The probe name remains `autogen` (it imports the `autogen` v0.2 package). Use the adapter's `.is_available()` method to test whether a specific adapter will dispatch successfully — it folds in the `implemented` marker.
+</Note>
+
+---
+
+## Adapter Availability vs Framework Availability
+
+Two distinct concepts affect whether an AutoGen-family adapter will actually work:
+
+| Question | API |
+|---|---|
+| "Is the underlying package importable?" | `is_available("autogen")` from `_framework_availability` |
+| "Will calling `adapter.run(...)` actually work?" | `AutoGenV4Adapter().is_available()` (folds `implemented` flag) |
+
+For AutoGen v0.4 and AG2 today: the package may import successfully, but the adapter still reports `False` because `implemented = False`. This is the safety-by-default behaviour added in PR #2086.
+
+```python
+from praisonai._framework_availability import is_available
+
+# Package-level check: is the v0.4 package installed?
+pkg_available = is_available("autogen_v4")  # True if autogen-agentchat is installed
+
+# Adapter-level check: will dispatch actually work?
+from praisonai.framework_adapters.autogen_adapter import AutoGenV4Adapter
+adapter_available = AutoGenV4Adapter().is_available()  # False — implemented = False
+
+# pkg_available may be True while adapter_available is False
+# Always use adapter.is_available() to test dispatch-readiness
+```
+
 ---
 
 ## AG2 Detection Quirk

--- a/docs/features/tool-registry-autogen-migration.mdx
+++ b/docs/features/tool-registry-autogen-migration.mdx
@@ -173,21 +173,25 @@ adapter = AutoGenAdapter()
 
 ### Builtin Registration
 
+<Warning>
+Since PR #2086, `AgentsGenerator.__init__` only calls `register_builtin_autogen_adapters()` when the chosen framework is in the autogen family (`autogen`, `autogen_v2`, `autogen_v4`, `ag2`). If you construct tools outside the orchestrator (e.g. using `ToolRegistry` directly with CrewAI or praisonai framework), and you want the autogen-shaped tool wrappers anyway, call `registry.register_builtin_autogen_adapters()` yourself.
+</Warning>
+
 ```python
-# Legacy approach
 from praisonai.tool_registry import ToolRegistry
 
+# Inside an autogen-family framework: orchestrator does this for you
+# (called automatically by AgentsGenerator.__init__ when framework in
+#  {"autogen", "autogen_v2", "autogen_v4", "ag2"})
+
+# Outside framework dispatch (e.g. you only use ToolRegistry directly):
 registry = ToolRegistry()
-registry.register_builtin_autogen_adapters()
-print("Builtin adapters registered")
-
-# Recommended approach
-from praisonai.framework_adapters import AutoGenAdapter
-
-adapter = AutoGenAdapter()
-# AutoGen integration handled by adapter
-print("AutoGen adapter ready")
+registry.register_builtin_autogen_adapters()   # call this yourself if you want them
 ```
+
+<Note>
+This change closes a hot-path regression where every `AgentsGenerator()` construction triggered the `praisonai_tools` import chain (`CodeDocsSearchTool`, `CSVSearchTool`, `DirectoryReadTool`, `PDFSearchTool`, `RagTool`, `ScrapeWebsiteTool`, `YoutubeChannelSearchTool`, ...) regardless of framework. CrewAI/praisonai users now skip the import entirely.
+</Note>
 
 ---
 

--- a/docs/framework/autogen.mdx
+++ b/docs/framework/autogen.mdx
@@ -1,10 +1,15 @@
 ---
 title: "AutoGen with PraisonAI"
-description: "Use AutoGen v0.2, AutoGen v0.4, or AG2 frameworks with PraisonAI for multi-agent collaboration"
+sidebarTitle: "AutoGen"
+description: "Use AutoGen v0.2 via the AutoGen family router or autogen_v2 direct alias in PraisonAI"
 icon: "robot"
 ---
 
-PraisonAI supports three AutoGen-family frameworks: AutoGen v0.2, AutoGen v0.4, and AG2. Each provides multi-agent collaboration with different implementations and capabilities.
+PraisonAI integrates with the AutoGen family via a version router that picks the right adapter at runtime.
+
+<Warning>
+AutoGen v0.4 (`framework: autogen_v4`) and the standalone AG2 adapter (`framework: ag2`) are **not yet implemented in PraisonAI**. Calling them raises `NotImplementedError` with a pointer to `framework: autogen` (v0.2). Track [issue #1590](https://github.com/MervinPraison/PraisonAI/issues/1590) for implementation status.
+</Warning>
 
 <Note>
 Need a framework that isn't listed here? See [Framework Adapter Plugins](/docs/features/framework-adapter-plugins) to register your own via Python entry points.
@@ -12,274 +17,98 @@ Need a framework that isn't listed here? See [Framework Adapter Plugins](/docs/f
 
 ```mermaid
 graph LR
-    subgraph "AutoGen Family"
-        YAML[📄 YAML Config] --> V2[🤖 AutoGen v0.2]
-        YAML --> V4[🤖 AutoGen v0.4]
-        YAML --> AG2[🤖 AG2]
+    subgraph "AutoGen Family Router"
+        YAML[📄 YAML Config] --> Router[🔀 AutoGenFamilyAdapter]
+        Router -->|AUTOGEN_VERSION=v0.2 or auto| V2[✅ AutoGen v0.2]
+        Router -->|AUTOGEN_VERSION=v0.4| V4[🚧 v0.4 Stub]
+        Router -->|AUTOGEN_VERSION=ag2| AG2[🚧 AG2 Stub]
         V2 --> Result[✅ Result]
-        V4 --> Result
-        AG2 --> Result
     end
 
     classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef router fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef working fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef stub fill:#8B0000,stroke:#7C90A0,color:#fff
 
     class YAML input
-    class V2,V4,AG2 process
-    class Result output
+    class Router router
+    class V2,Result working
+    class V4,AG2 stub
 ```
 
 ## Which AutoGen Option to Choose
 
-PraisonAI supports three AutoGen-family backends with different capabilities:
+Only AutoGen v0.2 is working today. Both v0.4 and AG2 adapters are stubs that raise `NotImplementedError`.
 
 ```mermaid
 graph TB
-    Start[Which AutoGen backend?] --> Q1{Need latest AG2<br/>+ AWS Bedrock?}
-    Q1 -->|Yes| A1["framework: ag2<br/>pip install praisonai[ag2]"]
-    Q1 -->|No| Q2{Already using<br/>AutoGen v0.4 stack?}
-    Q2 -->|Yes| A2["framework: autogen_v4<br/>pip install praisonai[autogen-v4]"]
-    Q2 -->|No| Q3{Using legacy<br/>AutoGen v0.2?}
-    Q3 -->|Yes| A3["framework: autogen<br/>pip install praisonai[autogen]"]
-    Q3 -->|New project| A1
+    Start[Which AutoGen framework name?] --> Q1{Do you need to pin<br/>exactly v0.2?}
+    Q1 -->|Yes| A1["framework: autogen_v2<br/>pip install praisonai[autogen]"]
+    Q1 -->|No| Q2{Let the router pick<br/>based on AUTOGEN_VERSION?}
+    Q2 -->|Yes| A2["framework: autogen<br/>pip install praisonai[autogen]"]
+    Q2 -->|Future v0.4| A3["framework: autogen_v4 🚧<br/>raises NotImplementedError today"]
 
     classDef question fill:#6366F1,stroke:#7C90A0,color:#fff
     classDef answer fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef stub fill:#8B0000,stroke:#7C90A0,color:#fff
 
-    class Start,Q1,Q2,Q3 question
-    class A1,A2,A3 answer
+    class Start,Q1,Q2 question
+    class A1,A2 answer
+    class A3 stub
 ```
 
-| Framework | Install | Best For |
-|-----------|---------|----------|
-| `framework: ag2` | `pip install "praisonai[ag2]"` | New projects, AWS Bedrock, latest features |
-| `framework: autogen_v4` | `pip install "praisonai[autogen-v4]"` | AutoGen v0.4 stack (autogen-agentchat + autogen-ext) |
-| `framework: autogen` | `pip install "praisonai[autogen]"` | Legacy AutoGen v0.2 projects |
+| Framework | Install | Best For | Status |
+|-----------|---------|----------|--------|
+| `framework: autogen` | `pip install "praisonai[autogen]"` | Family router — picks variant via `AUTOGEN_VERSION` | ✅ Working (v0.2 only) |
+| `framework: autogen_v2` | `pip install "praisonai[autogen]"` | Pin v0.2 directly, skip the router | ✅ Working |
+| `framework: autogen_v4` | `pip install "praisonai[autogen-v4]"` | Future AutoGen v0.4 support | 🚧 Stub — raises `NotImplementedError` |
+| `framework: ag2` | `pip install "praisonai[ag2]"` | Future AG2 support | 🚧 Stub — raises `NotImplementedError` |
 
-<<<<<<< HEAD
+---
+
 ## Auto Version Selection
 
-**Tip:** You can also write `framework: autogen` and let PraisonAI pick the concrete version at runtime. Set the `AUTOGEN_VERSION` environment variable to control the choice:
+`framework: autogen` routes to a family adapter (`AutoGenFamilyAdapter`) that picks the concrete version at runtime. Control it with `AUTOGEN_VERSION`:
 
 | `AUTOGEN_VERSION` | Behaviour |
 |---|---|
-| `auto` (default) | Pick v0.4 if available, otherwise v0.2 |
-| `v0.4` | Force v0.4 (must be installed) |
-| `v0.2` | Force v0.2 (must be installed) |
-| anything else | Pick the only one that's available; if both are installed, prefers v0.2 |
+| `auto` (default) | Pick `autogen_v2` if available, else `autogen_v4` (with warning), else `ag2`. If none available, raise `ImportError` with install hints. |
+| `v0.2` | Force `autogen_v2`. Warns if not installed; still returns the name (caller hits `ImportError` at run). |
+| `v0.4` | Force `autogen_v4`. **Currently raises `NotImplementedError` at run** — adapter is a stub. |
+| `ag2` | Force `ag2`. **Currently raises `NotImplementedError` at run** — adapter is a stub. |
+
+<Note>
+`auto` no longer prefers v0.4. Until the v0.4 adapter is implemented (`implemented = True`), it is treated as unavailable and `auto` lands on v0.2.
+</Note>
 
 ```bash
-# Force v0.4
-export AUTOGEN_VERSION=v0.4
-praisonai agents.yaml --framework autogen
-
-# Force v0.2 (legacy)
+# Force v0.2 (default behaviour)
 export AUTOGEN_VERSION=v0.2
 praisonai agents.yaml --framework autogen
+
+# Explicit v0.2 alias — skip the router entirely
+praisonai agents.yaml --framework autogen_v2
 ```
 
-<Note>If you explicitly write `framework: autogen_v4` in YAML, the version-resolution step is skipped — you get exactly that adapter. The env var only kicks in when you write `framework: autogen`.</Note>
-=======
-### Async Usage
+<Note>
+If you write `framework: autogen_v4` or `framework: autogen_v2` directly in YAML, the version-resolution step is skipped — you get exactly that adapter. The `AUTOGEN_VERSION` env var only applies when `framework: autogen` is used.
+</Note>
 
-AutoGen v0.4 runs directly on the caller's event loop when used with `await praisonai.arun()`.
+If no AutoGen variant is installed, the family router raises:
 
 ```python
-import praisonai
-
-# Works with AutoGen v0.4 native async execution
-result = await praisonai.arun(agent_file="agents.yaml", framework="autogen_v4")
+# No AutoGen variant installed → ImportError:
+#   No AutoGen variant is available. Install with:
+#     pip install 'praisonai[autogen]' for v0.2
+#     pip install 'praisonai[autogen-v4]' for v0.4
+#     pip install 'praisonai[ag2]' for AG2
 ```
-
-See [Async Crew Kickoff](/docs/features/async-crew-kickoff) for running AutoGen crews from FastAPI, Jupyter, or other async contexts.
-
-AutoGen availability is checked via cached `importlib.util.find_spec` — no `autogen` import during framework probes, so CLI startup stays fast even with the package installed.
->>>>>>> origin/main
 
 ---
 
-## AutoGen v0.4
+## AutoGen v0.2
 
-AutoGen v0.4 uses the new `autogen-agentchat` and `autogen-ext` packages with `OpenAIChatCompletionClient` and `RoundRobinGroupChat`.
-
-<Steps>
-
-<Step title="Install">
-```bash
-pip install "praisonai[autogen-v4]"
-```
-</Step>
-
-<Step title="Create YAML file">
-```yaml
-framework: autogen_v4
-topic: Research the latest developments in AI agents
-
-roles:
-  researcher:
-    role: AI Research Specialist
-    goal: Find and summarize recent AI agent developments
-    backstory: Expert researcher with deep knowledge of AI trends.
-    tasks:
-      research_task:
-        description: Research the latest developments in {topic}
-        expected_output: Summary report with key findings
-```
-</Step>
-
-<Step title="Run">
-```bash
-export OPENAI_API_KEY=your-key
-praisonai agents.yaml --framework autogen_v4
-```
-</Step>
-
-</Steps>
-
-### How AutoGen v0.4 Works
-
-```mermaid
-sequenceDiagram
-    participant PraisonAI
-    participant Client as OpenAIChatCompletionClient
-    participant Agents as AssistantAgent(s)
-    participant Chat as RoundRobinGroupChat
-    participant Term as TextMentionTermination
-
-    PraisonAI->>Client: Create with model config
-    PraisonAI->>Agents: Create from YAML roles
-    PraisonAI->>Chat: Create RoundRobinGroupChat
-    PraisonAI->>Term: Set TERMINATE termination
-    Chat->>Agents: Route messages in round-robin
-    Agents->>Agents: Collaborate with tools
-    Agents-->>Term: Reply with "TERMINATE"
-    Chat-->>PraisonAI: Final message content
-```
-
-### AutoGen v0.4 Features
-
-- **Model Configuration**: Reads `llm_config[0]` for `model`, `api_key`, `base_url` (defaults: `gpt-4o-mini`, `OPENAI_API_KEY`, `https://api.openai.com/v1`)
-- **Agent Creation**: One `AssistantAgent` per YAML role with `reflect_on_tool_use=True`
-- **Agent Name Sanitization**: Non-alphanumeric characters become `_`, leading digits get `agent_` prefix, Python keywords get trailing `_`
-- **Tool Registration**: Tools must expose `.run()` method, passed to `AssistantAgent(tools=...)`
-- **Execution**: `RoundRobinGroupChat` with `TextMentionTermination("TERMINATE") | MaxMessageTermination(max_messages=20)`
-- **Turn Limit**: `max_turns = len(agents) * 3` (currently hardcoded)
-
-<Warning>
-Agent names are auto-sanitized: `"Research Analyst!"` becomes `"Research_Analyst_"`. This ensures valid Python identifiers for AutoGen v0.4 internal usage.
-</Warning>
-
----
-
-## AG2 (Full)
-
-AG2 is the community fork of AutoGen with enhanced features and AWS Bedrock support.
-
-<Steps>
-
-<Step title="Install">
-```bash
-pip install "praisonai[ag2]"
-```
-</Step>
-
-<Step title="Create YAML file">
-```yaml
-framework: ag2
-topic: Write a technical analysis report
-
-roles:
-  analyst:
-    role: Technical Analyst
-    goal: Analyze market data and trends
-    backstory: Expert in financial analysis with 10 years experience.
-    tasks:
-      analysis_task:
-        description: Analyze the technical indicators for {topic}
-        expected_output: Detailed technical analysis with charts and recommendations
-```
-</Step>
-
-<Step title="Run">
-```bash
-export OPENAI_API_KEY=your-key
-praisonai agents.yaml --framework ag2
-```
-</Step>
-
-</Steps>
-
-### How AG2 Works
-
-```mermaid
-sequenceDiagram
-    participant PraisonAI
-    participant UserProxy as UserProxyAgent
-    participant Assistants as AssistantAgent(s)
-    participant GroupChat
-    participant Manager as GroupChatManager
-
-    PraisonAI->>UserProxy: Create with TERMINATE check
-    PraisonAI->>Assistants: Create from YAML roles
-    PraisonAI->>GroupChat: Create with all agents
-    PraisonAI->>Manager: Create GroupChatManager
-    UserProxy->>Manager: Initiate chat
-    Manager->>Assistants: Route messages
-    Assistants->>Assistants: Collaborate
-    Assistants-->>UserProxy: TERMINATE
-    UserProxy-->>PraisonAI: ChatResult.summary
-```
-
-### AG2 Features
-
-- **LLM Configuration**: Resolution order: top-level `llm.*` > first role's `llm.*` > `llm_config[0]` > environment > defaults
-- **AWS Bedrock**: `api_type: bedrock` skips `api_key`, uses AWS SDK credential chain
-- **Tool Registration**: Uses `assistant.register_for_llm()` + `user_proxy.register_for_execution()`
-- **Agent Names**: Sanitized with `[^a-zA-Z0-9_\-]` → `_`
-- **GroupChat**: Standard `GroupChat(max_round=12)` with `GroupChatManager`
-- **Result Extraction**: Prefers `chat_result.summary`, falls back to scanning messages in reverse
-
-### YAML `llm` Block Precedence
-
-For AG2, the `llm:` configuration can be placed at the top level or under the first role:
-
-| Location | Priority | Example |
-|----------|----------|---------|
-| Top-level | Highest | `llm: { model: "gpt-4o", api_key: "..." }` |
-| First role | Medium | `roles: { analyst: { llm: { ... } } }` |
-| Dispatcher | Lowest | `llm_config[0]` from command |
-
-### AWS Bedrock with AG2
-
-```yaml
-framework: ag2
-topic: Cloud architecture design
-
-roles:
-  cloud_architect:
-    role: AWS Solutions Architect
-    goal: Design scalable cloud architectures
-    backstory: Expert in AWS services and serverless design.
-    llm:
-      model: bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
-      api_type: bedrock
-      aws_region: us-east-1
-    tasks:
-      design_task:
-        description: Design a serverless architecture for {topic}
-        expected_output: Architecture diagram with component descriptions
-```
-
-<Info>
-With `api_type: bedrock`, no `api_key` is required. AG2 uses standard AWS credentials from `~/.aws/credentials`, environment variables, or IAM roles.
-</Info>
-
----
-
-## AutoGen v0.2 (Legacy)
-
-Original AutoGen v0.2 support for existing projects.
+Original AutoGen v0.2 support — the only fully-working AutoGen adapter today.
 
 <Steps>
 
@@ -308,86 +137,155 @@ roles:
 
 <Step title="Run">
 ```bash
-export OPENAI_API_KEY=your-key
+export OPENAI_API_KEY=sk-...
 praisonai agents.yaml --framework autogen
 ```
 </Step>
 
 </Steps>
 
+### Pin v0.2 directly
+
+Use `autogen_v2` to skip the family router and get AutoGen v0.2 unconditionally:
+
+```yaml
+framework: autogen_v2
+topic: Create a movie script about cats on Mars
+
+roles:
+  researcher:
+    role: Research Analyst
+    goal: Gather information about Mars and cat behavior
+    backstory: Skilled researcher with focus on accurate information.
+    tasks:
+      research_task:
+        description: Research Mars environment and cat behavior for {topic}
+        expected_output: Research findings document with key facts
+```
+
+```bash
+praisonai agents.yaml --framework autogen_v2
+```
+
 ### AutoGen v0.2 Features
 
 - **Simple Architecture**: `UserProxyAgent` + `AssistantAgent` with `initiate_chats`
 - **Configuration**: Uses `config_list` format for LLM configuration
 - **Code Execution**: Built-in `code_execution_config` with working directory
-- **Termination**: Checks for "terminate" or "TERMINATE" in message content
-- **Tool Support**: Limited compared to v0.4 and AG2
+- **Termination**: Checks for `"terminate"` or `"TERMINATE"` in message content
+
+---
+
+## AutoGen v0.4
+
+<Warning>
+The `autogen_v4` adapter is currently a stub. `framework: autogen_v4` raises `NotImplementedError` at runtime:
+
+```
+NotImplementedError: AutoGen v0.4 adapter is not yet implemented. Use framework='autogen' (v0.2) or pin AUTOGEN_VERSION=v0.2.
+```
+
+Use `framework: autogen` (or `framework: autogen_v2`) for working AutoGen support.
+</Warning>
+
+`AutoGenV4Adapter.implemented = False` causes `is_available()` to return `False`, so `framework: autogen` and `AUTOGEN_VERSION=auto` will not route to it.
+
+When implemented, AutoGen v0.4 will use `autogen-agentchat` + `autogen-ext` with `OpenAIChatCompletionClient` and `RoundRobinGroupChat`.
+
+Track [issue #1590](https://github.com/MervinPraison/PraisonAI/issues/1590) for implementation status.
+
+---
+
+## AG2
+
+<Warning>
+The standalone `AG2Adapter` is currently a stub. `framework: ag2` raises `NotImplementedError` at runtime:
+
+```
+NotImplementedError: AG2 adapter is not yet implemented. Use framework='autogen' (v0.2) or pin AUTOGEN_VERSION=v0.2.
+```
+
+Use `framework: autogen` for working AutoGen/AG2-family support via v0.2.
+</Warning>
+
+`AG2Adapter.implemented = False` causes `is_available()` to return `False`, so `AUTOGEN_VERSION=ag2` will log a warning and fall through.
+
+Track [issue #1590](https://github.com/MervinPraison/PraisonAI/issues/1590) for implementation status.
+
+---
+
+## How the AutoGen Family Router Works
+
+`AutoGenFamilyAdapter` (registered as `autogen`) is a router — it never runs directly. Instead it calls `resolve()` to get the concrete adapter, which the orchestrator then calls `.run()` on.
+
+```mermaid
+sequenceDiagram
+    participant YAML as YAML Config
+    participant Orch as Orchestrator
+    participant Family as AutoGenFamilyAdapter
+    participant V2 as AutoGenAdapter (v0.2)
+
+    YAML->>Orch: framework: autogen
+    Orch->>Family: resolve()
+    Family->>Family: resolve_alias() → check AUTOGEN_VERSION
+    Family-->>Orch: AutoGenAdapter instance
+    Orch->>V2: run(config, llm_config, topic)
+    V2-->>Orch: result
+```
+
+`AutoGenFamilyAdapter.run()` raises `RuntimeError` if called directly — this is intentional. Always go through the orchestrator.
 
 ---
 
 ## Troubleshooting
 
-### Installation Errors
-
-- **AutoGen v0.4**: `pip install "praisonai[autogen-v4]"` — requires both `autogen-agentchat` and `autogen-ext`
-- **AG2**: `pip install "praisonai[ag2]"` — requires AG2 distribution
-- **AutoGen v0.2**: `pip install "praisonai[autogen]"` — requires legacy `autogen` package
-
 ### Import Errors
 
-- **v0.4 missing `autogen_agentchat`**: Install `autogen-agentchat` package
-- **v0.4 missing `autogen_ext`**: Install `autogen-ext` package
-- **AG2 not detected**: Ensure both `ag2` distribution and `autogen` namespace are available
+When no AutoGen variant is installed and `framework: autogen` is used:
 
-### Agent Name Issues
+```
+ImportError: No AutoGen variant is available. Install with:
+  pip install 'praisonai[autogen]' for v0.2
+  pip install 'praisonai[autogen-v4]' for v0.4
+  pip install 'praisonai[ag2]' for AG2
+```
 
-- **AG2**: `Research Analyst!` → `Research_Analyst_` (sanitization is intentional)
-- **v0.4**: Names become valid Python identifiers (e.g., `"123Agent"` → `"agent_123Agent"`)
+Fix: `pip install "praisonai[autogen]"` for v0.2 (the only working option today).
 
-### Bedrock Configuration
+### NotImplementedError on v0.4 or AG2
 
-- **Missing AWS credentials**: `api_type: bedrock` requires standard AWS credential setup
-- **Wrong region**: Ensure `aws_region` matches your Bedrock model availability
+```
+NotImplementedError: AutoGen v0.4 adapter is not yet implemented. Use framework='autogen' (v0.2) or pin AUTOGEN_VERSION=v0.2.
+NotImplementedError: AG2 adapter is not yet implemented. Use framework='autogen' (v0.2) or pin AUTOGEN_VERSION=v0.2.
+```
 
-### Message Generation
+Switch to `framework: autogen` or `framework: autogen_v2`. Both adapters are stubs pending [issue #1590](https://github.com/MervinPraison/PraisonAI/issues/1590).
 
-- **v0.4 "No messages generated"**: `MaxMessageTermination(20)` was hit; consider the hardcoded `max_turns = len(agents) * 3` limitation
+### AUTOGEN_VERSION=v0.4 warns but continues
 
-**Not-yet-implemented adapters**: 
-- `framework: autogen_v4` raises `NotImplementedError("AutoGen v0.4 adapter is not yet fully implemented. Please use 'autogen' framework for AutoGen v0.2 support.")`
-- `framework: ag2` (the placeholder `AG2Adapter`, distinct from the working `ag2` backend) raises `NotImplementedError("AG2 adapter is not yet fully implemented. Please use 'autogen' framework for AutoGen/AG2 support.")`
-
-Use `framework: autogen` (v0.2) or the fully-registered `framework: ag2` backend instead.
+When `AUTOGEN_VERSION=v0.4` is set but v0.4 is not installed (or is a stub), the router logs a warning and returns `"autogen_v4"` — the caller then hits `NotImplementedError` when `.run()` is invoked. This is expected behaviour; switch to `v0.2`.
 
 **Plugin authors**: Framework adapters now accept dispatcher kwargs (`tools_dict`, `agent_callback`, `task_callback`, `cli_config`). See [Framework Adapter Plugins](/docs/features/framework-adapter-plugins) for custom adapter development.
-
-If the framework is not installed, PraisonAI now fails fast at CLI entry with:
-```
-Framework 'autogen' was requested but is not installed.
-Install it with:
-    pip install 'praisonai[autogen]'  # or: pip install pyautogen
-```
-The error appears **immediately**, before YAML parsing — so a typo in `--framework` is caught before any expensive setup runs.
 
 ---
 
 ## Best Practices
 
 <AccordionGroup>
-  <Accordion title="Choose the right backend for your needs">
-    Use AG2 for new projects with Bedrock needs, AutoGen v0.4 for existing v0.4 stacks, and AutoGen v0.2 only for legacy compatibility.
+  <Accordion title="Use framework: autogen for new projects">
+    `framework: autogen` is the recommended name — it routes through the family adapter and will automatically switch to v0.4 or AG2 once those adapters are implemented, without needing YAML changes.
   </Accordion>
 
-  <Accordion title="Plan for agent name sanitization">
-    Both AG2 and v0.4 sanitize agent names differently. Test your role names to understand the final agent identifiers.
+  <Accordion title="Use framework: autogen_v2 to pin v0.2 explicitly">
+    If you need to guarantee v0.2 regardless of `AUTOGEN_VERSION`, write `framework: autogen_v2`. This skips the family router entirely.
   </Accordion>
 
-  <Accordion title="Configure LLM settings appropriately">
-    AG2 supports top-level `llm:` blocks for shared configuration. AutoGen v0.4 uses `llm_config[0]` from the dispatcher.
+  <Accordion title="Do not use framework: autogen_v4 or framework: ag2 yet">
+    Both raise `NotImplementedError` today. Using them will fail at runtime. Wait for [issue #1590](https://github.com/MervinPraison/PraisonAI/issues/1590).
   </Accordion>
 
-  <Accordion title="Use tools properly for each backend">
-    AutoGen v0.4 requires tools with `.run()` methods. AG2 uses `register_for_llm`/`register_for_execution` pattern.
+  <Accordion title="Check adapter availability correctly">
+    `is_available("autogen")` from `_framework_availability` tests whether the `autogen` Python package is importable. `AutoGenV4Adapter().is_available()` additionally folds in the `implemented = False` marker. Always use the adapter method to test dispatch-readiness.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary

Documents the behaviour changes from [PR #2086](https://github.com/MervinPraison/PraisonAI/pull/2086) in PraisonAI:

- **Fixes merge conflict** in `docs/framework/autogen.mdx` (lines 60–98 with `<<<<<<< HEAD` / `=======` / `>>>>>>> origin/main` markers)
- **Rewrites** AutoGen v0.4 and AG2 sections as stubs with prominent `<Warning>` callouts — both now raise `NotImplementedError` at runtime
- **Updates** AUTOGEN_VERSION table: `auto` now prefers v0.2 (not v0.4), adds `ag2` as a valid value
- **Adds** `autogen_v2` as a new framework name (direct v0.2 alias, skips the family router)
- **Updates** decision-tree mermaid to not recommend `autogen_v4` or `ag2` for new projects
- **Documents** `AutoGenFamilyAdapter` router pattern (`framework: autogen` → router → concrete adapter)
- **Adds** `resolve_alias() -> str` to the Adapter Protocol table with worked example and reconciliation note vs `resolve_variant()`
- **Warns** that `register_builtin_autogen_adapters()` is now conditional (autogen-family frameworks only) and adds manual-registration guidance
- **Clarifies** adapter availability vs package availability (`implemented = False` marker)

## Files Changed

- `docs/framework/autogen.mdx` — conflict resolved, major rewrite
- `docs/features/framework-availability.mdx` — adapter vs package availability section
- `docs/features/framework-adapter-plugins.mdx` — resolve_alias() protocol method + AutoGenFamilyAdapter example
- `docs/features/tool-registry-autogen-migration.mdx` — conditional registration warning

Fixes #718

Generated with [Claude Code](https://claude.ai/code)