### PR TITLE
docs: add praisonai validate CLI page and update YAML validation behaviour

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -488,7 +488,7 @@
                   "docs/features/cloud-databases",
                   "docs/features/neon",
                   "docs/features/supabase",
-                  "docs/features/turso", 
+                  "docs/features/turso",
                   "docs/features/cockroachdb",
                   "docs/features/xata"
                 ]
@@ -594,7 +594,6 @@
                   "docs/features/middleware"
                 ]
               },
-
               {
                 "group": "LLM & Models",
                 "icon": "microchip",
@@ -628,7 +627,7 @@
                   "docs/features/langchain",
                   "docs/integrations/langflow",
                   "docs/features/load-mcp-tools",
-                  "docs/features/mcp-tool-filtering", 
+                  "docs/features/mcp-tool-filtering",
                   "docs/features/mcp-client-protocol",
                   "docs/features/mcp-yaml-config",
                   "docs/features/n8n-integration",
@@ -1207,7 +1206,8 @@
                   "docs/cli/serve",
                   "docs/cli/dashboard",
                   "docs/cli/mcp-server",
-                  "docs/cli/workflow"
+                  "docs/cli/workflow",
+                  "docs/cli/validate"
                 ]
               },
               {

--- a/docs/cli/validate.mdx
+++ b/docs/cli/validate.mdx
@@ -1,0 +1,388 @@
+---
+title: "Validate"
+sidebarTitle: "Validate"
+description: "Fail-fast YAML configuration validation with aggregated, actionable errors"
+icon: "circle-check"
+---
+
+Catch configuration mistakes before they cause runtime failures — `praisonai validate` checks your YAML files against the full schema and reports every error at once.
+
+```mermaid
+graph LR
+    Y["📄 YAML File"] --> S["🔍 Schema Check"]
+    S --> X["🔗 Cross-Reference Check"]
+    X --> T["🔧 Tool Check"]
+    T --> OK["✅ Valid"]
+    T --> ERR["❌ Errors"]
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#EF4444,stroke:#7C90A0,color:#fff
+
+    class Y input
+    class S,X,T process
+    class OK success
+    class ERR error
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Validate a single file (success path)">
+```bash
+praisonai validate agents.yaml
+```
+
+Output:
+```
+✅ agents.yaml is valid
+```
+</Step>
+
+<Step title="Validate a file with errors (failure path)">
+```bash
+praisonai validate agents.yaml
+```
+
+Output when the config has problems:
+```
+❌ agents.yaml is invalid
+
+Configuration validation failed with 2 error(s):
+  1. Agent 'researcher': missing required field 'goal'
+  2. Task 'write_report': references unknown agent 'writer' (not defined in agents/roles)
+
+Additionally, there are 1 warning(s):
+  1. Unknown agent field 'instrutions' in agent 'researcher'. This field will be ignored.
+```
+
+Exit code: `1`
+</Step>
+
+<Step title="CI usage — strict mode + JSON output">
+```bash
+praisonai validate agents.yaml --strict --json
+```
+
+Output:
+```json
+{
+  "file": "agents.yaml",
+  "valid": false,
+  "errors": [
+    "Agent 'researcher': missing required field 'goal'"
+  ],
+  "warnings": [
+    "Unknown agent field 'instrutions' in agent 'researcher'. This field will be ignored."
+  ],
+  "strict_mode": true
+}
+```
+
+With `--strict`, warnings are also treated as errors, so exit code is `1` even when only warnings are present.
+</Step>
+</Steps>
+
+---
+
+## Subcommands
+
+| Command | Purpose |
+|---------|---------|
+| `praisonai validate <file>` | Validate a single YAML file |
+| `praisonai validate check [directory]` | Validate every YAML file in a directory |
+| `praisonai validate schema` | Print the YAML config schema (fields, types, required markers) |
+
+---
+
+## Flags
+
+### `praisonai validate <file>`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `file` (positional) | `str` | — | Path to YAML config to validate |
+| `--strict` | `bool` | `False` | Treat warnings as errors |
+| `--quiet` / `-q` | `bool` | `False` | Only show errors, suppress success messages |
+| `--json` | `bool` | `False` | Emit results as JSON (for CI) |
+
+### `praisonai validate check [directory]`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `directory` (positional) | `str` | `"."` | Directory to search for YAML files |
+| `--pattern` / `-p` | `str` | `"*.yaml"` | Glob pattern (also auto-includes `*.yml` when using the default) |
+| `--strict` | `bool` | `False` | Treat warnings as errors |
+| `--stop-on-error` | `bool` | `False` | Stop on the first invalid file |
+
+### `praisonai validate schema`
+
+Prints all main config sections with field names, types, and required markers — no extra flags.
+
+---
+
+## What Gets Validated
+
+```mermaid
+graph TB
+    subgraph "Validation Pipeline"
+        A["📋 agents.yaml"] --> B["1️⃣ Schema Check"]
+        B --> C["2️⃣ Cross-Reference Check"]
+        C --> D["3️⃣ Tool Check"]
+        D --> E["4️⃣ Unknown Fields"]
+    end
+
+    B --> B1["Required fields present?\nTypes correct?\nEnum values valid?"]
+    C --> C1["task.agent → exists in roles?\nworkflow step agent → exists?\nhandoff.to → exists?"]
+    D --> D1["Tool installed? → error if unknown\nOptional dep? → warning"]
+    E --> E1["Unknown keys → warning\n(not error)"]
+
+    classDef file fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef check fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef detail fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class A file
+    class B,C,D,E check
+    class B1,C1,D1,E1 detail
+```
+
+### 1. Schema Validation
+
+Enforces the Pydantic schema. Every agent must have **`role`**, **`goal`**, and **`backstory`** — these are required. Every task must have **`description`** and **`agent`** (matching `^[a-zA-Z0-9_-]+$`).
+
+When `process: workflow`, the config must also include `steps` or `workflow`.
+
+### 2. Cross-Reference Validation
+
+- Every `tasks[i].agent` must name an agent defined under `roles` / `agents`
+- Workflow step `agent` fields are validated recursively (through nested `steps` and `routes`)
+- Every `handoff.to` target must resolve to a known role
+
+### 3. Tool Validation
+
+Tool names are resolved through `ToolResolver`:
+
+- **Unknown tool** → **error**: *"Unknown tool 'X'. Ensure it's properly installed or defined in your configuration."*
+- **Known optional tool** (e.g. `PostgreSQLTool`, `SlackTool`, `AWSTool`, `BrowserTool`, `PandasTool`, `KubernetesTool`) → **warning**: *"Tool 'X' requires additional dependencies. Install with: pip install 'praisonai[tools]' …"*
+
+### 4. Unknown Fields
+
+Top-level unknown keys and unknown agent/role fields produce **warnings**, not errors:
+
+*"Unknown agent field 'X'. This field will be ignored."*
+
+<Note>
+Unknown-field warnings are non-blocking — your workflow still runs. Only errors (missing required fields, bad cross-references, unknown tools) cause a hard failure.
+</Note>
+
+---
+
+## Output Formats
+
+<Tabs>
+<Tab title="Plain (Rich)">
+Default output uses Rich formatting for easy reading in the terminal:
+
+```
+✅ agents.yaml is valid
+  Warnings:
+    • Unknown agent field 'stream' in agent 'writer'. This field will be ignored.
+```
+
+```
+❌ agents.yaml is invalid
+
+Configuration validation failed with 2 error(s):
+  1. Agent 'researcher': missing required field 'goal'
+  2. Task 'write_report': references unknown agent 'writer' (not defined in agents/roles)
+
+Additionally, there are 1 warning(s):
+  1. Unknown agent field 'instrutions' in agent 'researcher'. This field will be ignored.
+```
+</Tab>
+
+<Tab title="Quiet (-q)">
+Only errors are printed; success messages and warnings are suppressed:
+
+```bash
+praisonai validate agents.yaml -q
+```
+
+Produces no output when valid. On error, only the error block is shown.
+</Tab>
+
+<Tab title="JSON (--json)">
+Structured output for CI pipelines:
+
+```bash
+praisonai validate agents.yaml --json
+```
+
+```json
+{
+  "file": "agents.yaml",
+  "valid": true,
+  "errors": [],
+  "warnings": [],
+  "strict_mode": false
+}
+```
+
+When invalid:
+```json
+{
+  "file": "agents.yaml",
+  "valid": false,
+  "errors": [
+    "Agent 'researcher': missing required field 'goal'"
+  ],
+  "warnings": [
+    "Unknown agent field 'instrutions' in agent 'researcher'. This field will be ignored."
+  ],
+  "strict_mode": false
+}
+```
+</Tab>
+
+<Tab title="Directory Scan">
+`praisonai validate check` renders a Rich table:
+
+```
+┌──────────────────┬─────────┬────────┬──────────┐
+│ File             │ Status  │ Errors │ Warnings │
+├──────────────────┼─────────┼────────┼──────────┤
+│ agents.yaml      │ ✅ PASS │ 0      │ 1        │
+│ workflow.yaml    │ ❌ FAIL │ 2      │ 0        │
+└──────────────────┴─────────┴────────┴──────────┘
+
+Summary: 1/2 files valid
+```
+</Tab>
+</Tabs>
+
+---
+
+## CI Integration
+
+Add validation to your GitHub Actions workflow to block merges on broken configs:
+
+```yaml
+name: Validate PraisonAI Config
+on: [push, pull_request]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PraisonAI
+        run: pip install praisonai
+
+      - name: Validate all YAML configs
+        run: praisonai validate check . --strict --json
+```
+
+Exit code `1` on any validation failure causes the step to fail.
+
+---
+
+## Strict Mode
+
+Strict mode promotes warnings to errors — useful in CI to keep configs clean.
+
+Enable per-command:
+
+```bash
+praisonai validate agents.yaml --strict
+praisonai validate check . --strict
+```
+
+Enable globally via environment variable:
+
+```bash
+export PRAISONAI_VALIDATE_STRICT=true
+praisonai validate agents.yaml
+```
+
+With `PRAISONAI_VALIDATE_STRICT=true`, **all** validation runs (including the automatic pre-run check in `agents_generator.py`) use strict mode.
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | File is valid (or all files in directory are valid) |
+| `1` | One or more errors found, or the file does not exist |
+
+---
+
+## Backward-Compatible Aliases
+
+The validator automatically normalises these field aliases — you can use either form:
+
+| Alias | Canonical |
+|-------|-----------|
+| `agents:` | `roles:` |
+| `topic:` | `input:` |
+| `stream:` | `streaming:` |
+
+---
+
+## Fail-Fast Runtime Validation
+
+When you run `praisonai start agents.yaml`, validation now runs automatically **before** execution. If any errors are found, the run aborts with an aggregated `ValueError`:
+
+```
+Configuration validation failed with 2 error(s):
+  1. Agent 'researcher': missing required field 'goal'
+  2. Task 'write_report': references unknown agent 'writer'
+
+Additionally, there are 1 warning(s):
+  1. Unknown agent field 'instrutions'. This field will be ignored.
+```
+
+This replaces the old behaviour where invalid configs emitted non-blocking warnings and continued running.
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Run validate before every commit">
+Add `praisonai validate agents.yaml` to your pre-commit checks or CI pipeline to catch errors early.
+</Accordion>
+
+<Accordion title="Use --json in automated pipelines">
+JSON output is easy to parse in scripts or CI steps that need to inspect specific error messages programmatically.
+</Accordion>
+
+<Accordion title="Set PRAISONAI_VALIDATE_STRICT=true in production">
+Strict mode treats warnings as errors, preventing unknown or misspelled fields from silently being ignored in production environments.
+</Accordion>
+
+<Accordion title="Use validate schema to discover required fields">
+Run `praisonai validate schema` to see all fields, their types, and which are required — before writing a new config from scratch.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="YAML Configuration Reference" icon="book" href="/docs/features/yaml-configuration-reference">
+    Complete field reference for agents.yaml and workflow.yaml
+  </Card>
+  <Card title="CLI Reference" icon="terminal" href="/docs/features/cli">
+    All available CLI commands
+  </Card>
+  <Card title="Doctor" icon="stethoscope" href="/docs/cli/doctor">
+    Diagnose environment and dependency issues
+  </Card>
+  <Card title="Workflow CLI" icon="diagram-project" href="/docs/cli/workflow">
+    Run and manage YAML workflows from the terminal
+  </Card>
+</CardGroup>

--- a/docs/features/cli.mdx
+++ b/docs/features/cli.mdx
@@ -105,6 +105,34 @@ PraisonAI CLI provides a simple way to interact with AI agents directly from you
   </Card>
 </CardGroup>
 
+## Validate CLI
+
+Validate YAML configuration files before running:
+
+```bash
+# Validate a single file
+praisonai validate agents.yaml
+
+# Validate all YAML files in a directory
+praisonai validate check . --strict
+
+# Print the full configuration schema
+praisonai validate schema
+
+# JSON output for CI
+praisonai validate agents.yaml --json
+```
+
+| Subcommand | Purpose |
+|------------|---------|
+| `validate <file>` | Validate a single YAML config |
+| `validate check [dir]` | Scan a directory for YAML errors |
+| `validate schema` | Print schema fields, types, and required markers |
+
+See the [Validate CLI reference](/docs/cli/validate) for all flags and output formats.
+
+---
+
 ## Workflow CLI
 
 Manage and execute YAML workflows directly from the command line:

--- a/docs/features/yaml-configuration-reference.mdx
+++ b/docs/features/yaml-configuration-reference.mdx
@@ -118,27 +118,39 @@ PraisonAI accepts both old and new field names. **Use canonical names for new pr
 - **S**teps - What they do
 </Tip>
 
+<Note>
+The validator automatically normalises these aliases — `agents`↔`roles`, `topic`↔`input`, and `stream`↔`streaming` are all accepted and converted to their canonical form. You can mix old and new names freely.
+</Note>
+
 ---
 
 ## Automatic Field Validation
 
-PraisonAI automatically checks every field name in your `agents.yaml` and warns you about typos when the workflow starts.
+PraisonAI validates every field name in your `agents.yaml` before execution begins — unknown fields produce warnings and invalid configs abort immediately.
 
 ```mermaid
 graph LR
-    Y[agents.yaml] --> P[Parser]
-    P --> V{Field known?}
-    V -->|Yes| OK[Use value]
-    V -->|No| F[Fuzzy match]
-    F --> W[Log warning + suggestion]
-    
+    Y["📄 agents.yaml"] --> S["🔍 Schema Check"]
+    S --> X["🔗 Cross-Ref Check"]
+    X --> T["🔧 Tool Check"]
+    T --> OK["✅ Run Workflow"]
+    S --> ERR["❌ Abort (ValueError)"]
+    X --> ERR
+    T --> ERR
+
     style Y fill:#8B0000,stroke:#7C90A0,color:#fff
-    style P fill:#189AB4,stroke:#7C90A0,color:#fff
-    style V fill:#F59E0B,stroke:#7C90A0,color:#fff
+    style S fill:#189AB4,stroke:#7C90A0,color:#fff
+    style X fill:#189AB4,stroke:#7C90A0,color:#fff
+    style T fill:#189AB4,stroke:#7C90A0,color:#fff
     style OK fill:#10B981,stroke:#7C90A0,color:#fff
-    style F fill:#6366F1,stroke:#7C90A0,color:#fff
-    style W fill:#EF4444,stroke:#7C90A0,color:#fff
+    style ERR fill:#EF4444,stroke:#7C90A0,color:#fff
 ```
+
+<Warning>
+Configuration errors now **fail fast**. If any error is found (missing required field, bad cross-reference, unknown tool), the run aborts with a `ValueError` that lists every error at once — nothing runs with a broken config.
+
+Unknown-field **warnings** are still non-blocking: the unrecognised field is ignored and the workflow continues.
+</Warning>
 
 <Steps>
 <Step title="Create YAML with typo">
@@ -150,7 +162,7 @@ agents:
   researcher:
     role: Research Analyst
     goal: Provide a historical summary
-    instrutions: "Focus ONLY on years 1989–2000."   # typo
+    instrutions: "Focus ONLY on years 1989–2000."   # typo — warning
     backstory: Expert researcher.
 ```
 </Step>
@@ -160,20 +172,87 @@ agents:
 praisonai start agents.yaml
 ```
 
-Output:
+Output (unknown field → warning, workflow still runs):
 ```
-WARNING: Unknown field 'instrutions' in agent 'researcher'. Did you mean 'instructions'?
+WARNING: Unknown agent field 'instrutions' in agent 'researcher'. This field will be ignored.
 ```
 </Step>
 
-<Step title="Fix the typo">
-```yaml
-    instructions: "Focus ONLY on years 1989–2000."   # fixed
+<Step title="Validate before running">
+```bash
+praisonai validate agents.yaml
 ```
 
-Now the warning disappears and the field is properly used.
+Catch all errors upfront without running the workflow.
 </Step>
 </Steps>
+
+### Fail-Fast Errors
+
+These conditions abort the run immediately with an aggregated error message.
+
+**Missing required field:**
+```yaml
+agents:
+  researcher:
+    role: Research Analyst
+    # goal is required but missing
+    backstory: Expert researcher.
+```
+
+Result:
+```
+Configuration validation failed with 1 error(s):
+  1. Agent 'researcher': missing required field 'goal'
+```
+
+**Bad cross-reference (task references undefined agent):**
+```yaml
+agents:
+  researcher:
+    role: Research Analyst
+    goal: Research topics
+    backstory: Expert researcher.
+
+tasks:
+  write_report:
+    description: Write a report
+    agent: writer      # 'writer' is not defined!
+```
+
+Result:
+```
+Configuration validation failed with 1 error(s):
+  1. Task 'write_report': references unknown agent 'writer' (not defined in agents/roles)
+```
+
+**Unknown tool:**
+```yaml
+agents:
+  researcher:
+    role: Research Analyst
+    goal: Research topics
+    backstory: Expert researcher.
+    tools:
+      - nonexistent_tool
+```
+
+Result:
+```
+Configuration validation failed with 1 error(s):
+  1. Unknown tool 'nonexistent_tool'. Ensure it's properly installed or defined in your configuration.
+```
+
+Optional tools with extra dependencies produce a **warning** instead:
+```
+WARNING: Tool 'BrowserTool' requires additional dependencies. Install with: pip install 'praisonai[tools]'
+```
+
+### Required Agent Fields
+
+<Note>
+`role`, `goal`, and `backstory` are **schema-enforced required fields** for every agent. Omitting any of them aborts the run with a `ValueError`.
+</Note>
 
 ### Recognized Fields
 
@@ -211,28 +290,39 @@ All recognized field names for agents in both `agents:` and `roles:` sections:
 | `cli_backend` | string / dict | CLI backend (e.g. `claude-code`) or `{id: ..., overrides: {...}}`. Requires `framework: praisonai`. See [CLI Backend Protocol](/docs/features/cli-backend-protocol). |
 | `reflection` | bool/object | Reflection configuration |
 
-### How Suggestions Work
+### Unknown-Field Warnings
 
-PraisonAI uses Python's built-in `difflib` with a 0.6 similarity cutoff. Only the single closest match is shown, and only when a close match exists.
+Unknown keys at the top level or in agent/role definitions produce warnings:
 
-<Note>
-Warnings are **non-blocking**. Your workflow still runs; the typo'd field is simply ignored. Always check warnings before assuming an agent is configured correctly.
-</Note>
+```
+WARNING: Unknown agent field 'instrutions' in agent 'researcher'. This field will be ignored.
+WARNING: Unknown agent field 'xyz_random_field' in agent 'test_agent'. This field will be ignored.
+```
+
+Warnings are **non-blocking** — the unrecognised field is ignored and the workflow continues. Only use `--strict` (or `PRAISONAI_VALIDATE_STRICT=true`) to promote them to errors.
 
 <Tip>
-Set your log level to `WARNING` or below (`INFO`, `DEBUG`) to see these messages. They're emitted via the standard `praisonai` logger.
+Set your log level to `WARNING` or below (`INFO`, `DEBUG`) to see these messages. They are emitted via the standard `praisonai` logger.
 </Tip>
-
-### Sample Output
-
-```bash
-WARNING: Unknown field 'instrutions' in agent 'researcher'. Did you mean 'instructions'?
-WARNING: Unknown field 'xyz_random_field' in agent 'test_agent'.
-```
 
 ### Both Sections Covered
 
 The validator inspects both `agents:` and `roles:` sections. The warning text changes from `agent 'X'` to `role 'X'` accordingly.
+
+### Strict Mode
+
+Promote all warnings to errors globally:
+
+```bash
+export PRAISONAI_VALIDATE_STRICT=true
+praisonai start agents.yaml
+```
+
+Or per-command:
+
+```bash
+praisonai validate agents.yaml --strict
+```
 
 <AccordionGroup>
 <Accordion title="Run once after editing YAML" icon="play">
@@ -947,16 +1037,26 @@ steps:
 
 ## Validation
 
-Validate your YAML configuration:
+Validate your YAML configuration before running:
 
 ```bash
-praisonai workflow validate my-workflow.yaml
+praisonai validate agents.yaml
 ```
 
 Output shows:
-- ✅ Valid fields
-- 💡 Suggestions for canonical names
-- ❌ Errors if invalid
+- ✅ Valid configuration
+- ⚠️ Non-blocking warnings (unknown fields, optional tool deps)
+- ❌ Errors that would abort execution
+
+Scan an entire directory:
+
+```bash
+praisonai validate check . --strict --json
+```
+
+See the [Validate CLI page](/docs/cli/validate) for all flags, JSON output format, and CI integration examples.
+
+`praisonai workflow validate` is the workflow-specific variant and remains available for backwards compatibility.
 
 ---
 
@@ -978,5 +1078,5 @@ Output shows:
 </CardGroup>
 
 <Tip>
-Run `praisonai workflow validate <file.yaml>` to check for issues and get suggestions for canonical field names.
+Run `praisonai validate <file.yaml>` to check for all schema errors, cross-reference problems, and unknown tool references before starting a workflow. Use `praisonai validate schema` to print all recognised fields and their types.
 </Tip>


### PR DESCRIPTION
## Summary

- **New page** `docs/cli/validate.mdx`: complete reference for `praisonai validate`, `validate check`, and `validate schema` subcommands including all flags, output formats (plain/quiet/JSON/table), CI GitHub Actions snippet, strict mode (`--strict` + `PRAISONAI_VALIDATE_STRICT`), exit codes, backward-compat aliases, and fail-fast runtime behaviour
- **Updated** `docs/features/yaml-configuration-reference.mdx`: rewrites Automatic Field Validation section to reflect fail-fast behaviour, adds Fail-Fast Errors subsection with missing-field/cross-reference/unknown-tool examples, adds Required Agent Fields note (role/goal/backstory schema-enforced), removes old `difflib` "Did you mean" copy, adds `PRAISONAI_VALIDATE_STRICT` docs, adds backward-compat aliases callout, updates Validation section to reference new `praisonai validate` command
- **Updated** `docs/features/cli.mdx`: adds Validate CLI section with subcommands table and link to the new page
- **Updated** `docs.json`: adds `docs/cli/validate` under Core Commands in the CLI tab

Fixes #725

Generated with [Claude Code](https://claude.ai/code)