### PR TITLE
docs: add Industry Templates feature pages (Manufacturing, Energy, Healthcare, Agriculture, Transportation)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -243,6 +243,18 @@
             "icon": "stars",
             "pages": [
               {
+                "group": "Industry Templates",
+                "icon": "building-2",
+                "pages": [
+                  "docs/features/industry-templates/overview",
+                  "docs/features/industry-templates/manufacturing",
+                  "docs/features/industry-templates/energy",
+                  "docs/features/industry-templates/healthcare",
+                  "docs/features/industry-templates/agriculture",
+                  "docs/features/industry-templates/transportation"
+                ]
+              },
+              {
                 "group": "Agent Capabilities",
                 "icon": "robot",
                 "pages": [
@@ -488,7 +500,7 @@
                   "docs/features/cloud-databases",
                   "docs/features/neon",
                   "docs/features/supabase",
-                  "docs/features/turso", 
+                  "docs/features/turso",
                   "docs/features/cockroachdb",
                   "docs/features/xata"
                 ]
@@ -594,7 +606,6 @@
                   "docs/features/middleware"
                 ]
               },
-
               {
                 "group": "LLM & Models",
                 "icon": "microchip",
@@ -628,7 +639,7 @@
                   "docs/features/langchain",
                   "docs/integrations/langflow",
                   "docs/features/load-mcp-tools",
-                  "docs/features/mcp-tool-filtering", 
+                  "docs/features/mcp-tool-filtering",
                   "docs/features/mcp-client-protocol",
                   "docs/features/mcp-yaml-config",
                   "docs/features/n8n-integration",

--- a/docs/features/industry-templates/agriculture.mdx
+++ b/docs/features/industry-templates/agriculture.mdx
@@ -1,0 +1,181 @@
+---
+title: "Agriculture Template"
+sidebarTitle: "Agriculture"
+description: "Four-agent precision farming pipeline — multispectral imagery analysis, pest and disease detection, targeted spray recommendations, and yield forecasting."
+icon: "wheat"
+---
+
+Analyse drone or satellite imagery, detect crop stress and pests before they spread, and receive actionable treatment plans — all from a single workflow call.
+
+```mermaid
+graph LR
+    subgraph "Precision Agriculture Workflow"
+        IN["🛸 Drone/Satellite"] --> MA["🤖 MultispectralAnalyzer"]
+        MA --> DI["🤖 DiseaseIdentifier"]
+        DI --> SR["🤖 SprayRecommender"]
+        SR --> YP["🤖 YieldPredictor"]
+        YP --> OUT["✅ Farmer App"]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class IN input
+    class MA,DI,SR,YP agent
+    class OUT output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Run the prebuilt workflow for multiple fields">
+
+```python
+from praisonaiagents import Agent, tool
+from examples.cookbooks.Industry_Templates.agriculture_template import precision_agriculture_workflow
+
+fields  = ["FIELD-001", "FIELD-002", "FIELD-003"]
+weather = {"temperature": 25, "humidity": 60, "wind_speed": 8, "precipitation": 0}
+
+result = precision_agriculture_workflow(fields, "wheat", weather)
+
+print(result["alerts"])
+print(result["yield_forecasts"])
+print(f"Sustainability score: {result['sustainability_score']:.0f}/100")
+```
+</Step>
+
+<Step title="Use IoT sensor network agent for real-time data">
+
+```python
+from examples.cookbooks.Industry_Templates.agriculture_template import IoTSensorPatterns
+
+sensor_agent = IoTSensorPatterns.create_sensor_network_agent(
+    sensor_types=["soil_moisture", "temperature", "humidity", "ph"]
+)
+
+status = sensor_agent.start("Collect sensor readings from all FIELD-001 nodes")
+print(status)
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Drone as "Drone/Satellite"
+    participant MultispectralAnalyzer
+    participant DiseaseIdentifier
+    participant SprayRecommender
+    participant YieldPredictor
+    participant FarmerApp as "Farmer App"
+
+    Drone->>MultispectralAnalyzer: Raw multispectral imagery
+    MultispectralAnalyzer-->>DiseaseIdentifier: MultispectralData schema (NDVI, NDRE, CCCI)
+    DiseaseIdentifier-->>SprayRecommender: PestDiseaseReport schema
+    SprayRecommender-->>YieldPredictor: SprayRecommendation schema
+    YieldPredictor-->>FarmerApp: YieldForecast schema
+```
+
+| Agent | Responsibility | SLA |
+|-------|---------------|-----|
+| `MultispectralAnalyzer` | Calculate NDVI/NDRE/CCCI vegetation indices and identify stress zones | ≤ 2 min per field |
+| `DiseaseIdentifier` | AI-based pest and disease classification with severity level | ≤ 30 s |
+| `SprayRecommender` | Targeted spray strategy — product, rate, GPS zones, weather window | ≤ 1 min |
+| `YieldPredictor` | Harvest yield forecast with quality grade and market value estimate | ≤ 45 s |
+
+---
+
+## Configuration Options
+
+Pydantic I/O schemas used by this template:
+
+| Schema | Key Fields |
+|--------|-----------|
+| `MultispectralData` | `field_id`, `ndvi_index`, `ndre_index`, `ccci_index`, `moisture_level`, `temperature`, `affected_area`, `gps_coordinates` |
+| `PestDiseaseReport` | `report_id`, `field_id`, `pest_type`, `disease_type`, `severity`, `affected_crops`, `spread_rate`, `confidence_score` |
+| `SprayRecommendation` | `recommendation_id`, `field_id`, `treatment_type`, `product_name`, `application_rate`, `target_zones`, `optimal_time`, `cost_estimate`, `environmental_impact` |
+| `YieldForecast` | `forecast_id`, `field_id`, `crop_type`, `predicted_yield`, `confidence_interval`, `harvest_window`, `quality_grade`, `market_price_estimate` |
+
+**Severity levels** (used in `PestDiseaseReport`)
+
+| Level | Meaning | Typical action |
+|-------|---------|---------------|
+| `none` | No threat detected | Routine fertiliser application |
+| `low` | Early blight signs | Organic treatment (e.g. Neem Oil) |
+| `moderate` | Localised infestation | Targeted fungicide/pesticide |
+| `high` | Spreading infestation | Systemic treatment + monitoring |
+| `severe` | Field-wide outbreak | Emergency intervention |
+
+---
+
+## Common Patterns
+
+**Integrated Pest Management (IPM) strategy by severity**
+
+```python
+from examples.cookbooks.Industry_Templates.agriculture_template import SustainableFarmingPatterns
+
+strategy = SustainableFarmingPatterns.integrated_pest_management("moderate")
+print(strategy)
+```
+
+**Precision irrigation based on soil moisture**
+
+```python
+from examples.cookbooks.Industry_Templates.agriculture_template import SustainableFarmingPatterns
+
+irrigation = SustainableFarmingPatterns.precision_irrigation(
+    moisture_level=25.0,
+    crop_stage="flowering"
+)
+print(f"Irrigate: {irrigation['irrigation_needed']}, Amount: {irrigation['amount_mm']} mm")
+```
+
+**Recommend next crop for rotation**
+
+```python
+from examples.cookbooks.Industry_Templates.agriculture_template import SustainableFarmingPatterns
+
+next_crop = SustainableFarmingPatterns.crop_rotation_optimizer("wheat", soil_data={})
+print(f"Next crop: {next_crop}")
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Fly imagery in optimal lighting conditions">
+`MultispectralAnalyzer` accuracy degrades significantly in overcast conditions or when shadows cover more than 20 % of a field. Schedule drone flights within 2 hours of solar noon for best NDVI readings.
+</Accordion>
+
+<Accordion title="Act on high-severity alerts within 24 hours">
+`DiseaseIdentifier` reports `spread_rate` in % per day. At high severity (`spread_rate > 2 %`), a one-day delay can double the affected area. The workflow automatically generates a `SprayRecommendation` for high/severe findings.
+</Accordion>
+
+<Accordion title="Monitor the sustainability_score trend">
+The workflow calculates a `sustainability_score` (0–100) based on total chemical application. Track this per season — a declining score signals overuse of pesticides, which correlates with long-term soil health degradation.
+</Accordion>
+
+<Accordion title="Validate GPS spray zones before field application">
+`SprayRecommendation.target_zones` contains GPS polygon boundaries. Always cross-check these against your field boundary GIS layer to prevent off-target application near water bodies or buffer zones.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Industry Templates Overview" icon="building-2" href="/docs/features/industry-templates/overview">
+  Hub page — choose the right template and understand cross-industry reuse.
+</Card>
+<Card title="Transportation Template" icon="truck" href="/docs/features/industry-templates/transportation">
+  LiDAR structural analysis, displacement tracking, and infrastructure safety heatmaps.
+</Card>
+</CardGroup>

--- a/docs/features/industry-templates/energy.mdx
+++ b/docs/features/industry-templates/energy.mdx
@@ -1,0 +1,175 @@
+---
+title: "Energy Template"
+sidebarTitle: "Energy"
+description: "Four-agent pipeline for wind-farm SCADA monitoring, vibration-based fault detection, power forecasting, and predictive maintenance."
+icon: "bolt"
+---
+
+Monitor an entire wind farm, detect mechanical faults early, forecast 24-hour power output, and schedule maintenance — all in one workflow call.
+
+```mermaid
+graph LR
+    subgraph "Energy Monitoring Workflow"
+        IN["📡 SCADA Feed"] --> SR["🤖 SCADAReader"]
+        SR --> VA["🤖 VibrationAnalyzer"]
+        VA --> PF["🤖 PowerForecaster"]
+        PF --> MS["🤖 MaintenanceScheduler"]
+        MS --> OUT["✅ Ops Dashboard"]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class IN input
+    class SR,VA,PF,MS agent
+    class OUT output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Run the prebuilt workflow">
+
+```python
+from praisonaiagents import Agent, tool
+from examples.cookbooks.Industry_Templates.energy_template import energy_monitoring_workflow
+
+turbines = ["WT-001", "WT-002", "WT-003"]
+weather  = {"wind_speed": 14.0, "direction": "NW", "temperature": 15.0}
+
+result = energy_monitoring_workflow(turbines, weather)
+print(result["alerts"])
+print(result["power_forecast"])
+```
+</Step>
+
+<Step title="Adapt for solar or battery storage">
+
+```python
+from examples.cookbooks.Industry_Templates.energy_template import EnergyPatternAdapter
+
+solar_agent   = EnergyPatternAdapter.adapt_for_solar_farm()
+grid_agent    = EnergyPatternAdapter.adapt_for_power_grid()
+battery_agent = EnergyPatternAdapter.adapt_for_battery_storage()
+
+status = solar_agent.start("Monitor panel efficiency for array SOLAR-A1")
+print(status)
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant SCADA as "SCADA Feed"
+    participant SCADAReader
+    participant VibrationAnalyzer
+    participant PowerForecaster
+    participant MaintenanceScheduler
+    participant Dashboard as "Ops Dashboard"
+
+    SCADA->>SCADAReader: Real-time telemetry
+    SCADAReader-->>VibrationAnalyzer: TurbineData schema
+    VibrationAnalyzer-->>PowerForecaster: VibrationAnalysis schema
+    PowerForecaster-->>MaintenanceScheduler: PowerForecast schema
+    MaintenanceScheduler-->>Dashboard: MaintenancePlan schema
+```
+
+| Agent | Responsibility | SLA |
+|-------|---------------|-----|
+| `SCADAReader` | Process real-time turbine telemetry | ≤ 1 s |
+| `VibrationAnalyzer` | FFT analysis and early fault detection | ≤ 5 s per turbine |
+| `PowerForecaster` | 24-hour generation forecast | ≤ 30 s |
+| `MaintenanceScheduler` | Condition-based maintenance planning | ≤ 1 min |
+
+---
+
+## Configuration Options
+
+Pydantic I/O schemas used by this template:
+
+| Schema | Key Fields |
+|--------|-----------|
+| `TurbineData` | `turbine_id`, `wind_speed`, `power_output`, `rotor_speed`, `vibration_level`, `operational_status` |
+| `VibrationAnalysis` | `turbine_id`, `vibration_rms`, `frequency_peaks`, `anomaly_detected`, `failure_probability`, `recommended_action` |
+| `PowerForecast` | `forecast_id`, `predicted_output` (24 h list), `confidence_interval`, `weather_factors`, `grid_demand` |
+| `MaintenancePlan` | `plan_id`, `turbine_id`, `maintenance_type`, `scheduled_date`, `estimated_duration`, `required_parts` |
+
+---
+
+## Common Patterns
+
+**Attach a live weather API tool to PowerForecaster**
+
+```python
+from praisonaiagents import tool
+from examples.cookbooks.Industry_Templates.energy_template import power_forecaster
+
+@tool
+def fetch_weather_forecast(location: str) -> dict:
+    """Fetch 24-hour weather forecast from weather service"""
+    return {"wind_speed": 13.5, "direction": "SW", "cloud_cover": 0.3}
+
+power_forecaster.tools.append(fetch_weather_forecast)
+forecast = power_forecaster.start("Forecast power for farm at coordinates 51.5, -0.1")
+```
+
+**Handle turbine failure with built-in fallback**
+
+```python
+from examples.cookbooks.Industry_Templates.energy_template import EnergyFallbackStrategies
+
+strategy = EnergyFallbackStrategies.turbine_failure_fallback(
+    failed_turbine_id="WT-003",
+    available_turbines=["WT-001", "WT-002", "WT-004", "WT-005"]
+)
+print(strategy)
+```
+
+**Communicate failure to grid operator**
+
+```python
+from examples.cookbooks.Industry_Templates.energy_template import EnergyFallbackStrategies
+
+comm_fallback = EnergyFallbackStrategies.communication_failure_fallback()
+print(comm_fallback["actions"])
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Set vibration anomaly thresholds per turbine model">
+The default anomaly threshold is `vibration_level > 5.0 mm/s`. Older turbine models often tolerate higher baseline vibration. Override the `analyze_vibration_patterns` tool logic to use model-specific thresholds.
+</Accordion>
+
+<Accordion title="Run SCADAReader within 1 second">
+Grid stability decisions depend on real-time data. Any custom SCADA integration tool must complete within the 1-second SLA — use streaming MQTT connections rather than polling REST APIs.
+</Accordion>
+
+<Accordion title="Use conservative forecasts during system failures">
+`EnergyFallbackStrategies.forecast_failure_fallback()` returns the last known forecast with reduced confidence. Always request additional grid reserves when operating in fallback mode.
+</Accordion>
+
+<Accordion title="Minimise production loss during maintenance windows">
+`MaintenanceScheduler` calculates `production_loss` in MW. Schedule non-critical maintenance during low-wind forecasts to reduce grid impact.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Industry Templates Overview" icon="building-2" href="/docs/features/industry-templates/overview">
+  Hub page — choose the right template and understand cross-industry reuse.
+</Card>
+<Card title="Healthcare Template" icon="stethoscope" href="/docs/features/industry-templates/healthcare">
+  Emergency triage, HIPAA-compliant EMR retrieval, and resource allocation.
+</Card>
+</CardGroup>

--- a/docs/features/industry-templates/healthcare.mdx
+++ b/docs/features/industry-templates/healthcare.mdx
@@ -1,0 +1,195 @@
+---
+title: "Healthcare Template"
+sidebarTitle: "Healthcare"
+description: "Four-agent emergency triage pipeline — vital signs capture, HIPAA-compliant EMR retrieval, ESI-based triage, and hospital resource allocation."
+icon: "stethoscope"
+---
+
+From patient arrival to bed assignment in four coordinated agents — with built-in HIPAA-compliant data handling and safety red-flag detection at every step.
+
+```mermaid
+graph LR
+    subgraph "Emergency Triage Workflow"
+        IN["🏥 Patient Monitor"] --> VS["🤖 VitalSignsCapture"]
+        VS --> EM["🤖 EMRRetrieval"]
+        EM --> TR["🤖 TriageRecommendation"]
+        TR --> RA["🤖 ResourceAllocator"]
+        RA --> OUT["✅ Clinician"]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class IN input
+    class VS,EM,TR,RA agent
+    class OUT output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Run the prebuilt triage workflow">
+
+```python
+from praisonaiagents import Agent, tool
+from examples.cookbooks.Industry_Templates.healthcare_template import emergency_triage_workflow
+
+result = emergency_triage_workflow(
+    patient_id="PT-2024-00123",
+    chief_complaint="severe chest pain radiating to left arm"
+)
+
+print(result["clinical_pathway"])
+print(result["safety_checks"])
+```
+</Step>
+
+<Step title="Add a specialised coordinator for labs or radiology">
+
+```python
+from examples.cookbooks.Industry_Templates.healthcare_template import (
+    HealthcareCoordinationPatterns, TriageLevel
+)
+
+lab_agent = HealthcareCoordinationPatterns.coordinate_lab_orders(
+    patient_id="PT-2024-00123",
+    triage_level=TriageLevel.EMERGENT.value
+)
+
+lab_result = lab_agent.start("Order STAT troponin and CBC")
+print(lab_result)
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Monitor as "Patient Monitor"
+    participant VitalSignsCapture
+    participant EMRRetrieval
+    participant TriageRecommendation
+    participant ResourceAllocator
+    participant Clinician
+
+    Monitor->>VitalSignsCapture: Sensor readings
+    VitalSignsCapture-->>EMRRetrieval: VitalSigns schema
+    EMRRetrieval-->>TriageRecommendation: MedicalHistory schema
+    TriageRecommendation-->>ResourceAllocator: TriageAssessment schema
+    ResourceAllocator-->>Clinician: ResourceAllocation schema
+```
+
+| Agent | Responsibility | SLA |
+|-------|---------------|-----|
+| `VitalSignsCapture` | Capture vital signs from monitoring devices with HIPAA handling | ≤ 30 s |
+| `EMRRetrieval` | Retrieve patient EMR with consent verification and audit trail | ≤ 5 s |
+| `TriageRecommendation` | ESI-based triage assessment with red-flag detection | ≤ 1 min |
+| `ResourceAllocator` | Assign bed, staff, and equipment by priority score | ≤ 30 s |
+
+---
+
+## Configuration Options
+
+Pydantic I/O schemas used by this template:
+
+| Schema | Key Fields |
+|--------|-----------|
+| `VitalSigns` | `patient_id`, `heart_rate`, `blood_pressure_systolic`, `blood_pressure_diastolic`, `respiratory_rate`, `temperature`, `oxygen_saturation`, `pain_scale`, `consciousness_level` |
+| `MedicalHistory` | `patient_id`, `allergies`, `chronic_conditions`, `current_medications`, `recent_visits`, `insurance_status` |
+| `TriageAssessment` | `assessment_id`, `patient_id`, `triage_level`, `chief_complaint`, `recommended_department`, `estimated_wait_time`, `required_resources`, `red_flags` |
+| `ResourceAllocation` | `allocation_id`, `patient_id`, `assigned_bed`, `assigned_staff`, `equipment_needed`, `department`, `priority_score` |
+
+**Triage Levels (ESI standard)**
+
+| Level | Value | Meaning |
+|-------|-------|---------|
+| 1 | `1_resuscitation` | Immediate life-saving intervention |
+| 2 | `2_emergent` | High risk, severe pain or distress |
+| 3 | `3_urgent` | Stable but multiple resources needed |
+| 4 | `4_less_urgent` | Stable, one resource needed |
+| 5 | `5_non_urgent` | Stable, no resources needed |
+
+---
+
+## Common Patterns
+
+**Audit every EMR access for HIPAA compliance**
+
+```python
+from examples.cookbooks.Industry_Templates.healthcare_template import HIPAACompliancePatterns
+
+audit = HIPAACompliancePatterns.audit_log_access(
+    user_id="DR-001",
+    patient_id="PT-2024-00123",
+    action="EMR_ACCESS",
+    reason="emergency_triage"
+)
+print(audit)
+```
+
+**Anonymise data before sending to analytics**
+
+```python
+from examples.cookbooks.Industry_Templates.healthcare_template import HIPAACompliancePatterns
+
+raw_triage = {
+    "patient_id": "PT-123",
+    "triage_level": "2_emergent",
+    "department": "emergency",
+    "wait_time": 10
+}
+safe_data = HIPAACompliancePatterns.anonymize_patient_data(raw_triage)
+print(safe_data)
+```
+
+**Coordinate radiology for an urgent patient**
+
+```python
+from examples.cookbooks.Industry_Templates.healthcare_template import HealthcareCoordinationPatterns
+
+radiology = HealthcareCoordinationPatterns.coordinate_radiology(
+    patient_id="PT-2024-00123",
+    imaging_type="chest_xray"
+)
+schedule = radiology.start("Book urgent chest X-ray, check for contrast allergy")
+print(schedule)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Verify patient consent before EMR access">
+`EMRRetrieval` accepts `consent_verified=True`. In production, gate this on an explicit consent check from your registration system — never assume consent for new patients.
+</Accordion>
+
+<Accordion title="Treat fallback triage as ESI-3 (Urgent)">
+If `TriageRecommendation` fails, the built-in fallback defaults to `3_urgent`. This is a conservative choice — always escalate to a human nurse when the AI pipeline cannot complete.
+</Accordion>
+
+<Accordion title="Alert on clinical red flags immediately">
+`TriageAssessment.red_flags` is populated when vital signs suggest life-threatening conditions (e.g. `low_oxygen`, `altered_consciousness`). Wire these to your nurse-call or PA system with zero delay.
+</Accordion>
+
+<Accordion title="Log all resource allocations for audit">
+`ResourceAllocator` returns `allocation_id` and `assigned_staff`. Persist every allocation to your incident tracking system to satisfy accreditation and shift-handover requirements.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Industry Templates Overview" icon="building-2" href="/docs/features/industry-templates/overview">
+  Hub page — choose the right template and understand cross-industry reuse.
+</Card>
+<Card title="Agriculture Template" icon="wheat" href="/docs/features/industry-templates/agriculture">
+  Multispectral crop analysis, disease detection, and yield forecasting.
+</Card>
+</CardGroup>

--- a/docs/features/industry-templates/manufacturing.mdx
+++ b/docs/features/industry-templates/manufacturing.mdx
@@ -1,0 +1,193 @@
+---
+title: "Manufacturing Template"
+sidebarTitle: "Manufacturing"
+description: "Four-agent pipeline for order parsing, inventory checking, production scheduling, and quality inspection — ready in three lines."
+icon: "factory"
+---
+
+Turn an unstructured order (email, PDF, API payload) into a quality-checked production schedule with a single function call.
+
+```mermaid
+graph LR
+    subgraph "Manufacturing Workflow"
+        IN["📋 Order Text"] --> PO["🤖 ParseOrder"]
+        PO --> CI["🤖 CheckInventory"]
+        CI --> OS["🤖 OptimizeSchedule"]
+        OS --> DD["🤖 DefectDetect"]
+        DD --> OUT["✅ Quality Report"]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class IN input
+    class PO,CI,OS,DD agent
+    class OUT output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Run the prebuilt workflow">
+
+```python
+from praisonaiagents import Agent, tool
+from examples.cookbooks.Industry_Templates.manufacturing_template import manufacturing_workflow
+
+result = manufacturing_workflow(
+    "Customer ABC needs 100 units of Product-XYZ by March 15th, high priority"
+)
+print(result)
+```
+
+`result` is a dict with keys `order`, `inventory`, `schedule`, and `quality`.
+</Step>
+
+<Step title="Build a custom agent with IndustryAgentPattern">
+
+```python
+from examples.cookbooks.Industry_Templates.manufacturing_template import IndustryAgentPattern
+
+custom_parser = IndustryAgentPattern.create_data_parser(
+    name="XMLOrderParser",
+    domain="XML purchase orders",
+    sla_seconds=15
+)
+
+order_data = custom_parser.start("Parse <order><id>999</id><qty>50</qty></order>")
+print(order_data)
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant ParseOrder
+    participant CheckInventory
+    participant OptimizeSchedule
+    participant DefectDetect
+    participant Report
+
+    Operator->>ParseOrder: Raw order text
+    ParseOrder-->>Operator: OrderDetails schema
+    Operator->>CheckInventory: product_id + quantity
+    CheckInventory-->>Operator: InventoryStatus schema
+    Operator->>OptimizeSchedule: order + inventory
+    OptimizeSchedule-->>Operator: ProductionSchedule schema
+    Operator->>DefectDetect: batch_id
+    DefectDetect-->>Operator: QualityReport schema
+    Operator->>Report: Complete result
+```
+
+| Agent | Responsibility | SLA |
+|-------|---------------|-----|
+| `ParseOrder` | Extract structured order info from any format | ≤ 30 s |
+| `CheckInventory` | Validate material availability and reorder levels | ≤ 5 s |
+| `OptimizeSchedule` | Generate optimal production schedule | ≤ 2 min |
+| `DefectDetect` | Automated quality inspection per batch | ≤ 1 min |
+
+---
+
+## Configuration Options
+
+Pydantic I/O schemas used by this template:
+
+| Schema | Fields |
+|--------|--------|
+| `OrderDetails` | `order_id`, `customer_id`, `product_id`, `quantity`, `priority`, `due_date`, `requirements` |
+| `InventoryStatus` | `material_id`, `available_quantity`, `reorder_level`, `supplier_lead_time`, `location` |
+| `ProductionSchedule` | `schedule_id`, `production_line`, `start_time`, `end_time`, `assigned_workers`, `estimated_completion`, `bottleneck_analysis` |
+| `QualityReport` | `batch_id`, `inspection_time`, `defect_rate`, `defect_types`, `passed`, `recommendations` |
+
+---
+
+## Common Patterns
+
+**Plug a custom ERP tool into ParseOrder**
+
+```python
+from praisonaiagents import tool
+from examples.cookbooks.Industry_Templates.manufacturing_template import order_parser
+
+@tool
+def erp_order_lookup(order_ref: str) -> dict:
+    """Fetch order details from ERP system"""
+    return {"erp_confirmed": True, "order_ref": order_ref, "priority": "high"}
+
+order_parser.tools.append(erp_order_lookup)
+result = order_parser.start("Look up order ORD-2024-555 in ERP")
+print(result)
+```
+
+**Swap the fallback strategy for inventory**
+
+```python
+from examples.cookbooks.Industry_Templates.manufacturing_template import (
+    manufacturing_workflow, inventory_checker
+)
+
+def conservative_inventory(order_text: str) -> dict:
+    try:
+        return manufacturing_workflow(order_text)
+    except Exception:
+        return {
+            "status": "manual_review_required",
+            "reason": "inventory_system_unavailable"
+        }
+
+result = conservative_inventory("Rush order: 200 units PART-999")
+```
+
+**Scale with IndustryAgentPattern**
+
+```python
+from examples.cookbooks.Industry_Templates.manufacturing_template import IndustryAgentPattern
+
+optimizer = IndustryAgentPattern.create_optimizer(
+    name="ShiftOptimizer",
+    optimization_target="shift scheduling across 3 production lines",
+    sla_minutes=5
+)
+schedule = optimizer.start("Optimize night shift for lines A, B, C with 80% capacity")
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Always validate priority before scheduling">
+The `OptimizeSchedule` agent sorts by priority (`urgent > high > normal`). Ensure `ParseOrder` correctly extracts the priority field — incorrect priorities cascade into suboptimal schedules.
+</Accordion>
+
+<Accordion title="Keep SLA budgets per agent">
+`CheckInventory` must respond within 5 seconds to avoid blocking production scheduling. Any custom inventory tool you attach should query a cache or pre-indexed store rather than a slow ERP endpoint.
+</Accordion>
+
+<Accordion title="Use fallback_strategies for supply chain disruptions">
+When `CheckInventory` cannot find stock, the built-in fallback returns an alternative-supplier flag. Extend this by attaching a `@tool` that queries a supplier API before escalating to manual review.
+</Accordion>
+
+<Accordion title="Run quality inspection on every batch, not just failures">
+`DefectDetect` returns a `defect_rate` even when `passed=True`. Log these rates over time to catch drift in machine calibration before it causes real rejections.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Industry Templates Overview" icon="building-2" href="/docs/features/industry-templates/overview">
+  Hub page — choose the right template and understand cross-industry reuse.
+</Card>
+<Card title="Energy Template" icon="bolt" href="/docs/features/industry-templates/energy">
+  Wind-farm monitoring, vibration fault detection, and predictive maintenance.
+</Card>
+</CardGroup>

--- a/docs/features/industry-templates/overview.mdx
+++ b/docs/features/industry-templates/overview.mdx
@@ -1,0 +1,241 @@
+---
+title: "Industry Templates"
+sidebarTitle: "Overview"
+description: "Pre-built agent workforces for Manufacturing, Energy, Healthcare, Agriculture, and Transportation — ready to run in minutes."
+icon: "building-2"
+---
+
+Five production-ready agent pipelines built on the SRAO Framework, each targeting a specific industry with typed I/O schemas, SLA targets, and graceful fallback strategies.
+
+```mermaid
+graph LR
+    subgraph "Industry Templates"
+        SRAO["🏭 SRAO-Based Templates"] --> MFG["⚙️ Manufacturing"]
+        SRAO --> ENG["⚡ Energy"]
+        SRAO --> HC["🏥 Healthcare"]
+        SRAO --> AG["🌾 Agriculture"]
+        SRAO --> TR["🚇 Transportation"]
+    end
+
+    classDef hub fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef industry fill:#189AB4,stroke:#7C90A0,color:#fff
+
+    class SRAO hub
+    class MFG,ENG,HC,AG,TR industry
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Pick an industry and run">
+
+Each template ships a single workflow function you can call immediately:
+
+```python
+from praisonaiagents import Agent, tool
+
+# Manufacturing: order → inventory → schedule → quality
+from examples.cookbooks.Industry_Templates.manufacturing_template import manufacturing_workflow
+
+result = manufacturing_workflow("Customer ABC needs 100 units of Product-XYZ by March 15th, high priority")
+print(result)
+```
+</Step>
+
+<Step title="Customise with IndustryAgentPattern">
+
+Every template exposes `IndustryAgentPattern` — a base class you can mix into any domain:
+
+```python
+from examples.cookbooks.Industry_Templates.manufacturing_template import IndustryAgentPattern
+
+# Build a domain-specific parser in one line
+parser = IndustryAgentPattern.create_data_parser(
+    name="CustomParser",
+    domain="pharmaceutical batch records",
+    sla_seconds=20
+)
+
+result = parser.start("Parse batch record BR-2024-001")
+print(result)
+```
+</Step>
+</Steps>
+
+---
+
+## Which Template Should I Use?
+
+```mermaid
+graph TB
+    Q1{"What do you need?"}
+
+    Q1 -->|"Order → Production → QC"| MFG["⚙️ Manufacturing"]
+    Q1 -->|"Turbine/grid monitoring"| ENG["⚡ Energy"]
+    Q1 -->|"Patient triage & EMR"| HC["🏥 Healthcare"]
+    Q1 -->|"Crop health & yield"| AG["🌾 Agriculture"]
+    Q1 -->|"Tunnel/bridge safety"| TR["🚇 Transportation"]
+
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef leaf fill:#189AB4,stroke:#7C90A0,color:#fff
+
+    class Q1 decision
+    class MFG,ENG,HC,AG,TR leaf
+```
+
+---
+
+## Templates at a Glance
+
+| Industry | Key Agents | Highlights |
+|----------|-----------|------------|
+| **Manufacturing** | `ParseOrder`, `CheckInventory`, `OptimizeSchedule`, `DefectDetect` | Multi-format order processing, real-time inventory, production optimisation, quality inspection |
+| **Energy** | `SCADAReader`, `VibrationAnalyzer`, `PowerForecaster`, `MaintenanceScheduler` | Wind-farm monitoring, vibration-based fault detection, power forecasting, predictive maintenance |
+| **Healthcare** | `VitalSignsCapture`, `EMRRetrieval`, `TriageRecommendation`, `ResourceAllocator` | Emergency triage workflow, HIPAA-compliant data handling, ESI-based triage, resource allocation |
+| **Agriculture** | `MultispectralAnalyzer`, `DiseaseIdentifier`, `SprayRecommender`, `YieldPredictor` | Drone/satellite multispectral analysis, pest/disease detection, targeted spraying, yield forecasting |
+| **Transportation** | `LiDARFusion`, `DisplacementCalculator`, `HeatmapGenerator`, `MaintenancePlanner` | Tunnel/bridge LiDAR analysis, displacement tracking, safety heatmaps, predictive maintenance |
+
+---
+
+## How It Works
+
+All five templates share the same SRAO architecture — only the domain logic differs.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Workflow
+    participant Agent1 as "Parser / Reader"
+    participant Agent2 as "Analyser / Checker"
+    participant Agent3 as "Optimiser / Recommender"
+    participant Agent4 as "Inspector / Planner"
+
+    User->>Workflow: Call workflow(input)
+    Workflow->>Agent1: Parse / capture raw data
+    Agent1-->>Workflow: Structured schema
+    Workflow->>Agent2: Validate / analyse
+    Agent2-->>Workflow: Analysis result
+    Workflow->>Agent3: Optimise / recommend
+    Agent3-->>Workflow: Decision
+    Workflow->>Agent4: Inspect / plan
+    Agent4-->>Workflow: Final report
+    Workflow-->>User: Complete result dict
+```
+
+Every step includes a fallback strategy — if an agent fails, the workflow degrades gracefully rather than crashing.
+
+---
+
+## Cross-Industry Reuse with `IndustryAgentPattern`
+
+`IndustryAgentPattern` provides four factory methods that power ~70 % of every template:
+
+```python
+from examples.cookbooks.Industry_Templates.manufacturing_template import IndustryAgentPattern
+
+# Generic parser — works for any domain
+parser    = IndustryAgentPattern.create_data_parser("MyParser", "logistics data", sla_seconds=15)
+
+# Generic availability checker
+checker   = IndustryAgentPattern.create_resource_checker("BedChecker", "hospital bed", sla_seconds=3)
+
+# Generic optimiser
+optimizer = IndustryAgentPattern.create_optimizer("IrrigationOpt", "water usage", sla_minutes=5)
+
+# Generic inspector
+inspector = IndustryAgentPattern.create_inspector("TunnelInspect", "structural integrity", sla_minutes=2)
+```
+
+| Method | Purpose | SLA param |
+|--------|---------|-----------|
+| `create_data_parser(name, domain, sla_seconds)` | Extract/structure raw inputs | `sla_seconds=30` |
+| `create_resource_checker(name, resource_type, sla_seconds)` | Verify availability | `sla_seconds=5` |
+| `create_optimizer(name, optimization_target, sla_minutes)` | Find optimal solution | `sla_minutes=2` |
+| `create_inspector(name, inspection_type, sla_minutes)` | Analyse quality/safety | `sla_minutes=1` |
+
+---
+
+## Pydantic I/O Schemas
+
+Every template uses Pydantic models to enforce typed data between agents:
+
+| Industry | Input Schema | Output Schema |
+|----------|-------------|---------------|
+| Manufacturing | `OrderDetails` | `QualityReport` |
+| Energy | `TurbineData` | `MaintenancePlan` |
+| Healthcare | `VitalSigns` | `ResourceAllocation` |
+| Agriculture | `MultispectralData` | `YieldForecast` |
+| Transportation | `LiDARScan` | `MaintenanceSchedule` |
+
+---
+
+## Common Patterns
+
+**Add a custom tool to any agent**
+
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def my_erp_lookup(order_id: str) -> dict:
+    """Look up order in ERP system"""
+    return {"erp_status": "confirmed", "order_id": order_id}
+
+from examples.cookbooks.Industry_Templates.manufacturing_template import order_parser
+
+order_parser.tools.append(my_erp_lookup)
+result = order_parser.start("Parse order ORD-999")
+```
+
+**Override the fallback strategy**
+
+```python
+def custom_fallback(error: Exception) -> dict:
+    return {"status": "queued_for_review", "error": str(error)}
+
+try:
+    result = manufacturing_workflow("urgent order text")
+except Exception as e:
+    result = custom_fallback(e)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Start with the prebuilt workflow function">
+Call `manufacturing_workflow()`, `energy_monitoring_workflow()`, etc. before customising. These functions already wire up all agents and fallbacks in the correct order.
+</Accordion>
+
+<Accordion title="Use Pydantic schemas for typed hand-offs">
+Pass structured Pydantic objects (e.g. `OrderDetails`, `VitalSigns`) between agents instead of raw strings. This catches type errors early and makes pipelines easier to test.
+</Accordion>
+
+<Accordion title="Respect SLA targets per agent">
+Each agent declares its SLA in its instructions. Keep custom tools within those bounds — e.g. inventory checks must complete in ≤ 5 seconds to not block downstream agents.
+</Accordion>
+
+<Accordion title="Attribution: SRAO Framework">
+These templates are based on the [SRAO Framework (MIT)](https://github.com/beixuan577/SRAO-Framework). The `IndustryAgentPattern` class provides the shared 70 % reuse layer.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Manufacturing Template" icon="factory" href="/docs/features/industry-templates/manufacturing">
+  Order processing, inventory, scheduling, and quality control agents.
+</Card>
+<Card title="Energy Template" icon="bolt" href="/docs/features/industry-templates/energy">
+  Wind-farm monitoring, vibration analysis, and predictive maintenance agents.
+</Card>
+<Card title="Healthcare Template" icon="stethoscope" href="/docs/features/industry-templates/healthcare">
+  Emergency triage, EMR retrieval, and resource allocation agents.
+</Card>
+<Card title="Agriculture Template" icon="wheat" href="/docs/features/industry-templates/agriculture">
+  Multispectral analysis, disease detection, and yield prediction agents.
+</Card>
+</CardGroup>

--- a/docs/features/industry-templates/transportation.mdx
+++ b/docs/features/industry-templates/transportation.mdx
@@ -1,0 +1,197 @@
+---
+title: "Transportation Template"
+sidebarTitle: "Transportation"
+description: "Four-agent infrastructure safety pipeline — LiDAR fusion, structural displacement analysis, safety heatmap generation, and predictive maintenance planning."
+icon: "truck"
+---
+
+Process LiDAR scans of tunnels and bridges, calculate structural displacement in millimetres, generate safety heatmaps, and schedule maintenance — all in one workflow call.
+
+```mermaid
+graph LR
+    subgraph "Infrastructure Monitoring Workflow"
+        IN["📡 LiDAR Sensor"] --> LF["🤖 LiDARFusion"]
+        LF --> DC["🤖 DisplacementCalculator"]
+        DC --> HG["🤖 HeatmapGenerator"]
+        HG --> MP["🤖 MaintenancePlanner"]
+        MP --> OUT["✅ Safety Engineer"]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class IN input
+    class LF,DC,HG,MP agent
+    class OUT output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Run the prebuilt monitoring workflow">
+
+```python
+from praisonaiagents import Agent, tool
+from examples.cookbooks.Industry_Templates.transportation_template import (
+    infrastructure_monitoring_workflow,
+    InfrastructureType
+)
+
+tunnels = ["TUN-001", "TUN-002", "TUN-003"]
+traffic = {"peak_volume": 3000, "off_peak_volume": 800, "peak_hours": [7, 9, 17, 19]}
+
+result = infrastructure_monitoring_workflow(tunnels, InfrastructureType.TUNNEL, traffic)
+
+print(result["safety_assessments"])
+print(result["emergency_alerts"])
+print(f"Network health score: {result['network_health_score']:.1f}/100")
+```
+</Step>
+
+<Step title="Adapt for bridges, railways, or airports">
+
+```python
+from examples.cookbooks.Industry_Templates.transportation_template import MultiModalTransportPatterns
+
+bridge_monitor  = MultiModalTransportPatterns.adapt_for_bridge_monitoring()
+railway_monitor = MultiModalTransportPatterns.adapt_for_railway_tracks()
+runway_monitor  = MultiModalTransportPatterns.adapt_for_airport_runways()
+
+result = bridge_monitor.start("Check deck deflection and cable tension for BRG-007")
+print(result)
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Sensor as "LiDAR Sensor"
+    participant LiDARFusion
+    participant DisplacementCalculator
+    participant HeatmapGenerator
+    participant MaintenancePlanner
+    participant Engineer as "Safety Engineer"
+
+    Sensor->>LiDARFusion: Point cloud data
+    LiDARFusion-->>DisplacementCalculator: LiDARScan schema
+    DisplacementCalculator-->>HeatmapGenerator: DisplacementAnalysis schema
+    HeatmapGenerator-->>MaintenancePlanner: SafetyHeatmap schema
+    MaintenancePlanner-->>Engineer: MaintenanceSchedule schema
+```
+
+| Agent | Responsibility | SLA |
+|-------|---------------|-----|
+| `LiDARFusion` | Process 5M-point scans from mobile and terrestrial LiDAR | ≤ 5 min |
+| `DisplacementCalculator` | Compare current vs. baseline scan; calculate mm-level settlement | ≤ 2 min |
+| `HeatmapGenerator` | Generate 2D safety grid highlighting critical zones | ≤ 1 min |
+| `MaintenancePlanner` | Plan preventive, corrective, or emergency maintenance | ≤ 3 min |
+
+---
+
+## Configuration Options
+
+Pydantic I/O schemas used by this template:
+
+| Schema | Key Fields |
+|--------|-----------|
+| `LiDARScan` | `scan_id`, `infrastructure_id`, `point_cloud_size`, `scan_resolution`, `coverage_area`, `anomaly_points`, `reference_baseline` |
+| `DisplacementAnalysis` | `analysis_id`, `infrastructure_id`, `max_displacement`, `displacement_vector`, `critical_zones`, `settlement_rate`, `tilt_angle`, `safety_factor` |
+| `SafetyHeatmap` | `heatmap_id`, `infrastructure_id`, `grid_resolution`, `safety_scores`, `critical_areas`, `overall_safety`, `risk_trends` |
+| `MaintenanceSchedule` | `schedule_id`, `infrastructure_id`, `maintenance_type`, `priority_level`, `scheduled_date`, `estimated_duration`, `traffic_impact`, `cost_estimate` |
+
+**Safety levels** (used in `SafetyHeatmap.overall_safety`)
+
+| Level | `safety_factor` range | Action |
+|-------|----------------------|--------|
+| `safe` | ≥ 0.9 | Routine monitoring |
+| `caution` | 0.8 – 0.9 | Preventive maintenance within 30 days |
+| `warning` | 0.7 – 0.8 | Corrective maintenance within 7 days |
+| `danger` | 0.3 – 0.7 | Emergency maintenance within 24 h |
+| `critical` | < 0.3 | Immediate closure |
+
+---
+
+## Common Patterns
+
+**Predict structural failure probability from displacement history**
+
+```python
+from examples.cookbooks.Industry_Templates.transportation_template import PredictiveMaintenancePatterns
+
+displacement_history = [2.0, 2.3, 2.8, 3.5, 4.3]  # mm over past 5 months
+environment = {"temp_variation": 30, "humidity": 75}
+
+prob = PredictiveMaintenancePatterns.predict_failure_probability(
+    displacement_history, environment
+)
+print(f"Failure probability: {prob:.2%}")
+```
+
+**Optimise maintenance budget across a network**
+
+```python
+from examples.cookbooks.Industry_Templates.transportation_template import PredictiveMaintenancePatterns
+
+conditions = [
+    {"id": "TUN-001", "safety_factor": 0.65, "cost": 80000, "recommended_date": "2024-04-01"},
+    {"id": "TUN-002", "safety_factor": 0.92, "cost": 30000, "recommended_date": "2024-06-01"},
+]
+
+schedule = PredictiveMaintenancePatterns.optimize_maintenance_schedule(
+    infrastructure_conditions=conditions,
+    budget_constraint=100000.0
+)
+print(schedule)
+```
+
+**Plan traffic flow during maintenance**
+
+```python
+from examples.cookbooks.Industry_Templates.transportation_template import TrafficManagementPatterns
+
+traffic_plan = TrafficManagementPatterns.optimize_traffic_flow(
+    maintenance_window={"start_time": "22:00", "duration": 8},
+    traffic_patterns={"peak_hours": [7, 9, 17, 19]}
+)
+print(traffic_plan["diversion_routes"])
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Establish a baseline scan before going live">
+`DisplacementCalculator` computes change relative to a `reference_baseline`. Capture this baseline during construction or last major rehabilitation, and store it in a versioned database alongside each new scan.
+</Accordion>
+
+<Accordion title="Close to traffic when overall_safety reaches 'danger'">
+The workflow automatically raises an `emergency_alert` with `immediate_action: close_to_traffic` for danger/critical safety levels. Wire this alert to your traffic management system to trigger lane closures without human delay.
+</Accordion>
+
+<Accordion title="Schedule LiDAR scans during low-traffic windows">
+Scan accuracy degrades when vehicles pass through the scan envelope. Use `TrafficManagementPatterns.optimize_traffic_flow()` to identify overnight windows with minimal traffic before dispatching the LiDAR crew.
+</Accordion>
+
+<Accordion title="Use network_health_score for KPI reporting">
+The `network_health_score` (0–100) aggregates safety factors across all monitored structures. Report this monthly to asset managers — a score below 70 should trigger a portfolio-level maintenance budget review.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Industry Templates Overview" icon="building-2" href="/docs/features/industry-templates/overview">
+  Hub page — choose the right template and understand cross-industry reuse.
+</Card>
+<Card title="Manufacturing Template" icon="factory" href="/docs/features/industry-templates/manufacturing">
+  Order processing, inventory management, and quality inspection agents.
+</Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

Adds six new documentation pages for the Industry Templates feature introduced in PraisonAI PR [#2143](https://github.com/MervinPraison/PraisonAI/pull/2143).

**New pages under `docs/features/industry-templates/`:**

- **overview.mdx** — Hub page with SRAO decision diagram, cross-industry reuse guide, IndustryAgentPattern docs, and Pydantic schema tables
- **manufacturing.mdx** — ParseOrder → CheckInventory → OptimizeSchedule → DefectDetect pipeline
- **energy.mdx** — SCADAReader → VibrationAnalyzer → PowerForecaster → MaintenanceScheduler pipeline
- **healthcare.mdx** — VitalSignsCapture → EMRRetrieval → TriageRecommendation → ResourceAllocator pipeline
- **agriculture.mdx** — MultispectralAnalyzer → DiseaseIdentifier → SprayRecommender → YieldPredictor pipeline
- **transportation.mdx** — LiDARFusion → DisplacementCalculator → HeatmapGenerator → MaintenancePlanner pipeline

**docs.json** updated to add an "Industry Templates" subgroup under the existing "Features" navigation group (not under Concepts).

## Quality Checklist

- [x] Frontmatter complete on every page (title, sidebarTitle, description, icon)
- [x] Hero Mermaid diagram on every page (correct colour scheme: #8B0000, #189AB4, #10B981, white text, classDef)
- [x] Decision diagram present on overview.mdx
- [x] Steps, AccordionGroup, CardGroup used as prescribed
- [x] Code snippets use correct imports from source templates
- [x] Imports verified against PraisonAI upstream source files
- [x] No forbidden phrases
- [x] Sections start with single-sentence intros
- [x] docs.json updated under Features group (NOT Concepts), valid JSON
- [x] Nothing added under docs/concepts/ (human-only folder)

Fixes #723

Generated with [Claude Code](https://claude.ai/code)