### PR TITLE
docs: update framework-adapter-plugins to reflect PR #2083 protocol v…

### DIFF
--- a/docs/features/framework-adapter-plugins.mdx
+++ b/docs/features/framework-adapter-plugins.mdx
@@ -34,25 +34,35 @@ graph LR
 Register a framework adapter directly in your code:
 
 ```python
+from typing import Any, Callable, Dict, List, Optional
 from praisonai.framework_adapters.registry import get_default_registry
 from praisonai.framework_adapters.base import FrameworkAdapter
 
 class MyFrameworkAdapter:
     name = "myframework"
-    
+
     def is_available(self) -> bool:
         try:
             import myframework
             return True
         except ImportError:
             return False
-    
-    def run(self, config, llm_config, topic):
+
+    def run(
+        self,
+        config: Dict[str, Any],
+        llm_config: List[Dict],
+        topic: str,
+        *,
+        tools_dict: Optional[Dict[str, Any]] = None,
+        agent_callback: Optional[Callable] = None,
+        task_callback: Optional[Callable] = None,
+        cli_config: Optional[Dict[str, Any]] = None,
+    ) -> str:
         # Framework execution logic
         return "Framework execution result"
-    
+
     def cleanup(self) -> None:
-        # Optional cleanup
         pass
 
 # Register the adapter (preferred for app code)
@@ -133,7 +143,7 @@ The framework adapter registry provides a central point for managing framework i
 | `register(name, cls)` | `name: str`, `cls: Type[FrameworkAdapter]` | Register adapter at runtime |
 | `unregister(name)` | `name: str` → `bool` | Remove adapter; returns `True` if found |
 | `resolve(name)` | `name: str` → `Type` | Get adapter class; raises `ValueError` if missing |
-| `create(name, *args, **kwargs)` | varies | Create an adapter instance |
+| `create(name, *args, **kwargs)` | varies | Create an adapter instance; validates the `run()` signature (PR #2083) and raises `TypeError` if the four protocol kwargs are missing |
 | `list_names()` | None → `list[str]` | Sorted list of registered names |
 | `list_registered()` | None → `list[str]` | **Backward-compat alias** of `list_names()` |
 | `is_available(name)` | `name: str` → `bool` | Check adapter is registered AND its `is_available()` returns `True` |
@@ -148,8 +158,19 @@ Framework adapters must implement the `FrameworkAdapter` protocol:
 | `is_available()` | ✅ | Check framework dependencies |
 | `resolve()` | ❌ | Pick the concrete adapter variant (default returns `self`) |
 | `setup(*, framework_tag)` | ❌ | Framework-specific pre-run hooks (default no-op) |
-| `run(config, llm_config, topic)` | ✅ | Execute framework logic |
+| `run(config, llm_config, topic, *, tools_dict, agent_callback, task_callback, cli_config)` | ✅ | Execute framework logic (all four trailing kwargs are validated at registration time — see Troubleshooting) |
 | `cleanup()` | ✅ | Clean up resources |
+
+### Protocol Validation (PR #2083)
+
+Since PR #2083, `FrameworkAdapterRegistry.create()` validates every adapter at construction time. If the `run()` method does not accept the four keyword-only parameters `tools_dict`, `agent_callback`, `task_callback`, and `cli_config`, instantiation fails with:
+
+```
+TypeError: FrameworkAdapter '<name>' does not implement the protocol:
+missing keyword-only parameters ['agent_callback', 'cli_config', 'task_callback', 'tools_dict']
+```
+
+Adapters that fail validation also report `registry.is_available("<name>") == False` instead of raising — so a broken plugin will simply disappear from the available-framework list rather than crashing the CLI.
 
 **Single authoritative `arun()` (PR #1857):** The Protocol declares `arun()` once; `BaseFrameworkAdapter` provides a single default that offloads `run()` to a worker thread via `asyncio.to_thread`. Sync-only adapters (crewai, autogen v0.2) inherit this and need do nothing. Native-async adapters override `arun()`. Earlier revisions of the codebase declared `arun()` twice on both the Protocol and the base class; those duplicate declarations have been removed and there is now exactly one default to override.
 
@@ -212,23 +233,34 @@ sequenceDiagram
 ### Override Built-in Adapter
 
 ```python
+from typing import Any, Callable, Dict, List, Optional
 from praisonai.framework_adapters.registry import get_default_registry
 from praisonai.framework_adapters.base import FrameworkAdapter
 
 class CustomCrewAIAdapter:
     name = "crewai"
-    
+
     def is_available(self) -> bool:
         try:
             import crewai
             return True
         except ImportError:
             return False
-    
-    def run(self, config, llm_config, topic):
+
+    def run(
+        self,
+        config: Dict[str, Any],
+        llm_config: List[Dict],
+        topic: str,
+        *,
+        tools_dict: Optional[Dict[str, Any]] = None,
+        agent_callback: Optional[Callable] = None,
+        task_callback: Optional[Callable] = None,
+        cli_config: Optional[Dict[str, Any]] = None,
+    ) -> str:
         # Custom CrewAI execution logic
         return "Custom CrewAI result"
-    
+
     def cleanup(self) -> None:
         pass
 
@@ -241,20 +273,31 @@ registry.register("crewai", CustomCrewAIAdapter)
 
 ```python
 import subprocess
+from typing import Any, Callable, Dict, List, Optional
 from praisonai.framework_adapters.base import BaseFrameworkAdapter
 
 class NonPythonAdapter(BaseFrameworkAdapter):
     name = "external_framework"
-    
+
     def is_available(self) -> bool:
         try:
-            subprocess.run(["external_framework", "--version"], 
+            subprocess.run(["external_framework", "--version"],
                          capture_output=True, check=True)
             return True
         except (subprocess.CalledProcessError, FileNotFoundError):
             return False
-    
-    def run(self, config, llm_config, topic):
+
+    def run(
+        self,
+        config: Dict[str, Any],
+        llm_config: List[Dict],
+        topic: str,
+        *,
+        tools_dict: Optional[Dict[str, Any]] = None,
+        agent_callback: Optional[Callable] = None,
+        task_callback: Optional[Callable] = None,
+        cli_config: Optional[Dict[str, Any]] = None,
+    ) -> str:
         # Convert config to external format
         cmd = ["external_framework", "run", "--topic", topic]
         result = subprocess.run(cmd, capture_output=True, text=True)
@@ -265,13 +308,14 @@ class NonPythonAdapter(BaseFrameworkAdapter):
 
 ```python
 import logging
+from typing import Any, Callable, Dict, List, Optional
 from praisonai.framework_adapters.base import BaseFrameworkAdapter
 
 logger = logging.getLogger(__name__)
 
 class OptionalDepsAdapter(BaseFrameworkAdapter):
     name = "advanced_framework"
-    
+
     def is_available(self) -> bool:
         try:
             # Check multiple optional dependencies
@@ -281,11 +325,21 @@ class OptionalDepsAdapter(BaseFrameworkAdapter):
         except ImportError as e:
             logger.debug(f"Framework not available: {e}")
             return False
-    
-    def run(self, config, llm_config, topic):
+
+    def run(
+        self,
+        config: Dict[str, Any],
+        llm_config: List[Dict],
+        topic: str,
+        *,
+        tools_dict: Optional[Dict[str, Any]] = None,
+        agent_callback: Optional[Callable] = None,
+        task_callback: Optional[Callable] = None,
+        cli_config: Optional[Dict[str, Any]] = None,
+    ) -> str:
         if not self.is_available():
             raise RuntimeError("Framework dependencies not installed")
-        
+
         import advanced_framework
         return advanced_framework.execute(config, llm_config, topic)
 ```
@@ -475,6 +529,43 @@ auto = AutoGenerator(
     adapter_registry=reg,
 )
 ```
+
+---
+
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="TypeError: missing keyword-only parameters ['agent_callback', 'cli_config', 'task_callback', 'tools_dict']">
+
+Your adapter's `run()` method is missing the four keyword-only parameters required by the `FrameworkAdapter` protocol. As of [PR #2083](https://github.com/MervinPraison/PraisonAI/pull/2083), `FrameworkAdapterRegistry.create()` validates these at adapter construction time.
+
+Update your `run()` signature to:
+
+```python
+def run(
+    self,
+    config,
+    llm_config,
+    topic,
+    *,
+    tools_dict=None,
+    agent_callback=None,
+    task_callback=None,
+    cli_config=None,
+):
+    ...
+```
+
+Your code can still ignore the values — the signature just needs to accept them. The four parameters can be either `KEYWORD_ONLY` (after `*`) or `POSITIONAL_OR_KEYWORD`; either form passes validation.
+
+</Accordion>
+
+<Accordion title="My adapter disappeared from the available frameworks list">
+
+If `praisonai --list-frameworks` (or `registry.list_names()`) no longer shows your adapter, run `registry.is_available("<your-adapter-name>")`. Since PR #2083, `is_available()` catches `TypeError` from the new protocol validator and returns `False` rather than raising — so a malformed plugin is silently filtered out of the available list. Check the application logs for the `TypeError` message above and fix the `run()` signature.
+
+</Accordion>
+</AccordionGroup>
 
 ---
 


### PR DESCRIPTION
…alidation (fixes #721)

- Update all five run() signatures to include the four required keyword-only parameters: tools_dict, agent_callback, task_callback, cli_config
- Update Adapter Protocol table to show canonical run() signature
- Add 'Protocol Validation (PR #2083)' subsection under Adapter Protocol
- Update Registry Methods table create() row to mention validation
- Add Troubleshooting section with two accordions covering TypeError and 'adapter disappeared from list' symptoms