### PR TITLE
docs: add HandoffToolPolicy page and cross-links (Fixes #558)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -663,6 +663,7 @@
                   "docs/features/a2a-push-notifications",
                   "docs/features/a2a-security",
                   "docs/features/handoffs",
+                  "docs/features/handoff-tool-policy",
                   "docs/features/typed-handoffs",
                   "docs/features/multi-agent-patterns",
                   "docs/features/agent-api-launch",

--- a/docs/configuration/handoff-config.mdx
+++ b/docs/configuration/handoff-config.mdx
@@ -435,7 +435,38 @@ rule_based_routing = {
 }
 ```
 
+## Tool Policy
+
+`HandoffConfig.tool_policy` (`HandoffToolPolicy`) enforces tool boundaries when one agent hands off to another. Default mode is **`intersect`** (secure): the target receives only tools shared with the source, minus any `blocked_tools`.
+
+```python
+from praisonaiagents import Agent, handoff, HandoffConfig, HandoffToolPolicy
+
+config = HandoffConfig(
+    tool_policy=HandoffToolPolicy(
+        mode="intersect",
+        blocked_tools=["execute_code"],
+    ),
+)
+
+router = Agent(
+    name="Router",
+    handoffs=[handoff(automation_agent, config=config)],
+)
+```
+
+The `handoff()` factory also accepts shorthand kwargs:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `tool_policy_mode` | `Optional[Literal["intersect","passthrough"]]` | `None` | Shorthand for `config.tool_policy.mode` |
+| `blocked_tools` | `Optional[List[str]]` | `None` | Shorthand for `config.tool_policy.blocked_tools` |
+
+See [Handoff Tool Policy](/docs/features/handoff-tool-policy) for modes, patterns, and migration guidance.
+
 ## Handoff Security and Validation
+
+Tool policy (`HandoffConfig.tool_policy`) is the primary **tool-level** security mechanism during handoffs. The settings below cover transport, authorisation, and payload validation.
 
 ```python
 security_config = {

--- a/docs/features/handoff-tool-policy.mdx
+++ b/docs/features/handoff-tool-policy.mdx
@@ -1,0 +1,255 @@
+---
+title: "Handoff Tool Policy"
+sidebarTitle: "Tool Policy"
+description: "Secure tool boundaries when one agent hands off to another"
+icon: "shield-check"
+---
+
+Tool policy limits which tools the target agent can use during a handoff — so a low-trust gatekeeper cannot escalate privileges by handing off to a powerful automation agent.
+
+<Note>
+Handoffs are **secure by default** since [PR #1848](https://github.com/MervinPraison/PraisonAI/pull/1848). The target agent only receives tools shared with the source agent. Use `tool_policy_mode="passthrough"` only when you intentionally need legacy behaviour.
+</Note>
+
+```mermaid
+flowchart LR
+    GK["Gatekeeper Agent<br/>search_tool"] --> POLICY{"HandoffToolPolicy<br/>mode: intersect"}
+    POLICY --> AUTO["Automation Agent<br/>search_tool only"]
+    POLICY -.->|blocked| BLOCK["execute_code ❌"]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+    classDef allowed fill:#10B981,color:#fff
+    classDef blocked fill:#F59E0B,color:#fff
+
+    class GK,AUTO agent
+    class POLICY tool
+    class AUTO allowed
+    class BLOCK blocked
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Secure by default">
+No extra configuration needed — `handoff(target)` already enforces intersect mode.
+
+```python
+from praisonaiagents import Agent, handoff, tool
+
+@tool
+def search_tool(query: str) -> str:
+    """Search the knowledge base."""
+    return f"Results for: {query}"
+
+@tool
+def execute_code(code: str) -> str:
+    """Run code in a sandbox."""
+    return "executed"
+
+gatekeeper = Agent(name="Gatekeeper", tools=[search_tool])
+automation = Agent(name="Automation", tools=[search_tool, execute_code])
+
+triage = Agent(
+    name="Triage",
+    handoffs=[handoff(automation)],  # automation only gets search_tool during handoff
+)
+```
+</Step>
+
+<Step title="Block dangerous tools">
+Always strip specific tool names regardless of mode.
+
+```python
+from praisonaiagents import Agent, handoff
+
+triage = Agent(
+    name="Triage",
+    handoffs=[handoff(automation, blocked_tools=["execute_code"])],
+)
+```
+</Step>
+
+<Step title="Opt into legacy passthrough">
+<Warning>
+Passthrough gives the target its full tool set (minus `blocked_tools`). Only use this when the source agent is intentionally delegating more capability than it holds.
+</Warning>
+
+```python
+from praisonaiagents import Agent, handoff
+
+triage = Agent(
+    name="Triage",
+    handoffs=[
+        handoff(
+            automation,
+            tool_policy_mode="passthrough",
+            blocked_tools=["execute_code"],
+        ),
+    ],
+)
+```
+</Step>
+
+<Step title="Full HandoffConfig">
+```python
+from praisonaiagents import Agent, handoff, HandoffConfig, HandoffToolPolicy
+
+config = HandoffConfig(
+    tool_policy=HandoffToolPolicy(
+        mode="intersect",
+        blocked_tools=["execute_code", "shell_access"],
+    ),
+)
+
+triage = Agent(
+    name="Triage",
+    handoffs=[handoff(automation, config=config)],
+)
+```
+</Step>
+</Steps>
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Source as Source Agent
+    participant Policy as HandoffToolPolicy
+    participant Target as Target Agent
+
+    Source->>Policy: handoff invoked
+    Policy->>Policy: intersect source ∩ target tools
+    Policy->>Policy: strip blocked_tools
+    Policy->>Target: effective tool set
+    Target->>Target: invoke only allowed tools
+```
+
+## Modes
+
+| Mode | Default? | Target tool set | Use when |
+|------|----------|-----------------|----------|
+| `intersect` | ✅ Yes | Tools **both** agents have, minus `blocked_tools` | Multi-agent systems with mixed trust levels (recommended) |
+| `passthrough` | No (opt-in) | Target's own tools minus `blocked_tools` | Legacy code, or intentional capability delegation |
+
+```mermaid
+flowchart TD
+    START["Need handoff tool policy?"] --> TRUST{"Source and target<br/>same trust level?"}
+    TRUST -->|No| INTERSECT["Use intersect (default)"]
+    TRUST -->|Yes, intentional delegation| LEGACY{"Migrating legacy code?"}
+    LEGACY -->|Yes| PASS["Use passthrough + blocked_tools"]
+    LEGACY -->|No| INTERSECT
+    INTERSECT --> BLOCK["Add blocked_tools for dangerous tools"]
+    PASS --> BLOCK
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+    class START,TRUST,LEGACY agent
+    class INTERSECT,PASS,BLOCK tool
+```
+
+## Configuration Options
+
+### HandoffToolPolicy
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `mode` | `Literal["intersect", "passthrough"]` | `"intersect"` | How tools are filtered during handoff |
+| `blocked_tools` | `List[str]` | `[]` | Tool names always stripped regardless of mode |
+
+### handoff() shorthand kwargs
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `tool_policy_mode` | `Optional[Literal["intersect","passthrough"]]` | `None` | Shorthand for `config.tool_policy.mode` |
+| `blocked_tools` | `Optional[List[str]]` | `None` | Shorthand for `config.tool_policy.blocked_tools` |
+
+## Common Patterns
+
+### Gatekeeper → automation (secure default)
+
+```python
+from praisonaiagents import Agent, handoff, tool
+
+@tool
+def search_tool(query: str) -> str:
+    return f"Results for: {query}"
+
+@tool
+def execute_code(code: str) -> str:
+    return "executed"
+
+gatekeeper = Agent(name="Gatekeeper", tools=[search_tool])
+automation = Agent(name="Automation", tools=[search_tool, execute_code])
+
+router = Agent(name="Router", handoffs=[handoff(automation)])
+```
+
+### Always block destructive tools
+
+```python
+router = Agent(
+    name="Router",
+    handoffs=[
+        handoff(
+            automation,
+            blocked_tools=["execute_code", "shell_access", "delete_file"],
+        ),
+    ],
+)
+```
+
+### Passthrough with selective block list
+
+```python
+router = Agent(
+    name="Router",
+    handoffs=[
+        handoff(
+            automation,
+            tool_policy_mode="passthrough",
+            blocked_tools=["execute_code"],
+        ),
+    ],
+)
+```
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Default to intersect for least-privilege">
+Leave `tool_policy_mode` unset unless you have a specific reason to use passthrough. Intersect mode prevents silent privilege escalation.
+</Accordion>
+
+<Accordion title="Always block known dangerous tools">
+Even in intersect mode, add `blocked_tools` for tools like `execute_code` or `shell_access` if they appear in the shared set.
+</Accordion>
+
+<Accordion title="Fix the source toolset, not the policy">
+If intersect mode leaves the target without a needed tool, add that tool to the source agent rather than switching to passthrough.
+</Accordion>
+
+<Accordion title="Test handoff boundaries in security tests">
+Verify that a gatekeeper handoff cannot invoke tools the source agent does not hold.
+</Accordion>
+</AccordionGroup>
+
+## Migration Note
+
+<Warning>
+**Behaviour change (non-breaking API).** Before PR #1848, handoffs passed the target agent's full tool set. After PR #1848, the default is intersection. Existing code runs without changes, but the effective tool set during handoff is narrower. Restore legacy behaviour with one line: `tool_policy_mode="passthrough"`.
+</Warning>
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Agent Handoffs" icon="hand-holding-hand" href="/docs/features/handoffs">
+  Core handoff patterns and delegation
+</Card>
+<Card title="Handoff Filters" icon="filter" href="/docs/features/handoff-filters">
+  Filter context passed during handoff
+</Card>
+<Card title="Handoff Configuration" icon="handshake" href="/docs/configuration/handoff-config">
+  Full HandoffConfig reference
+</Card>
+</CardGroup>

--- a/docs/features/handoffs.mdx
+++ b/docs/features/handoffs.mdx
@@ -8,6 +8,10 @@ icon: "hand-holding-hand"
 
 Agent handoffs enable seamless task delegation between specialised agents, allowing you to build sophisticated multi-agent systems where each agent focuses on its area of expertise.
 
+<Note>
+Handoffs are now secure by default — the target agent only inherits tools shared with the source agent. See [Handoff Tool Policy](/docs/features/handoff-tool-policy).
+</Note>
+
 ## Overview
 
 Handoffs in PraisonAI allow agents to transfer control to other agents based on the conversation context. This pattern is particularly useful for:
@@ -29,7 +33,7 @@ When you specify handoffs for an agent, PraisonAI automatically:
 ### Simple Handoff
 
 ```python
-from praisonaiagents import Agent
+from praisonaiagents import Agent, HandoffToolPolicy
 
 # Create specialised agents
 billing_agent = Agent(
@@ -150,6 +154,26 @@ handoff_config = handoff(
     description="Escalate complex issues to a manager for resolution"
 )
 ```
+
+## Tool Security Boundary
+
+`HandoffToolPolicy` controls which tools the target agent may use during a handoff. The default **`intersect`** mode gives the target only tools that **both** agents share — preventing a low-trust gatekeeper from handing off to an automation agent with destructive tools it does not hold.
+
+```python
+from praisonaiagents import Agent, handoff, HandoffToolPolicy
+
+triage = Agent(
+    name="Triage",
+    handoffs=[
+        handoff(
+            automation_agent,
+            blocked_tools=["execute_code"],  # always stripped
+        ),
+    ],
+)
+```
+
+For full mode reference, migration notes, and decision guidance, see [Handoff Tool Policy](/docs/features/handoff-tool-policy).
 
 ## Handoff Results
 
@@ -385,6 +409,12 @@ Memory backends can implement the `on_delegation` hook to automatically store re
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Handoff Tool Policy" icon="shield-check" href="./handoff-tool-policy">
+  Secure tool boundaries during handoff
+</Card>
+<Card title="Handoff Filters" icon="filter" href="./handoff-filters">
+  Filter context passed during handoff
+</Card>
 <Card title="Agent Run Outcomes" icon="circle-check" href="./agent-run-outcomes">
   Typed outcomes for handoff results
 </Card>


### PR DESCRIPTION
Document secure-by-default tool boundaries for agent handoffs from PR #1848.