### PR TITLE
docs: AgentFlow naming alignment (Fixes #600)

### DIFF
--- a/docs/features/workflow-errors.mdx
+++ b/docs/features/workflow-errors.mdx
@@ -31,14 +31,14 @@ graph LR
 <Steps>
 <Step title="Basic Error Handling">
 ```python
-from praisonaiagents import Agent, Workflow, WorkflowStepError
+from praisonaiagents import Agent, AgentFlow, WorkflowStepError
 
 agent = Agent(
     name="Research Agent", 
     instructions="Research topics that might fail"
 )
 
-workflow = Workflow(steps=[agent])
+workflow = AgentFlow(steps=[agent])
 
 try:
     result = workflow.start("Research invalid topic")
@@ -50,9 +50,9 @@ except WorkflowStepError as e:
 
 <Step title="Handling Multiple Errors">
 ```python
-from praisonaiagents import parallel, WorkflowStepError
+from praisonaiagents import AgentFlow, parallel, WorkflowStepError
 
-workflow = Workflow(steps=[
+workflow = AgentFlow(steps=[
     parallel([agent_a, agent_b, agent_c], on_failure="fail_all"),
 ])
 
@@ -74,14 +74,14 @@ except WorkflowStepError as e:
 ```mermaid
 sequenceDiagram
     participant User
-    participant Workflow
+    participant AgentFlow
     participant Step
     participant ErrorHandler
     
-    User->>Workflow: start()
-    Workflow->>Step: execute
-    Step-->>Workflow: Exception
-    Workflow->>ErrorHandler: WorkflowStepError
+    User->>AgentFlow: start()
+    AgentFlow->>Step: execute
+    Step-->>AgentFlow: Exception
+    AgentFlow->>ErrorHandler: WorkflowStepError
     ErrorHandler-->>User: Structured Error
 ```
 
@@ -198,12 +198,12 @@ workflow = PraisonAIAgents(
 
 ### Pattern 1: Single Step Recovery
 ```python
-from praisonaiagents import Agent, Workflow, WorkflowStepError
+from praisonaiagents import Agent, AgentFlow, WorkflowStepError
 
 def with_retry():
     for attempt in range(3):
         try:
-            workflow = Workflow(steps=[unreliable_agent])
+            workflow = AgentFlow(steps=[unreliable_agent])
             return workflow.start("Task")
         except WorkflowStepError as e:
             if attempt == 2:  # Last attempt

--- a/docs/features/workflow-parallel.mdx
+++ b/docs/features/workflow-parallel.mdx
@@ -206,22 +206,22 @@ graph TB
 ### Examples
 
 ```python
-from praisonaiagents import Agent, Workflow, parallel, WorkflowStepError
+from praisonaiagents import Agent, AgentFlow, parallel, WorkflowStepError
 
 # partial_ok (default) — continue even if one branch fails
-workflow = Workflow(steps=[
+workflow = AgentFlow(steps=[
     parallel([agent_a, agent_b, agent_c]),
     aggregator,
 ])
 
 # fail_fast — abort on first failure
-workflow = Workflow(steps=[
+workflow = AgentFlow(steps=[
     parallel([agent_a, agent_b, agent_c], on_failure="fail_fast"),
     aggregator,
 ])
 
 # fail_all — gather all errors then fail
-workflow = Workflow(steps=[
+workflow = AgentFlow(steps=[
     parallel([agent_a, agent_b, agent_c], on_failure="fail_all"),
     aggregator,
 ])

--- a/docs/features/workflow-patterns.mdx
+++ b/docs/features/workflow-patterns.mdx
@@ -31,14 +31,12 @@ graph TD
 
 ```python
 from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-# Or use Pipeline (alias for Workflow)
-from praisonaiagents import Pipeline
 from praisonaiagents import route, parallel, loop, repeat
 ```
 
-<Tip>
-`Pipeline` and `Workflow` are the same class. Use whichever term you prefer!
-</Tip>
+<Note>
+`AgentFlow` is the primary class for deterministic pipelines (v1.0+). `Workflow` and `Pipeline` are silent aliases kept for backward compatibility — new code should use `AgentFlow`.
+</Note>
 
 ## Pattern Overview
 

--- a/examples/workflows/workflow_loop_csv.py
+++ b/examples/workflows/workflow_loop_csv.py
@@ -4,7 +4,7 @@ Agentic Loop with CSV Workflow Example
 Demonstrates iterating over a CSV file with an agent processing each row.
 """
 
-from praisonaiagents import Agent, Workflow
+from praisonaiagents import Agent, AgentFlow
 from praisonaiagents.workflows import loop
 import tempfile
 import os

--- a/examples/workflows/workflow_repeat.py
+++ b/examples/workflows/workflow_repeat.py
@@ -5,7 +5,7 @@ Demonstrates the evaluator-optimizer pattern where an agent
 generates content and another evaluates it, repeating until approved.
 """
 
-from praisonaiagents import Agent, Workflow
+from praisonaiagents import Agent, AgentFlow
 from praisonaiagents.workflows import repeat
 
 # Create generator agent


### PR DESCRIPTION
## Summary
- Fix broken examples importing Workflow but using AgentFlow
- Normalise workflow-errors.mdx and workflow-parallel.mdx to AgentFlow
- Add backward-compat alias note on workflow-patterns.mdx

Fixes #600

## Test plan
- [x] No Workflow( in docs/features code samples
- [x] examples/ no Workflow import paired with AgentFlow usage