### PR TITLE
docs: Document praisonai doctor runtime --team preflight (Fixes #607)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -366,6 +366,7 @@
                       "docs/features/cli-backend-protocol",
                       "docs/features/runtime-capabilities",
                       "docs/features/doctor-runtime-migration",
+                      "docs/features/runtime-preflight",
                       "docs/features/external-agents-ui",
                       "docs/features/resource-lifecycle",
                       "docs/features/agent-cloning"

--- a/docs/cli/doctor-cli.mdx
+++ b/docs/cli/doctor-cli.mdx
@@ -209,9 +209,36 @@ praisonai doctor runtime --deep
 | `--fix` | `False` | Enable migration mode |
 | `--dry-run / --execute` | `--dry-run` | Preview vs apply |
 | `--team TEXT` | — | Team YAML file to validate |
-| `--workflow TEXT` | — | Workflow YAML file to validate |
+| `--workflow TEXT` | — | Workflow YAML file to validate (placeholder — returns SKIP) |
 | `--json` | `False` | JSON output |
 | `--deep` | `False` | Enable deeper probes |
+
+### Runtime Preflight Checks
+
+Validate team YAML for runtime compatibility, handoffs, and installed frameworks without LLM calls. See [Runtime Preflight](/docs/features/runtime-preflight) for the full guide.
+
+```bash
+# Basic team validation
+praisonai doctor runtime --team agents.yaml
+
+# JSON output for CI
+praisonai doctor runtime --team team.yaml --json
+
+# Deep mode (flag accepted; runtime checks do not branch on it today)
+praisonai doctor runtime --team config.yaml --deep
+
+# Workflow placeholder (returns SKIP — not yet implemented)
+praisonai doctor runtime --workflow workflow.yaml
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--team TEXT` | Team YAML file to validate |
+| `--workflow TEXT` | Workflow YAML file (placeholder) |
+| `--json` | Machine-readable output for CI |
+| `--deep` | Enable deeper probes |
+
+**Exit codes:** `0` — no issues; `1` — issues detected or team file missing; `2` — internal error.
 
 ### Docker Checks
 

--- a/docs/cli/doctor.mdx
+++ b/docs/cli/doctor.mdx
@@ -45,7 +45,7 @@ praisonai doctor ci
 | `llm-providers` | Check LLM providers configuration |
 | `memory-store` | Check memory store backends |
 | `metadata-store` | Check metadata store configuration |
-| `runtime` | Check runtime configuration and migrate legacy `cli_backend` settings |
+| `runtime` | Runtime preflight for team YAML (`--team`) and migrate legacy `cli_backend` settings (`--fix`) |
 
 ## Global Flags
 
@@ -169,6 +169,21 @@ praisonai doctor selftest --live
 
 # Use specific model
 praisonai doctor selftest --live --model gpt-4o
+```
+
+### Runtime Preflight
+
+Validate multi-agent team YAML for runtime compatibility before `AgentTeam.start()`. No LLM calls or API keys required. See [Runtime Preflight](/docs/features/runtime-preflight) for the capability matrix and check IDs.
+
+```bash
+# Preflight team YAML
+praisonai doctor runtime --team agents.yaml
+
+# JSON output for CI
+praisonai doctor runtime --team team.yaml --json
+
+# Deep mode (flag accepted; runtime checks do not branch on it today)
+praisonai doctor runtime --team config.yaml --deep
 ```
 
 ### Runtime Migration
@@ -417,6 +432,13 @@ graph LR
 - LLM configuration
 - Mock/live chat testing
 - Tools wiring
+
+### Runtime (`runtime`)
+- Team YAML runtime compatibility (`--team`)
+- Handoff and capability validation across agents
+- Mixed-runtime warnings
+- Legacy `cli_backend` migration (`--fix`, `--execute`)
+- Workflow YAML placeholder (`--workflow` — returns SKIP)
 
 ### Serve & Endpoints (`serve`)
 - Serve module availability

--- a/docs/features/runtime-preflight.mdx
+++ b/docs/features/runtime-preflight.mdx
@@ -1,0 +1,244 @@
+---
+title: "Runtime Preflight"
+sidebarTitle: "Runtime Preflight"
+description: "Validate multi-agent team YAML for runtime compatibility before AgentTeam.start()"
+icon: "shield-check"
+---
+
+Validate team YAML for runtime compatibility, handoffs, and installed frameworks **without LLM calls or API keys**. Run this as a preflight step before `AgentTeam.start()` or a workflow run.
+
+```mermaid
+graph LR
+    YAML[team.yaml] --> Doctor[doctor runtime --team]
+    Doctor --> Pass[Pass — exit 0]
+    Doctor --> Fail[Fail — exit 1 with remediation]
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef err fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class YAML input
+    class Doctor tool
+    class Pass ok
+    class Fail err
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Define your team">
+```yaml
+# agents.yaml
+framework: praisonai
+roles:
+  researcher:
+    role: Researcher
+    handoff:
+      to: writer
+  writer:
+    role: Writer
+```
+</Step>
+
+<Step title="Run preflight (no API keys required)">
+```bash
+praisonai doctor runtime --team agents.yaml
+```
+</Step>
+
+<Step title="Start the team when checks pass">
+```python
+from praisonaiagents import Agent, AgentTeam, Task
+
+researcher = Agent(name="researcher", instructions="Research topics")
+writer = Agent(name="writer", instructions="Write content")
+task = Task(description="Research and write", agent=researcher)
+
+team = AgentTeam(agents=[researcher, writer], tasks=[task])
+team.start()  # safe to run after preflight passes
+```
+</Step>
+</Steps>
+
+## How It Works
+
+`praisonai doctor runtime --team` parses your team YAML and checks:
+
+- Known runtime IDs and installed packages
+- Required capabilities (handoffs, tools, `cli_backend`, etc.)
+- Handoff target existence and compatibility
+- Mixed-runtime warnings across the team
+
+```mermaid
+graph TD
+    A[Agent runtime: field] -->|set| UseAgent[Use agent runtime ID]
+    A -->|unset| B{framework: autogen?}
+    B -->|no| UseFW[Use framework value]
+    B -->|yes| C{autogen_version / AUTOGEN_VERSION}
+    C -->|v0.4| V4[autogen_v4 if installed]
+    C -->|v0.2| V2[autogen if installed]
+    C -->|auto default| Auto[autogen_v4 else autogen]
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef decide fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef runtime fill:#189AB4,stroke:#7C90A0,color:#fff
+
+    class A agent
+    class B,C decide
+    class UseAgent,UseFW,V4,V2,Auto runtime
+```
+
+**Resolution order** (mirrors the framework):
+
+1. Agent-level `runtime:` wins.
+2. Otherwise falls back to top-level `framework:` (default `praisonai`).
+3. When `framework: autogen`, version comes from `autogen_version:` or `$AUTOGEN_VERSION`:
+   - `v0.4` → `autogen_v4` (if available)
+   - `v0.2` → `autogen`
+   - `auto` (default) → prefers `autogen_v4` if installed, else `autogen`
+
+## Runtime Capability Matrix
+
+| Runtime ID | Display Name | Handoff support | Tool loop |
+|------------|--------------|-----------------|-----------|
+| `praisonai` | PraisonAI Agents | Yes | Yes |
+| `crewai` | CrewAI | No | Yes |
+| `autogen` | AutoGen v0.2 | No | Yes |
+| `autogen_v4` | AutoGen v0.4 | Yes | Yes |
+| `ag2` | AG2 (AutoGen Next) | No | Yes |
+
+Capability names referenced by the checker: `agent_creation`, `tool_execution`, `handoff_support`, `context_sharing`, `cli_backend`, `sequential_execution`, `hierarchical_execution`, `group_chat`.
+
+## Configuration
+
+### CLI flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--team` | string | Team YAML file to validate |
+| `--workflow` | string | Workflow YAML file to validate (placeholder — returns SKIP) |
+| `--json` | flag | Emit JSON for CI integration |
+| `--deep` | flag | Enable deeper probes (accepted; runtime checks do not branch on it today) |
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | No issues found |
+| `1` | Issues detected (or team file missing) — non-zero blocks CI |
+| `2` | Internal error |
+
+```bash
+# Basic team validation
+praisonai doctor runtime --team agents.yaml
+
+# JSON output for CI
+praisonai doctor runtime --team team.yaml --json
+
+# Workflow placeholder (returns SKIP — not yet implemented)
+praisonai doctor runtime --workflow workflow.yaml
+```
+
+## What the Checker Detects
+
+| Check ID prefix | What it catches | Severity |
+|-----------------|-----------------|----------|
+| `runtime.yaml_parse` | YAML file fails to parse | CRITICAL |
+| `runtime.unknown_runtime.{role}` | Agent's `runtime:` value isn't a known runtime ID | HIGH |
+| `runtime.unavailable.{role}` | Runtime package not installed in current env | HIGH |
+| `runtime.missing_capabilities.{role}` | Agent needs a capability the runtime doesn't provide | HIGH |
+| `runtime.handoff_unsupported.{role}` | Agent has `handoff:` but runtime doesn't support handoffs | HIGH |
+| `runtime.handoff_target_missing.{role}` | Handoff target role name doesn't exist in the YAML | HIGH |
+| `runtime.handoff_target_incompatible.{role}` | Handoff target uses a runtime that may not support tool loops | MEDIUM |
+| `runtime.mixed_runtimes` | Multiple runtimes in one team — informational warning | MEDIUM |
+| `runtime.mixed_handoff_incompatible` | Mixed runtime team has handoffs routed through incompatible runtimes | HIGH |
+
+## Common Patterns
+
+### Good team YAML (passes)
+
+```yaml
+framework: praisonai
+roles:
+  researcher:
+    role: Researcher
+    handoff:
+      to: writer
+  writer:
+    role: Writer
+```
+
+### Bad team YAML (multiple failures)
+
+```yaml
+framework: crewai
+roles:
+  researcher:
+    role: Researcher
+    handoff:
+      to: ghost   # handoff_target_missing AND handoff_unsupported (crewai)
+  writer:
+    runtime: autogen
+    role: Writer
+    # mixed_runtimes + mixed_handoff_incompatible
+```
+
+### CI integration
+
+```yaml
+- name: Runtime preflight
+  run: |
+    pip install praisonai
+    praisonai doctor runtime --team agents.yaml --json
+```
+
+### Programmatic API
+
+```python
+from praisonai.cli.features.doctor.checks.runtime_checks import lint_runtime_team
+
+results = lint_runtime_team("agents.yaml")
+for r in results:
+    print(r.id, r.status, r.message)
+# Empty list means no issues
+```
+
+<Note>
+The same `praisonai doctor runtime` command also handles legacy `cli_backend` migration (`--fix`, `--execute`). See [Runtime Config Migration](/docs/features/doctor-runtime-migration) for migration flags.
+</Note>
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Run preflight before every team deploy">
+Add `praisonai doctor runtime --team agents.yaml` to CI and local scripts before `AgentTeam.start()` or `praisonai workflow run`.
+</Accordion>
+
+<Accordion title="Use --json in CI pipelines">
+JSON output integrates cleanly with GitHub Actions and other CI systems — exit code `1` blocks the pipeline when compatibility issues are found.
+</Accordion>
+
+<Accordion title="Prefer a single runtime for handoff teams">
+Only `praisonai` and `autogen_v4` support handoffs. Mixed-runtime teams with handoffs through `crewai`, `autogen`, or `ag2` fail preflight.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Doctor CLI" icon="stethoscope" href="/docs/cli/doctor">
+  Full reference for praisonai doctor subcommands and check categories
+</Card>
+<Card title="AgentTeam" icon="users" href="/docs/concepts/agentteam">
+  Multi-agent orchestration with AgentTeam and Task
+</Card>
+<Card title="PraisonAI Agents Framework" icon="robot" href="/docs/framework/praisonaiagents">
+  Framework options including handoffs and runtime selection
+</Card>
+<Card title="Runtime Config Migration" icon="arrow-right-arrow-left" href="/docs/features/doctor-runtime-migration">
+  Migrate legacy cli_backend fields with praisonai doctor runtime --fix
+</Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Adds `docs/features/runtime-preflight.mdx` with hero Mermaid, Quick Start, capability matrix, check IDs, good/bad YAML examples, CI snippet, and `lint_runtime_team()` API
- Updates `docs/cli/doctor.mdx` — runtime subcommand description, RUNTIME check category, Runtime Preflight examples
- Updates `docs/cli/doctor-cli.mdx` — Runtime Preflight Checks section with `--team`, `--workflow`, `--json`, `--deep`
- Registers page in `docs.json` under Features

Fixes #607

## Human follow-up (not in this PR)
Per AGENTS.md, add a one-line Tip at the top of `docs/concepts/agentteam.mdx` recommending `praisonai doctor runtime --team agents.yaml` before `team.start()`.

## Test plan
- [x] New page follows AGENTS.md structure (hero Mermaid, Quick Start, Related cards)
- [x] Five runtime IDs with correct handoff/tool-loop values
- [x] Nine runtime.* check IDs documented with severity
- [x] No edits to `docs/concepts/*`
- [x] `docs.json` updated under Features group

Made with [Cursor](https://cursor.com)