### PR TITLE
docs: Model-scoped runtime selection page (Fixes #608)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -364,6 +364,7 @@
                       "docs/features/cloud-provider-registry",
                       "docs/features/external-cli-integrations",
                       "docs/features/cli-backend-protocol",
+                      "docs/features/runtime-selection",
                       "docs/features/runtime-capabilities",
                       "docs/features/doctor-runtime-migration",
                       "docs/features/runtime-preflight",

--- a/docs/features/agent-cloning.mdx
+++ b/docs/features/agent-cloning.mdx
@@ -91,7 +91,8 @@ Agent cloning creates a fresh instance with the same configuration but isolated 
 | `tools` | Shallow-copied (`list(self.tools)`) |
 | `handoffs` | Reset to `None` (channels should not share handoffs) |
 | All feature configs: `memory`, `knowledge`, `planning`, `reflection`, `guardrails`, `web`, `context`, `autonomy`, `output`, `execution`, `templates`, `caching`, `hooks`, `skills`, `approval`, `learn`, `sandbox` | Forwarded from the stored `_<name>_config` attributes |
-| `tool_config` (which holds `timeout`, `retry_policy`, `parallel`), `cli_backend`, `runtime` / `_runtime_config` | Forwarded |
+| `tool_config` (which holds `timeout`, `retry_policy`, `parallel`), `runtime` / `_runtime_config` | Forwarded |
+| `cli_backend` | Forwarded (**deprecated** — use `runtime` instead) |
 | `interrupt_controller` | **Fresh instance** (no cross-channel interference) |
 | `__cache_lock` (`threading.RLock`) | **Fresh instance** |
 | `_cost_lock` (`threading.Lock`) | **Fresh instance** |

--- a/docs/features/cli-backend-protocol.mdx
+++ b/docs/features/cli-backend-protocol.mdx
@@ -6,7 +6,7 @@ icon: "plug"
 ---
 
 <Warning>
-**`cli_backend` is deprecated.** Use the `runtime` parameter and [Runtime Capabilities](/docs/features/runtime-capabilities) for capability-validated, model-scoped runtime selection. For YAML migration, run `praisonai doctor runtime --fix --execute` — see [Runtime Config Migration](/docs/features/doctor-runtime-migration).
+**Deprecated — use [Runtime Selection](/docs/features/runtime-selection) instead.** `cli_backend` still works through 2.0.0 but emits `DeprecationWarning`. For YAML migration, run `praisonai doctor runtime --fix --execute` — see [Runtime Config Migration](/docs/features/doctor-runtime-migration).
 
 ```python
 # Before
@@ -382,6 +382,9 @@ The legacy `--external-agent claude` and `ClaudeCodeIntegration` class still wor
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Runtime Selection" icon="play" href="/docs/features/runtime-selection">
+  Model-scoped runtime configuration (replaces cli_backend)
+</Card>
 <Card title="External CLI Integrations" icon="link" href="/docs/features/external-cli-integrations">
   Legacy class-based CLI integration approach
 </Card>

--- a/docs/features/runtime-selection.mdx
+++ b/docs/features/runtime-selection.mdx
@@ -1,0 +1,278 @@
+---
+title: "Runtime Selection"
+sidebarTitle: "Runtime"
+description: "Choose which runtime executes each model — per model, per provider, or per agent"
+icon: "play"
+---
+
+Runtime selection lets you pick which execution backend (Claude Code, Codex CLI, the built-in PraisonAI runtime) runs each model — declared on the model map, not the agent.
+
+```mermaid
+graph LR
+    subgraph "Runtime Resolution Order"
+        A[Per-model runtime] --> B[Per-provider default]
+        B --> C[Auto-selection]
+        C --> D[Built-in praisonai]
+    end
+
+    classDef model fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef provider fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef auto fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef default fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A model
+    class B provider
+    class C auto
+    class D default
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Simplest">
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Coder",
+    instructions="Write Python code",
+    runtime="claude-code"
+)
+
+agent.start("Build a CLI tool that lists open PRs")
+```
+</Step>
+
+<Step title="With config">
+```python
+from praisonaiagents import Agent
+from praisonaiagents.runtime import AgentRuntimeConfig
+
+agent = Agent(
+    name="Coder",
+    instructions="Write Python code",
+    runtime=AgentRuntimeConfig(
+        runtime="claude-code",
+        config_overrides={"timeout": 120}
+    )
+)
+```
+</Step>
+</Steps>
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Resolver as RuntimeResolver
+    participant Registry as RuntimeRegistry
+    participant Runtime
+
+    User->>Agent: agent.start("...")
+    Agent->>Resolver: resolve(model, provider)
+    Resolver->>Resolver: check per-model runtime
+    Resolver->>Resolver: fall back to per-provider default
+    Resolver->>Resolver: fall back to built-in praisonai
+    Resolver->>Registry: resolve(runtime_id)
+    Registry-->>Resolver: Runtime instance
+    Resolver-->>Agent: RuntimeResolutionResult
+    Agent->>Runtime: execute turn
+    Runtime-->>User: response
+```
+
+**Resolution order** (from `RuntimeResolver`):
+
+1. **Per-model runtime** — `model_runtime_configs[model_name]`
+2. **Per-provider default** — `provider_runtime_configs[provider_name]`
+3. **Auto-selection** — placeholder; currently returns `None` (reserved for a future release)
+4. **Built-in default** — `"praisonai"`
+5. **Legacy `cli_backend`** — emits `DeprecationWarning`
+
+Provider is inferred from the model name: split on `/` first, otherwise `claude*` → `anthropic`, `gpt*`/`openai*` → `openai`, `gemini*`/`google*` → `google`, `llama*` → `meta`.
+
+## Configuration
+
+### Agent parameter forms
+
+| Form | Example | When to use |
+|------|---------|-------------|
+| `str` (runtime ID) | `runtime="claude-code"` | Most cases |
+| `dict` | `runtime={"runtime": "claude-code", "config_overrides": {...}}` | Inline overrides |
+| `AgentRuntimeConfig` | `runtime=AgentRuntimeConfig(runtime="claude-code", ...)` | Full programmatic control |
+| `None` (default) | omit | Use model-map / provider-default / built-in |
+
+Invalid types raise:
+
+```
+Invalid runtime type: <type>. Expected bool, str, dict, RuntimeConfig, or AgentRuntimeConfig instance.
+```
+
+### YAML — choose your level
+
+```mermaid
+graph TD
+    Start[Need runtime control?] -->|One backend for all models| Prov[Set providers.*.runtime_default]
+    Start -->|Different backend per model| Model[Set models.*.runtime]
+    Start -->|One agent is special| Agent[Set agent runtime override]
+    Prov --> Run[framework: praisonai required]
+    Model --> Run
+    Agent --> Run
+
+    classDef decide fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef config fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef gate fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class Start decide
+    class Prov,Model,Agent config
+    class Run gate
+```
+
+```yaml
+framework: praisonai   # required — runtime features only work here
+
+providers:
+  anthropic:
+    runtime_default: claude-code
+  openai:
+    runtime_default: codex-cli
+
+models:
+  claude-3-sonnet:
+    runtime: claude-code
+  gpt-4o:
+    runtime: praisonai
+
+agents:
+  coder:
+    role: Developer
+    llm: claude-3-sonnet
+    # resolves to claude-code from models.claude-3-sonnet.runtime
+  reviewer:
+    role: Reviewer
+    llm: gpt-4o
+    runtime: claude-code   # agent-level override beats model/provider
+```
+
+### `AgentRuntimeConfig` options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `runtime` | `Optional[str]` | `None` | Runtime ID (e.g. `"claude-code"`, `"codex-cli"`, `"praisonai"`) |
+| `config_overrides` | `Dict[str, Any]` | `{}` | Runtime-specific config passed to the runtime factory |
+| `provider_default` | `Optional[str]` | `None` | Provider default (YAML `providers.<name>.runtime_default`) |
+| `enable_auto_selection` | `bool` | `True` | Allow auto-selection step in resolution order |
+| `metadata` | `Dict[str, Any]` | `{}` | Free-form metadata |
+
+Helper methods: `from_runtime_id(id, **kwargs)`, `from_dict(d)`, `to_dict()`, `merge_overrides(overrides)`, `with_runtime(id)`, `is_explicit()`.
+
+### Built-in runtime IDs
+
+Reference IDs: `"claude-code"`, `"codex-cli"`, `"praisonai"`. Built-in default is `"praisonai"`.
+
+### Framework gate
+
+Runtime features only work with `framework: praisonai`. Other frameworks raise:
+
+```
+Runtime features (runtime, models.*.runtime, providers.*.runtime_default) are not supported for framework='<x>'. Remove these fields from your YAML or switch to framework='praisonai'.
+```
+
+### Fail-closed behaviour
+
+Unknown runtime IDs raise — they do **not** silently fall back:
+
+```
+Unknown runtime ID: <id>. Available runtimes: [...]. Original error: ...
+```
+
+Top-level `RuntimeError` from Agent:
+
+```
+Runtime resolution failed for agent='<name>', model='<model>': <err>. Fix the runtime ID/configuration or remove the runtime override.
+```
+
+<Warning>
+If you typo a runtime ID, the agent fails at start. This is intentional — silent fallbacks should not ship to production.
+</Warning>
+
+## Common Patterns
+
+1. **One provider, one runtime everywhere** — set `providers.anthropic.runtime_default: claude-code`.
+2. **Mix runtimes per model** — `models.claude-3-sonnet.runtime: claude-code` plus `models.gpt-4o.runtime: praisonai`.
+3. **Per-agent override** — agent-level `runtime` beats model/provider config when one role needs different behaviour.
+
+## Migration from `cli_backend`
+
+`cli_backend` still works but emits `DeprecationWarning` (slated for removal in 2.0.0).
+
+```python
+# Before (deprecated)
+agent = Agent(name="X", cli_backend="claude-code")
+
+# After
+agent = Agent(name="X", runtime="claude-code")
+```
+
+```yaml
+# Before
+agents:
+  coder:
+    cli_backend: claude-code
+
+# After (preferred — declare at the model)
+models:
+  claude-3-sonnet:
+    runtime: claude-code
+agents:
+  coder:
+    llm: claude-3-sonnet
+```
+
+For automatic YAML migration, run `praisonai doctor runtime --fix --execute` — see [Runtime Config Migration](/docs/features/doctor-runtime-migration).
+
+Agent-level YAML warning:
+
+```
+Agent-level 'cli_backend' in YAML is deprecated. Use 'runtime' parameter or model-scoped runtime configuration instead.
+```
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Prefer model-map config over agent-level">
+Keep runtime choice with the model, not the role. Use `models.<name>.runtime` unless one agent truly needs an override.
+</Accordion>
+
+<Accordion title="Always set a provider_default">
+`providers.<name>.runtime_default` makes adding new models painless — new models inherit the provider backend automatically.
+</Accordion>
+
+<Accordion title="Don't catch the fail-closed error">
+Typo'd runtime IDs should fail at startup, not silently fall back to the built-in runtime.
+</Accordion>
+
+<Accordion title="Migrate cli_backend to runtime">
+Use the migration table above or `praisonai doctor runtime --fix` before 2.0.0 removes `cli_backend`.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="CLI Backend Protocol" icon="plug" href="/docs/features/cli-backend-protocol">
+  Legacy cli_backend reference (deprecated — see Runtime Selection)
+</Card>
+<Card title="YAML Configuration Reference" icon="file-code" href="/docs/features/yaml-configuration-reference">
+  Full YAML field reference including models.*.runtime
+</Card>
+<Card title="Runtime Preflight" icon="shield-check" href="/docs/features/runtime-preflight">
+  Validate team YAML before AgentTeam.start()
+</Card>
+<Card title="Runtime Config Migration" icon="arrow-right-arrow-left" href="/docs/features/doctor-runtime-migration">
+  Migrate legacy cli_backend with praisonai doctor runtime --fix
+</Card>
+</CardGroup>

--- a/docs/features/yaml-configuration-reference.mdx
+++ b/docs/features/yaml-configuration-reference.mdx
@@ -287,8 +287,8 @@ All recognized field names for agents in both `agents:` and `roles:` sections:
 | `stream` | bool | Alias for streaming |
 | `approval` | bool | Require human approval |
 | `skills` | array | Skill definitions |
-| `runtime` | string / list / dict | Runtime selection + capability requirements. Accepts a runtime id (`"native"`, `"claude-code"`), a list of required capability names, or a full config dict. See [Runtime Capabilities](/docs/features/runtime-capabilities). |
-| `cli_backend` | string / dict | **Legacy** — use `runtime` or `models.default.runtime` instead. CLI backend (e.g. `claude-code`) or `{id: ..., overrides: {...}}`. Requires `framework: praisonai`. Run `praisonai doctor runtime --fix --execute` to migrate automatically. See [Runtime Config Migration](/docs/features/doctor-runtime-migration) and [CLI Backend Protocol](/docs/features/cli-backend-protocol). |
+| `runtime` | string / dict | Per-agent runtime override. Requires `framework: praisonai`. See [Runtime Selection](/docs/features/runtime-selection). |
+| `cli_backend` | string / dict | **Deprecated** — use `runtime` or `models.<name>.runtime` instead. Still works through 2.0.0 with `DeprecationWarning`. Run `praisonai doctor runtime --fix --execute` to migrate. See [Runtime Selection](/docs/features/runtime-selection). |
 | `reflection` | bool/object | Reflection configuration |
 
 ### Unknown-Field Warnings
@@ -459,6 +459,30 @@ All options available at the root level of your YAML file.
     | `{{variable_name}}` | Custom variable |
     | `{{item}}` | Current loop item |
     | `{{item.field}}` | Field in loop item |
+  </Accordion>
+
+  <Accordion title="Runtime Selection" icon="play">
+    Model-scoped runtime configuration. Requires `framework: praisonai`. See [Runtime Selection](/docs/features/runtime-selection).
+
+    ```yaml
+    providers:
+      anthropic:
+        runtime_default: claude-code
+      openai:
+        runtime_default: codex-cli
+
+    models:
+      claude-3-sonnet:
+        runtime: claude-code
+      gpt-4o:
+        runtime: praisonai
+    ```
+
+    | Field | Type | Description |
+    |-------|------|-------------|
+    | `providers.<name>.runtime_default` | string | Provider-wide default runtime for all models from that provider |
+    | `models.<name>.runtime` | string | Per-model runtime override (wins over provider default) |
+    | `runtime` (agent-level) | string / dict | Per-agent override (wins over model and provider) |
   </Accordion>
 
   <Accordion title="Custom Models" icon="microchip">


### PR DESCRIPTION
## Summary
- Adds `docs/features/runtime-selection.mdx` — AgentRuntimeConfig, resolution order, YAML forms, fail-closed behaviour, migration from cli_backend
- Updates `cli-backend-protocol.mdx` deprecation banner → Runtime Selection
- Updates `yaml-configuration-reference.mdx` — runtime rows, providers.*.runtime_default, models.*.runtime accordion
- Updates `agent-cloning.mdx` — flags cli_backend as deprecated, runtime forwarded
- Registers page in `docs.json` under Features

Fixes #608

## Test plan
- [x] New page follows AGENTS.md structure
- [x] cli_backend marked deprecated on updated pages
- [x] docs.json updated under Features
- [x] No edits to docs/concepts/

Made with [Cursor](https://cursor.com)