### PR TITLE
docs: Bot run cancellation & timeout (Fixes #610)

### DIFF
--- a/docs/features/bot-commands.mdx
+++ b/docs/features/bot-commands.mdx
@@ -138,7 +138,7 @@ flowchart LR
 - Next message starts a fresh task
 
 <Note>
-The `/stop` command requires [Bot Run Control](/docs/features/bot-run-control) to be enabled. Set `busy_mode` to any value other than the default to enable this feature.
+`/stop` works out of the box on any bot using the default `BotSessionManager` — Telegram, Discord, Slack, and WhatsApp all register it. Enabling [Bot Run Control](/docs/features/bot-run-control) with `busy_mode` adds mid-run interruption plus pending-message handling on top of basic cancellation.
 </Note>
 
 ### /help
@@ -296,6 +296,7 @@ from praisonaiagents import Agent
 
 agent = Agent(name="assistant", instructions="Be helpful")
 bot = WhatsAppBot(mode="web", agent=agent)
+# /stop, /status, /new, /help registered automatically
 
 import asyncio
 asyncio.run(bot.start())

--- a/docs/features/bot-run-control.mdx
+++ b/docs/features/bot-run-control.mdx
@@ -84,6 +84,8 @@ sequenceDiagram
     Bot->>Agent: start new task
 ```
 
+When `run_timeout` is exceeded (default 300 seconds), `BotSessionManager` raises `BotRunTimeout` and cancels the in-flight run. Timeout failures are **not** pushed to the DLQ, so slow agents do not retry in a loop.
+
 ---
 
 ## Choosing a Busy Mode
@@ -135,6 +137,30 @@ bot = TelegramBot(
 |--------|------|---------|-------------|
 | `busy_mode` | `str` | `"queue"` | Policy for mid-run messages. One of `"queue"`, `"interrupt"`, `"steer"`. |
 | `busy_ack` | `str` | `"⏳ {action} — will be considered next"` | Template for busy acknowledgment. `{action}` is replaced with `"noted"` (queued) or `"added to pending request"` (merged). |
+| `run_timeout` | `float` | `300.0` | Maximum seconds a single agent run may take before it is cancelled with `BotRunTimeout`. Set to `0` or a negative value to disable. Applies to both streaming (`agent.astart`) and non-streaming (`agent.chat`) paths. |
+
+### Programmatic cancellation
+
+`BotSessionManager` exposes cancellation for admin hooks or custom integrations:
+
+```python
+from praisonaiagents import Agent
+from praisonai.bots import TelegramBot
+
+agent = Agent(name="assistant", instructions="Be helpful")
+bot = TelegramBot(token="YOUR_TOKEN", agent=agent)
+
+# Cancel a specific user's in-flight run (e.g. from an admin endpoint)
+bot._session.cancel_run(user_id="123456789", reason="admin_kill")
+
+# See who has a run in progress right now
+print(bot._session.get_active_runs())
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `cancel_run(user_id, reason="user_cancel")` | `bool` | `True` if an active run existed and was signalled |
+| `get_active_runs()` | `list[str]` | Storage keys with runs currently in progress |
 
 <Card title="BotConfig API Reference" icon="code" href="/docs/sdk/reference/typescript/classes/BotConfig">
   Full configuration options for bot settings
@@ -208,10 +234,8 @@ Use **interrupt mode** for conversational bots where the latest message reflects
 Use **steer mode** (experimental) for collaborative scenarios where users provide guidance during long tasks. Currently falls back to queue mode.
 </Accordion>
 
-<Accordion title="Why /stop Requires Run Control">
-The `/stop` command works through the `SessionRunControl` system. Without run control enabled, bots process messages sequentially with traditional locking, so `/stop` would queue behind the current task instead of interrupting it.
-
-Enable run control by setting `busy_mode` to any value other than the default.
+<Accordion title="How /stop Finds the Right Cancel Path">
+`/stop` works on stock bots without setting `busy_mode`. The handler tries `SessionRunControl.stop()` first when run control is enabled, then falls back to `BotSessionManager.cancel_run()` on the default session manager. Enable run control (`busy_mode`) when you also want mid-run pending-message handling — not as a prerequisite for `/stop`.
 </Accordion>
 
 <Accordion title="Race Protection via run_generation">

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -324,6 +324,9 @@ event = GatewayEvent(
 | Event Type | Description | Session-tracked |
 |------------|-------------|----------------|
 | `MESSAGE` | Text message between parties | ✅ |
+| `MESSAGE_ACK` | Acknowledgement that a message was received by the peer | |
+| `MESSAGE_ABORT` | Request to cancel an in-flight message run (used by `/stop`-style cancellation) | |
+| `TYPING` | Typing indicator | |
 | `CONNECT` | Client/agent connected | |
 | `DISCONNECT` | Client/agent disconnected | |
 | `ERROR` | Error notification | ✅ |


### PR DESCRIPTION
## Summary
- Updates `bot-run-control.mdx` — run_timeout, programmatic cancel_run/get_active_runs, BotRunTimeout, /stop dual-path accordion
- Updates `bot-commands.mdx` — /stop works without run control; WhatsApp note
- Updates `gateway.mdx` — MESSAGE_ACK, MESSAGE_ABORT, TYPING event types

Fixes #610

## Test plan
- [x] No new pages; no docs/concepts edits
- [x] Friendly imports in code samples

Made with [Cursor](https://cursor.com)