### PR TITLE
Fixes #611: Update bot streaming docs for simplified BotConfig API

### DIFF
--- a/docs/cli/bot.mdx
+++ b/docs/cli/bot.mdx
@@ -157,6 +157,13 @@ Enable agent capabilities via CLI flags:
 | `--stt` | Enable STT tool for speech-to-text |
 | `--stt-model MODEL` | STT model (default: `openai/whisper-1`) |
 
+### Streaming (progressive replies)
+
+| Option | Description |
+|--------|-------------|
+| `--stream` | Enable progressive streaming responses (bot edits the message live as tokens arrive) |
+| `--stream-edit-interval MS` | Minimum interval between edits in milliseconds (default: `700`) |
+
 <Note>
 **Default Tools (Always Enabled)**:
 - `execute_command` - Run shell commands
@@ -231,6 +238,22 @@ praisonai bot slack --token $SLACK_BOT_TOKEN --app-token $SLACK_APP_TOKEN \
 <Warning>
 Use `--auto-approve` only in trusted environments. This skips all confirmation prompts for tool executions.
 </Warning>
+
+### With Live Streaming Replies
+
+```bash
+# Default streaming (edits every 700ms)
+praisonai bot telegram --token $TELEGRAM_BOT_TOKEN --stream
+
+# Slower edits for stricter rate limits
+praisonai bot telegram --token $TELEGRAM_BOT_TOKEN \
+  --stream \
+  --stream-edit-interval 1500
+```
+
+<Tip>
+Streaming is currently wired up for Telegram. Other channels fall back to single-message mode until their adapters add streaming support.
+</Tip>
 
 ### With TTS/STT (Voice)
 
@@ -352,6 +375,9 @@ knowledge:
   </Card>
   <Card title="Browser CLI" icon="globe" href="/cli/browser">
     Browser control commands
+  </Card>
+  <Card title="Bot Streaming Replies" icon="message-pen" href="/features/bot-streaming-replies">
+    Progressive live replies with `--stream`
   </Card>
   <Card title="Bot vs Gateway" icon="code-compare" href="/concepts/bot-vs-gateway">
     Choose the right deployment model

--- a/docs/features/bot-streaming-replies.mdx
+++ b/docs/features/bot-streaming-replies.mdx
@@ -27,51 +27,68 @@ graph LR
 ## Quick Start
 
 <Steps>
-<Step title="Simple Usage (YAML)">
+<Step title="Enable with one flag (CLI)">
 
-Enable streaming with default settings in your `bot.yaml`:
-
-```yaml
-channels:
-  telegram:
-    token: "${TELEGRAM_BOT_TOKEN}"
-    streaming:
-      mode: draft
+```bash
+praisonai bot telegram --token $TELEGRAM_BOT_TOKEN --stream
 ```
 
 </Step>
 
-<Step title="Python API">
+<Step title="Enable in YAML">
 
-Configure streaming programmatically:
+```yaml
+channels:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+    streaming: true
+    stream_edit_interval_ms: 700
+```
+
+</Step>
+
+<Step title="Enable in Python">
 
 ```python
 from praisonaiagents import Agent
-from praisonai.bots import TelegramBot, StreamingConfig, StreamingMode
+from praisonai.bots import TelegramBot
+from praisonaiagents.bots import BotConfig
 
-bot = TelegramBot(token="...", agent=Agent(instructions="..."))
-bot.configure_streaming(StreamingConfig(mode=StreamingMode.DRAFT))
+agent = Agent(name="assistant", instructions="Be helpful and concise.")
+
+bot = TelegramBot(
+    token="...",
+    agent=agent,
+    config=BotConfig(
+        token="...",
+        streaming=True,
+        stream_edit_interval_ms=700,
+    ),
+)
 bot.start()
 ```
 
 </Step>
-
-<Step title="Tuned Configuration">
-
-Customize for slower platforms with higher thresholds:
-
-```yaml
-channels:
-  telegram:
-    streaming:
-      mode: draft
-      min_interval: 2.0
-      min_delta: 200
-      placeholder_text: "Working on it..."
-```
-
-</Step>
 </Steps>
+
+```mermaid
+graph TB
+    A{How much control<br/>do you need?} --> B[Just enable it]
+    A --> C[Tune the speed]
+    A --> D[Custom placeholder<br/>or progress mode]
+
+    B --> E["streaming: true<br/>(or --stream)"]
+    C --> F["streaming: true<br/>stream_edit_interval_ms: 1000"]
+    D --> G[StreamingConfig with<br/>mode=PROGRESS, ...]
+
+    classDef simple fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef advanced fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef question fill:#189AB4,stroke:#7C90A0,color:#fff
+
+    class A,B,C,D question
+    class E,F simple
+    class G advanced
+```
 
 ---
 
@@ -106,7 +123,20 @@ sequenceDiagram
 
 ---
 
-## Streaming Modes
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `streaming` | `bool` | `False` | Enable progressive streaming — bot sends a placeholder then edits it live as the agent produces tokens |
+| `stream_edit_interval_ms` | `int` | `700` | Minimum milliseconds between message edits (respects platform rate limits) |
+
+---
+
+## Advanced configuration (StreamingConfig)
+
+For `progress` mode, custom placeholder text, or fine-grained `min_delta` control, use the lower-level `StreamingConfig` API.
+
+### Streaming Modes
 
 Three modes are available to match different use cases:
 
@@ -136,12 +166,10 @@ graph TB
 | `progress` | Tool status updates, then final answer | Tool-heavy agents, user wants progress |
 
 <Note>
-Streaming replies are currently wired up for **Telegram**. The `DraftStreamer` is platform-agnostic (it speaks to any adapter that implements `send_message` + `edit_message`), but the YAML/`configure_streaming()` surface is only connected on Telegram in the initial release. Slack, Discord, and WhatsApp wiring will follow.
+Streaming replies are currently wired up for **Telegram**. The simple `streaming: true` / `--stream` form enables `draft` mode automatically. Other platforms (Discord, Slack, WhatsApp, Email, AgentMail) fall back to the existing blocking mode until their adapters are extended.
 </Note>
 
----
-
-## Configuration Options
+### StreamingConfig options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -217,6 +245,10 @@ await streamer.finalize(final_response_text)             # final edit with full 
 ## Best Practices
 
 <AccordionGroup>
+<Accordion title="Start with `--stream` — tune `stream_edit_interval_ms` only if needed">
+The default `700ms` interval works well on Telegram. If you hit "message is not modified" or 429 errors on a shared/busy channel, raise it to `1000`–`2000`. On Discord (stricter limits), prefer `2000` or use the advanced `StreamingConfig` form.
+</Accordion>
+
 <Accordion title="Tune min_interval to your platform's edit rate limit">
 Each platform has different edit rate limits. Telegram allows ~1 edit/sec/chat, while Slack's `chat_update` API is more generous. Set `min_interval` to match your platform's limits to avoid 429 errors.
 

--- a/docs/features/messaging-bots.mdx
+++ b/docs/features/messaging-bots.mdx
@@ -895,20 +895,25 @@ praisonai bot start --config whatsapp-web-bot.yaml
 
 ## Live Streaming Replies
 
-Channel bots can show live draft replies that update in real-time as your agent thinks, replacing the old "stare at typing indicator for 45 seconds" experience. Currently available on Telegram with other platforms coming soon.
+Channel bots can show live draft replies that update in real-time as your agent thinks — enable with `--stream`, `streaming: true` in YAML, or `BotConfig(streaming=True)`. Currently wired up for Telegram; other platforms fall back to single-message mode.
+
+```bash
+praisonai bot telegram --token $TELEGRAM_BOT_TOKEN --stream
+```
 
 ```python
-from praisonai.bots import TelegramBot, StreamingConfig, StreamingMode
+from praisonaiagents.bots import BotConfig
+from praisonai.bots import TelegramBot
 
-bot = TelegramBot(token="...", agent=agent)
-bot.configure_streaming(StreamingConfig(mode=StreamingMode.DRAFT))
+bot = TelegramBot(
+    token="...",
+    agent=agent,
+    config=BotConfig(streaming=True, stream_edit_interval_ms=700),
+)
 bot.start()
 ```
 
-Three modes are available:
-- `off` (default) — Single final message after completion
-- `draft` — Progressive edits with growing answer text  
-- `progress` — Show tool status, then replace with final answer
+For `progress` mode, custom placeholders, or fine-grained tuning, see the advanced `StreamingConfig` API on the dedicated page.
 
 <Card title="Bot Streaming Replies" icon="message-pen" href="/docs/features/bot-streaming-replies">
   Complete guide to streaming reply configuration and best practices


### PR DESCRIPTION
## Summary
- Restructure  to lead with  /  / simplified YAML
- Preserve  content under Advanced configuration section
- Add  and  to 
- Surface simple streaming API on 

Fixes #611

## Test plan
- [x] Quick Start shows CLI, YAML, and Python simple API first
- [x] Advanced StreamingConfig section preserved
- [x] CLI flags documented with example
- [x] No docs/concepts/ edits