### PR TITLE
Fixes #614: Document Session TTL and cleanup methods

### DIFF
--- a/docs/features/session-persistence.mdx
+++ b/docs/features/session-persistence.mdx
@@ -54,6 +54,10 @@ Sessions are stored in: `~/.praisonai/sessions/{session_id}.json`
 
 ## Behavior Matrix
 
+<Note>
+**Session expiry / cleanup.** This page covers the low-level `session_id` + `DefaultSessionStore` path used by `Agent(memory={"session_id": ...})`. If you instead use the high-level `Session(...)` wrapper, it supports `session_ttl`, `is_expired()`, `time_to_expiry()`, and `close()` — see [Sessions & Remote Agents → Session Expiry & Cleanup](/features/sessions#session-expiry--cleanup).
+</Note>
+
 | Scenario | Behavior |
 |----------|----------|
 | `session_id` provided, no DB | JSON persistence (automatic) |

--- a/docs/features/sessions.mdx
+++ b/docs/features/sessions.mdx
@@ -230,6 +230,7 @@ session = Session(
     
     # Optional
     user_id="user_identifier",
+    session_ttl=3600,  # Expire after 1 hour (None = never)
     
     # Memory configuration (use memory= consolidated param)
     memory=True,  # Enable memory with defaults
@@ -355,6 +356,145 @@ session = Session(
     middleware=[logging_middleware]
 )
 ```
+
+## Session Expiry & Cleanup
+
+Sessions can auto-expire after a fixed lifetime and release their resources with a single `close()` call.
+
+```python
+from praisonaiagents import Session
+
+# Session expires 1 hour after creation
+session = Session(
+    session_id="chat_123",
+    session_ttl=3600,
+)
+
+agent = session.Agent(
+    name="Assistant",
+    instructions="You are a helpful assistant",
+)
+
+agent.start("Hello!")
+
+# Later — gate on expiry before answering
+if session.is_expired():
+    print("Session expired, please start a new one")
+else:
+    agent.start("Continue our chat")
+
+# Always release resources when done
+session.close()
+```
+
+```mermaid
+graph LR
+    subgraph "Session Lifecycle"
+        Create[🆕 Create<br/>session_ttl=3600] --> Active[✅ Active]
+        Active -->|time_to_expiry > 0| Active
+        Active -->|elapsed >= ttl| Expired[⏰ Expired]
+        Active -->|close called| Closed[🧹 Closed]
+        Expired -->|close called| Closed
+    end
+
+    classDef create fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef active fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef expired fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef closed fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class Create create
+    class Active active
+    class Expired expired
+    class Closed closed
+```
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant App
+    participant Session
+    participant Agent
+
+    User->>App: "Continue chat"
+    App->>Session: is_expired()?
+    alt Expired
+        Session-->>App: true
+        App-->>User: "Session expired, starting fresh"
+        App->>Session: close()
+        App->>Session: Session(session_ttl=...)
+    else Still valid
+        Session-->>App: false
+        App->>Agent: start(message)
+        Agent-->>User: Response
+    end
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `session_ttl` | `Optional[int]` | `None` | Lifetime in seconds. `None` = never expire. Must be `>= 0`; negative raises `ValueError`. |
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `is_expired()` | `bool` | `True` once `time_to_expiry() == 0`. Always `False` when `session_ttl is None`. |
+| `time_to_expiry()` | `Optional[float]` | Seconds left before expiry (clamped to `0`). `None` if no TTL set. |
+| `close()` | `None` | Flushes agent chat histories, closes memory connections, clears knowledge and agents. No-op on remote sessions. |
+
+<Tabs>
+<Tab title="Poll before each turn">
+
+```python
+session = Session(session_id="chat", session_ttl=1800)
+agent = session.Agent(name="Assistant")
+
+while True:
+    if session.is_expired():
+        print("Session expired")
+        session.close()
+        break
+    user_input = input("You: ")
+    print(agent.start(user_input))
+```
+
+</Tab>
+<Tab title="Show remaining time">
+
+```python
+remaining = session.time_to_expiry()
+if remaining is not None:
+    print(f"{int(remaining)}s left in this session")
+```
+
+</Tab>
+<Tab title="Cleanup with close()">
+
+```python
+session = Session(session_id="chat", session_ttl=600)
+try:
+    agent = session.Agent(name="Assistant")
+    agent.start("Quick question")
+finally:
+    session.close()
+```
+
+</Tab>
+</Tabs>
+
+<AccordionGroup>
+<Accordion title="Pick a TTL that matches your UX">
+Use 30–60 min for chat assistants, 24 h for long-running bots, `None` for batch jobs.
+</Accordion>
+<Accordion title="Use monotonic semantics, not wall-clock">
+`is_expired()` measures elapsed runtime; it does not reflect calendar time. Do not compare internal timestamps against `time.time()`.
+</Accordion>
+<Accordion title="Always close() in a finally block">
+Even without TTL, `close()` releases memory-adapter connections and flushes pending chat history.
+</Accordion>
+<Accordion title="Negative TTL is a programming error">
+The constructor raises `ValueError` immediately — surface this to the developer, do not catch silently.
+</Accordion>
+</AccordionGroup>
+
+---
 
 ## Use Cases
 


### PR DESCRIPTION
Fixes #614

- Add Session Expiry & Cleanup section to sessions.mdx
- Add session_ttl to Local Session Options
- Cross-link from session-persistence.mdx