### PR TITLE
Fixes #615: Framework adapter and tool-resolver docs for PR #1988

### DIFF
--- a/docs/features/framework-adapter-plugins.mdx
+++ b/docs/features/framework-adapter-plugins.mdx
@@ -156,7 +156,8 @@ Framework adapters must implement the `FrameworkAdapter` protocol:
 |--------|----------|-------------|
 | `name` | ✅ | Unique framework identifier |
 | `is_available()` | ✅ | Check framework dependencies |
-| `resolve()` | ❌ | Pick the concrete adapter variant (default returns `self`) |
+| `resolve()` | ❌ | Pick the concrete adapter variant from YAML config (default returns `self`) |
+| `resolve_variant(config, registry)` | ❌ | Lower-level variant hook; family adapters may override when config-driven routing is needed |
 | `resolve_alias()` | ❌ | Return the concrete adapter name to dispatch to (string). Default returns `self.name`. Override when your adapter is a router that picks a sibling adapter at runtime by name. |
 | `setup(*, framework_tag)` | ❌ | Framework-specific pre-run hooks (default no-op) |
 | `run(config, llm_config, topic, *, tools_dict, agent_callback, task_callback, cli_config)` | ✅ | Execute framework logic (all four trailing kwargs are validated at registration time — see Troubleshooting) |
@@ -301,8 +302,8 @@ sequenceDiagram
 
     Gen->>Reg: resolve(framework)
     Reg-->>Gen: initial_adapter
-    Gen->>Adapter: resolve()
-    Note over Adapter,FamilyAdapter: For family adapters, resolve() calls<br/>resolve_alias() internally to pick name,<br/>then returns concrete adapter from registry
+    Gen->>Adapter: resolve(config=config)
+    Note over Adapter,FamilyAdapter: Family adapters read autogen_version<br/>from config, then return concrete adapter
     Adapter-->>Gen: concrete_adapter
     Gen->>Gen: assert_framework_available(adapter.name)
     Gen->>Obs: init_observability(adapter.name)

--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -433,20 +433,36 @@ The `ToolResolver` maintains two separate caches for performance:
 **Resolve cache**:
 - **Per-tool caching**: Memoises `resolve(name)` results for each tool name
 - **Negative results**: Unknown tool names are cached too, so repeated lookups don't walk every source
+- **`invalidate(name=None)`**: Clear one tool or the entire resolve cache. `ToolRegistry` changes auto-invalidate via `set_resolver()`.
 - **Thread safety**: Uses `_resolve_cache_lock` for concurrent access. Fixed in [PR #2147](https://github.com/MervinPraison/PraisonAI/pull/2147) — an earlier lock-free fast-path read could race with `ToolRegistry.invalidate()` and miss freshly-registered tools; the cache lookup now happens inside the lock.
 
 ```python
 resolver = ToolResolver()
 
-# First resolve() walks the 5-source ladder and caches result
-tool1 = resolver.resolve("tavily_search")  # Loads from source
+# First resolve() walks sources and caches result
+tool1 = resolver.resolve("tavily_search")
 
-# Second resolve() returns cached result immediately  
-tool2 = resolver.resolve("tavily_search")  # Uses cache
+# Invalidate one tool after registry change
+resolver.invalidate("tavily_search")
+tool2 = resolver.resolve("tavily_search")  # Re-resolves from sources
 
-# Clear both caches
-resolver.clear_cache()
-tool3 = resolver.resolve("tavily_search")  # Loads from source again
+# Or clear everything
+resolver.invalidate()
+```
+
+### ToolSource protocol (experimental)
+
+`ToolSource` is an optional extensibility hook — pass custom sources via `ToolResolver(sources=[...])`. The resolver does not yet iterate `_sources` in `resolve()`; treat this as experimental until wired.
+
+```python
+from praisonai.tool_resolver import ToolResolver, ToolSource
+
+class MyToolSource:
+    name = "my_tools"
+    def lookup(self, name: str):
+        ...
+
+resolver = ToolResolver(sources=[MyToolSource()])
 ```
 
 **Class tools and the cache:** When `tools.py` exports `BaseTool` subclasses (rather than plain functions), pass `instantiate=True` to get a ready-to-use instance back. The cache returns the same instantiation path whether or not `has_tool()` or `validate_yaml_tools()` warmed the cache first — so YAML validation flows that check tools exist before resolving them no longer return uninstantiated classes (fixed in [PR #1858](https://github.com/MervinPraison/PraisonAI/pull/1858)).

--- a/docs/framework/autogen.mdx
+++ b/docs/framework/autogen.mdx
@@ -68,9 +68,20 @@ graph TB
 
 ## Auto Version Selection
 
-`framework: autogen` routes to a family adapter (`AutoGenFamilyAdapter`) that picks the concrete version at runtime. Control it with `AUTOGEN_VERSION`:
+`framework: autogen` routes to a family adapter that picks the concrete version at runtime. Control it with the YAML `autogen_version` field (takes precedence) or `AUTOGEN_VERSION`:
 
-| `AUTOGEN_VERSION` | Behaviour |
+| Source | Precedence |
+|---|---|
+| `autogen_version:` in team YAML | Highest — overrides env var |
+| `$AUTOGEN_VERSION` env var | Used when YAML field is absent |
+| `"auto"` | Default when neither is set |
+
+```yaml
+framework: autogen
+autogen_version: v0.2   # "auto" | "v0.2" | "v0.4"
+```
+
+| `autogen_version` / `AUTOGEN_VERSION` | Behaviour |
 |---|---|
 | `auto` (default) | Pick `autogen_v2` if available, else `autogen_v4` (with warning), else `ag2`. If none available, raise `ImportError` with install hints. |
 | `v0.2` | Force `autogen_v2`. Warns if not installed; still returns the name (caller hits `ImportError` at run). |


### PR DESCRIPTION
Fixes #615

- Add autogen_version YAML field to autogen.mdx
- Update framework-adapter-plugins orchestrator diagram
- Document ToolResolver.invalidate and ToolSource in tool-resolver.mdx