### PR TITLE
Fixes #616: Sync MCP lifecycle CLI docs

### DIFF
--- a/docs/cli/mcp-lifecycle.mdx
+++ b/docs/cli/mcp-lifecycle.mdx
@@ -1,132 +1,111 @@
 ---
 title: "MCP Lifecycle CLI"
-description: "CLI commands for MCP connection management"
+description: "CLI commands for MCP server lifecycle and agent integration"
 icon: "terminal"
 ---
 
-# MCP Lifecycle CLI
+Commands for running PraisonAI's MCP server, inspecting built-in tools, and attaching external MCP servers to agent runs.
 
-Commands for managing MCP (Model Context Protocol) connections and lifecycle.
-
-## Commands
-
-### Start MCP Server
-
-Start an MCP server for testing:
+## Quick Start
 
 ```bash
-praisonai mcp start "uvx mcp-server-time"
+# Start the built-in MCP server (stdio)
+praisonai mcp serve
+
+# List built-in MCP tools
+praisonai mcp list-tools
+
+# Run an agent with an external MCP server
+praisonai "What time is it?" --mcp "uvx mcp-server-time"
 ```
 
-### Test MCP Connection
+## MCP server commands
 
-Test connectivity to an MCP server:
+### Serve
+
+Start the PraisonAI MCP server:
 
 ```bash
-praisonai mcp test "uvx mcp-server-time"
+praisonai mcp serve --transport stdio
+praisonai mcp serve --transport http-stream --host 127.0.0.1 --port 8080
 ```
 
-**Output:**
-```
-Testing MCP connection...
-✓ Connection established
-✓ Tools discovered: get_current_time
-✓ Connection closed cleanly
-```
+Common flags: `--name`, `--debug`, `--response-mode batch|stream`, `--session-ttl`, `--log-level`, `--json`.
 
-### List MCP Tools
-
-List available tools from an MCP server:
+### Inspect built-in tools
 
 ```bash
-praisonai mcp tools "uvx mcp-server-time"
+# List all tools
+praisonai mcp list-tools
+
+# Search tools
+praisonai mcp tools search "web"
+
+# Tool details and schema
+praisonai mcp tools info tavily_search
+praisonai mcp tools schema tavily_search
 ```
 
-**Output:**
-```
-Available MCP Tools:
-  - get_current_time: Get the current time in a timezone
+### Health check
+
+Use the doctor command to verify MCP connectivity (not `praisonai mcp doctor`):
+
+```bash
+praisonai doctor mcp
+praisonai doctor mcp --deep
 ```
 
-## Using MCP with Agents
+## Using MCP with agents
 
-### Basic Usage
+### Basic usage
 
 ```bash
 praisonai "What time is it?" --mcp "uvx mcp-server-time"
 ```
 
-### Multiple MCP Servers
+### Multiple MCP servers
 
 ```bash
 praisonai "Get time and search" \
   --mcp "uvx mcp-server-time" \
-  --mcp "uvx mcp-server-fetch"
+  --mcp "npx -y @modelcontextprotocol/server-brave-search"
 ```
 
-### With Environment Variables
+### With environment variables
 
 ```bash
 export BRAVE_API_KEY="your-key"
-praisonai "Search for Python" --mcp "npx -y @modelcontextprotocol/server-brave-search"
+praisonai "Search for Python" \
+  --mcp "npx -y @modelcontextprotocol/server-brave-search" \
+  --mcp-env "BRAVE_API_KEY=${BRAVE_API_KEY}"
 ```
 
-## Connection Types
+## Connection types
 
-### Stdio (Command)
+| Transport | Example `--mcp` value |
+|-----------|----------------------|
+| Stdio (command) | `"uvx mcp-server-time"` |
+| SSE URL | `"http://localhost:8080/sse"` |
+| HTTP stream | `"http://localhost:8080"` |
+| WebSocket | `"ws://localhost:8080"` |
 
-```bash
-praisonai "Task" --mcp "uvx mcp-server-time"
-```
+## Lifecycle management
 
-### SSE URL
-
-```bash
-praisonai "Task" --mcp "http://localhost:8080/sse"
-```
-
-### HTTP Stream
+Connections opened via `--mcp` are cleaned up automatically when the agent run finishes:
 
 ```bash
-praisonai "Task" --mcp "http://localhost:8080"
-```
-
-### WebSocket
-
-```bash
-praisonai "Task" --mcp "ws://localhost:8080"
-```
-
-## Lifecycle Management
-
-### Automatic Cleanup
-
-The CLI automatically handles cleanup:
-
-```bash
-# Connection opened, used, and closed automatically
 praisonai "What time is it?" --mcp "uvx mcp-server-time"
-```
-
-### Timeout Configuration
-
-Set connection timeout:
-
-```bash
-praisonai "Task" --mcp "uvx mcp-server-time" --mcp-timeout 30
 ```
 
 ## Debugging
 
-### Verbose Mode
-
-Enable verbose output for debugging:
+### Verbose agent run
 
 ```bash
 praisonai "Task" --mcp "uvx mcp-server-time" --verbose
 ```
 
-### Check MCP Status
+### Python connectivity check
 
 ```bash
 python -c "
@@ -140,33 +119,19 @@ print('Cleanup: OK')
 "
 ```
 
-## Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `MCP_TIMEOUT` | Default timeout in seconds |
-| `MCP_DEBUG` | Enable debug logging |
-
-## Error Handling
-
-### Connection Errors
-
-```bash
-# If MCP server fails to start
-praisonai "Task" --mcp "invalid-server"
-# Error: Failed to connect to MCP server
-```
-
-### Timeout Errors
-
-```bash
-# If operation times out
-praisonai "Task" --mcp "slow-server" --mcp-timeout 5
-# Error: MCP operation timed out after 5 seconds
-```
-
 ## Related
 
-- [MCP Lifecycle (Code)](/docs/features/mcp-lifecycle)
-- [MCP Module](/docs/sdk/praisonaiagents/mcp/mcp)
-- [MCP Transports](/docs/mcp/transports)
+<CardGroup cols={2}>
+  <Card title="MCP CLI Reference" icon="terminal" href="/cli/mcp">
+    Full MCP command reference
+  </Card>
+  <Card title="Doctor CLI" icon="stethoscope" href="/cli/doctor">
+    MCP health checks via doctor mcp
+  </Card>
+  <Card title="MCP Tool Search" icon="magnifying-glass" href="/cli/mcp-tool-search">
+    Search and inspect MCP tools
+  </Card>
+  <Card title="MCP Lifecycle" icon="rotate" href="/features/mcp-lifecycle">
+    SDK-level MCP lifecycle
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Fixes #616 — primary fix for mcp-lifecycle.mdx (non-existent start/test/tools commands).

Follow-up: mcp.mdx still references mcp test/sync; separate pass needed.