### PR TITLE
Docs: bounded memory for long-running bots (Fixes #617)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -319,6 +319,7 @@
                       "docs/features/bot-gateway",
                       "docs/features/inbound-dlq",
                       "docs/features/inbound-journal",
+                      "docs/features/long-running-bots",
                       "docs/features/durable-delivery",
                       "docs/features/bot-routing",
                       "docs/features/platform-aware-agents",

--- a/docs/cli/mcp.mdx
+++ b/docs/cli/mcp.mdx
@@ -303,33 +303,25 @@ praisonai mcp disable <name>
 praisonai mcp delete <name>
 ```
 
-## Test & Sync MCP Servers
+## Verify MCP Setup
 
-PraisonAI supports both local (stdio) and remote (HTTP) MCP servers. The `mcp test` and `mcp sync` commands work with both types.
-
-### Test Servers
+Check server health and inspect available tools before wiring them into agents.
 
 ```bash
-# Local server (stdio)
-praisonai mcp test filesystem
+# Health check — config, dependencies, protocol version
+praisonai mcp doctor
 
-# Remote server (HTTP)
-praisonai mcp test github-remote
+# List tools exposed by the PraisonAI MCP server
+praisonai mcp list-tools
+praisonai mcp list-tools --json
+
+# Search or inspect a specific tool
+praisonai mcp tools search "filesystem"
+praisonai mcp tools schema <tool-name>
 ```
-
-For remote servers, `mcp test` performs an HTTP probe to `server.url` and reports the HTTP status. This requires the `httpx` package for remote testing.
-
-### Sync Tools
-
-```bash
-# Sync tools (works for both local AND remote)
-praisonai mcp sync
-```
-
-This command fetches available tools from all enabled servers and updates the local cache.
 
 <Note>
-For `praisonai mcp test` with local servers, the environment is now merged with `os.environ` (rather than replacing it) so PATH and other system variables resolve correctly.
+For ad-hoc server runs, use `praisonai mcp serve --transport stdio` (local) or `--transport http-stream` (remote). Saved configs live under `~/.praisonai/mcp/`.
 </Note>
 
 ### Configuration File Format

--- a/docs/features/long-running-bots.mdx
+++ b/docs/features/long-running-bots.mdx
@@ -1,0 +1,92 @@
+---
+title: "Long-Running Bots"
+sidebarTitle: "Long-Running Bots"
+description: "Run bots 24/7 without memory leaks or silent corruption"
+icon: "infinity"
+---
+
+Run Telegram, Discord, Slack, and other bots for weeks — bounded lock caches and agent-scoped locks keep memory stable with no extra configuration.
+
+```mermaid
+graph LR
+    U[👤 User] --> B[🤖 Bot]
+    B --> M[BotSessionManager]
+    M --> AL[Agent locks<br/>WeakKeyDictionary]
+    M --> PL[Per-user locks<br/>LRU 10k / 1h TTL]
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class U agent
+    class B,M agent
+    class AL,PL process
+```
+
+## Quick Start
+
+```python
+from praisonaiagents import Agent
+from praisonai.bots import Bot
+
+agent = Agent(name="assistant", instructions="Be helpful")
+bot = Bot("telegram", agent=agent)
+bot.run()  # Bounded locks are active by default
+```
+
+Nothing extra is required — debounce, session, and run-control paths share the same bounded per-user lock cache.
+
+## What's Bounded by Default
+
+| Resource | Default limit | When it cleans up |
+|---|---|---|
+| Per-user lock cache | 10,000 entries, 1 hour TTL | Idle, unlocked entries evict automatically |
+| Agent locks | One per agent instance | Removed when the agent is garbage-collected |
+| Session histories | Opt-in via `session_ttl` | See [Session Persistence](/features/session-persistence) |
+
+<Note>
+Recreating agents per request is safe. Agent locks no longer reuse stale `id(agent)` keys, so unrelated users cannot share locks or swap histories.
+</Note>
+
+## Operational Knobs
+
+Trim conversation state when you need tighter control than the default lock cache:
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.bots import BotConfig
+from praisonai.bots import Bot
+
+agent = Agent(name="assistant", instructions="Be helpful")
+config = BotConfig(session_ttl=86400)  # Reap idle sessions after 24h
+
+bot = Bot("telegram", agent=agent, config=config)
+bot.run()
+```
+
+For mid-run cancellation and stale session cleanup, see [Bot Run Control](/features/bot-run-control) — `SessionRunControl.cleanup_stale_sessions(max_age_seconds=3600)` removes abandoned run-control state.
+
+## Multi-Agent Safety
+
+Earlier releases keyed agent locks on `id(agent)`. CPython may reuse that integer after garbage collection, so long-running gateways that recreated agents per request could silently mix up two users' histories. Agent locks now follow agent lifetime via `WeakKeyDictionary`; per-user locks stay bounded even if you never call cleanup helpers.
+
+<Info>
+**Released in PR #1972** — Upgrade to pick up the fix. See [Session Persistence → Bounded lock caches](/features/session-persistence#bounded-lock-caches) for details.
+</Info>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Session Persistence" icon="floppy-disk" href="/features/session-persistence">
+    Bot session storage and bounded lock behaviour
+  </Card>
+  <Card title="Messaging Bots" icon="message-circle" href="/features/messaging-bots">
+    Platform setup, debounce, and chunking
+  </Card>
+  <Card title="Inbound DLQ" icon="inbox" href="/features/inbound-dlq">
+    Persist failed messages for replay
+  </Card>
+  <Card title="Cross-Platform Mirror" icon="repeat" href="/features/cross-platform-mirror">
+    One conversation across every channel
+  </Card>
+</CardGroup>

--- a/docs/features/mcp-tool-filtering.mdx
+++ b/docs/features/mcp-tool-filtering.mdx
@@ -230,7 +230,7 @@ When using filters, comment why specific tools are allowed or blocked. This help
 </Accordion>
 
 <Accordion title="Test Tool Availability">
-Before deploying, verify that your filtered tool set provides the capabilities your agent needs. Use `praisonai mcp test` to inspect available tools.
+Before deploying, verify that your filtered tool set provides the capabilities your agent needs. Use `praisonai mcp list-tools` and `praisonai mcp tools search` to inspect available tools.
 </Accordion>
 
 <Accordion title="Consider Tool Dependencies">

--- a/docs/features/messaging-bots.mdx
+++ b/docs/features/messaging-bots.mdx
@@ -1654,6 +1654,10 @@ platforms:
   Recommended: **1000–2000ms** for conversational bots.
 </Tip>
 
+<Note>
+The per-user debounce lock cache is bounded (default: 10,000 entries, 1 hour TTL). Long-running bots with millions of distinct users won't leak memory — idle entries are evicted automatically.
+</Note>
+
 ---
 
 ## Smart Message Chunking

--- a/docs/features/session-persistence.mdx
+++ b/docs/features/session-persistence.mdx
@@ -20,6 +20,10 @@ PraisonAI Agents provides automatic session persistence with zero configuration.
 **Released in PR #2102** — Earlier versions of the gateway session-resume path used the **first** `session_data` system message it found, which was the empty snapshot written at session create. Reconnecting always restored an empty history. Resume now iterates all system messages and keeps the latest snapshot. Also: `WebSocketGateway.stop()` previously called `session.close()` directly, bypassing persistence; it now goes through `close_session()`, so graceful shutdown (SIGTERM) persists in-flight sessions identically to a WebSocket disconnect.
 </Info>
 
+<Info>
+**Released in PR #1972** — Earlier versions of `BotSessionManager` keyed agent locks on `id(agent)`, which CPython is free to reuse once an agent is garbage-collected. In long-running gateways that recreated agents per request, two unrelated users could silently serialize on the same lock — or worse, swap histories. Agent locks now use a `WeakKeyDictionary`, so they auto-clean when the agent is GC'd. Per-user locks are bounded by an LRU+TTL cache. Upgrade to pick up the fix.
+</Info>
+
 ## Quick Start
 
 ```python
@@ -389,6 +393,17 @@ Configure these settings in your `bot.yaml` under each channel:
 <Note>
 Without a `store` parameter, `BotSessionManager` falls back to in-memory-only mode for backward compatibility.
 </Note>
+
+### Bounded lock caches
+
+Long-running bots keep concurrency safe without unbounded memory growth:
+
+| Lock type | Scope | Cleanup |
+|---|---|---|
+| Agent locks | One lock per agent instance | Tied to agent lifetime — auto-removed when the agent is garbage-collected |
+| Per-user locks | Debounce, session, and run-control paths | Bounded LRU cache (max 10,000 entries, 1 hour TTL) — idle entries evict automatically |
+
+Recreating agents per request is safe: locks no longer share stale `id(agent)` keys across unrelated users.
 
 ## Session Store Protocol
 

--- a/docs/mcp/mcp-remote.mdx
+++ b/docs/mcp/mcp-remote.mdx
@@ -152,17 +152,17 @@ MCP Servers
 praisonai mcp auth github
 ```
 
-### Test Connection
+### Verify Connection
 
 ```bash
-# Test remote server (HTTP probe)
-praisonai mcp test tavily
+# Check MCP server health and configuration
+praisonai mcp doctor
 
-# Test local server
-praisonai mcp test filesystem
+# List tools available from configured servers
+praisonai mcp list-tools
 ```
 
-For remote servers, `mcp test` performs an HTTP probe to the server URL and reports the HTTP status. This requires the `httpx` package. For more details, see [MCP CLI documentation](../cli/mcp#test--sync-mcp-servers).
+For more CLI commands, see [MCP CLI documentation](../cli/mcp#verify-mcp-setup).
 
 ## Multiple Remote Servers
 


### PR DESCRIPTION
## Summary
- Add bounded lock-cache Note to messaging-bots debounce section
- Add PR #1972 callout and bounded lock subsection to session-persistence
- New long-running-bots operator page under Features
- Remove stale `praisonai mcp test` / `mcp sync` references (#616 follow-up)

## Test plan
- [x] docs.json validates
- [x] No remaining `mcp test` / `mcp sync` in Python CLI docs
- [ ] Mintlify preview

Fixes #617