### PR TITLE
Docs: CLI auth credentials page (Fixes #625)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1235,6 +1235,7 @@
                   "docs/cli/knowledge-cli",
                   "docs/cli/agents",
                   "docs/cli/acp",
+                  "docs/cli/auth",
                   "docs/cli/auto",
                   "docs/cli/init",
                   "docs/cli/serve",

--- a/docs/cli/auth.mdx
+++ b/docs/cli/auth.mdx
@@ -1,0 +1,107 @@
+---
+title: "Auth"
+sidebarTitle: "Auth"
+description: "Store and manage LLM provider API keys securely"
+icon: "key"
+---
+
+`praisonai auth` stores provider API keys locally so `praisonai run` works without exporting env vars every session.
+
+## Quick Start
+
+```bash
+# Interactive — key is hidden at the prompt
+praisonai auth login openai
+
+# Then run immediately
+praisonai run "What is 2+2?"
+```
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `auth login <provider>` | Store credentials (prompts if `--key` omitted) |
+| `auth list` | List stored providers (keys redacted) |
+| `auth status [provider]` | Check format; add `--validate` for live OpenAI check |
+| `auth logout <provider>` | Remove one provider |
+| `auth logout --all` | Remove all stored credentials |
+
+### Login
+
+```bash
+praisonai auth login openai
+praisonai auth login openai --key sk-...
+echo "sk-..." | praisonai auth login openai --key-stdin
+
+# Optional extras
+praisonai auth login openai --key sk-... --base-url https://api.openai.com/v1 --model gpt-4o
+praisonai auth login openai --skip-validation
+```
+
+### List & status
+
+```bash
+praisonai auth list
+praisonai auth status
+praisonai auth status openai --validate
+```
+
+### Logout
+
+```bash
+praisonai auth logout openai
+praisonai auth logout --all
+```
+
+## Storage & Security
+
+| Item | Value |
+|---|---|
+| File | `~/.praison/credentials.json` |
+| Permissions | `0o600` (auto-corrected on read if loose) |
+| Writes | Atomic via temp file + `os.replace` |
+| Display | Keys redacted as `sk-1***efgh` everywhere except the file |
+
+## Supported Providers
+
+| Provider | Key prefix | Env var injected at run time |
+|---|---|---|
+| `openai` | `sk-` | `OPENAI_API_KEY` (+ `OPENAI_BASE_URL` if set) |
+| `anthropic` | `sk-ant-` | `ANTHROPIC_API_KEY` |
+| `google` / `gemini` | `AI` | `GOOGLE_API_KEY` / `GEMINI_API_KEY` |
+| `tavily` | `tvly-` | `TAVILY_API_KEY` |
+| `groq` | `gsk_` | `GROQ_API_KEY` |
+| `cohere` | (none) | `COHERE_API_KEY` |
+
+Unknown providers accept keys with length ≥ 10.
+
+## How Run Uses Credentials
+
+`praisonai run` resolves credentials in this order:
+
+1. Environment variables (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …)
+2. Stored credentials (injected into `os.environ` before the run)
+3. LLM endpoint resolution via `resolve_llm_endpoint_with_credentials`
+
+If nothing is found, non-interactive mode exits with:
+
+```
+Error: No API key configured. Run: praisonai auth login
+```
+
+See [Run](/cli/run#first-run-credential-check) for the interactive wizard path.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Run" icon="play" href="/cli/run">
+    Preflight credential check before execution
+  </Card>
+  <Card title="Config" icon="gear" href="/cli/config">
+    Default model via `[llm]` in config.toml
+  </Card>
+  <Card title="Setup" icon="wand-magic-sparkles" href="/cli/setup">
+    First-run setup wizard
+  </Card>
+</CardGroup>

--- a/docs/cli/config.mdx
+++ b/docs/cli/config.mdx
@@ -69,6 +69,29 @@ Configuration can also be set via environment variables:
 | `PRAISONAI_MODEL` | Default model |
 | `PRAISONAI_VERBOSE` | Enable verbose mode |
 
+## LLM defaults (`[llm]`)
+
+Configure default model settings in `~/.praisonai/config.toml`. The legacy `[model]` section still works but `[llm]` is preferred.
+
+```toml
+[llm]
+model = "gpt-4o-mini"
+provider = "openai"          # optional
+base_url = "https://api.openai.com/v1"  # optional
+temperature = 0.7
+max_tokens = 16000
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `model` | `str` | `gpt-4o-mini` | Default model |
+| `provider` | `str` | — | Default provider name |
+| `base_url` | `str` | — | Custom API base URL |
+| `temperature` | `float` | `0.7` | Sampling temperature |
+| `max_tokens` | `int` | `16000` | Max output tokens |
+
+Store API keys separately with [`praisonai auth`](/cli/auth) — config holds defaults, not secrets.
+
 ## TOML Configuration
 
 The CLI also reads a structured TOML config from `~/.praisonai/config.toml` (or `.praisonai/config.toml` in your project). This is separate from the SDK's `[defaults.*]` config — it controls **CLI behaviour** like auto-injection of project instructions.

--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -149,7 +149,7 @@ export OPENAI_API_KEY=sk-...
 praisonai run "hello"
 ```
 
-See [First-run Onboarding](/docs/features/first-run-onboarding) for the full behaviour matrix and CI examples.
+See [Auth](/cli/auth) and [First-run Onboarding](/docs/features/first-run-onboarding) for the full behaviour matrix and CI examples.
 
 ---
 


### PR DESCRIPTION
## Summary
- New `docs/cli/auth.mdx` for `praisonai auth login/list/status/logout`
- `config.mdx`: document `[llm]` defaults section
- `run.mdx`: link to auth page from credential check

Fixes #625