### PR TITLE
docs: bring stub feature pages into AGENTS.md compliance

### DIFF
--- a/docs/features/a2ui.mdx
+++ b/docs/features/a2ui.mdx
@@ -1,87 +1,96 @@
 ---
 title: "A2UI Protocol"
+sidebarTitle: "A2UI"
 description: "Optional declarative UI via Google's a2ui-agent-sdk"
 icon: "window"
 ---
 
-# A2UI (Agent-to-User Interface)
+A2UI lets agents send declarative JSON UI specs that clients render with trusted component catalogues — integrate via the optional `a2ui-agent-sdk` package.
 
-PraisonAI integrates with the official [Google A2UI](https://github.com/google/A2UI) protocol via the optional **`a2ui-agent-sdk`** package — not a reimplemented copy in core.
+```mermaid
+graph LR
+    A[Agent] --> J[A2UI JSON]
+    J --> P[parse_a2ui_response]
+    P --> R[External Renderer]
+    R --> U[User UI]
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef ui fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A agent
+    class J,P process
+    class R,U ui
+```
 
 <Warning>
 Install the optional extra: `pip install praisonaiagents[a2ui]`
 </Warning>
 
-## Overview
+For most web apps, **structured output** or **AG-UI** is simpler. Use A2UI when you need a portable UI spec across React, Flutter, Lit, and other renderers.
 
-A2UI lets agents send **declarative JSON** describing UI components. Clients render using trusted component catalogs (React, Flutter, Lit, etc.) from the [A2UI renderers](https://github.com/google/A2UI/tree/main/renderers).
+## Quick Start
 
-For most web apps, **structured output** or **AG-UI** is simpler. Use A2UI when you need a portable UI spec across multiple renderers.
-
-See also: [Generative UI overview](/docs/features/generative-ui)
-
-## Quick start
-
-### Facade API
-
-```python
-from praisonaiagents.ui import A2UI
-
-# Wrap payload for A2A transport
-part = A2UI.create_part({"createSurface": {"surfaceId": "main", "catalogId": "..."}})
-
-# Build LLM system prompt with schema + examples
-prompt = A2UI.system_prompt(
-    role_description="You are a helpful assistant that returns rich UI.",
-    ui_description="Use cards and buttons from the basic catalog.",
-)
-```
-
-### Agent tool
+<Steps>
+<Step title="Add A2UI to an agent">
 
 ```python
 from praisonaiagents import Agent
 from praisonaiagents.tools.a2ui_tools import send_a2ui_messages
 
-agent = Agent(name="assistant", tools=[send_a2ui_messages])
+agent = Agent(
+    name="assistant",
+    instructions="Return rich UI when helpful.",
+    tools=[send_a2ui_messages],
+)
+
+agent.start("Show me a card with a summary button")
 ```
 
-### Low-level adapter
+</Step>
+
+<Step title="Build prompts with the facade API">
 
 ```python
-from praisonaiagents.ui.a2ui.adapter import (
-    create_a2ui_part,
-    parse_a2ui_response,
-    get_schema_manager,
-    generate_a2ui_system_prompt,
+from praisonaiagents.ui import A2UI
+
+prompt = A2UI.system_prompt(
+    role_description="You are a helpful assistant that returns rich UI.",
+    ui_description="Use cards and buttons from the basic catalog.",
 )
+
+part = A2UI.create_part({
+    "createSurface": {"surfaceId": "main", "catalogId": "basic"},
+})
 ```
 
-## Generative UI flow (Google SDK)
+</Step>
+</Steps>
+
+## Generative UI Flow
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant SDK as A2UI SDK
+    participant Client
+
+    Agent->>SDK: generate_a2ui_system_prompt()
+    Agent->>Agent: LLM returns A2UI JSON
+    Agent->>SDK: parse_a2ui_response()
+    SDK->>Client: create_a2ui_part (A2A DataPart)
+    Client->>Client: Render with catalog
+```
 
 1. `get_schema_manager()` — load JSON schemas and catalog
-2. `generate_a2ui_system_prompt()` — inject schema into LLM instructions
-3. Agent returns A2UI JSON (via tool or structured output)
+2. `generate_a2ui_system_prompt()` — inject schema into instructions
+3. Agent returns A2UI JSON via tool or structured output
 4. `parse_a2ui_response()` — validate and split text vs UI parts
-5. `create_a2ui_part()` — wrap for A2A (`application/json+a2ui`)
-6. External renderer draws the UI
+5. External renderer draws the UI
 
-Reference: [agent_sdks/python](https://github.com/google/A2UI/tree/main/agent_sdks/python)
+## Tool Input Shapes
 
-## A2A integration
-
-Sync `message/send` responses include an A2UI `DataPart` when the agent's last tool result uses `application/json+a2ui`. Streaming A2A over `message/stream` still returns text-only artifacts today.
-
-```python
-from praisonaiagents.ui.a2ui import create_a2ui_part, is_a2ui_part
-
-part = create_a2ui_part({"createSurface": {"surfaceId": "main", "catalogId": "..."}})
-assert is_a2ui_part(part)
-```
-
-## Tool argument shapes
-
-`send_a2ui_messages` accepts common LLM formats (minimal unwrap in core; full normalisation belongs in your UI layer):
+`send_a2ui_messages` accepts:
 
 | Input | Accepted |
 |-------|----------|
@@ -90,10 +99,29 @@ assert is_a2ui_part(part)
 | `{"messages": [...]}` dict | Yes |
 | Single message dict | Yes (wrapped in a list) |
 
-For version fields and surface inference, see [Integrate A2UI with Your Frontend](/docs/features/integrate-a2ui-frontend) and PraisonAIUI `a2ui_utils`.
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Prefer Generative UI for simple web apps">
+[Generative UI](/docs/features/generative-ui) covers most CopilotKit and structured-output cases with less setup.
+</Accordion>
+
+<Accordion title="Validate with parse_a2ui_response before sending to clients">
+Catch schema errors server-side before the renderer receives invalid JSON.
+</Accordion>
+
+<Accordion title="Use A2A DataParts for transport">
+Wrap payloads with `create_a2ui_part()` for `application/json+a2ui` compatibility.
+</Accordion>
+</AccordionGroup>
 
 ## Related
 
-- [Integrate A2UI with Your Frontend](/docs/features/integrate-a2ui-frontend) — any UI system
-- [AG-UI Server](/docs/deploy/servers/agui) — streaming for CopilotKit
-- [Generative UI](/docs/features/generative-ui) — tiered overview
+<CardGroup cols={2}>
+  <Card title="Generative UI" icon="sparkles" href="/docs/features/generative-ui">
+    Tiered UI options overview
+  </Card>
+  <Card title="Integrate A2UI Frontend" icon="code" href="/docs/features/integrate-a2ui-frontend">
+    Connect any UI framework
+  </Card>
+</CardGroup>

--- a/docs/features/agent-max-budget.mdx
+++ b/docs/features/agent-max-budget.mdx
@@ -1,15 +1,39 @@
 ---
-title: "Agent max_budget"
-sidebarTitle: "max_budget"
+title: "Agent Max Budget"
+sidebarTitle: "Max Budget"
 description: "Set a USD cap on agent spend via ExecutionConfig"
 icon: "wallet"
 ---
+
+Cap how much an agent can spend per run with `ExecutionConfig(max_budget=...)` — when the limit is hit, PraisonAI stops the run and raises `BudgetExceededError`.
+
+```mermaid
+graph LR
+    U[User Prompt] --> A[Agent Run]
+    A --> T[Track Token Cost]
+    T --> C{Under Budget?}
+    C -->|Yes| R[Continue]
+    C -->|No| X[BudgetExceededError]
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef stop fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class U input
+    class A,T process
+    class R ok
+    class C,X stop
+```
 
 <Warning>
 The top-level `Agent(max_budget=...)` shortcut was **removed** (PraisonAI PR #1642). Use `execution=ExecutionConfig(max_budget=...)` — see [CLI budget handling](/docs/features/cli-budget-handling).
 </Warning>
 
-Set a hard USD limit on agent runs with `ExecutionConfig`:
+## Quick Start
+
+<Steps>
+<Step title="Set a simple USD cap">
 
 ```python
 from praisonaiagents import Agent, ExecutionConfig
@@ -23,4 +47,92 @@ agent = Agent(
 agent.start("Research the history of AI")
 ```
 
-When the cap is exceeded, PraisonAI raises `BudgetExceededError` with the agent name and spend totals. The CLI surfaces a clean message — details in [CLI budget handling](/docs/features/cli-budget-handling).
+When spend reaches $0.50, the run stops with `BudgetExceededError` including agent name and totals.
+
+</Step>
+
+<Step title="Warn instead of stopping">
+
+```python
+from praisonaiagents import Agent, ExecutionConfig
+
+agent = Agent(
+    name="Analyst",
+    instructions="Analyse data carefully",
+    execution=ExecutionConfig(
+        max_budget=1.00,
+        on_budget_exceeded="warn",
+    ),
+)
+
+agent.start("Summarise this quarterly report")
+```
+
+With `on_budget_exceeded="warn"`, the agent logs a warning but continues. Default is `"stop"`.
+
+</Step>
+</Steps>
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant LLM
+    participant Budget
+
+    User->>Agent: start(prompt)
+    loop Each LLM call
+        Agent->>LLM: chat completion
+        LLM-->>Agent: response + usage
+        Agent->>Budget: add cost
+        Budget-->>Agent: total vs max_budget
+    end
+    Agent-->>User: result or BudgetExceededError
+```
+
+Budget tracking adds zero overhead when `max_budget` is `None` (the default).
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `max_budget` | `float \| None` | `None` | Hard USD limit per agent run. `None` disables tracking. |
+| `on_budget_exceeded` | `"stop" \| "warn" \| callable` | `"stop"` | Action when the cap is reached |
+
+<CardGroup cols={2}>
+  <Card title="ExecutionConfig" icon="code" href="/docs/sdk/reference/praisonaiagents/classes/ExecutionConfig">
+    Full execution configuration reference
+  </Card>
+  <Card title="CLI Budget Handling" icon="terminal" href="/docs/features/cli-budget-handling">
+    Budget limits from the CLI
+  </Card>
+</CardGroup>
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Start with a conservative cap in production">
+Set `max_budget` on any agent that runs unattended or loops over tools. $0.25–$1.00 is a sensible starting range for research agents.
+</Accordion>
+
+<Accordion title="Use warn mode during development">
+`on_budget_exceeded="warn"` lets you see full output while still logging when you'd have been stopped in production.
+</Accordion>
+
+<Accordion title="Combine with rate limiting">
+Budget caps control spend; rate limiters control request frequency. Use both for cost-sensitive deployments.
+</Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="CLI Budget Handling" icon="wallet" href="/docs/features/cli-budget-handling">
+    Set budgets from the command line
+  </Card>
+  <Card title="Execution Config" icon="settings" href="/docs/features/execution-config">
+    All execution options in one place
+  </Card>
+</CardGroup>

--- a/docs/features/context-budgeter-cli.mdx
+++ b/docs/features/context-budgeter-cli.mdx
@@ -1,31 +1,82 @@
 ---
 title: "Context Budgeter CLI"
-description: "CLI reference for context budget configuration"
+sidebarTitle: "Context Budgeter"
+description: "Configure context budget allocation from the CLI"
 icon: "gauge"
 ---
 
-Configure context budget allocation via CLI flags and interactive commands.
+Reserve output tokens and inspect per-segment budgets so long agent runs don't exhaust context before the model can reply.
 
-## CLI Flags
+```mermaid
+graph LR
+    M[Model Limit] --> B[Budget Allocator]
+    B --> S[System Prompt]
+    B --> H[History]
+    B --> T[Tool Outputs]
+    B --> O[Output Reserve]
 
-### Output Reserve
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef segment fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef reserve fill:#10B981,stroke:#7C90A0,color:#fff
 
-```bash
-# Set output token reserve
-praisonai chat --context-output-reserve 16000
+    class M config
+    class B process
+    class S,H,T segment
+    class O reserve
 ```
 
-Default: 8000 tokens
+## Quick Start
 
-## Interactive Commands
+<Steps>
+<Step title="Run an agent, then inspect budget">
 
-### View Budget
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    instructions="Answer helpfully within context limits.",
+)
+
+agent.start("Summarise the key points of context budgeting")
+```
+
+From the CLI session:
 
 ```bash
+praisonai chat
 > /context budget
 ```
 
-**Output:**
+</Step>
+
+<Step title="Increase output reserve for long replies">
+
+```bash
+praisonai chat --context-output-reserve 16000
+```
+
+Default output reserve is 8000 tokens. Raise it when the model truncates final answers.
+
+</Step>
+</Steps>
+
+## CLI Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--context-output-reserve` | `8000` | Tokens reserved for model output |
+
+## Interactive Commands
+
+```bash
+> /context budget   # Allocation breakdown
+> /context stats    # Current usage vs budget
+```
+
+Example `/context budget` output:
+
 ```
 Budget Allocation
   Model Limit:     128,000
@@ -34,27 +85,9 @@ Budget Allocation
 
   Segment Budgets:
     System Prompt: 2,000
-    Rules:         500
-    Skills:        500
-    Memory:        1,000
-    Tool Schemas:  2,000
-    Tool Outputs:  20,000
     History:       84,616
-    Buffer:        1,000
-```
-
-### View Stats
-
-```bash
-> /context stats
-```
-
-Shows current usage vs budget per segment.
-
-## Environment Variables
-
-```bash
-export PRAISONAI_CONTEXT_OUTPUT_RESERVE=8000
+    Tool Outputs:  20,000
+    ...
 ```
 
 ## config.yaml
@@ -65,28 +98,31 @@ context:
   default_tool_output_max: 10000
 ```
 
-## Model Limits
+Environment variable: `PRAISONAI_CONTEXT_OUTPUT_RESERVE`.
 
-| Model | Context Limit | Default Reserve |
-|-------|--------------|-----------------|
-| gpt-4o | 128,000 | 16,384 |
-| gpt-4o-mini | 128,000 | 16,384 |
-| gpt-4-turbo | 128,000 | 4,096 |
-| claude-3-opus | 200,000 | 8,192 |
-| gemini-1.5-pro | 2,097,152 | 8,192 |
+## Best Practices
 
-## Troubleshooting
+<AccordionGroup>
+<Accordion title="Raise output reserve before raising compaction threshold">
+If replies are cut off, increase `--context-output-reserve` first — compaction may not be the issue.
+</Accordion>
 
-### Not enough space for output
+<Accordion title="Check /context stats after heavy tool use">
+Tool outputs consume the largest share; stats show which segment is filling fastest.
+</Accordion>
 
-```bash
-# Increase output reserve
-praisonai chat --context-output-reserve 16000
-```
+<Accordion title="Pair with token estimation mode">
+Use [Token Estimation CLI](/docs/features/context-token-estimation-cli) accurate mode when validating budget numbers.
+</Accordion>
+</AccordionGroup>
 
-### Context filling too fast
+## Related
 
-```bash
-# Lower threshold for earlier compaction
-praisonai chat --context-threshold 0.7
-```
+<CardGroup cols={2}>
+  <Card title="Token Estimation CLI" icon="calculator" href="/docs/features/context-token-estimation-cli">
+    Configure estimation accuracy
+  </Card>
+  <Card title="Context Compaction" icon="compress" href="/docs/features/context-compaction">
+    Automatic overflow protection
+  </Card>
+</CardGroup>

--- a/docs/features/context-token-estimation-cli.mdx
+++ b/docs/features/context-token-estimation-cli.mdx
@@ -1,14 +1,77 @@
 ---
 title: "Token Estimation CLI"
-description: "CLI reference for token estimation configuration"
+sidebarTitle: "Token Estimation"
+description: "Configure how PraisonAI estimates token counts from the CLI"
 icon: "calculator"
 ---
 
-Configure token estimation behavior via CLI flags and environment variables.
+Control token estimation mode from the CLI — choose fast heuristics or accurate tiktoken counts when debugging context usage.
+
+```mermaid
+graph LR
+    U[User / CLI] --> M[Estimation Mode]
+    M --> H[Heuristic]
+    M --> A[Accurate tiktoken]
+    M --> V[Validated]
+    H --> C[Context Stats]
+    A --> C
+    V --> C
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef mode fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class U input
+    class M process
+    class H,A,V mode
+    class C output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Run an agent with accurate token counts">
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    instructions="Answer questions concisely.",
+)
+
+agent.start("Explain token estimation in one paragraph")
+```
+
+Then check counts from the CLI:
+
+```bash
+praisonai chat --context-estimation-mode accurate
+# In session: /context stats
+```
+
+</Step>
+
+<Step title="Enable mismatch logging for debugging">
+
+```bash
+praisonai chat \
+  --context-estimation-mode validated \
+  --context-log-mismatch
+```
+
+Validated mode compares heuristic vs accurate estimates and logs when they diverge by more than 15%.
+
+</Step>
+</Steps>
 
 ## CLI Flags
 
-### Estimation Mode
+| Flag | Values | Default | Description |
+|------|--------|---------|-------------|
+| `--context-estimation-mode` | `heuristic`, `accurate`, `validated` | `heuristic` | How tokens are counted |
+| `--context-log-mismatch` | flag | off | Log when heuristic differs from accurate |
 
 ```bash
 # Fast heuristic (default)
@@ -16,48 +79,14 @@ praisonai chat --context-estimation-mode heuristic
 
 # Accurate with tiktoken
 praisonai chat --context-estimation-mode accurate
-
-# Validated (compares both, logs mismatches)
-praisonai chat --context-estimation-mode validated
-```
-
-| Mode | Description | Performance |
-|------|-------------|-------------|
-| `heuristic` | Character-based estimate | Fastest |
-| `accurate` | Uses tiktoken tokenizer | Slower |
-| `validated` | Compares both, logs errors | Slowest |
-
-### Mismatch Logging
-
-```bash
-# Log when heuristic differs from accurate by >15%
-praisonai chat --context-log-mismatch
-```
-
-## Environment Variables
-
-```bash
-export PRAISONAI_CONTEXT_ESTIMATION_MODE=heuristic
-export PRAISONAI_CONTEXT_LOG_MISMATCH=false
 ```
 
 ## Interactive Commands
 
-### View Estimation Config
-
 ```bash
-> /context config
+> /context config   # View estimation mode
+> /context stats    # Token counts per segment
 ```
-
-Shows current estimation mode and mismatch logging setting.
-
-### View Token Stats
-
-```bash
-> /context stats
-```
-
-Shows token counts per segment using configured estimation mode.
 
 ## config.yaml
 
@@ -69,23 +98,31 @@ context:
     mismatch_threshold_pct: 15.0
 ```
 
-## Troubleshooting
+Environment variables: `PRAISONAI_CONTEXT_ESTIMATION_MODE`, `PRAISONAI_CONTEXT_LOG_MISMATCH`.
 
-### Inaccurate token counts
+## Best Practices
 
-```bash
-# Use accurate mode for precise counts
-praisonai chat --context-estimation-mode accurate
-```
+<AccordionGroup>
+<Accordion title="Use heuristic in production">
+Heuristic mode is fastest and sufficient for compaction triggers in normal use.
+</Accordion>
 
-### Debug estimation errors
+<Accordion title="Switch to accurate when counts look wrong">
+If compaction fires too early or too late, run with `--context-estimation-mode accurate` and check `/context stats`.
+</Accordion>
 
-```bash
-# Enable validated mode with logging
-praisonai chat --context-estimation-mode validated --context-log-mismatch
-```
+<Accordion title="Use validated mode briefly when tuning">
+Enable validated + log-mismatch for a short session to calibrate heuristic accuracy for your model and prompt style.
+</Accordion>
+</AccordionGroup>
 
-Watch for log messages like:
-```
-WARNING: Token estimation mismatch: heuristic=1250, accurate=1100, error=13.6%
-```
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Context Budgeter CLI" icon="gauge" href="/docs/features/context-budgeter-cli">
+    Allocate token budgets per segment
+  </Card>
+  <Card title="Context Management" icon="layer-group" href="/docs/features/context-management">
+    Full context system overview
+  </Card>
+</CardGroup>

--- a/docs/features/dynamic-context-discovery.mdx
+++ b/docs/features/dynamic-context-discovery.mdx
@@ -1,12 +1,35 @@
 ---
 title: "Dynamic Context Discovery"
+sidebarTitle: "Context Discovery"
 description: "Artifact-based storage for large tool outputs"
 icon: "box-archive"
 ---
 
-Dynamic Context Discovery automatically queues large tool outputs to artifacts, preventing context flooding while enabling on-demand retrieval.
+Large tool outputs are queued to artifacts automatically — the agent sees compact references instead of flooding context, and explores data on demand with artifact tools.
+
+```mermaid
+graph LR
+    T[Large Tool Output] --> M[Middleware]
+    M --> A[Artifact Store]
+    M --> R[Compact Ref in Context]
+    R --> Agent[Agent]
+    Agent --> G[artifact_grep / tail]
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef store fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class T input
+    class M process
+    class A store
+    class R,Agent,G output
+```
 
 ## Quick Start
+
+<Steps>
+<Step title="Enable dynamic context on an agent">
 
 ```python
 from praisonaiagents import Agent
@@ -15,84 +38,76 @@ from praisonai.context import setup_dynamic_context
 ctx = setup_dynamic_context()
 
 agent = Agent(
+    name="Analyst",
     instructions="You are a data analyst.",
     tools=ctx.get_tools(),
     hooks=[ctx.get_middleware()],
 )
 
-response = agent.chat("Fetch and analyze the large dataset")
+agent.start("Fetch and analyse the large dataset")
 ```
 
-**What happens:**
-- Large tool outputs (>32KB) are automatically saved as artifacts
-- Agent receives compact references instead of flooding context
-- Agent can use `artifact_tail`, `artifact_grep` to explore data on-demand
+Outputs over 32 KB are saved as artifacts; the agent receives references and uses `artifact_tail`, `artifact_grep`, etc.
 
-## Configuration
+</Step>
+
+<Step title="Tune the inline threshold">
 
 ```python
 ctx = setup_dynamic_context(
-    inline_max_kb=16,       # Queue outputs > 16KB (default: 32)
-    redact_secrets=True,    # Auto-redact API keys, passwords
-    history_enabled=True,   # Persist conversation history
+    inline_max_kb=16,
+    redact_secrets=True,
+    history_enabled=True,
 )
 ```
 
-## Available Tools
+</Step>
+</Steps>
 
-When you pass `ctx.get_tools()`, agents get:
+## Available Tools
 
 | Tool | Description |
 |------|-------------|
-| `artifact_tail` | Get last N lines |
-| `artifact_head` | Get first N lines |
+| `artifact_tail` | Last N lines |
+| `artifact_head` | First N lines |
 | `artifact_grep` | Search for pattern |
-| `artifact_chunk` | Get line range |
+| `artifact_chunk` | Line range |
 | `artifact_list` | List artifacts |
 
-## How It Works
+## Configuration
 
-```
-Tool Output (large) → Middleware → ArtifactStore → ArtifactRef (inline)
-                                                          ↓
-                                            Agent uses artifact_tail/grep
-```
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `inline_max_kb` | `32` | Queue outputs larger than this |
+| `redact_secrets` | `True` | Redact API keys and passwords |
+| `history_enabled` | `True` | Persist conversation history |
+| `base_dir` | `~/.praisonai/runs` | Artifact storage directory |
 
-1. Middleware intercepts tool outputs
-2. Outputs > threshold are saved to `~/.praisonai/runs/`
-3. Compact reference returned in context
-4. Agent uses artifact tools to explore data
+Environment variables: `PRAISONAI_ARTIFACT_DIR`, `PRAISONAI_ARTIFACT_INLINE_MAX_KB`, `PRAISONAI_ARTIFACT_REDACT`.
 
-## Environment Variables
+## Best Practices
 
-```bash
-PRAISONAI_ARTIFACT_DIR=~/.praisonai/runs
-PRAISONAI_ARTIFACT_INLINE_MAX_KB=32
-PRAISONAI_ARTIFACT_REDACT=true
-```
+<AccordionGroup>
+<Accordion title="Lower inline_max_kb for memory-heavy agents">
+16 KB keeps more headroom in context for long multi-tool sessions.
+</Accordion>
 
-## API Reference
+<Accordion title="Keep redact_secrets enabled in production">
+Automatic redaction prevents credentials in tool output from reaching the LLM or disk logs.
+</Accordion>
 
-### setup_dynamic_context()
+<Accordion title="Use artifact_grep before loading full files">
+Search artifacts first — avoid pulling entire multi-MB outputs into a single prompt.
+</Accordion>
+</AccordionGroup>
 
-```python
-def setup_dynamic_context(
-    base_dir: str = "~/.praisonai/runs",
-    inline_max_kb: int = 32,
-    redact_secrets: bool = True,
-    history_enabled: bool = True,
-    terminal_logging: bool = False,
-) -> DynamicContextSetup
-```
+## Related
 
-### DynamicContextSetup
-
-| Method | Returns |
-|--------|---------|
-| `get_tools()` | List of artifact tools for `Agent(tools=...)` |
-| `get_middleware()` | Queue middleware for `Agent(hooks=...)` |
-
-## See Also
-
-- [Context Management](/docs/features/context-management)
-- [Security & Redaction](/docs/features/context-security-redaction)
+<CardGroup cols={2}>
+  <Card title="Context Management" icon="layer-group" href="/docs/features/context-management">
+    Full context system
+  </Card>
+  <Card title="Security & Redaction" icon="shield" href="/docs/features/context-security-redaction">
+    Secret redaction details
+  </Card>
+</CardGroup>

--- a/docs/features/dynamic-variables.mdx
+++ b/docs/features/dynamic-variables.mdx
@@ -1,42 +1,83 @@
 ---
 title: "Dynamic Variables"
+sidebarTitle: "Dynamic Variables"
 description: "Use {{today}}, {{now}}, {{uuid}} and other dynamic variables in prompts and workflows"
 icon: "calendar"
 ---
 
-Dynamic variables are resolved at runtime, allowing you to use current date, time, and other values without hardcoding them.
+Dynamic variables resolve at runtime — inject today's date, timestamps, or custom values into prompts without hardcoding.
+
+```mermaid
+graph LR
+    P[Prompt with {{today}}] --> R[Resolver]
+    R --> V[Built-in Providers]
+    R --> C[Custom Providers]
+    V --> O[Resolved Text]
+    C --> O
+    O --> A[Agent]
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class P input
+    class R process
+    class V,C config
+    class O,A output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Use built-in variables in a prompt">
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Researcher",
+    instructions="You research news. Today is {{today}}.",
+)
+
+agent.start("Find AI news for {{today}}")
+# Resolves to: "Find AI news for June 23, 2026"
+```
+
+</Step>
+
+<Step title="Register a custom provider">
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.utils import register_variable_provider
+
+register_variable_provider("author", lambda: "PraisonAI Team")
+
+agent = Agent(name="Writer", instructions="Articles by {{author}}")
+agent.start("Write a summary for {{today}}")
+```
+
+</Step>
+</Steps>
 
 ## Built-in Variables
 
 | Variable | Example Output | Description |
 |----------|----------------|-------------|
-| `{{today}}` | January 19, 2026 | Human-readable date |
-| `{{date}}` | 2026-01-19 | ISO date format |
-| `{{now}}` | 2026-01-19T11:00:00 | ISO datetime |
+| `{{today}}` | June 23, 2026 | Human-readable date |
+| `{{date}}` | 2026-06-23 | ISO date format |
+| `{{now}}` | 2026-06-23T11:00:00 | ISO datetime |
 | `{{timestamp}}` | 1737280800 | Unix timestamp |
 | `{{uuid}}` | a1b2c3d4-... | Random UUID |
 | `{{year}}` | 2026 | Current year |
-| `{{month}}` | January | Current month name |
+| `{{month}}` | June | Current month name |
 
-## Usage in Agent
+Variables resolve in `Agent.start()`, `Agent.run()`, and workflow execution.
 
-```python
-from praisonaiagents import Agent
+## Common Patterns
 
-# Dynamic variable in prompt
-agent = Agent(instructions="You are a news researcher")
-result = agent.start("Find AI news for {{today}}")
-# Resolves to: "Find AI news for January 19, 2026"
-
-# Dynamic variable in instructions
-agent = Agent(
-    instructions="You research news. Today is {{today}}.",
-    role="Researcher"
-)
-result = agent.run("What's new in AI?")
-```
-
-## Usage in Workflow YAML
+### Workflow YAML
 
 ```yaml
 framework: praisonai
@@ -52,39 +93,41 @@ roles:
         expected_output: "Summary with sources"
 ```
 
-## Custom Providers
-
-Register your own dynamic variables:
+### Direct substitution
 
 ```python
-from praisonaiagents.utils import register_variable_provider
+from praisonaiagents.utils import substitute_variables
 
-# Simple function
-register_variable_provider("author", lambda: "PraisonAI Team")
-
-# Now {{author}} works in any prompt
-agent.start("Article by {{author}} on {{today}}")
+text = substitute_variables("Hello {{today}}", {"topic": "AI"})
 ```
 
 <Note>
-Dynamic variables are resolved in `Agent.start()`, `Agent.run()`, and `Workflow` execution. 
-The import is lazy-loaded, so there's no performance impact if you don't use them.
+Dynamic variables are lazy-loaded — no performance impact when unused.
 </Note>
 
-## API Reference
+## Best Practices
 
-```python
-from praisonaiagents.utils import (
-    substitute_variables,      # Main function
-    get_provider_registry,     # Get the registry
-    register_variable_provider # Register custom provider
-)
+<AccordionGroup>
+<Accordion title="Prefer {{today}} over hardcoded dates">
+Prompts with `{{today}}` stay accurate across sessions without manual updates.
+</Accordion>
 
-# Direct substitution
-text = substitute_variables("Hello {{today}}", {})
-# Returns: "Hello January 19, 2026"
+<Accordion title="Register custom providers once at startup">
+Call `register_variable_provider()` before creating agents that reference custom variables.
+</Accordion>
 
-# With static variables
-text = substitute_variables("Topic: {{topic}} Date: {{today}}", {"topic": "AI"})
-# Returns: "Topic: AI Date: January 19, 2026"
-```
+<Accordion title="Combine with static template variables">
+Pass static values via `substitute_variables(text, {"topic": "AI"})` alongside built-in dynamic ones.
+</Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Templates" icon="file-code" href="/docs/features/templates">
+    System and prompt templates
+  </Card>
+  <Card title="Workflows" icon="diagram-project" href="/docs/features/workflows">
+    YAML workflows with variable substitution
+  </Card>
+</CardGroup>

--- a/docs/ocr/overview.mdx
+++ b/docs/ocr/overview.mdx
@@ -1,49 +1,108 @@
 ---
-title: OCR Overview
-description: Extract text from documents and images
-icon: file-lines
+title: "OCR Overview"
+sidebarTitle: "OCR"
+description: "Extract text from documents and images with OCRAgent"
+icon: "file-lines"
 ---
+
+Extract text from PDFs and images with `OCRAgent` — pass a URL or base64 source and get markdown-ready text back.
+
+```mermaid
+graph LR
+    D[Document URL] --> O[OCRAgent]
+    O --> T[Extracted Text]
+    T --> A[Agent / Pipeline]
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class D input
+    class O process
+    class T,A output
+```
 
 <Note>Source must be a URL (`https://`) or base64-encoded document. Local file paths are not supported.</Note>
 
-## Extract Text
+## Quick Start
 
-<Tabs>
-  <Tab title="Basic">
+<Steps>
+<Step title="Extract text from a PDF">
+
 ```python
-from praisonaiagents import OCRAgent
+from praisonaiagents import Agent, OCRAgent
 
-agent = OCRAgent()
-text = agent.read("https://arxiv.org/pdf/2201.04234")
-print(text)
+agent = Agent(
+    name="Reader",
+    instructions="Summarise documents clearly.",
+)
+
+ocr = OCRAgent()
+text = ocr.read("https://arxiv.org/pdf/2201.04234")
+summary = agent.start(f"Summarise this paper:\n\n{text[:4000]}")
 ```
-  </Tab>
-  <Tab title="Advanced">
+
+</Step>
+
+<Step title="Extract specific pages">
+
 ```python
 from praisonaiagents import OCRAgent
 
-agent = OCRAgent()
+ocr = OCRAgent()
+result = ocr.extract("https://arxiv.org/pdf/2201.04234", pages=[0, 1])
 
-# Extract specific pages (0-indexed)
-result = agent.extract("https://arxiv.org/pdf/2201.04234", pages=[0, 1])
 for page in result.pages:
     print(f"Page {page.index}: {page.markdown[:100]}")
 ```
-  </Tab>
-</Tabs>
+
+</Step>
+</Steps>
 
 ## From Image URL
 
 ```python
 from praisonaiagents import OCRAgent
 
-agent = OCRAgent()
-text = agent.read("https://example.com/screenshot.png")
+ocr = OCRAgent()
+text = ocr.read("https://example.com/screenshot.png")
 print(text)
 ```
 
 ## Providers
 
 <CardGroup cols={2}>
-  <Card title="Mistral" icon="m" href="/docs/ocr/mistral">Best-in-class OCR</Card>
+  <Card title="Mistral OCR" icon="m" href="/docs/ocr/mistral">
+    Best-in-class OCR provider
+  </Card>
+  <Card title="Knowledge / RAG" icon="book" href="/docs/features/knowledge">
+    Index extracted text for retrieval
+  </Card>
+</CardGroup>
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Use HTTPS URLs only">
+Local file paths are not supported — upload to a reachable URL or encode as base64.
+</Accordion>
+
+<Accordion title="Extract pages selectively for large PDFs">
+Use `pages=[0, 1, 2]` to limit cost and latency on multi-hundred-page documents.
+</Accordion>
+
+<Accordion title="Chain with an Agent for summarisation">
+OCR returns raw text; pass it to an `Agent` for structured extraction, Q&A, or summarisation.
+</Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Mistral OCR" icon="m" href="/docs/ocr/mistral">
+    Provider configuration and options
+  </Card>
+  <Card title="Knowledge" icon="brain" href="/docs/features/knowledge">
+    Store and search extracted content
+  </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Rewrite 6 remaining stub pages (A1, A6–A10) with AGENTS.md template
- Refresh OCR overview (B1) with hero diagram, Steps, Best Practices
- A2–A5, A7 middleware/configurable-model/generative-ui/injected-state already compliant on main

Fixes #626 (B2/B3 parity scanner mapping left for follow-up)

Made with [Cursor](https://cursor.com)