### PR TITLE
docs: update bot streaming, cli_backend, and default tools for PR #2004

### DIFF
--- a/docs/features/bot-default-tools.mdx
+++ b/docs/features/bot-default-tools.mdx
@@ -250,6 +250,18 @@ To disable auto-injection, pass an explicit empty list: `Agent(tools=[])`. Passi
 
 ---
 
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="My bot only has a few tools, not the 20+ listed here">
+If your bot is missing most default tools (only sees a small fallback set), upgrade to the version that includes [PR #2004](https://github.com/MervinPraison/PraisonAI/pull/2004). A regression caused `ToolResolver` to be imported from the wrong module, which silently dropped the full default toolset and left only a small hardcoded fallback.
+
+Verify the fix is active by checking that imports resolve from `praisonai.tool_resolver`, not `praisonaiagents.tools`.
+</Accordion>
+</AccordionGroup>
+
+---
+
 ## Related
 
 <CardGroup cols={2}>

--- a/docs/features/bot-streaming-replies.mdx
+++ b/docs/features/bot-streaming-replies.mdx
@@ -24,6 +24,10 @@ graph LR
     class D output
 ```
 
+<Note>
+Progressive streaming on Telegram/Discord/Slack required a [bug fix in PR #2004](https://github.com/MervinPraison/PraisonAI/pull/2004) — earlier versions crashed on the first message with `TypeError: achat() got an unexpected keyword argument 'stream_callback'`. Upgrade to the latest release if you hit that error.
+</Note>
+
 ## Quick Start
 
 <Steps>
@@ -94,25 +98,33 @@ graph TB
 
 ## How It Works
 
+<Info>
+Streaming events flow through `agent.stream_emitter`, not as a `stream_callback` kwarg to `astart()`. The bot adds a temporary callback for the duration of the run and removes it on completion (and on timeout/cancel).
+</Info>
+
 ```mermaid
 sequenceDiagram
     participant User
     participant TelegramBot
     participant DraftStreamer
+    participant Emitter as agent.stream_emitter
     participant Agent
-    
+
     User->>TelegramBot: Send message
     TelegramBot->>DraftStreamer: start()
     DraftStreamer->>TelegramBot: send_message(placeholder)
-    TelegramBot->>Agent: astart(prompt, stream_callback)
-    
+    TelegramBot->>Emitter: add_callback(bridged_handler)
+    TelegramBot->>Agent: astart(prompt, stream=True, cancel_token=...)
+
     loop For each token
-        Agent->>DraftStreamer: on_event(DELTA_TEXT)
+        Agent->>Emitter: emit(DELTA_TEXT)
+        Emitter->>DraftStreamer: bridged_handler(event)
         DraftStreamer->>TelegramBot: edit_message(updated_content)
     end
-    
-    Agent->>DraftStreamer: on_event(STREAM_END)
+
+    Agent->>Emitter: emit(STREAM_END)
     DraftStreamer->>TelegramBot: edit_message(final_response)
+    TelegramBot->>Emitter: remove_callback(bridged_handler)
 ```
 
 | Component | Purpose | Responsibility |
@@ -248,7 +260,7 @@ streamer = DraftStreamer(
 )
 
 message_id = await streamer.start()                      # sends placeholder
-# ... agent run subscribes streamer.on_event as the stream callback ...
+# ... agent run subscribes streamer.on_event through agent.stream_emitter.add_callback(...) ...
 await streamer.finalize(final_response_text)             # final edit with full text
 ```
 

--- a/docs/features/cli-backend-protocol.mdx
+++ b/docs/features/cli-backend-protocol.mdx
@@ -184,7 +184,7 @@ graph TB
 | `crewai`, `autogen`, `autogen_v4`, `ag2` | **Raises** `ValueError: cli_backend requires framework='praisonai', but framework='<x>' was specified`. Validation runs before any agent starts, so no partial run is performed. |
 
 <Note>
-This is a behaviour change in PR #1797 — previously `cli_backend` was silently ignored under non-praisonai frameworks. Now it fails loudly at config-load time.
+This is a behaviour change in PR #1797 — previously `cli_backend` was silently ignored under non-praisonai frameworks. Now it fails loudly at config-load time. A follow-up fix ([PR #2004](https://github.com/MervinPraison/PraisonAI/pull/2004)) restored this validation for `framework: praisonai` — previously a regression caused all `cli_backend` configs to fail at validation regardless of framework.
 </Note>
 
 ---


### PR DESCRIPTION
## Summary
- Update `bot-streaming-replies.mdx` sequence diagram to use `agent.stream_emitter.add_callback` (not `stream_callback` kwarg)
- Append PR #2004 follow-up note to `cli-backend-protocol.mdx` Framework Compatibility section
- Add Troubleshooting accordion to `bot-default-tools.mdx` for silent tool fallback regression

Fixes #633

## Test plan
- [x] Sequence diagram reflects PR #2004 implementation
- [x] No new docs.json entries (content updates only)
- [x] No docs/concepts/ edits

Made with [Cursor](https://cursor.com)