### PR TITLE
docs: document unified CLI configuration hierarchy (PR #2039)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -372,6 +372,7 @@
                       "docs/features/external-cli-integrations",
                       "docs/features/cli-backend-protocol",
                       "docs/features/runtime-selection",
+                      "docs/features/cli-configuration",
                       "docs/features/prepared-turn-context",
                       "docs/features/runtime-capabilities",
                       "docs/features/doctor-runtime-migration",

--- a/docs/cli/config.mdx
+++ b/docs/cli/config.mdx
@@ -1,10 +1,48 @@
 ---
 title: "Config"
-description: "Configuration management for PraisonAI"
+description: "Layered, project-aware configuration for the praisonai CLI"
 icon: "gear"
 ---
 
-The `config` command manages PraisonAI configuration settings.
+The `config` command manages layered CLI defaults — global, project, environment, and runtime flags merged into one resolved config.
+
+```mermaid
+graph TB
+    subgraph "Configuration Precedence (highest wins)"
+        CLI[⚡ CLI flags] --> ENV[🌱 Environment variables]
+        ENV --> PROJ[📁 Project config]
+        PROJ --> GLOB[🏠 Global config]
+        GLOB --> DEF[📋 Built-in defaults]
+    end
+
+    classDef high fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef mid fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef low fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class CLI,ENV high
+    class PROJ,GLOB mid
+    class DEF low
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Set a default model">
+
+```bash
+praisonai config set agent.model gpt-4o-mini
+```
+
+</Step>
+
+<Step title="Verify resolution">
+
+```bash
+praisonai config show
+```
+
+</Step>
+</Steps>
 
 ## Usage
 
@@ -16,122 +54,142 @@ praisonai config [OPTIONS] COMMAND [ARGS]...
 
 | Command | Description |
 |---------|-------------|
-| `show` | Show current configuration |
-| `set` | Set a configuration value |
-| `get` | Get a configuration value |
-| `reset` | Reset configuration to defaults |
+| `show` | Show fully resolved configuration |
+| `sources` | List configuration layers in precedence order |
+| `validate [FILE]` | Validate YAML syntax and schema |
+| `list` | List all configuration values |
+| `get KEY` | Get a value by dotted path (e.g. `agent.model`) |
+| `set KEY VALUE` | Set a value (`--scope user\|project`) |
+| `reset` | Reset config to defaults (`--scope user\|project`) |
+| `path` | Show config file path |
+| `env` | Show registered environment variables |
+| `doctor` | Run configuration diagnostics |
 
-## Examples
-
-### Show current configuration
-
-```bash
-praisonai config show
-```
-
-### Set a configuration value
+### `show`
 
 ```bash
-praisonai config set model gpt-4o
+praisonai config show                          # YAML (default)
+praisonai config show --format json            # JSON output
+praisonai config show --format table           # Flat key=value table
+praisonai config show --sources                # Include contributing layers
 ```
 
-### Get a specific value
+### `validate`
 
 ```bash
-praisonai config get model
+praisonai config validate                      # Validate resolved config
+praisonai config validate .praisonai/config.yaml  # Validate a specific file
 ```
 
-### Reset to defaults
+### `sources`
 
 ```bash
-praisonai config reset
+praisonai config sources
 ```
+
+Prints the five-layer hierarchy and which global/project/env sources are currently active.
+
+### `set` / `get` / `reset` / `path`
+
+```bash
+praisonai config set agent.model gpt-4o-mini
+praisonai config set agent.temperature 0.3 --scope project
+praisonai config get agent.model
+praisonai config reset --scope project -y
+praisonai config path --scope user
+```
+
+| Scope | File | Permissions |
+|-------|------|-------------|
+| `user` (default) | `~/.praisonai/config.yaml` | `0600` |
+| `project` | `./.praisonai/config.yaml` | `0644` |
+
+---
 
 ## Configuration File
 
-Configuration is stored in `~/.praisonai/config.yaml`:
+Primary format is **YAML** at `~/.praisonai/config.yaml` (global) or `./.praisonai/config.yaml` (project):
 
 ```yaml
-model: gpt-4o-mini
-verbose: false
-memory: false
-telemetry: false
+agent:
+  model: gpt-4o-mini
+  temperature: 0.7
+  max_tokens: 16000
+  stream: true
+
+output:
+  verbose: false
+  color: true
+
+telemetry: true
 ```
+
+<Note>
+Model lives under `agent.model`, not at the top level. See [CLI Configuration](/docs/features/cli-configuration) for the full schema.
+</Note>
+
+### Project discovery
+
+From `cwd`, the resolver walks up to the git root searching:
+
+1. `.praisonai/config.yaml`
+2. `.praisonai/config.yml`
+3. `praison.yaml` / `praison.yml`
+4. `.praison/config.toml` (legacy)
+
+---
+
+## `agent.*` Schema
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `agent.model` | `str` | — | Default model |
+| `agent.provider` | `str` | — | Provider name |
+| `agent.base_url` | `str` | — | Custom API base URL |
+| `agent.tools` | `list[str]` | `[]` | Default tool names |
+| `agent.toolset` | `str` | — | Named toolset |
+| `agent.default_agent` | `str` | — | Default agent slug |
+| `agent.memory` | `bool`/`dict` | — | Memory config |
+| `agent.stream` | `bool` | `true` | Stream responses |
+| `agent.temperature` | `float` | `0.7` | Sampling temperature |
+| `agent.max_tokens` | `int` | `16000` | Max output tokens |
+
+Store API keys via env vars or [`praisonai auth`](/docs/cli/auth) — `api_key` is never written to YAML.
+
+---
 
 ## Environment Variables
 
-Configuration can also be set via environment variables:
+| Variable | Maps to |
+|----------|---------|
+| `MODEL_NAME` / `OPENAI_MODEL_NAME` / `PRAISONAI_MODEL` | `agent.model` |
+| `PRAISONAI_PROVIDER` | `agent.provider` |
+| `OPENAI_BASE_URL` / `OPENAI_API_BASE` / `PRAISONAI_BASE_URL` | `agent.base_url` |
+| `PRAISONAI_OUTPUT_FORMAT` | `output.format` |
+| `PRAISONAI_COLOR` | `output.color` |
+| `PRAISONAI_VERBOSE` | `output.verbose` |
+| `PRAISONAI_QUIET` | `output.quiet` |
+| `PRAISONAI_TELEMETRY` | `telemetry` |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` | Secrets (env only) |
 
-| Variable | Description |
-|----------|-------------|
-| `OPENAI_API_KEY` | OpenAI API key |
-| `ANTHROPIC_API_KEY` | Anthropic API key |
-| `PRAISONAI_MODEL` | Default model |
-| `PRAISONAI_VERBOSE` | Enable verbose mode |
+---
 
-## LLM defaults (`[llm]`)
+## Legacy Formats
 
-Configure default model settings in `~/.praisonai/config.toml`. The legacy `[model]` section still works but `[llm]` is preferred.
+Legacy paths still work and are migrated on read:
 
-```toml
-[llm]
-model = "gpt-4o-mini"
-provider = "openai"          # optional
-base_url = "https://api.openai.com/v1"  # optional
-temperature = 0.7
-max_tokens = 16000
-```
+| Path | Status |
+|------|--------|
+| `~/.praison/config.toml` | Read if no YAML; migrated to `agent.*` / `rag.*` |
+| `~/.praisonai/.env` | Merged for model/provider when no YAML |
+| `.praison/config.toml` (project) | Found via walk-up discovery |
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `model` | `str` | `gpt-4o-mini` | Default model |
-| `provider` | `str` | — | Default provider name |
-| `base_url` | `str` | — | Custom API base URL |
-| `temperature` | `float` | `0.7` | Sampling temperature |
-| `max_tokens` | `int` | `16000` | Max output tokens |
+TOML `[rules]`, `[output]`, `[mcp]`, `[traces]`, and `[session]` sections remain valid in legacy files. New projects should use YAML.
 
-Store API keys separately with [`praisonai auth`](/cli/auth) — config holds defaults, not secrets.
-
-## TOML Configuration
-
-The CLI also reads a structured TOML config from `~/.praisonai/config.toml` (or `.praisonai/config.toml` in your project). This is separate from the SDK's `[defaults.*]` config — it controls **CLI behaviour** like auto-injection of project instructions.
-
-```toml
-# ~/.praisonai/config.toml
-
-[rules]
-# Auto-inject project instruction files (AGENTS.md, CLAUDE.md, PRAISON.md, etc.)
-# into prompts run via `praisonai run` and `praisonai chat`.
-auto = true              # Default: true
-max_chars = 32000        # Total character cap across all rules. Default: 32000.
-```
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `auto` | `bool` | `true` | Auto-inject project instruction files into CLI prompts. Set to `false` to disable globally. |
-| `max_chars` | `int` | `32000` | Maximum total characters loaded from rules. Per-file cap is fixed at 12000. |
-
-### Disable rules globally
-
-```toml
-[rules]
-auto = false
-```
-
-You can still load rules on-demand with `praisonai run "task" --include-rules security`.
-
-### Other CLI config sections
-
-| Section | Purpose |
-|---------|---------|
-| `[output]` | Output preset, verbose, stream, metrics |
-| `[traces]` | Telemetry providers |
-| `[mcp]` | MCP server registrations |
-| `[model]` | Default model and provider settings |
-| `[session]` | Auto-save, history limit |
-| `[rules]` | **New** — auto-injection of project instructions |
+---
 
 ## See Also
 
-- [Profile](/docs/cli/profile) - Performance profiling
-- [Environment](/docs/cli/env) - Environment diagnostics
+- [CLI Configuration](/docs/features/cli-configuration) — feature guide with diagrams and best practices
+- [Profile](/docs/cli/profile) — Performance profiling
+- [Environment](/docs/cli/env) — Environment diagnostics

--- a/docs/configuration/index.mdx
+++ b/docs/configuration/index.mdx
@@ -74,7 +74,21 @@ This section provides comprehensive documentation for all configuration options 
   >
     Configuration best practices and common patterns
   </Card>
+
+  <Card
+    title="CLI Configuration"
+    icon="gear"
+    href="/docs/features/cli-configuration"
+  >
+    Layered, project-aware defaults for the praisonai CLI (`~/.praisonai/config.yaml`)
+  </Card>
 </CardGroup>
+
+<Note>
+**CLI config** (`~/.praisonai/config.yaml`, project `.praisonai/config.yaml`) holds runtime defaults for the `praisonai` CLI itself — model, output, MCP servers, rules. See [CLI Configuration](/docs/features/cli-configuration) and [`praisonai config`](/docs/cli/config).
+
+**Agents YAML** (`agents.yaml` or similar) is the SDK-level definition of agents, tasks, and workflows. See [Agent Configuration](/configuration/agent-config) and [Task Configuration](/configuration/task-config).
+</Note>
 
 ## Quick Reference
 

--- a/docs/features/cli-configuration.mdx
+++ b/docs/features/cli-configuration.mdx
@@ -1,0 +1,277 @@
+---
+title: "CLI Configuration"
+sidebarTitle: "CLI Configuration"
+description: "One config, every project: layered, project-aware defaults for the praisonai CLI"
+icon: "gear"
+---
+
+The `praisonai` CLI reads defaults from a layered hierarchy so you can set a model once and have it work everywhere — globally, per project, or per command.
+
+```mermaid
+graph TB
+    subgraph "Configuration Precedence (highest wins)"
+        CLI[⚡ CLI flags] --> ENV[🌱 Environment variables]
+        ENV --> PROJ[📁 Project config<br/>.praisonai/config.yaml]
+        PROJ --> GLOB[🏠 Global config<br/>~/.praisonai/config.yaml]
+        GLOB --> DEF[📋 Built-in defaults]
+    end
+
+    classDef high fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef mid fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef low fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class CLI,ENV high
+    class PROJ,GLOB mid
+    class DEF low
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Set a default model">
+
+```bash
+praisonai config set agent.model gpt-4o-mini
+```
+
+</Step>
+
+<Step title="Run any agent">
+
+```bash
+praisonai run "Summarise this README"
+```
+
+The model from config is picked automatically — no `--model` flag needed.
+
+</Step>
+
+<Step title="Inspect what was resolved">
+
+```bash
+praisonai config show --sources
+```
+
+</Step>
+</Steps>
+
+When you `praisonai run`, CLI defaults flow into the agent automatically:
+
+```python
+from praisonaiagents import Agent
+
+# Model, temperature, and tools come from resolved CLI config
+agent = Agent(name="assistant", instructions="Be helpful.")
+# praisonai run "..." uses agent.model from ~/.praisonai/config.yaml or project config
+```
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as praisonai CLI
+    participant Resolver as ConfigResolver
+    participant Project as Project config
+    participant Agent
+
+    User->>CLI: praisonai run "task"
+    CLI->>Resolver: resolve_config()
+    Resolver->>Project: walk-up discovery from cwd
+    Project-->>Resolver: .praisonai/config.yaml
+    Resolver-->>CLI: merged ResolvedConfig
+    CLI->>Agent: agent.model, temperature, tools
+    Agent-->>User: response
+```
+
+Layers are **deep-merged**. Lists are concatenated. Scalars are overridden by higher layers.
+
+| Layer | Source | Precedence |
+|-------|--------|------------|
+| 1 | Built-in defaults | Lowest |
+| 2 | Global `~/.praisonai/config.yaml` (+ legacy paths) | |
+| 3 | Project config (walk-up to git root) | |
+| 4 | Environment variables | |
+| 5 | CLI flags | Highest |
+
+---
+
+## Project vs Global Config
+
+| Location | Scope | Commit to repo? |
+|----------|-------|-----------------|
+| `~/.praisonai/config.yaml` | All projects on this machine | No |
+| `./.praisonai/config.yaml` | This project (and subdirectories) | Yes |
+| `./praison.yaml` / `./praison.yml` | Alternative project names | Yes |
+| `./.praison/config.toml` | Legacy TOML (backward compat) | Optional |
+
+Walk-up discovery searches, at each directory from `cwd` up to the git root:
+
+1. `.praisonai/config.yaml`
+2. `.praisonai/config.yml`
+3. `praison.yaml`
+4. `praison.yml`
+5. `.praison/config.toml` (legacy)
+
+```yaml
+# .praisonai/config.yaml — commit this to your repo
+agent:
+  model: claude-sonnet-4-6
+  temperature: 0.3
+  max_tokens: 16000
+  tools:
+    - search_web
+    - read_file
+```
+
+```bash
+# Anywhere inside the repo (including subdirs):
+praisonai run "Find recent benchmarks for retrieval-augmented generation"
+# Uses claude-sonnet-4-6 automatically — no --model flag needed
+```
+
+---
+
+## Choose Your Scope
+
+```mermaid
+graph TB
+    Q{Where should this setting live?}
+    Q -->|Just this one command| A[CLI flag]
+    Q -->|This shell session only| B[Environment variable]
+    Q -->|This repo / team-wide| C[Project config<br/>.praisonai/config.yaml]
+    Q -->|All my projects| D[Global config<br/>~/.praisonai/config.yaml]
+
+    classDef question fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef option fill:#10B981,stroke:#7C90A0,color:#fff
+    class Q question
+    class A,B,C,D option
+```
+
+---
+
+## Configuration Schema
+
+### `agent.*` defaults
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `agent.model` | `str` | `None` | e.g. `gpt-4o-mini`, `claude-sonnet-4-6` |
+| `agent.provider` | `str` | `None` | e.g. `openai`, `anthropic` |
+| `agent.base_url` | `str` | `None` | Custom LLM base URL |
+| `agent.tools` | `list[str]` | `[]` | Default tool names |
+| `agent.toolset` | `str` | `None` | Named toolset |
+| `agent.default_agent` | `str` | `None` | Default agent slug |
+| `agent.memory` | `bool` or `dict` | `None` | Enable memory or config dict |
+| `agent.stream` | `bool` | `True` | Stream responses |
+| `agent.temperature` | `float` | `0.7` | LLM temperature |
+| `agent.max_tokens` | `int` | `16000` | LLM token budget |
+
+<Note>
+`api_key` is never serialised to YAML — use environment variables or [`praisonai auth`](/docs/cli/auth).
+</Note>
+
+Other top-level sections (`output`, `mcp`, `rules`, `traces`, `session`) are unchanged — see [Config CLI reference](/docs/cli/config) and linked feature pages.
+
+---
+
+## Environment Variables
+
+| Variable | Maps to | Notes |
+|----------|---------|-------|
+| `MODEL_NAME` | `agent.model` | |
+| `OPENAI_MODEL_NAME` | `agent.model` | |
+| `PRAISONAI_MODEL` | `agent.model` | |
+| `PRAISONAI_PROVIDER` | `agent.provider` | |
+| `OPENAI_BASE_URL` | `agent.base_url` | |
+| `OPENAI_API_BASE` | `agent.base_url` | |
+| `PRAISONAI_BASE_URL` | `agent.base_url` | |
+| `PRAISONAI_OUTPUT_FORMAT` | `output.format` | |
+| `PRAISONAI_COLOR` | `output.color` | bool: `true`/`1`/`yes` |
+| `PRAISONAI_VERBOSE` | `output.verbose` | bool |
+| `PRAISONAI_QUIET` | `output.quiet` | bool |
+| `PRAISONAI_TELEMETRY` | `telemetry` | bool |
+
+---
+
+## Subcommand Reference
+
+| Command | Flags | Behaviour |
+|---------|-------|-----------|
+| `praisonai config show` | `--format yaml\|json\|table`, `--sources/-s` | Prints fully resolved config; with `--sources`, lists contributing layers |
+| `praisonai config validate [FILE]` | optional FILE | Validates YAML syntax + schema; no arg validates resolved config |
+| `praisonai config sources` | none | Prints precedence hierarchy and active layers |
+| `praisonai config list` | `--scope all\|user\|project` | Lists resolved values; verbose shows sources |
+| `praisonai config get KEY` | dotted path | e.g. `agent.model` |
+| `praisonai config set KEY VALUE` | `--scope user\|project` | Writes YAML (`0600` user, `0644` project) |
+| `praisonai config reset` | `--scope user\|project`, `-y` | Deletes corresponding `config.yaml` |
+| `praisonai config path` | `--scope user\|project` | Shows config file path and existence |
+| `praisonai config env` | `--scope`, `--validate` | Registered env vars and validation |
+| `praisonai config doctor` | none | Configuration diagnostics |
+
+```bash
+# Verify resolution
+praisonai config show --sources
+# Shows sources: defaults, project:/path/to/repo/.praisonai/config.yaml, ...
+```
+
+---
+
+## Backward Compatibility
+
+<AccordionGroup>
+<Accordion title="Legacy ~/.praison/config.toml">
+Still read on startup if no YAML config exists. RAG and model keys are migrated to the new `agent.*` / `rag.*` schema automatically.
+</Accordion>
+
+<Accordion title="Legacy ~/.praisonai/.env">
+Model and provider keys from `.env` are merged into the resolved config when no YAML is present.
+</Accordion>
+
+<Accordion title="Project .praison/config.toml">
+Walk-up discovery still finds legacy TOML project configs and migrates them on read.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Pin model per project">
+Commit `.praisonai/config.yaml` to your repo so teammates get the same defaults.
+</Accordion>
+
+<Accordion title="Keep secrets out of YAML">
+`api_key` is never serialised; use env vars or `praisonai auth`.
+</Accordion>
+
+<Accordion title="Use config sources to debug">
+When behaviour surprises you, `praisonai config sources` prints exactly which layer won.
+</Accordion>
+
+<Accordion title="Walk-up means subdirectories inherit">
+Running `praisonai` from `repo/scripts/` finds `repo/.praisonai/config.yaml`.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Config CLI Reference" icon="terminal" href="/docs/cli/config">
+  Full subcommand reference for `praisonai config`
+</Card>
+<Card title="Configuration Index" icon="settings" href="/configuration">
+  SDK-level agents, tasks, and memory configuration
+</Card>
+<Card title="Runtime Selection" icon="play" href="/docs/features/runtime-selection">
+  Model-scoped runtime configuration
+</Card>
+<Card title="LLM Endpoint Config" icon="link" href="/docs/features/llm-endpoint-config">
+  Custom base URLs and provider routing
+</Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Rewrite `docs/cli/config.mdx` for YAML-based layered config and new subcommands
- Create `docs/features/cli-configuration.mdx` with precedence diagrams and schema
- Add CLI config card + callout to `docs/configuration/index.mdx`
- Add nav entry under Features in `docs.json`

Fixes #634

## Test plan
- [x] docs.json validates
- [x] No docs/concepts/ edits

Made with [Cursor](https://cursor.com)