### PR TITLE
docs: bot platform capabilities (Fixes #641)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -691,6 +691,7 @@
                   "docs/features/plugins",
                   "docs/features/framework-adapter-plugins",
                   "docs/features/framework-availability",
+                  "docs/features/bot-platform-capabilities",
                   "docs/features/bot-platform-plugins",
                   "docs/features/registry-dependency-injection",
                   "docs/features/persistence-backend-plugins",

--- a/docs/features/bot-platform-capabilities.mdx
+++ b/docs/features/bot-platform-capabilities.mdx
@@ -1,0 +1,176 @@
+---
+title: "Bot Platform Capabilities"
+sidebarTitle: "Platform Capabilities"
+description: "Declare what a messaging platform can do — Praison uses it for uniform streaming, chunking, and rate limiting"
+icon: "sliders"
+---
+
+Platform capabilities tell PraisonAI what your bot's platform can do, so streaming, chunking, and rate limiting work the same way everywhere.
+
+```mermaid
+graph LR
+    A[Bot Adapter] --> B[PlatformCapabilities]
+    B --> C[Unified Delivery]
+    C --> D[Chunk]
+    C --> E[Stream]
+    C --> F[Rate limit]
+    D --> G[User]
+    E --> G
+    F --> G
+
+    classDef adapter fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef caps fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef delivery fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef user fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A adapter
+    class B caps
+    class C,D,E,F delivery
+    class G user
+```
+
+## Quick Start
+
+<Steps>
+
+<Step title="Look up built-in capabilities">
+
+```python
+from praisonai import Bot
+from praisonaiagents import Agent
+from praisonai.bots._registry import get_platform_capabilities
+
+agent = Agent(name="assistant", instructions="Be helpful")
+caps = get_platform_capabilities("telegram")
+print(caps.max_message_length)  # 4096
+print(caps.length_unit)         # utf16
+
+bot = Bot("telegram", agent=agent)
+```
+
+</Step>
+
+<Step title="Register a custom platform">
+
+```python
+from praisonaiagents.bots import PlatformCapabilities
+from praisonai.bots._registry import register_platform
+
+class MyBot:
+    async def start(self): ...
+    async def stop(self): ...
+
+register_platform(
+    "mybot",
+    MyBot,
+    capabilities=PlatformCapabilities(
+        max_message_length=2000,
+        supports_edit=True,
+        markdown_dialect="markdown",
+    ),
+)
+```
+
+</Step>
+
+</Steps>
+
+## How it works
+
+`UnifiedDelivery` (via `create_delivery(bot)`) reads `platform_capabilities` to chunk long replies, stream edits, and apply rate limits.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant B as Bot
+    participant D as UnifiedDelivery
+    participant P as Platform
+
+    U->>B: message
+    B->>D: send/stream(text)
+    D->>D: read capabilities
+    D->>P: chunked / edited message
+    P-->>U: delivery
+```
+
+## Configuration options
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_message_length` | `int` | `4096` | Maximum message length in the platform's unit |
+| `length_unit` | `str` | `"codepoints"` | `"codepoints"` or `"utf16"` |
+| `supports_edit` | `bool` | `False` | In-place message edits (streaming) |
+| `supports_typing` | `bool` | `True` | Typing indicators |
+| `markdown_dialect` | `str` | `"markdown"` | e.g. `"telegram_markdown_v2"`, `"discord_markdown"` |
+| `needs_rate_limit` | `bool` | `True` | Apply Praison rate limiting |
+| `edit_interval_ms` | `int` | `1000` | Minimum ms between edits |
+| `max_files_per_message` | `int` | `1` | Attachments per message |
+| `max_file_size_mb` | `int` | `10` | Max file size in MB |
+| `supported_file_types` | `List[str]` | `["*"]` | Allowed mime types or extensions |
+
+Methods: `to_dict()` and `from_dict(data)`.
+
+## Built-in platform defaults
+
+| Platform | Notes |
+|----------|-------|
+| **Telegram** | `max_message_length=4096`, `length_unit="utf16"`, `supports_edit=True`, `markdown_dialect="telegram_markdown_v2"`, `needs_rate_limit=True`, `edit_interval_ms=1000`, `max_file_size_mb=50` |
+| **Discord** | `max_message_length=2000`, `length_unit="codepoints"`, `supports_edit=True`, `needs_rate_limit=False`, `edit_interval_ms=500`, `max_files_per_message=10`, `max_file_size_mb=8` |
+| slack, whatsapp, linear, email, agentmail | Uses `PlatformCapabilities()` defaults until the adapter declares its own |
+
+## Common patterns
+
+**Subclass with `default_capabilities()`** (Telegram and Discord use this):
+
+```python
+@classmethod
+def default_capabilities(cls) -> PlatformCapabilities:
+    return PlatformCapabilities(max_message_length=2000, supports_edit=True)
+```
+
+**Serialise for config files:**
+
+```python
+caps = get_platform_capabilities("telegram")
+data = caps.to_dict()
+restored = PlatformCapabilities.from_dict(data)
+```
+
+## Best practices
+
+<AccordionGroup>
+
+<Accordion title="Use utf16 for Telegram">
+Telegram counts UTF-16 code units. Wrong `length_unit` can silently truncate messages.
+</Accordion>
+
+<Accordion title="Set needs_rate_limit=False only when the SDK rate-limits">
+Discord.py handles limits internally; raw Telegram HTTP does not.
+</Accordion>
+
+<Accordion title="Enable supports_edit only with edit_message()">
+`UnifiedDelivery` streams via edits when this flag is true.
+</Accordion>
+
+<Accordion title="Prefer default_capabilities() on the adapter class">
+Keeps registry caching consistent when platforms override defaults.
+</Accordion>
+
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Bot Platform Plugins" icon="puzzle-piece" href="/docs/features/bot-platform-plugins">
+    Register custom adapters
+  </Card>
+  <Card title="Bot Streaming Replies" icon="stream" href="/docs/features/bot-streaming-replies">
+    Uses supports_edit and edit_interval_ms
+  </Card>
+  <Card title="Bot Rate Limiting" icon="gauge" href="/docs/features/bot-rate-limiting">
+    Uses needs_rate_limit
+  </Card>
+  <Card title="Chunking Strategies" icon="scissors" href="/docs/features/chunking-strategies">
+    Uses max_message_length and length_unit
+  </Card>
+</CardGroup>

--- a/docs/features/bot-platform-plugins.mdx
+++ b/docs/features/bot-platform-plugins.mdx
@@ -107,7 +107,8 @@ The bot platform registry supports both programmatic and entry-point registratio
 
 | Function | Purpose |
 |----------|---------|
-| `register_platform(name, cls)` | Register at runtime (backward-compat helper) |
+| `register_platform(name, cls, capabilities=None)` | Register at runtime (optional `PlatformCapabilities` descriptor) |
+| `get_platform_capabilities(name)` | Get the capabilities descriptor for a registered platform |
 | `list_platforms()` | List all registered platform names |
 | `resolve_adapter(name)` | Get class for a platform name |
 | `get_platform_registry()` | Backward-compat: returns `dict[name, class]` of all platforms |
@@ -130,6 +131,26 @@ PraisonAI includes these built-in bot platforms:
 ---
 
 ## Common Patterns
+
+### Declare Platform Capabilities
+
+```python
+from praisonaiagents.bots import PlatformCapabilities
+from praisonai.bots._registry import register_platform
+
+register_platform(
+    "mybot",
+    MyBot,
+    capabilities=PlatformCapabilities(
+        max_message_length=2000,
+        length_unit="codepoints",
+        supports_edit=True,
+        markdown_dialect="markdown",
+    ),
+)
+```
+
+Capabilities let PraisonAI's shared delivery layer chunk, stream, and rate-limit messages correctly for your platform — see [Bot Platform Capabilities](/docs/features/bot-platform-capabilities) for the full field list.
 
 ### Override a Built-in Platform
 
@@ -267,6 +288,9 @@ class RobustBot:
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Bot Platform Capabilities" icon="sliders" href="/docs/features/bot-platform-capabilities">
+  Declare streaming, chunking, and rate-limit behaviour
+</Card>
 <Card title="Framework Adapter Plugins" icon="puzzle-piece" href="/docs/features/framework-adapter-plugins">
   Learn about extending PraisonAI with custom execution frameworks
 </Card>

--- a/docs/features/bot-rate-limiting.mdx
+++ b/docs/features/bot-rate-limiting.mdx
@@ -260,4 +260,7 @@ whatsapp_limiter = RateLimiter(RateLimitConfig(
 <Card title="Messaging Bots" icon="message-circle" href="/features/messaging-bots">
   Build bots for Telegram, Discord, Slack, and WhatsApp platforms
 </Card>
+<Card title="Bot Platform Capabilities" icon="sliders" href="/docs/features/bot-platform-capabilities">
+  How platform capabilities drive this feature
+</Card>
 </CardGroup>

--- a/docs/features/bot-streaming-replies.mdx
+++ b/docs/features/bot-streaming-replies.mdx
@@ -330,4 +330,7 @@ Even if every intermediate edit fails due to network issues or rate limits, the 
 <Card title="Messaging Bots" icon="message-circle" href="/docs/features/messaging-bots">
   Complete guide to messaging bot setup and features
 </Card>
+<Card title="Bot Platform Capabilities" icon="sliders" href="/docs/features/bot-platform-capabilities">
+  How platform capabilities drive this feature
+</Card>
 </CardGroup>

--- a/docs/features/chunking-strategies.mdx
+++ b/docs/features/chunking-strategies.mdx
@@ -215,4 +215,7 @@ This installs the chonkie library automatically.
   <Card title="RAG Agents" icon="robot" href="/features/rag">
     Build retrieval-augmented agents
   </Card>
+  <Card title="Bot Platform Capabilities" icon="sliders" href="/docs/features/bot-platform-capabilities">
+    How platform capabilities drive this feature
+  </Card>
 </CardGroup>

--- a/docs/features/messaging-bots.mdx
+++ b/docs/features/messaging-bots.mdx
@@ -1993,4 +1993,7 @@ bot.run()
   <Card title="Webhooks" icon="webhook" href="/features/webhooks">
     Event-driven integrations
   </Card>
+  <Card title="Bot Platform Capabilities" icon="sliders" href="/docs/features/bot-platform-capabilities">
+    How platform capabilities drive this feature
+  </Card>
 </CardGroup>


### PR DESCRIPTION
Fixes #641

- Add bot-platform-capabilities feature page
- Update bot-platform-plugins with capabilities API
- Cross-link streaming, rate-limit, chunking, messaging pages
- Union docs.json nav entry