### PR TITLE
docs: unified GatewayConfigSchema and gateway doctor checks (Fixes #646)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -359,6 +359,7 @@
                       "docs/features/l3-dashboard-pages",
                       "docs/features/gateway-error-handling",
                       "docs/features/gateway-flow-control",
+                      "docs/features/gateway-config-migration",
                       "docs/features/autonomy-loop",
                       "docs/features/tool-circuit-breaker",
                       "docs/features/prompt-injection-protection",

--- a/docs/best-practices/bot-security.mdx
+++ b/docs/best-practices/bot-security.mdx
@@ -7,9 +7,24 @@ icon: "shield-keyhole"
 
 Bot security enables safe deployment of PraisonAI agents across messaging channels with built-in protection against abuse and unauthorized access.
 
+<Note>
+**Secure defaults landed in PraisonAI [#2038](https://github.com/MervinPraison/PraisonAI/pull/2038).** `group_policy` now defaults to `mention_only` (was `respond_all`), and `praisonai doctor --only gateway_security` **FAIL**s on channels with no `allowed_users`, `allowlist`, or `blocklist`. Set `GATEWAY_AUTH_TOKEN` for non-loopback gateway deployments.
+</Note>
+
 <Warning>
 **Field name is `allowed_users`, not `allowlist`.** The gateway YAML parser only recognizes `allowed_users:` and `allowed_channels:`. Examples using `allowlist:` will silently produce a bot with **no enforcement**. (Fixed in [PR #1791](https://github.com/MervinPraison/PraisonAI/pull/1791).)
 </Warning>
+
+Secure baseline for new configs (passes `gateway_security`):
+
+```yaml
+channels:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+    allowed_users:                    # required for gateway_security to PASS
+      - "${TELEGRAM_OWNER_ID}"
+    # group_policy: mention_only      # default since #2038 — omit unless you need respond_all
+```
 
 ```mermaid
 graph LR
@@ -165,7 +180,7 @@ channels:
       - "123456789"  # User ID
     admin_users: ${TELEGRAM_ADMIN_USERS}
     user_allowed_commands: "help,status,whoami"
-    group_policy: "mention_only"  # Only respond when mentioned
+    # group_policy defaults to mention_only — set explicitly only if you need respond_all
 ```
 
 **Security features:**

--- a/docs/cli/doctor-cli.mdx
+++ b/docs/cli/doctor-cli.mdx
@@ -47,17 +47,35 @@ praisonai doctor config --schema
 
 ### Bot Config Checks
 
-`praisonai doctor` validates `bot.yaml` via `load_and_validate_bot_yaml` against `BotYamlSchema` for every bot-related check (`bot_tokens`, `bot_config`, `bot_security`, `multi_channel_tokens`). Common failures and fixes:
+`praisonai doctor` validates `bot.yaml` and `gateway.yaml` via `load_and_validate_gateway_yaml` against the unified `GatewayConfigSchema` (`BotYamlSchema` is an alias). Common failures and fixes:
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `Invalid bot.yaml configuration: Unknown channel 'X'. Supported: agentmail, discord, email, slack, telegram, whatsapp` | Channel key is not a recognized platform name (e.g. `telegram_cfo` instead of `telegram`). | Use only platform names as channel keys in bot.yaml, or migrate to gateway.yaml which supports custom keys with `platform:` field. |
+| `Invalid gateway/bot configuration: Unknown channel 'X'` | Channel platform not recognised. | Use a supported platform: `telegram`, `discord`, `slack`, `whatsapp`, `email`, `agentmail`, `linear`. Custom channel keys require an explicit `platform:` field. |
 | `No channels configured` | `channels:` block is empty. | Add at least one channel. Re-run `praisonai onboard` to regenerate. |
 | `Invalid mode 'X'` | Unknown transport mode. | Use one of `poll`, `ws`, `webhook`, `hybrid`. |
+| `Environment variable 'X' not set` | `${VAR}` in config is unresolved. | Export the variable or add it to `~/.praisonai/.env`. Run `praisonai doctor --only gateway_env_substitution`. |
 
-<Tip>
-The current `BotYamlSchema` requires channel keys to be platform names (`telegram`, `discord`, etc). For multi-bot setups with custom keys like `telegram_cfo`, use `gateway.yaml` instead of `bot.yaml` — gateway runtime supports custom channel keys with explicit `platform:` fields. See [Gateway Configuration](/docs/features/gateway).
-</Tip>
+<Info>
+Single-bot (`platform` + `token`), multi-channel (`agents` + `channels`), and BotOS (`platforms:`) YAML shapes all validate against the same schema. See [Gateway Config Migration](/docs/features/gateway-config-migration).
+</Info>
+
+### Gateway Doctor Checks
+
+Run individual gateway checks:
+
+```bash
+praisonai doctor --only gateway_config_validation,gateway_security
+praisonai doctor --only gateway_config_migration
+praisonai doctor --only gateway_env_substitution
+```
+
+| Check ID | Severity | What it verifies |
+|----------|----------|------------------|
+| `gateway_config_validation` | HIGH | Config file validates against `GatewayConfigSchema`. |
+| `gateway_security` | HIGH | User restrictions, tokens, and `GATEWAY_AUTH_TOKEN`. |
+| `gateway_config_migration` | MEDIUM | Legacy format migration opportunities. |
+| `gateway_env_substitution` | MEDIUM | All `${VAR}` references resolve. |
 
 ### Packaging Checks
 

--- a/docs/cli/doctor.mdx
+++ b/docs/cli/doctor.mdx
@@ -456,6 +456,10 @@ graph LR
 - Bot.yaml configuration file validation (`bot_config`)
 - Bot security configuration checks (`bot_security`)
 - Multi-channel token configuration validation (`multi_channel_tokens`)
+- Gateway config validation (`gateway_config_validation`) — **HIGH**
+- Gateway security settings (`gateway_security`) — **HIGH**
+- Gateway config migration (`gateway_config_migration`) — **MEDIUM**
+- Gateway environment variables (`gateway_env_substitution`) — **MEDIUM**
 
 #### Multi-Channel Token Check Details
 
@@ -483,3 +487,62 @@ The `multi_channel_tokens` check validates your multi-channel bot setup:
 **Sample Remediation Messages:**
 - "Each channel must have a unique bot token. Create separate bots in @BotFather and use unique environment variables."
 - "Consider following the naming convention PLATFORM_ROLE_BOT_TOKEN for clarity."
+
+#### Gateway Config Validation (`gateway_config_validation`)
+
+**Severity:** HIGH
+
+| Status | Condition |
+|--------|-----------|
+| PASS | `gateway.yaml` or `bot.yaml` validates against `GatewayConfigSchema`; message includes channel and agent counts. |
+| WARN | No config file found — suggests `praisonai onboard`. |
+| FAIL | Schema validation errors in the config file. |
+
+```bash
+praisonai doctor --only gateway_config_validation
+```
+
+#### Gateway Security (`gateway_security`)
+
+**Severity:** HIGH
+
+| Status | Condition |
+|--------|-----------|
+| PASS | Every channel has user restrictions, tokens, and no critical issues. |
+| WARN | `respond_all` group policy and/or `GATEWAY_AUTH_TOKEN` not set. |
+| FAIL | Channel has no `allowed_users`/`allowlist`/`blocklist` (open to everyone) or missing token. |
+| SKIP | No config file found. |
+
+```bash
+praisonai doctor --only gateway_security
+```
+
+#### Gateway Config Migration (`gateway_config_migration`)
+
+**Severity:** MEDIUM
+
+| Status | Condition |
+|--------|-----------|
+| PASS | Config already uses the canonical format. |
+| WARN | Legacy single-bot, BotOS `platforms:`, or string `allowed_users` detected — migration available. |
+| SKIP | No config file found. |
+
+```bash
+praisonai doctor --only gateway_config_migration
+```
+
+See [Gateway Config Migration](/docs/features/gateway-config-migration) for before/after examples.
+
+#### Gateway Environment Variables (`gateway_env_substitution`)
+
+**Severity:** MEDIUM
+
+| Status | Condition |
+|--------|-----------|
+| PASS | All `${VAR}` references in the config resolve (or none referenced). |
+| FAIL | One or more referenced environment variables are unset. |
+| SKIP | No config file found. |
+
+```bash
+praisonai doctor --only gateway_env_substitution
+```

--- a/docs/features/gateway-config-migration.mdx
+++ b/docs/features/gateway-config-migration.mdx
@@ -1,0 +1,157 @@
+---
+title: "Gateway Config Migration"
+sidebarTitle: "Config Migration"
+description: "Upgrade legacy bot.yaml and platforms: configs to the canonical schema"
+icon: "arrows-rotate"
+---
+
+PraisonAI auto-migrates legacy `bot.yaml` and BotOS `platforms:` configs to the canonical `GatewayConfigSchema` at load time — `praisonai doctor` reports migration opportunities so you can persist them.
+
+```mermaid
+graph LR
+    A[bot.yaml<br/>platform + token] --> M[🧩 Canonical Schema]
+    B[gateway.yaml<br/>agents + channels] --> M
+    C[BotOS config<br/>agent + platforms] --> M
+    M --> N[✅ Channels dict<br/>auto-normalized]
+
+    classDef legacy fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef schema fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A,B,C legacy
+    class M schema
+    class N result
+```
+
+## Quick Start
+
+<Steps>
+
+<Step title="Detect legacy format">
+
+```bash
+praisonai doctor --only gateway_config_migration
+```
+
+If your config is already canonical, you will see **PASS — Config uses current format**.
+
+</Step>
+
+<Step title="Review WARN output">
+
+Example when migration is available:
+
+```
+⚠ Gateway Config Migration [MEDIUM]
+  Config can be migrated: 2 change(s)
+  • Single-bot format can be migrated to multi-channel format
+  • telegram: allowed_users string → list migration available
+```
+
+</Step>
+
+<Step title="Persist canonical YAML">
+
+Rewrite your config to the canonical `channels:` form (see migration table below). At runtime, legacy shapes already load — persisting is optional but recommended for clarity.
+
+</Step>
+
+</Steps>
+
+---
+
+## Migration Table
+
+### Single-bot → multi-channel
+
+**Before** (legacy `bot.yaml`):
+
+```yaml
+platform: telegram
+token: ${TELEGRAM_BOT_TOKEN}
+agent:
+  name: assistant
+  instructions: "Help users"
+```
+
+**After** (canonical):
+
+```yaml
+agent:
+  name: assistant
+  instructions: "Help users"
+channels:
+  telegram:
+    platform: telegram
+    token: ${TELEGRAM_BOT_TOKEN}
+```
+
+### BotOS `platforms:` → `channels:`
+
+**Before**:
+
+```yaml
+agent:
+  name: assistant
+platforms:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+  discord:
+    token: ${DISCORD_BOT_TOKEN}
+```
+
+**After**:
+
+```yaml
+agent:
+  name: assistant
+channels:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+  discord:
+    token: ${DISCORD_BOT_TOKEN}
+```
+
+### String `allowed_users` → list
+
+**Before**:
+
+```yaml
+channels:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+    allowed_users: "123456,789012"
+```
+
+**After**:
+
+```yaml
+channels:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+    allowed_users:
+      - "123456"
+      - "789012"
+```
+
+---
+
+## Behaviour Notes
+
+- `BotYamlSchema` is an alias of `GatewayConfigSchema` — existing Python imports keep working.
+- `group_policy` defaults to `mention_only` for **new** channels without an explicit value. Configs that explicitly set `respond_all` keep that value.
+- Comma-separated `allowed_users` strings are auto-converted to lists at load time.
+- All three YAML shapes (`platform`+`token`, `agents`+`channels`, `platforms:`) validate against one schema — see [Gateway](/docs/features/gateway).
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Gateway" icon="tower-broadcast" href="/docs/features/gateway">
+    Full gateway and channel configuration reference
+  </Card>
+  <Card title="Doctor" icon="stethoscope" href="/docs/cli/doctor">
+    Gateway doctor checks and remediation
+  </Card>
+</CardGroup>

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -163,6 +163,10 @@ config = GatewayConfig(
 
 ## YAML Configuration (`gateway.yaml`)
 
+<Info>
+`bot.yaml` and `gateway.yaml` are validated by the same schema (`GatewayConfigSchema`; `BotYamlSchema` is a backward-compatible alias). Single-bot (`platform` + `token`), multi-channel (`agents` + `channels`), and BotOS (`platforms:`) formats are all accepted and normalised to a canonical `channels:` dict at load time.
+</Info>
+
 Configure the gateway with a `gateway.yaml` file for multi-platform deployment:
 
 ```yaml
@@ -273,22 +277,57 @@ channels:
 
 ### Channel Configuration Reference
 
-Every entry under `channels:` accepts these fields:
+Every entry under `channels:` is validated by `ChannelConfigSchema`:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `platform` | `str` | inferred from key | Platform name (`telegram`, `discord`, `slack`, `whatsapp`, `email`, `agentmail`). Used by gateway runtime when channel key doesn't match a platform name (e.g. `telegram_cfo`). |
+| `platform` | `str` | inferred from key | Platform name: `telegram`, `discord`, `slack`, `whatsapp`, `email`, `agentmail`, `linear`. |
 | `token` | `str` | `""` | Bot token. Supports `${ENV_VAR}` interpolation. |
-| `allowed_users` | `str` or `list[str]` | `[]` | User IDs allowed to message this channel. Can be comma-separated string (for `${ENV_VAR}`) or list. |
-| `allowed_channels` | `str` or `list[str]` | `[]` | Channel IDs where bot responds. Can be comma-separated string or list. |
+| `app_token` | `str` | `None` | Slack Socket Mode app-level token. |
+| `mode` | `str` | `"poll"` | Transport: `poll`, `ws`, `webhook`, or `hybrid`. |
 | `group_policy` | `str` | `"mention_only"` | Group chat behaviour: `respond_all`, `mention_only`, or `command_only`. |
-| `auto_approve_tools` | `bool` | `true` | Whether safe tools are automatically approved without user confirmation. |
-| `default_tools` | `list[str]` | `[]` | Default tools available to agents in this channel. |
-| `routing` / `routes` | `dict[str, str]` | `{"default": "default"}` | Context-to-agent routing — keys are `dm` / `group` / `channel` / `default`, values are agent IDs from the `agents:` block. Both field names work. |
+| `allow_silence` | `bool` | `false` | Allow the agent to return `NO_REPLY` to stay silent. |
+| `silence_token` | `str` | `None` | Custom silence token (defaults to `NO_REPLY`). |
+| `allowlist` | `list[str]` | `[]` | User IDs always allowed. |
+| `blocklist` | `list[str]` | `[]` | User IDs always blocked. |
+| `allowed_users` | `list[str]` | `[]` | User IDs allowed to message this channel (legacy comma-separated strings are auto-converted). |
+| `admin_users` | `str` | `None` | Comma-separated admin user IDs. |
+| `user_allowed_commands` | `str` | `None` | Comma-separated commands non-admin users may invoke. |
+| `routing` / `routes` | `dict[str, str]` | `{}` | Context-to-agent routing — keys are `dm` / `group` / `channel` / `default`, values are agent IDs. |
+| `webhook_url` | `str` | `None` | Webhook URL for webhook/hybrid mode. |
+| `webhook_port` | `int` | `8080` | Local webhook listener port. |
+| `streaming` | `object` | `None` | Per-channel streaming reply config (`mode`, `min_interval`, `min_delta`, `placeholder_text`, `progress_prefix`). |
+| `home_channel` | `str` | `None` | Default channel ID for this platform. |
+| `aliases` | `dict[str, str]` | `{}` | Friendly name → channel ID map. |
+| `outbound_resilience` | `object` | `None` | Retry/DLQ settings (`enabled`, `initial_ms`, `max_ms`, `factor`, `max_attempts`, `jitter`, `dlq_path`). |
+| `session` | `object` | `None` | Session config (`max_history`, `reset` policy). |
+| `max_history` | `int` | `None` | Legacy alias for `session.max_history`. |
+| `phone_number_id` | `str` | `None` | WhatsApp Cloud API phone number ID. |
+| `verify_token` | `str` | `None` | WhatsApp webhook verify token. |
+| `whatsapp_mode` | `str` | `None` | WhatsApp mode: `"cloud"` or `"web"`. |
+| `creds_dir` | `str` | `None` | WhatsApp web-mode credentials directory. |
+| `email_address` | `str` | `None` | Email channel address. |
+| `imap_server` | `str` | `None` | Email IMAP server. |
+| `smtp_server` | `str` | `None` | Email SMTP server. |
+| `inbox_id` | `str` | `None` | AgentMail inbox ID. |
+| `domain` | `str` | `None` | AgentMail domain. |
 
-<Warning>
-The above fields are read by the **gateway runtime**. For `bot.yaml` validation, only these fields are validated by schema: `token`, `mode`, `group_policy`, `allowlist`, `blocklist`, `webhook_url`, `webhook_port`. See [Bot Config Schema](/docs/cli/doctor-cli#bot-config-checks) for bot.yaml validation.
-</Warning>
+### Agent Configuration Reference
+
+Each agent under `agent:` or `agents:` is validated by `AgentConfigSchema`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | `"assistant"` | Agent display name. |
+| `instructions` | `str` | `""` | System instructions. |
+| `model` | `str` | `"gpt-4o-mini"` | LLM model ID (optional). |
+| `llm` | `str` | `None` | Alias for `model` — if set and `model` is omitted, `model` is populated from `llm`. |
+| `memory` | `bool` | `false` | Enable agent memory. |
+| `tools` | `list[str]` | `[]` | Tool names to attach. |
+| `knowledge` | `bool` or `list[str]` | `false` | Enable knowledge/RAG. |
+| `web_search` | `bool` | `false` | Enable web search. |
+| `web_search_provider` | `str` | `"duckduckgo"` | Web search provider. |
+| `auto_approve` | `bool` | `false` | Auto-approve safe tool calls. |
 
 ### Routing Rules
 

--- a/docs/guides/troubleshoot-gateway.mdx
+++ b/docs/guides/troubleshoot-gateway.mdx
@@ -800,6 +800,65 @@ praisonai gateway resume telegram
 
 ---
 
+## Config Migration
+
+When `praisonai doctor --only gateway_config_migration` reports **Config can be migrated**, your YAML uses a legacy shape that loads correctly but can be rewritten to the canonical format.
+
+<Steps>
+<Step title="Detect migration opportunities">
+
+```bash
+praisonai doctor --only gateway_config_migration
+```
+
+Example WARN output:
+
+```
+⚠ Gateway Config Migration [MEDIUM]
+  Config can be migrated: 2 change(s)
+  • telegram: allowed_users string → list migration available
+  • Set telegram.group_policy to secure default 'mention_only'
+```
+
+</Step>
+
+<Step title="Understand auto-normalisation">
+
+At load time, `GatewayConfigSchema` already normalises legacy formats — your bot runs without rewriting the file. Persist the canonical form when you want the on-disk YAML to match what the schema produces.
+
+</Step>
+
+<Step title="Apply canonical YAML">
+
+| Legacy shape | Canonical form |
+|--------------|----------------|
+| Top-level `platform` + `token` | `channels:` dict with one entry |
+| BotOS `platforms:` dict | `channels:` dict (same keys) |
+| `allowed_users: "id1,id2"` (string) | `allowed_users: ["id1", "id2"]` (list) |
+
+See [Gateway Config Migration](/docs/features/gateway-config-migration) for before/after YAML.
+
+</Step>
+</Steps>
+
+---
+
+## Environment Variables in Config
+
+Gateway and bot configs support `${VAR}` substitution in any string value. Resolution order:
+
+1. Process environment variables
+2. `~/.praisonai/.env` (loaded automatically; override path with `PRAISONAI_ENV_FILE`)
+
+```bash
+# Verify all referenced variables resolve
+praisonai doctor --only gateway_env_substitution
+```
+
+Unset variables cause validation to **FAIL** at load time and in the `gateway_env_substitution` doctor check.
+
+---
+
 ## Related
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary
- Updates `gateway.mdx` with full ChannelConfigSchema/AgentConfigSchema reference, unified schema Info block, removes stale bot.yaml warning
- Adds 4 gateway doctor checks to `doctor.mdx` and `doctor-cli.mdx`
- Updates `bot-security.mdx` with secure defaults (#2038) and baseline YAML
- Adds Config Migration and env substitution sections to `troubleshoot-gateway.mdx`
- New page: `docs/features/gateway-config-migration.mdx` registered in `docs.json`

Fixes #646

## Test plan
- [x] `docs.json` validates as JSON
- [x] No edits under `docs/concepts/`