### PR TITLE
docs: bot session reset policies (Fixes #647)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -318,6 +318,7 @@
                       "docs/features/whatsapp-bot",
                       "docs/features/linear-bot",
                       "docs/features/bot-commands",
+                      "docs/features/bot-session-reset",
                       "docs/features/bot-command-access-control",
                       "docs/features/bot-run-control",
                       "docs/features/bot-gateway",

--- a/docs/features/bot-session-reset.mdx
+++ b/docs/features/bot-session-reset.mdx
@@ -1,0 +1,205 @@
+---
+title: "Bot Session Reset"
+sidebarTitle: "Session Reset"
+description: "Automatically reset bot sessions based on idle time or daily schedule"
+icon: "rotate"
+---
+
+Session reset policies automatically clear bot conversation history after inactivity or at a scheduled time, preventing unbounded context growth.
+
+```mermaid
+graph LR
+    U[User message] --> M[BotSessionManager]
+    M --> R{_should_reset?}
+    R -->|Yes| C[Clear history]
+    R -->|No| H[Load history]
+    C --> A[Agent]
+    H --> A
+    A --> U
+
+    classDef user fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class U user
+    class M process
+    class R decision
+    class C,H,A agent
+```
+
+## Quick Start
+
+<Steps>
+
+<Step title="Idle reset after 30 minutes">
+
+```yaml
+channels:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+    session:
+      reset:
+        mode: idle
+        idle_minutes: 30
+```
+
+</Step>
+
+<Step title="Daily reset at 04:00">
+
+```yaml
+channels:
+  discord:
+    token: ${DISCORD_BOT_TOKEN}
+    session:
+      reset:
+        mode: daily
+        at_hour: 4
+```
+
+</Step>
+
+<Step title="Combined idle + daily">
+
+```yaml
+channels:
+  slack:
+    token: ${SLACK_BOT_TOKEN}
+    app_token: ${SLACK_APP_TOKEN}
+    session:
+      max_history: 100
+      reset:
+        mode: both
+        idle_minutes: 60
+        at_hour: 4
+```
+
+</Step>
+
+</Steps>
+
+---
+
+## How It Works
+
+Reset checks run in `BotSessionManager._load_history()` **before** reusing existing history:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Bot
+    participant Manager as BotSessionManager
+    participant Agent
+
+    User->>Bot: Message
+    Bot->>Manager: _load_history()
+    Manager->>Manager: _should_reset_session()
+    alt Reset needed
+        Manager->>Manager: _clear_session_data()
+        Manager-->>Bot: []
+    else Continue session
+        Manager-->>Bot: existing history
+    end
+    Bot->>Agent: run with history
+    Agent-->>User: response
+```
+
+Idle timestamps are tracked **per user**. Idle timeout uses monotonic time; daily reset uses wall-clock hour.
+
+---
+
+## Reset Modes
+
+| Mode | Behaviour |
+|------|-----------|
+| `none` | No automatic reset (default — backward compatible) |
+| `idle` | Reset after N minutes of inactivity |
+| `daily` | Reset at a specific hour each day (0–23) |
+| `both` | Combine idle and daily reset |
+
+---
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `mode` | `str` | `"none"` | One of `none`, `idle`, `daily`, `both` |
+| `idle_minutes` | `int` | `60` | Minutes of inactivity before reset (≥1). Used when mode includes `idle`. |
+| `at_hour` | `int` | `None` | Daily reset hour (0–23). **Required** when mode is `daily` or `both`. |
+| `max_history` | `int` | `100` | Maximum history entries (parent `session` block). |
+
+Configure under each channel's `session.reset` block in `gateway.yaml` or `bot.yaml`.
+
+---
+
+## Common Patterns
+
+**Customer support** — drop stale conversations when the customer leaves:
+
+```yaml
+session:
+  reset:
+    mode: idle
+    idle_minutes: 30
+```
+
+**Daily briefing bot** — fresh start each midnight:
+
+```yaml
+session:
+  reset:
+    mode: daily
+    at_hour: 0
+```
+
+**Compliance bot** — idle timeout plus nightly sweep:
+
+```yaml
+session:
+  reset:
+    mode: both
+    idle_minutes: 15
+    at_hour: 2
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Session Reset vs Session Reaper">
+**Session Reset Policy** (this feature) clears a user's *conversation history* based on idle or scheduled time — configured per channel in YAML.
+
+**Session Reaper** (`session_ttl` on `BotConfig`) prunes the *in-memory session record* of stale users. They solve different problems; use both for long-running bots.
+</Accordion>
+
+<Accordion title="Pair with max_history">
+Combine `session.max_history` with reset policies to cap context size and cost. Reset clears history entirely; `max_history` trims retained turns during an active session.
+</Accordion>
+
+<Accordion title="Manual /new command">
+Users can always send `/new` for an immediate reset. Manual reset works alongside automatic policies — see [Bot Commands](/docs/features/bot-commands).
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Messaging Bots" icon="comments" href="/docs/features/messaging-bots">
+    Multi-platform bot setup and YAML config
+  </Card>
+  <Card title="Bot Commands" icon="terminal" href="/docs/features/bot-commands">
+    Built-in /new, /help, and /status commands
+  </Card>
+  <Card title="Sessions" icon="clock-rotate-left" href="/docs/features/sessions">
+    Agent-level session management
+  </Card>
+  <Card title="Session Persistence" icon="database" href="/docs/features/session-persistence">
+    Persisting session state to disk
+  </Card>
+</CardGroup>

--- a/docs/features/messaging-bots.mdx
+++ b/docs/features/messaging-bots.mdx
@@ -976,7 +976,7 @@ Built-in commands available on all platforms:
 |---------|-------------|
 | `/help` | Show available commands and agent info |
 | `/status` | Show agent name, model, platform, and uptime |
-| `/new` | Reset conversation session — starts a fresh chat |
+| `/new` | Reset conversation session — starts a fresh chat (works alongside automatic [session reset](/docs/features/bot-session-reset) policies) |
 
 You can register custom commands programmatically:
 
@@ -1358,6 +1358,11 @@ agents:
 channels:
   telegram:
     token: "${TELEGRAM_BOT_TOKEN}"
+    session:
+      max_history: 100
+      reset:
+        mode: idle
+        idle_minutes: 60
     routing:
       dm: "personal"
       group: "support"
@@ -1860,6 +1865,33 @@ sequenceDiagram
 | One `send_action("typing")` at T+0 | Renewed every 4s for the full run |
 | Bubble vanishes at T+5s | Bubble persists until the reply is sent |
 | Users assume bot is broken, send duplicates | Users see continuous activity |
+
+---
+
+## Session Reset Policy
+
+Per-channel YAML policies automatically clear a user's **conversation history** after idle time or at a scheduled hour — configured under `session.reset` on each channel.
+
+```yaml
+channels:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+    session:
+      max_history: 100
+      reset:
+        mode: both
+        idle_minutes: 60
+        at_hour: 4
+```
+
+| Feature | What it clears | Configuration |
+|---------|----------------|---------------|
+| **Session Reset Policy** | User conversation history | `channels.*.session.reset` in YAML |
+| **Session Reaper** (below) | In-memory session records | `BotConfig(session_ttl=...)` |
+
+<Card title="Bot Session Reset" icon="rotate" href="/docs/features/bot-session-reset">
+  Idle, daily, and combined reset modes with full configuration reference
+</Card>
 
 ---
 

--- a/docs/features/sessions.mdx
+++ b/docs/features/sessions.mdx
@@ -690,6 +690,9 @@ The standalone `auto_save` parameter on `Agent(...)` is **deprecated**. Use `mem
 ## Next Steps
 
 <CardGroup cols={2}>
+  <Card icon="rotate" href="/docs/features/bot-session-reset">
+    Bot session reset policies (idle / daily)
+  </Card>
   <Card icon="brain" href="/features/advanced-memory">
     Deep dive into memory capabilities
   </Card>


### PR DESCRIPTION
Fixes #647

- New `docs/features/bot-session-reset.mdx`
- Updated `messaging-bots.mdx` with session.reset YAML and Session Reset vs Reaper distinction
- Registered in docs.json; linked from sessions.mdx