### PR TITLE
docs: PR #1980 fixes (Fixes #650)

### DIFF
--- a/docs/features/bot-run-control.mdx
+++ b/docs/features/bot-run-control.mdx
@@ -56,6 +56,10 @@ While the bot is working, send `/stop` to cancel the current task. The bot respo
 
 ## How It Works
 
+<Note>
+Fixed in [PR #1980](https://github.com/MervinPraison/PraisonAI/pull/1980) (release after 2026-06-19): earlier releases wired the interrupt controller to the wrong attribute, so `/stop` and `busy_mode="interrupt"` silently had no effect. Queued follow-ups were surfaced in metadata but never drained — upgrade to pick up the fix.
+</Note>
+
 ```mermaid
 sequenceDiagram
     participant User
@@ -79,9 +83,11 @@ sequenceDiagram
     Bot-->>User: "✅ task cancelled"
     
     Agent-->>Bot: processing complete
-    Bot->>RunControl: next_pending()
-    RunControl-->>Bot: "actually focus on AI"
-    Bot->>Agent: start new task
+    loop Drain pending queue
+        Bot->>RunControl: next_pending()
+        RunControl-->>Bot: queued message (or none)
+        Bot->>Agent: start new task
+    end
 ```
 
 When `run_timeout` is exceeded (default 300 seconds), `BotSessionManager` raises `BotRunTimeout` and cancels the in-flight run. Timeout failures are **not** pushed to the DLQ, so slow agents do not retry in a loop.
@@ -139,6 +145,22 @@ bot = TelegramBot(
 | `busy_ack` | `str` | `"⏳ {action} — will be considered next"` | Template for busy acknowledgment. `{action}` is replaced with `"noted"` (queued) or `"added to pending request"` (merged). |
 | `run_timeout` | `float` | `300.0` | Maximum seconds a single agent run may take before it is cancelled with `BotRunTimeout`. Set to `0` or a negative value to disable. Applies to both streaming (`agent.astart`) and non-streaming (`agent.chat`) paths. |
 
+### Run metadata
+
+`chat_with_run_control` returns `{"response": str, "metadata": dict}`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `run_control` | `bool` | Always `True` when run control was active. |
+| `decision` | `str` | Initial decision: `"RUN_NOW"`, `"QUEUED"`, or `"INTERRUPTED"`. |
+| `completed` | `bool` | `True` after the run and drain loop finish cleanly. |
+| `run_generation` | `int` | Generation counter for race protection. |
+| `pending_processed` | `list[str]` | Queued follow-ups drained after the initial run (each truncated to 100 chars). Present only when at least one was processed. |
+| `interrupted` | `bool` | `True` if the run was cancelled mid-way. |
+| `reason` | `str` | Cancellation reason (when `interrupted` is `True`). |
+
+Queue drain implemented in [PR #1980](https://github.com/MervinPraison/PraisonAI/pull/1980).
+
 ### Programmatic cancellation
 
 `BotSessionManager` exposes cancellation for admin hooks or custom integrations:
@@ -183,7 +205,7 @@ agent = Agent(
 bot = TelegramBot(
     token="YOUR_TOKEN",
     agent=agent,
-    busy_mode="queue",  # Preserves work, processes follow-ups in order
+    busy_mode="queue",  # Preserves work — all follow-ups drained in order after each run
     busy_ack="📚 Research noted — {action}. Will incorporate after analysis."
 )
 

--- a/docs/features/context-compaction.mdx
+++ b/docs/features/context-compaction.mdx
@@ -1006,6 +1006,10 @@ Best used for:
 - Feature development ("payment integration")
 </Accordion>
 
+<Accordion title="System-only overflow no longer hangs">
+Since [PR #1980](https://github.com/MervinPraison/PraisonAI/pull/1980), `_truncate()` exits cleanly when only system messages remain over budget — previously this could loop indefinitely. The trade-off: when your system prompt alone exceeds `target_tokens`, post-compaction count may stay over target rather than dropping system messages.
+</Accordion>
+
 <Accordion title="Best practices for long-running agents">
 - Keep `enable_iterative_summary=True` (default) for context preservation
 - Use `focus_topic` when discussing specific technical areas

--- a/docs/features/inbound-journal.mdx
+++ b/docs/features/inbound-journal.mdx
@@ -60,6 +60,10 @@ You don't need to call `complete()` yourself when using `BotSessionManager.chat(
 
 ## How It Works
 
+<Note>
+Before [PR #1980](https://github.com/MervinPraison/PraisonAI/pull/1980), the default `chat()` path claimed entries but never called `complete()`. On startup, `journal.replay()` could re-issue messages the user had already received answers to. Upgrade to a release after 2026-06-19 — replay then only covers genuinely incomplete entries.
+</Note>
+
 ```mermaid
 sequenceDiagram
     participant Platform as Telegram/Discord/Slack

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -365,6 +365,10 @@ be reconfigured to write inside the sandbox root.
   </Accordion>
 </AccordionGroup>
 
+### FileMemory `user_id` sanitisation
+
+`FileMemory(user_id=...)` strips whitespace, rejects path-traversal characters, and uses the sanitised value for both the in-memory `user_id` and the on-disk `user_path`. Empty or whitespace-only inputs fall back to `"default"`. Fix landed in [PR #1980](https://github.com/MervinPraison/PraisonAI/pull/1980) — earlier releases used the raw input for the path, so `user_id="  alice  "` could write to a different directory than `mem.user_id` reported.
+
 ## Secure Implementation Guide
 
 ### Pattern 1: Secure Multi-Agent Workflow


### PR DESCRIPTION
Fixes #650

- bot-run-control: drain loop diagram, metadata table, PR #1980 note
- inbound-journal: complete() fix note
- context-compaction: system-only truncate note
- security.mdx: FileMemory user_id sanitisation

run.mdx/session.mdx covered by #649 (PR #1963).