### PR TITLE
Fixes #653: align tool resolution docs with PR #2059

### DIFF
--- a/docs/cli/recipes.mdx
+++ b/docs/cli/recipes.mdx
@@ -17,6 +17,10 @@ Run pre-built AI-powered workflows (recipes) directly from the command line.
 Recipes shipped with PraisonAI are trusted, but if you run a third-party or remotely fetched recipe, its `tools.py` will only execute if you have explicitly set `PRAISONAI_ALLOW_TEMPLATE_TOOLS=1`. This default-deny behaviour was introduced in PR #1579 (GHSA-xcmw-grxf-wjhj). Always inspect a recipe's `tools.py` before opting in. See [Security Environment Variables](/docs/features/security-environment-variables#praisonai_allow_template_tools) for details.
 </Warning>
 
+<Note>
+Tools registered via the wrapper `ToolRegistry`, shipped by `praisonai-tools`, or provided by core SDK plugins are now reachable from recipe `tools:` lists (PR #2059). Previously these worked only in the main agent build path. See [Tool Resolver](/docs/features/tool-resolver).
+</Note>
+
 ## List Available Recipes
 
 ```bash

--- a/docs/cli/tools-override.mdx
+++ b/docs/cli/tools-override.mdx
@@ -64,6 +64,10 @@ registry = create_tool_registry_with_overrides(
 # 2. Override directories
 # 3. Default custom dirs (~/.praisonai/tools)
 # 4. Built-in tools
+#
+# resolve_tools() delegates name resolution to ToolResolver (PR #2059),
+# so the override registry sits on top of the canonical five-source chain.
+# See /docs/features/tool-resolver for the full chain.
 ```
 
 ## Default Custom Tool Directories

--- a/docs/cli/tools-resolve.mdx
+++ b/docs/cli/tools-resolve.mdx
@@ -3,6 +3,14 @@ title: "Tools Resolve"
 description: "Resolve a tool name to its source location"
 ---
 
+`resolve_tools()` from `praisonai.templates.tool_override` delegates name resolution to the canonical [`ToolResolver`](/docs/features/tool-resolver). It preserves the `registry=` override layer and the `PRAISONAI_ALLOW_TEMPLATE_TOOLS` security gate for template-dir `tools.py` autoload, then falls back to name-variation matching (lowercase, `_`/`-`, `_tool`, `Tool` suffix) when the canonical lookup misses.
+
+Tools previously invisible to recipe/template resolution are now reachable:
+
+- Wrapper `ToolRegistry.register_function()` registrations
+- Tools from the `praisonai-tools` external package
+- Core SDK plugin-registered tools
+
 ## Code Usage
 
 ```python
@@ -41,7 +49,9 @@ tools = resolve_tools(["my_custom_tool"], registry=registry)
 ## Related
 
 <Note>
-**Alternative Tool Resolution:** For YAML-based tool resolution with per-agent isolation, see [YAML Tools - Tool Resolver](/docs/tools/yaml-tools#per-agent-tool-resolution) which uses the `praisonai.tool_resolver` module. The API documented on this page uses `praisonai.templates.tool_override` for template-based tool overrides.
+**Canonical resolution chain:** `resolve_tools()` is a thin wrapper around [`ToolResolver`](/docs/features/tool-resolver) with a registry-override layer on top. See [Templates Module → Tool Override](/docs/sdk/praisonai/templates#tool-override-integration) for programmatic usage.
 
-**CLI flag (`--tools name1,name2`)** also now goes through `praisonai.tool_resolver.ToolResolver` (PR #1857). See [Tool Resolver](/docs/features/tool-resolver) for the canonical 5-source chain.
+**Alternative Tool Resolution:** For YAML-based tool resolution with per-agent isolation, see [YAML Tools - Tool Resolver](/docs/tools/yaml-tools#per-agent-tool-resolution) which uses the `praisonai.tool_resolver` module directly.
+
+**CLI flag (`--tools name1,name2`)** also goes through `praisonai.tool_resolver.ToolResolver` (PR #1857). Recipe and template `tools:` lists share the same five-source chain as of PR #2059.
 </Note>

--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -77,24 +77,30 @@ Tools are resolved in a specific order, with the first match winning:
 graph TB
     Search[🔍 Tool Search] --> Step1{1. Local tools.py}
     Step1 -->|Found| Success1[✅ Return tool]
-    Step1 -->|Not found| Step2{2. praisonaiagents.tools}
+    Step1 -->|Not found| Step2{2. Wrapper ToolRegistry}
     Step2 -->|Found| Success2[✅ Return tool]
-    Step2 -->|Not found| Step3{3. praisonai-tools package}
-    Step3 -->|Found| Success3[✅ Return tool] 
-    Step3 -->|Not found| Step4{4. Tool registry}
+    Step2 -->|Not found| Step3{3. praisonaiagents.tools}
+    Step3 -->|Found| Success3[✅ Return tool]
+    Step3 -->|Not found| Step4{4. praisonai-tools package}
     Step4 -->|Found| Success4[✅ Return tool]
-    Step4 -->|Not found| NotFound[❌ Tool not found]
+    Step4 -->|Not found| Step5{5. Core SDK plugins}
+    Step5 -->|Found| Success5[✅ Return tool]
+    Step5 -->|Not found| NotFound[❌ Tool not found]
     
     classDef step fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef success fill:#10B981,stroke:#7C90A0,color:#fff
     classDef notfound fill:#8B0000,stroke:#7C90A0,color:#fff
     
-    class Step1,Step2,Step3,Step4 step
-    class Success1,Success2,Success3,Success4 success
+    class Step1,Step2,Step3,Step4,Step5 step
+    class Success1,Success2,Success3,Success4,Success5 success
     class NotFound notfound
 ```
 
-CLI, YAML, and Python all share this resolution chain. See [CLI Reference](/docs/cli/cli-reference) for `--tools` usage.
+CLI, YAML, recipes, templates, and Python all share this resolution chain. See [CLI Reference](/docs/cli/cli-reference) for `--tools` usage.
+
+<Note>
+**One resolution chain for every surface.** Whether you load tools via the CLI `--tools` flag, a YAML `tools:` list in `agents.yaml`, a recipe's `tools:` list, or `Agent(tools=[...])` in Python, PraisonAI walks the same five-source chain: local `tools.py` → wrapper `ToolRegistry` → `praisonaiagents.tools` → `praisonai-tools` → core SDK plugins. Tools registered through any of these become visible everywhere — no more "works in Python but not in the recipe."
+</Note>
 
 ---
 
@@ -164,9 +170,9 @@ The wrapper now invokes `resolve()` once per YAML-referenced tool name, with res
 
 Directory mode iterates each `.py` file and unions the results using the same security gates and extraction logic.
 
-### CLI uses the same resolver (PR #1857)
+### CLI and recipes use the same resolver (PR #1857, PR #2059)
 
-`praisonai --tools tavily_search,my_tool "..."` now goes through `ToolResolver.resolve(name, instantiate=True)`, identical to the YAML path. The CLI `_load_tools()` helper used to call `getattr(praisonaiagents.tools, name)` directly, which skipped the wrapper `ToolRegistry`, the optional `praisonai-tools` package, and core SDK plugin sources. Those sources are now reachable from the CLI.
+`praisonai --tools tavily_search,my_tool "..."` goes through `ToolResolver.resolve(name, instantiate=True)`, identical to the YAML path. Recipe and template tool loading via `resolve_tools()` also delegates to `ToolResolver` (PR #2059), so wrapper `ToolRegistry` registrations, `praisonai-tools` package tools, and core SDK plugin tools are reachable from recipes and templates — not just the agent build path.
 
 ---
 
@@ -661,6 +667,9 @@ export PRAISONAI_ALLOW_LOCAL_TOOLS=true
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Tools Resolve (CLI)" icon="terminal" href="/docs/cli/tools-resolve">
+  Recipe and template tool resolution via resolve_tools()
+</Card>
 <Card title="ToolRegistry API Reference" icon="code" href="/docs/sdk/reference/praisonai/classes/ToolRegistry">
   Complete API reference for ToolRegistry
 </Card>

--- a/docs/sdk/praisonai/templates.mdx
+++ b/docs/sdk/praisonai/templates.mdx
@@ -88,6 +88,8 @@ registry = create_tool_registry_with_overrides(
 tools = resolve_tools(["shell_tool"], registry=registry)
 ```
 
+`resolve_tools()` delegates name resolution to [`ToolResolver`](/docs/features/tool-resolver) (PR #2059). The `registry=` argument is preserved for backward compatibility — it sits on top of the canonical five-source chain (local `tools.py` → wrapper `ToolRegistry` → `praisonaiagents.tools` → `praisonai-tools` → core SDK plugins). See [Tools Resolve](/docs/cli/tools-resolve) for CLI usage.
+
 ## TEMPLATE.yaml Schema
 
 ```yaml


### PR DESCRIPTION
## Summary

- Update `tool-resolver.mdx` five-source resolution diagram and unified-surface callout
- Document `resolve_tools()` → `ToolResolver` delegation on `tools-resolve`, `templates`, `recipes`, and `tools-override` pages
- Bidirectional cross-links between feature, CLI, and SDK reference pages

## Test plan

- [x] Five-source chain wording consistent across updated pages
- [x] `PRAISONAI_ALLOW_TEMPLATE_TOOLS` gate described as unchanged
- [x] No new pages; no `docs.json` changes required


Made with [Cursor](https://cursor.com)