### PR TITLE
docs: PR #2069 behaviour updates (Fixes #656)

### DIFF
--- a/docs/concepts/approval.mdx
+++ b/docs/concepts/approval.mdx
@@ -7,6 +7,10 @@ icon: "shield-check"
 
 Route tool approvals to Slack, Discord, Telegram, a webhook, or a local dashboard. Agents pause before executing dangerous tools and wait for human approval via your chosen platform.
 
+<Info>
+**This page covers tool approval** — asking a human before running dangerous tools such as `execute_command` or `delete_file`. **Plan approval** (used by `planning=True`) is a separate system; see [Planning › Non-interactive environments](/concepts/planning#non-interactive-environments).
+</Info>
+
 ```python
 from praisonaiagents import Agent
 from praisonai.bots import SlackApproval
@@ -493,6 +497,9 @@ registry.remove_requirement("crawl")
   </Card>
   <Card title="CLI Tool Approval" icon="terminal" href="/cli/tool-approval">
     `--trust`, `--approve-level`, and `--approval` CLI flags
+  </Card>
+  <Card title="Planning" icon="list-check" href="/concepts/planning">
+    Plan approval and non-interactive auto-approve
   </Card>
   <Card title="Messaging Bots" icon="robot" href="/features/messaging-bots">
     Telegram, Discord, Slack, WhatsApp bots

--- a/docs/concepts/planning.mdx
+++ b/docs/concepts/planning.mdx
@@ -125,8 +125,44 @@ config = PlanningConfig(
 | `llm` | `str` | `None` | LLM model for planning (uses agent's LLM if not set) |
 | `tools` | `list` | `None` | Tools available during planning phase |
 | `reasoning` | `bool` | `False` | Show reasoning process |
-| `auto_approve` | `bool` | `False` | Auto-approve plans without confirmation |
+| `auto_approve` | `bool` | `False` | Auto-approve plans without confirmation. In non-interactive environments (no TTY on `stdin`), plans are auto-approved even when this is `False`. |
 | `read_only` | `bool` | `False` | Only allow read operations |
+
+### Non-interactive environments
+
+<Note id="non-interactive-environments">
+**Plans auto-approve in non-interactive environments.** When `stdin` is not a TTY — CI runners, cron jobs, Docker containers, GitHub Actions, or piped scripts — the default approval handler automatically approves every plan and execution continues. In an interactive terminal, the agent still prompts as before.
+</Note>
+
+```mermaid
+flowchart TD
+    Plan[Plan ready] --> TTY{stdin is TTY?}
+    TTY -->|Yes| Prompt[Prompt user]
+    TTY -->|No| Auto[Auto-approve]
+    Prompt --> Execute[Execute plan]
+    Auto --> Execute
+
+    classDef phase fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Plan phase
+    class TTY,Prompt,Auto decision
+    class Execute result
+```
+
+Force explicit approval everywhere (e.g. fail CI instead of auto-approving):
+
+```python
+import sys
+from praisonaiagents.planning import ApprovalCallback
+
+def deny_non_interactive(plan):
+    return sys.stdin is not None and sys.stdin.isatty()
+
+handler = ApprovalCallback(approve_fn=deny_non_interactive)
+# Pass handler into your planning flow where ApprovalCallback is accepted
+```
 
 ---
 

--- a/docs/concepts/reflection.mdx
+++ b/docs/concepts/reflection.mdx
@@ -91,6 +91,10 @@ sequenceDiagram
     Agent-->>User: Final response
 ```
 
+<Note>
+**Streaming behaviour:** Reflection regeneration always runs **non-streaming**, even when `stream=True` on the agent. The final answer still streams normally. This keeps `AgentTeam` and sync LLM adapters reliable during regeneration passes.
+</Note>
+
 ### The Reflection Process
 
 | Phase | What Happens | Purpose |
@@ -284,6 +288,10 @@ graph LR
   
   <Accordion title="Combine with planning for complex tasks">
     Use planning to break down the task, then reflection to ensure quality output.
+  </Accordion>
+
+  <Accordion title="Can I combine reflection=True with stream=True?">
+    Yes. Only the intermediate reflection passes are forced to non-streaming; the framework handles this for you and the final response still streams when `stream=True`.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/concepts/web.mdx
+++ b/docs/concepts/web.mdx
@@ -7,6 +7,17 @@ icon: "globe"
 
 Web capabilities let agents search the internet and fetch page content to answer questions with up-to-date information.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="News Agent",
+    instructions="Answer with up-to-date web results",
+    web="duckduckgo",  # search only — no API key
+)
+agent.start("What are today's AI headlines?")
+```
+
 ```mermaid
 graph LR
     subgraph "Web Capabilities"
@@ -137,6 +148,42 @@ config = WebConfig(
 | `search_config` | `dict` | `{}` | Provider config |
 | `fetch_config` | `dict` | `{}` | Fetch config |
 
+<Warning>
+**Provider preset strings disable fetch by default.** Passing a provider name as a string (e.g. `web="duckduckgo"`, `web="tavily"`) enables **search only** so the tool set stays compatible with OpenAI models. Enable fetch explicitly with `WebConfig(search=True, fetch=True, search_provider="duckduckgo")` or use `web=True` for both.
+</Warning>
+
+---
+
+## Choosing the right form
+
+```mermaid
+flowchart TD
+    Start([Need web tools?]) --> Q1{Provider string?}
+    Q1 -->|web="duckduckgo" etc.| SearchOnly[Search only]
+    Q1 -->|web="fetch_only"| FetchOnly[Fetch only]
+    Q1 -->|web=True| Both[Search + fetch]
+    Q1 -->|WebConfig(...)| Custom[Explicit flags]
+
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef choice fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Start start
+    class Q1 choice
+    class SearchOnly,FetchOnly,Both,Custom result
+```
+
+| Form | Search | Fetch |
+|------|--------|-------|
+| `web="duckduckgo"` | ✅ | ❌ |
+| `web="tavily"` | ✅ | ❌ |
+| `web="google"` | ✅ | ❌ |
+| `web="bing"` | ✅ | ❌ |
+| `web="serper"` | ✅ | ❌ |
+| `web="search_only"` | ✅ | ❌ |
+| `web="fetch_only"` | ❌ | ✅ |
+| `web=True` or `WebConfig(search=True, fetch=True)` | ✅ | ✅ |
+
 ---
 
 ## Search Providers
@@ -168,7 +215,15 @@ graph LR
 ### Using Different Providers
 
 ```python
-# DuckDuckGo (default, free)
+# Provider string — search only (default for presets)
+agent = Agent(web="duckduckgo")
+
+# Search + fetch explicitly
+agent = Agent(
+    web=WebConfig(search=True, fetch=True, search_provider="duckduckgo")
+)
+
+# DuckDuckGo via WebConfig (search only unless fetch=True)
 agent = Agent(
     web=WebConfig(search_provider="duckduckgo")
 )


### PR DESCRIPTION
## Summary
- Reflection: document non-streaming regeneration passes with `stream=True`.
- Web: provider preset strings disable fetch by default; decision table added.
- Planning: non-interactive auto-approve + `ApprovalCallback` opt-out example.
- Approval: distinguish tool approval from plan approval.

Fixes #656

Refs MervinPraison/PraisonAI#2069