### PR TITLE
docs: ExecutionConfig tool retry & backoff (Fixes #665)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -489,6 +489,7 @@
                   "docs/features/async-tool-safety",
                   "docs/features/concurrency",
                   "docs/features/tool-retry-policy",
+                  "docs/features/tool-retry-backoff",
                   "docs/features/agent-retry",
                   "docs/features/guardrails",
                   "docs/features/loop-guardrails",

--- a/docs/configuration/execution-config.mdx
+++ b/docs/configuration/execution-config.mdx
@@ -108,7 +108,10 @@ config = ExecutionConfig(
 | `max_iter` | `int` | `20` | Maximum tool-calling iterations. Now propagated to the `LLM` instance, so it controls every internal loop (previously some loops were hardcoded to 5/10/20/50). Both the `ExecutionConfig` default and the `LLM`-direct-construction default are `20` (aligned as of PR #1898). |
 | `max_rpm` | `int \| None` | `None` | Max requests per minute (rate limit) |
 | `max_execution_time` | `int \| None` | `None` | Max execution time in seconds |
-| `max_retry_limit` | `int` | `2` | Max retries on failure |
+| `max_retry_limit` | `int` | `2` | Max retries for retryable tool failures and guardrail validation failures. Total attempts = `1 + max_retry_limit`. Retries use exponential backoff with jitter (see `retry_initial_delay`, `retry_backoff_factor`, `retry_jitter`). |
+| `retry_initial_delay` | `float` | `1.0` | First retry delay in seconds. Subsequent delays grow exponentially. Must be `> 0`. |
+| `retry_backoff_factor` | `float` | `2.0` | Multiplier applied each attempt (`base = initial × factor^(attempt−1)`). Must be `>= 1.0`. |
+| `retry_jitter` | `float` | `0.1` | Random jitter added as a fraction of the base delay. Must be `>= 0`. |
 | `max_tool_calls_per_turn` | `int` | `10` | Maximum tool calls allowed in a single chat turn. When exceeded, execution stops with a clear message instead of looping forever. |
 | `context_compaction` | `bool \| ContextCompactionPolicy` | `False` | Proactive context-overflow protection. `True` uses the `BALANCED_POLICY` preset. Pass a `ContextCompactionPolicy` instance for custom routing. **Default flips to `True` in the next release** — a `DeprecationWarning` is emitted today when left at `False`. See [Context Compaction Policy](/features/context-compaction-policy). |
 | `max_budget` | `float \| None` | `None` | Hard USD cap per agent run. `None` = no limit. |
@@ -116,7 +119,13 @@ config = ExecutionConfig(
 
 <Note>
 For simple budget limits, use the `Agent(max_budget=...)` convenience parameter instead of importing `ExecutionConfig`. See [Agent max_budget](/docs/features/agent-max-budget) for details.
+
+These retry settings apply to both tool execution and guardrail validation retries.
 </Note>
+
+<Warning>
+Invalid values raise `ValueError`: `retry_initial_delay` must be `> 0`, `retry_backoff_factor` must be `>= 1.0`, `retry_jitter` must be `>= 0`.
+</Warning>
 
 ---
 
@@ -167,6 +176,32 @@ agent = Agent(
 )
 # The agent's LLM will respect 15 iterations in all internal loops
 ```
+
+---
+
+## Tool Retry & Exponential Backoff
+
+Tool and guardrail retries use exponential backoff with jitter so transient failures recover without hammering APIs.
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Tool
+    Agent->>Tool: Call
+    Tool-->>Agent: Retryable failure
+    Note over Agent: wait delay₁ (~1.0s)
+    Agent->>Tool: Retry
+    Tool-->>Agent: Retryable failure
+    Note over Agent: wait delay₂ (~2.0s)
+    Agent->>Tool: Retry
+    Tool-->>Agent: Success
+```
+
+Delay formula: `delay = min(initial_delay × factor^(attempt−1), 60s) + random(0, jitter × base)`.
+
+With defaults (`retry_initial_delay=1.0`, `retry_backoff_factor=2.0`), three retries wait roughly **1.0s**, **2.0s**, **4.0s** (plus up to 10% jitter).
+
+See [Tool Retry & Backoff](/docs/features/tool-retry-backoff) for retry classification and patterns.
 
 ---
 
@@ -252,7 +287,9 @@ agent = Agent(
     instructions="Handle failures gracefully",
     execution=ExecutionConfig(
         max_retry_limit=5,
-        max_iter=30
+        retry_initial_delay=0.5,
+        retry_backoff_factor=2.0,
+        retry_jitter=0.2,
     )
 )
 ```
@@ -314,5 +351,8 @@ Adjust `max_tool_calls_per_turn` based on your tools: lower for experimental too
 </Card>
 <Card title="Structured LLM Errors" icon="circle-alert" href="/features/structured-llm-errors">
   LLM error handling and retry policies
+</Card>
+<Card title="Tool Retry & Backoff" icon="rotate" href="/docs/features/tool-retry-backoff">
+  Exponential backoff for tool and guardrail retries
 </Card>
 </CardGroup>

--- a/docs/configuration/index.mdx
+++ b/docs/configuration/index.mdx
@@ -97,7 +97,10 @@ This section provides comprehensive documentation for all configuration options 
 | Component | Parameter | Type | Description |
 |-----------|-----------|------|-------------|
 | Agent | `max_iter` | int | Maximum iterations for task completion |
-| Agent | `max_retry_limit` | int | Maximum retries for failed operations |
+| Agent | `max_retry_limit` | int | Max retries for retryable tool and guardrail failures (`1 + limit` total attempts) |
+| Agent | `retry_initial_delay` | float | First retry delay in seconds (exponential backoff) |
+| Agent | `retry_backoff_factor` | float | Backoff multiplier per retry attempt |
+| Agent | `retry_jitter` | float | Jitter fraction added to each retry delay |
 | Task | `task_type` | str | Type of task execution |
 | Memory | `quality_threshold` | float | Minimum quality score for memory retrieval |
 | LLM | `timeout` | int | Request timeout in seconds |

--- a/docs/features/config-file.mdx
+++ b/docs/features/config-file.mdx
@@ -177,6 +177,9 @@ metrics = false
 [defaults.execution]
 max_iter = 20
 max_retry_limit = 2
+# retry_initial_delay = 1.0
+# retry_backoff_factor = 2.0
+# retry_jitter = 0.1
 ```
 </Tab>
 </Tabs>
@@ -452,6 +455,9 @@ metrics = false
 [defaults.execution]
 max_iter = 20
 max_retry_limit = 2
+# retry_initial_delay = 1.0
+# retry_backoff_factor = 2.0
+# retry_jitter = 0.1
 
 [defaults.caching]
 enabled = true

--- a/docs/features/tool-retry-backoff.mdx
+++ b/docs/features/tool-retry-backoff.mdx
@@ -1,0 +1,194 @@
+---
+title: "Tool Retry & Backoff"
+sidebarTitle: "Tool Retry & Backoff"
+description: "Automatically retry failing tool calls with exponential backoff and jitter"
+icon: "rotate"
+---
+
+`ExecutionConfig` retry settings re-run retryable tool failures and guardrail validation errors with exponential backoff and jitter.
+
+```mermaid
+graph LR
+    Request[📝 Request] --> Tool[🔧 Tool]
+    Tool -->|Fail| Backoff[⏱️ Backoff]
+    Backoff --> Retry[🔄 Retry]
+    Retry -->|Success| Done[✅ Done]
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+
+    class Request,Done agent
+    class Tool,Backoff,Retry tool
+```
+
+## Quick Start
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Resilient Agent",
+    instructions="Fetch data from flaky APIs",
+    tools=[my_flaky_tool],
+    max_retry_limit=3,  # Retries with backoff are automatic
+)
+agent.start("Get me the latest report")
+```
+
+Fine-tune backoff via `ExecutionConfig`:
+
+```python
+from praisonaiagents import Agent, ExecutionConfig
+
+agent = Agent(
+    name="Resilient Agent",
+    instructions="Fetch data from flaky APIs",
+    tools=[my_flaky_tool],
+    execution=ExecutionConfig(
+        max_retry_limit=3,
+        retry_initial_delay=0.5,
+        retry_backoff_factor=2.0,
+        retry_jitter=0.2,
+    ),
+)
+```
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Tool
+    Agent->>Tool: Attempt 1
+    Tool-->>Agent: Retryable error
+    Note over Agent: delay = min(1.0 × 2^0, 60s) + jitter
+    Agent->>Tool: Attempt 2
+    alt Non-retryable error
+        Tool-->>Agent: Return error as-is
+    else Retryable + under limit
+        Tool-->>Agent: Success or retry again
+    end
+```
+
+Total attempts = `1 + max_retry_limit`. Default `max_retry_limit=2` → up to **3** attempts.
+
+Delay: `min(initial_delay × factor^(attempt−1), 60s) + random(0, jitter × base)`.
+
+---
+
+## Choosing Your Settings
+
+```mermaid
+graph TB
+    Q{Use case?} -->|Rate-limited API| A[Higher initial_delay + jitter]
+    Q -->|Flaky network| B[Higher max_retry_limit]
+    Q -->|Deterministic tools| C[max_retry_limit=0]
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+
+    class Q agent
+    class A,B,C tool
+```
+
+---
+
+## Configuration
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `max_retry_limit` | `int` | `2` | Max retries after the first attempt |
+| `retry_initial_delay` | `float` | `1.0` | First retry delay (seconds) |
+| `retry_backoff_factor` | `float` | `2.0` | Exponential multiplier per attempt |
+| `retry_jitter` | `float` | `0.1` | Jitter fraction of base delay |
+
+<Note>
+For per-tool `RetryPolicy` overrides, see [Tool Retry Policy](/docs/features/tool-retry-policy).
+</Note>
+
+---
+
+## What Gets Retried
+
+| Outcome | Retried? |
+|---|---|
+| Tool timeouts | ✅ |
+| Circuit breaker open | ✅ |
+| Unexpected exceptions (not `ValueError` / `TypeError` / `AttributeError`) | ✅ |
+| Guardrail validation failures | ✅ |
+| Tool returns `{"error": ...}` without `timeout` / `circuit_open` | ❌ |
+| Programming errors (`ValueError`, `TypeError`, `AttributeError`) | ❌ |
+
+---
+
+## Common Patterns
+
+**Disable retries:**
+
+```python
+agent = Agent(name="strict", max_retry_limit=0)
+```
+
+**Rate-limited APIs:**
+
+```python
+execution=ExecutionConfig(
+    max_retry_limit=4,
+    retry_initial_delay=2.0,
+    retry_backoff_factor=3.0,
+    retry_jitter=0.3,
+)
+```
+
+**Low-latency tools:**
+
+```python
+execution=ExecutionConfig(
+    max_retry_limit=2,
+    retry_initial_delay=0.1,
+    retry_backoff_factor=1.5,
+)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Set jitter for parallel agents">
+Jitter spreads retry timing across agents and reduces thundering-herd spikes on shared APIs.
+</Accordion>
+
+<Accordion title="Don't retry programming errors">
+`ValueError`, `TypeError`, and `AttributeError` are treated as code bugs and are not retried.
+</Accordion>
+
+<Accordion title="Backoff is capped at 60s">
+Very large backoff factors cannot exceed a 60-second base delay per attempt.
+</Accordion>
+
+<Accordion title="Guardrails share these settings">
+Guardrail validation retries use the same `ExecutionConfig` backoff values.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="ExecutionConfig" icon="gauge-high" href="/docs/configuration/execution-config">
+  Full execution configuration reference
+</Card>
+<Card title="Guardrails" icon="shield" href="/docs/features/guardrails">
+  Input and output validation
+</Card>
+<Card title="Loop Guardrails" icon="shield-halved" href="/docs/features/loop-guardrails">
+  Cap tool calls per turn
+</Card>
+<Card title="Structured LLM Errors" icon="circle-alert" href="/docs/features/structured-llm-errors">
+  LLM-level retry and error handling
+</Card>
+</CardGroup>

--- a/docs/sdk/praisonaiagents/agent/agent.mdx
+++ b/docs/sdk/praisonaiagents/agent/agent.mdx
@@ -13,7 +13,7 @@ The core class for AI agents with tools, memory, knowledge, and handoffs.
 | Cluster | Legacy Params | Consolidated To | Status |
 |---------|---------------|-----------------|--------|
 | Output | `verbose`, `markdown`, `stream`, `metrics`, `reasoning_steps` | `output=` | ✅ |
-| Execution | `max_iter`, `max_rpm`, `max_execution_time`, `max_retry_limit` | `execution=` | ✅ |
+| Execution | `max_iter`, `max_rpm`, `max_execution_time`, `max_retry_limit`, `retry_initial_delay`, `retry_backoff_factor`, `retry_jitter` | `execution=` | ✅ |
 | Memory | `memory`, `auto_memory`, `claude_memory`, `user_id`, `session_id`, `db` | `memory=` | ✅ |
 | Knowledge | `knowledge`, `retrieval_config`, `embedder_config` | `knowledge=` | ✅ |
 | Planning | `planning`, `plan_mode`, `planning_tools`, `planning_reasoning` | `planning=` | ✅ |

--- a/docs/sdk/praisonaiagents/config/index.mdx
+++ b/docs/sdk/praisonaiagents/config/index.mdx
@@ -162,7 +162,10 @@ agent = Agent(instructions="...", execution="thorough")
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `max_iter` | `int` | `20` | Maximum iterations |
-| `max_retry_limit` | `int` | `3` | Maximum retries on failure |
+| `max_retry_limit` | `int` | `2` | Max retries for retryable tool and guardrail failures |
+| `retry_initial_delay` | `float` | `1.0` | First retry delay (seconds) |
+| `retry_backoff_factor` | `float` | `2.0` | Exponential backoff multiplier |
+| `retry_jitter` | `float` | `0.1` | Jitter fraction of base delay |
 | `timeout` | `int` | `None` | Execution timeout in seconds |
 | `code_execution` | `bool` | `False` | Enable code execution |
 | `code_mode` | `str` | `"safe"` | Code execution mode ("safe" or "unsafe") |


### PR DESCRIPTION
## Summary
- Add `docs/features/tool-retry-backoff.mdx` for `ExecutionConfig` retry/backoff fields from PraisonAI PR #2081
- Update `execution-config.mdx`, config index, SDK config reference, agent.mdx, and config-file TOML examples
- Wire new page in `docs.json` under Features (next to tool-retry-policy)

## Test plan
- [x] `docs.json` validates as JSON
- [ ] Mintlify preview for new page and ExecutionConfig section

Fixes #665

Made with [Cursor](https://cursor.com)