### PR TITLE
docs: precise conflict-safe file editing (Fixes #666)

### DIFF
--- a/docs/features/file-editing.mdx
+++ b/docs/features/file-editing.mdx
@@ -1,55 +1,88 @@
 ---
 title: "File Editing"
 sidebarTitle: "File Editing"
-description: "Fuzzy find-and-replace across files, scoped to a workspace"
+description: "Precise, conflict-safe find-and-replace across files, scoped to a workspace"
 icon: "file-pen"
 ---
 
-File editing tools provide secure, workspace-scoped file operations with fuzzy find-and-replace capabilities for precise code and content modifications.
+File editing tools provide secure, workspace-scoped file operations with **precise, conflict-safe** find-and-replace. Ambiguous matches fail loudly instead of editing the wrong occurrence, and a content-hash check prevents lost-update conflicts when files change between read and edit.
 
 ```mermaid
 graph LR
-    subgraph "File Editing Flow"
-        A[🤖 Agent] --> S[🔍 Search Files]
-        S --> F[📄 Find Pattern]
-        F --> E[✏️ Edit/Replace]
-        E --> W[📁 Workspace Check]
-        W --> V[✅ Verify & Save]
+    subgraph "Precise Edit Flow"
+        A[🤖 Agent] --> R[📖 read_file]
+        R --> H[#️⃣ content + hash]
+        H --> E[✏️ edit_file]
+        E --> C{🔍 Match unique?}
+        C -->|Yes| HC{🛡️ Hash matches?}
+        C -->|No| AMB[⚠️ Ambiguous match error]
+        HC -->|Yes| W[💾 Preserve LF/CRLF/BOM]
+        HC -->|No| STALE[⚠️ Stale file error]
+        W --> D[📋 Return diff]
     end
+
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef security fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef complete fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef step fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef check fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef warn fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+
     class A agent
-    class S,F,E process
-    class W security
-    class V complete
+    class R,E,W step
+    class C,HC check
+    class AMB,STALE warn
+    class H,D ok
 ```
 
 ## Quick Start
 
 <Steps>
-<Step title="Basic File Editing">
+<Step title="Simple precise edit">
+
 ```python
 from praisonaiagents import Agent
 
 agent = Agent(
     name="Code Editor",
-    instructions="Edit code files carefully using fuzzy search and replace.",
+    instructions="Edit code precisely. If a match is ambiguous, add more context.",
     tools=["edit_file", "search_files", "read_file"]
 )
 
-agent.start("Replace 'getUserName' with 'getUserEmail' in all JavaScript files.")
+agent.start("In src/user.js, replace getUserName() with getUserEmail().")
 ```
+
 </Step>
 
-<Step title="Search and Edit Workflow">
+<Step title="Conflict-safe read → edit">
+
 ```python
-# Agent workflow:
-# 1. search_files("./src", "getUserName", "*.js") - Find occurrences
-# 2. edit_file("src/user.js", "getUserName", "getUserEmail") - Make changes
-# 3. read_file("src/user.js") - Verify results
+from praisonaiagents.tools.edit_tools import read_file, edit_file
+
+content, file_hash = read_file("src/user.js")
+
+edit_file(
+    "src/user.js",
+    old_string="def getUserName(self):",
+    new_string="def getUserEmail(self):",
+    expected_hash=file_hash,
+)
 ```
+
+</Step>
+
+<Step title="Replace all occurrences">
+
+```python
+from praisonaiagents.tools.edit_tools import edit_file
+
+edit_file(
+    "styles.css",
+    old_string="color: blue",
+    new_string="color: green",
+    replace_all=True,
+)
+```
+
 </Step>
 </Steps>
 
@@ -60,31 +93,42 @@ agent.start("Replace 'getUserName' with 'getUserEmail' in all JavaScript files."
 ```mermaid
 sequenceDiagram
     participant A as 🤖 Agent
-    participant S as 🔍 Search
+    participant R as 📖 read_file
     participant W as 📁 Workspace
     participant F as 📄 File
-    
-    A->>S: search_files("./src", "pattern")
-    S->>W: validate path containment
-    W-->>S: ✅ allowed
-    S->>F: scan files for pattern
-    F-->>S: match locations
-    S-->>A: JSON results
-    A->>F: edit_file(path, old, new)
-    F->>W: validate workspace boundary  
-    W-->>F: ✅ contained
-    F-->>A: success message
-```
+    participant E as ✏️ edit_file
 
-File editing operations use workspace containment for security:
+    A->>R: read_file(path)
+    R->>W: validate containment
+    W-->>R: ✅ allowed
+    R->>F: read bytes
+    F-->>R: content
+    R-->>A: (content, sha256)
+    A->>E: edit_file(path, old, new, expected_hash=sha256)
+    E->>F: re-read + hash
+    F-->>E: current content
+    E->>E: ambiguity & hash checks
+    E->>F: write preserved LF/CRLF/BOM
+    E-->>A: success + unified diff
+```
 
 | Operation | Risk Level | Workspace Required | Purpose |
 |-----------|------------|-------------------|---------|
 | **search_files** | Low | No | Find patterns in files |
-| **read_file** | Low | No | Read file contents |
+| **read_file** *(edit_tools)* | Low | No | Read content + SHA-256 hash for staleness checks |
+| **read_file** *(file_tools)* | Low | No | Plain read returning a string |
 | **list_files** | Low | No | Directory listings |
-| **edit_file** | High | Recommended | Modify file contents |
+| **edit_file** | High | Recommended | Precise find-and-replace with ambiguity & staleness guards |
 | **write_file** | High | Recommended | Create/overwrite files |
+
+<Warning>
+Two modules export `read_file` with different signatures:
+
+- `from praisonaiagents.tools.file_tools import read_file` → `read_file(filepath, encoding='utf-8') -> str`
+- `from praisonaiagents.tools.edit_tools import read_file` → `read_file(filepath) -> Tuple[str, str]`
+
+Use **edit_tools** when passing `expected_hash` to `edit_file`.
+</Warning>
 
 ---
 
@@ -92,53 +136,49 @@ File editing operations use workspace containment for security:
 
 ### File Editing Functions
 
-| Function | Args | Description |
-|----------|------|-------------|
-| `edit_file` | `filepath`, `old_string`, `new_string`, `replace_all=False` | Fuzzy find-and-replace in file |
-| `search_files` | `directory`, `pattern`, `file_pattern="*"` | Search for text patterns |
-| `read_file` | `filepath` | Read file contents |
-| `write_file` | `filepath`, `content` | Write/overwrite file |
-| `list_files` | `directory` | List directory contents |
+| Function | Args | Returns | Notes |
+|----------|------|---------|-------|
+| `edit_file` | `filepath`, `old_string`, `new_string`, `replace_all=False`, `expected_hash=None` | `str` | High-risk; fails on ambiguous match unless `replace_all=True` |
+| `read_file` *(edit_tools)* | `filepath` | `Tuple[str, str]` | `(content, sha256_hex)` for staleness checks |
+| `read_file` *(file_tools)* | `filepath`, `encoding='utf-8'` | `str` | Simple read, no hash |
+| `search_files` | `directory`, `pattern`, `file_pattern='*'` | JSON string | Case-insensitive substring search |
+| `write_file` | `filepath`, `content` | `bool` | Full overwrite |
+| `list_files` | `directory` | `list[dict]` | Directory listing |
 
-### Search Parameters
+### Edit Parameters
 
-```python
-# Basic text search
-search_files("./src", "function getUserName")
-
-# File type filtering
-search_files("./src", "useState", "*.jsx")
-search_files("./docs", "# Introduction", "*.md")
-
-# Recursive directory search
-search_files("./", "TODO:", "*.py")
-```
-
-### Edit Options
+| Parameter | Type | Default | Purpose |
+|---|---|---|---|
+| `replace_all` | `bool` | `False` | Required when `old_string` matches more than once |
+| `expected_hash` | `Optional[str]` | `None` | SHA-256 hex digest from the last `read_file`; aborts if the file changed |
 
 ```python
-# Single replacement (default)
-edit_file("config.js", "port: 3000", "port: 8080")
+# Single unique match
+edit_file("config.py", "DEBUG = False", "DEBUG = True")
 
-# Replace all occurrences
+# Multiple matches — replace_all required
 edit_file("styles.css", "color: blue", "color: green", replace_all=True)
 
-# Case-sensitive replacement
-edit_file("README.md", "PraisonAI", "PraisonAI Framework")
+# Conflict-safe flow
+content, h = read_file("config.py")
+edit_file("config.py", "DEBUG = False", "DEBUG = True", expected_hash=h)
 ```
 
-### Workspace Integration
+### Error Messages
 
-```python
-from praisonaiagents.tools import create_edit_tools
-from praisonaiagents.workspace import Workspace
+| Trigger | Message |
+|---|---|
+| File not found | `Error: File not found: {filepath}` |
+| UTF-16 encoding | `Error: UTF-16 encoding is not supported. Please convert the file to UTF-8.` |
+| Stale hash | `Error: File has been modified since last read. Please re-read the file before editing. Expected hash: {expected_hash[:8]}..., Current hash: {current_hash[:8]}...` |
+| Empty `old_string` | `Error: old_string must be non-empty` |
+| String not found | `Error: String not found in file: '{preview}'` |
+| Ambiguous match | `Error: Ambiguous match - '{preview}' occurs {N} times. Please provide more surrounding context to make the match unique, or use replace_all=True to replace all occurrences.` |
+| Success | `Success: Made {N} replacement(s) in {filepath}\n\nDiff:\n{diff}` |
 
-workspace = Workspace(root=Path("./project"), access="rw")
-edit_tools = create_edit_tools(workspace=workspace)
-
-# All operations scoped to workspace
-result = edit_tools.edit_file("src/app.js", "old", "new")
-```
+<Warning>
+If a file contains mixed line endings, any CRLF present causes the file to be normalised to CRLF on save.
+</Warning>
 
 ---
 
@@ -147,49 +187,35 @@ result = edit_tools.edit_file("src/app.js", "old", "new")
 ### Code Refactoring
 
 ```python
-agent = Agent(
-    name="Refactoring Assistant",
-    instructions="""
-    For refactoring tasks:
-    1. Search for pattern occurrences first
-    2. Show user what will be changed
-    3. Apply edits systematically
-    4. Verify results by reading modified files
-    """,
-    tools=["search_files", "edit_file", "read_file"]
-)
+from praisonaiagents.tools.edit_tools import read_file, edit_file
 
-# User: "Rename all instances of 'oldFunction' to 'newFunction'"
-# Agent workflow:
-# search_files("./src", "oldFunction")  # Find all occurrences
-# edit_file("src/utils.js", "oldFunction", "newFunction", replace_all=True)
-# read_file("src/utils.js")  # Verify changes
+content, h = read_file("src/utils.js")
+edit_file(
+    "src/utils.js",
+    "function oldFunction(",
+    "function newFunction(",
+    expected_hash=h,
+)
 ```
 
 ### Configuration Updates
 
 ```python
-# Update environment variables
-edit_file(".env", "DATABASE_URL=localhost", "DATABASE_URL=production.db")
-
-# Update package versions  
-search_files(".", "\"react\": \"16", "package.json")
-edit_file("package.json", "\"react\": \"16.14.0\"", "\"react\": \"18.2.0\"")
-
-# Update documentation
-edit_file("README.md", "## Version 1.0", "## Version 2.0")
+# Ambiguous if port: 3000 appears twice — add context or use replace_all=True
+edit_file(
+    "config.js",
+    "server: {\n  port: 3000",
+    "server: {\n  port: 8080",
+)
 ```
 
-### Bulk Content Changes
+### Surviving Concurrent Edits
 
 ```python
-# Update copyright notices
-search_files("./src", "Copyright 2023", "*.js")
-edit_file("src/header.js", "Copyright 2023", "Copyright 2024", replace_all=True)
-
-# Update API endpoints
-search_files("./src", "/api/v1/", "*.js")
-edit_file("src/api.js", "/api/v1/", "/api/v2/", replace_all=True)
+content, h = read_file("config.py")
+# ... another process may edit the file here ...
+result = edit_file("config.py", "DEBUG = False", "DEBUG = True", expected_hash=h)
+# Returns stale-file error if content changed — re-read and retry
 ```
 
 ---
@@ -198,28 +224,27 @@ edit_file("src/api.js", "/api/v1/", "/api/v2/", replace_all=True)
 
 <AccordionGroup>
 <Accordion title="Search Before Edit">
-Always use `search_files` to locate patterns before making edits. This provides visibility into the scope of changes and prevents unexpected modifications.
+Use `search_files` to locate patterns before editing so you know scope and can craft a unique `old_string`.
+</Accordion>
+
+<Accordion title="Use the returned diff for verification">
+`edit_file` returns a bounded unified diff (10 lines max, 200 chars per line) so you rarely need a second read.
+</Accordion>
+
+<Accordion title="Pass expected_hash when files might change">
+Long-running agents, parallel sessions, or human edits during a run benefit from the staleness guard.
+</Accordion>
+
+<Accordion title="Make old_string unique">
+Include surrounding context so the match is unambiguous; use `replace_all=True` only when every occurrence should change.
+</Accordion>
+
+<Accordion title="Line endings and BOM are preserved">
+CRLF files stay CRLF, LF files stay LF, UTF-8 BOM is preserved. UTF-16 files are rejected with a clear error.
 </Accordion>
 
 <Accordion title="Workspace Security">
-File editing operations respect workspace boundaries. When `workspace` is omitted, `write_file` defaults to the current working directory and refuses paths that resolve outside it.
-
-Example of path that gets rejected:
-```python
-# This fails with workspace containment
-write_file("../escape.txt", "content")
-# Error: Path '../escape.txt' is outside the workspace
-```
-
-The `is_path_within_directory` check runs unconditionally against the effective workspace to prevent directory traversal attacks.
-</Accordion>
-
-<Accordion title="Verification Workflow">
-After making edits, use `read_file` to verify changes were applied correctly. This catches encoding issues or unexpected results.
-</Accordion>
-
-<Accordion title="Atomic Operations">
-Edit operations are atomic - they either succeed completely or leave the original file unchanged. This prevents file corruption from partial writes.
+File operations respect workspace boundaries. Paths outside the workspace are rejected to prevent directory traversal.
 </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary
- Rewrite `docs/features/file-editing.mdx` for PR #2099 precise edit behaviour
- Document `expected_hash`, ambiguous-match errors, edit_tools vs file_tools `read_file`, and diff output

Fixes #666

Made with [Cursor](https://cursor.com)