### PR TITLE
docs: Gateway session continuity & graceful drain (Fixes #669)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -353,6 +353,7 @@
                       "docs/features/gateway-hot-reload",
                       "docs/features/gateway-overview",
                       "docs/features/gateway-session-persistence",
+                      "docs/features/gateway-session-continuity",
                       "docs/features/gateway-client",
                       "docs/features/gateway-windows-deployment",
                       "docs/features/gateway-telegram-multichannel",

--- a/docs/features/gateway-cli.mdx
+++ b/docs/features/gateway-cli.mdx
@@ -132,6 +132,10 @@ Examples:
   praisonai gateway stop --port 9000
   praisonai gateway stop --force
 ```
+
+<Note>
+`praisonai gateway stop` performs a graceful drain — it waits up to **10 seconds** for in-flight agent turns and queued messages before closing. Use `--force` to skip the drain and terminate immediately.
+</Note>
 </Tab>
 
 <Tab title="status">

--- a/docs/features/gateway-error-handling.mdx
+++ b/docs/features/gateway-error-handling.mdx
@@ -96,6 +96,21 @@ Error handling is automatic with no required configuration. The feature is inclu
 
 ---
 
+## Reconnect After Disconnect
+
+Pending inbox messages and in-flight executions are preserved when a WebSocket disconnects. On reconnect with the same `session_id`, the client receives a `status` frame:
+
+```json
+{
+  "type": "status",
+  "message": "Resuming processing (2 pending messages)..."
+}
+```
+
+Queued messages are processed in FIFO order. See [Gateway Session Continuity](/docs/features/gateway-session-continuity) for drain behaviour and persisted session shape.
+
+---
+
 ## Common Patterns
 
 ### Recognized Error Types

--- a/docs/features/gateway-session-continuity.mdx
+++ b/docs/features/gateway-session-continuity.mdx
@@ -1,0 +1,197 @@
+---
+title: "Gateway Session Continuity"
+sidebarTitle: "Session Continuity"
+description: "Durable gateway sessions survive disconnects, restarts, and shutdowns"
+icon: "shield-check"
+---
+
+Gateway sessions preserve pending messages and in-flight executions across disconnects, restarts, and graceful shutdowns.
+
+```mermaid
+graph LR
+    C[Client] -->|m1 m2 m3| G[Gateway]
+    G -->|executing m1| A[Agent]
+    C -.->|disconnect| X[...]
+    X -->|reconnect| G
+    G -->|resume queue| A
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef gateway fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef client fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef drain fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class A agent
+    class G gateway
+    class C client
+    class X drain
+```
+
+## Quick Start
+
+<Steps>
+
+<Step title="Start gateway with an agent">
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="assistant",
+    instructions="Answer user messages in order.",
+)
+
+# Default drain timeout is 10 s on stop()
+# praisonai gateway start --config gateway.yaml
+```
+
+</Step>
+
+<Step title="Graceful shutdown with drain">
+
+```python
+import asyncio
+from praisonai.gateway.server import WebSocketGateway
+
+async def shutdown_gateway(gateway: WebSocketGateway):
+    await gateway.stop(drain_timeout=10.0)  # wait up to 10 s for in-flight turns
+
+asyncio.run(shutdown_gateway(gateway))
+```
+
+</Step>
+
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Gateway
+    participant Agent
+
+    Client->>Gateway: message m1
+    Gateway->>Agent: run m1
+    Client->>Gateway: message m2
+    Client->>Gateway: message m3
+    Note over Client,Gateway: WebSocket disconnect
+    Client->>Gateway: reconnect (same session_id)
+    Gateway-->>Client: status "Resuming processing (2 pending messages)..."
+    Agent-->>Gateway: m1 reply
+    Gateway->>Agent: m2
+    Gateway->>Agent: m3
+```
+
+When a client reconnects, the gateway checks whether the session has queued inbox messages or an in-flight execution. If so, it sends a `status` frame, marks the session as executing **before** spawning the queue task (preventing duplicate workers), and processes pending messages in FIFO order.
+
+---
+
+## Graceful Drain on Shutdown
+
+`WebSocketGateway.stop()` calls `_drain_active_sessions` before closing WebSocket clients. The gateway waits up to `drain_timeout` seconds (default **10.0**) for sessions that are executing or have a non-empty inbox.
+
+| Phase | Behaviour |
+|-------|-----------|
+| **Within timeout** | Sessions that finish are persisted via the configured session store |
+| **After timeout** | Remaining sessions are force-persisted with pending work; a `SESSION_END` event is emitted |
+
+Force-closed `SESSION_END` payload:
+
+```json
+{
+  "session_id": "...",
+  "reason": "Force-closed during shutdown after timeout",
+  "had_pending_work": true,
+  "was_executing": true
+}
+```
+
+Configure a `_session_store` so drained sessions survive restarts. Without one, force-closed sessions are only logged.
+
+---
+
+## Reconnect and Auto-Resume
+
+On resume, clients receive:
+
+```json
+{
+  "type": "status",
+  "message": "Resuming processing (2 pending messages)..."
+}
+```
+
+The gateway sets `mark_executing(True)` before launching `asyncio.create_task(_run_session_queue(...))`, so a race between reconnect and shutdown cannot spawn duplicate queue processors.
+
+---
+
+## Persisted Shape
+
+Gateway session snapshots now include pending work:
+
+```json
+{
+  "session_id": "...",
+  "messages": [],
+  "events": [],
+  "event_cursor": 42,
+  "pending_inbox": ["queued message 1", "queued message 2"],
+  "is_executing": true
+}
+```
+
+The inbox is snapshotted non-destructively: items are drained into a list and put back so live processing is unaffected.
+
+---
+
+## Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `drain_timeout` | `float` | `10.0` | Seconds to wait for in-flight sessions during `WebSocketGateway.stop()` before force-persisting |
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Tune drain_timeout for redeploys">
+Set `drain_timeout` to at least your longest expected agent turn so clean shutdowns finish naturally before force-persist.
+</Accordion>
+
+<Accordion title="Configure a session store">
+Without persistence, drained sessions cannot be resumed after restart — only logged.
+</Accordion>
+
+<Accordion title="Monitor SESSION_END events">
+Listen for `had_pending_work: true` or `was_executing: true` in audit or observability hooks to detect force-closed sessions.
+</Accordion>
+
+<Accordion title="Test reconnect under load">
+Send messages faster than the agent processes them, then drop the WebSocket — pending messages should resume in order on reconnect.
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Gateway" icon="tower-broadcast" href="/docs/features/gateway">
+    WebSocket control plane overview
+  </Card>
+  <Card title="Session Persistence" icon="database" href="/docs/features/gateway-session-persistence">
+    Persistent sessions and event replay
+  </Card>
+  <Card title="Error Handling" icon="shield-check" href="/docs/features/gateway-error-handling">
+    Reconnect and error recovery
+  </Card>
+  <Card title="Session Protocol" icon="messages" href="/docs/features/session-protocol">
+    Session message format
+  </Card>
+</CardGroup>

--- a/docs/features/gateway-session-persistence.mdx
+++ b/docs/features/gateway-session-persistence.mdx
@@ -7,6 +7,10 @@ icon: "database"
 
 Persistent sessions keep conversation state alive across gateway restarts and let clients resume mid-conversation with event replay.
 
+<Note>
+This page covers **agent session** persistence (messages, events, cursors). **Gateway** sessions additionally preserve `pending_inbox` and `is_executing` across disconnects and graceful shutdown — see [Gateway Session Continuity](/docs/features/gateway-session-continuity).
+</Note>
+
 ```mermaid
 graph LR
     A[Active session] --> B[Disconnect]

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -696,7 +696,7 @@ shutdown()
 
 `shutdown()` is also registered via `atexit`, so it runs automatically on interpreter exit. Call it manually when you need deterministic cleanup (flushing telemetry exporters, closing async HTTP/DB clients) before the process exits.
 
-When the gateway is stopped (via `praisonai gateway stop`, SIGTERM, or programmatic `stop()`), every active session is routed through `close_session()` so its full snapshot is written to the session store before the process exits. The next `create_session()` with the same `session_id` resumes the latest snapshot — no messages are dropped on shutdown. (Fixed in [PraisonAI#2102](https://github.com/MervinPraison/PraisonAI/pull/2102).)
+When the gateway is stopped (via `praisonai gateway stop`, SIGTERM, or programmatic `stop()`), it first drains active sessions for up to **10 seconds** (`drain_timeout` on `WebSocketGateway.stop()`), persisting pending inbox messages and in-flight executions before closing clients. Tune with `await gateway.stop(drain_timeout=30.0)` for longer turns. See [Gateway Session Continuity](/docs/features/gateway-session-continuity) for the full drain and reconnect story.
 
 ---
 

--- a/docs/guides/troubleshoot-gateway.mdx
+++ b/docs/guides/troubleshoot-gateway.mdx
@@ -65,7 +65,7 @@ Look for lines like:
 praisonai gateway stop
 ```
 
-This sends SIGTERM and waits for graceful shutdown. The PID lock file will be automatically cleaned up.
+This sends SIGTERM and waits for graceful shutdown. The gateway drains active sessions for up to **10 seconds** — in-flight turns and queued inbox messages are persisted before exit. Sessions that exceed the timeout are force-persisted with a `SESSION_END` event (`had_pending_work`, `was_executing`). Use `--force` to skip the drain. See [Gateway Session Continuity](/docs/features/gateway-session-continuity).
 </Step>
 
 <Step title="If gateway is stuck, force stop">


### PR DESCRIPTION
## Summary
- Add `gateway-session-continuity.mdx` covering pending inbox, drain_timeout, and reconnect auto-resume
- Cross-link from gateway, CLI, error handling, session persistence, and troubleshooting pages
- Register page in docs.json Features group

Fixes #669

## Test plan
- [x] docs.json validates as JSON
- [x] drain_timeout default 10.0 matches SDK
- [x] SESSION_END payload fields documented verbatim

Made with [Cursor](https://cursor.com)