### PR TITLE
docs: PR #2122 fail-loud defaults (Fixes #676)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -372,6 +372,7 @@
                       "docs/features/toolsets",
                       "docs/features/allowed-tools",
                       "docs/features/failover",
+                      "docs/features/fail-loud-defaults",
                       "docs/features/reliability",
                       "docs/features/sandbox",
                       "docs/features/sandbox-backends",

--- a/docs/features/approval.mdx
+++ b/docs/features/approval.mdx
@@ -7,6 +7,10 @@ icon: "shield-check"
 
 Approval pauses an agent before it runs a risky tool and asks a human (or another channel) to allow or deny it.
 
+<Warning>
+**Behaviour change (PR #2122):** Approval is **enabled by default**. YAML configs that omitted the `approval` key previously got `enabled: false`; they now get the prompting policy. Set `approval: false` to keep the old behaviour.
+</Warning>
+
 <Note>
 **Sync and Async Parity**: Approval checks now work uniformly in both sync and async tool execution paths. Previously, async calls bypassed approval prompts.
 </Note>
@@ -32,11 +36,27 @@ graph LR
 
 <Steps>
 <Step title="Simple Usage">
+Approval is on by default. To disable:
+
 ```python
 from praisonaiagents import Agent
 
-agent = Agent(name="Admin", instructions="Manage the server", approval=True)
+agent = Agent(name="Admin", instructions="Manage the server", approval=False)
 agent.start("Clean up old logs")
+```
+</Step>
+
+<Step title="Per-tool approval">
+```python
+agent = Agent(
+    name="Admin",
+    instructions="...",
+    approval={
+        "enabled": True,
+        "default_policy": "prompt",
+        "approve_tools": {"shell": "critical", "read_file": "low"},
+    },
+)
 ```
 </Step>
 
@@ -86,12 +106,14 @@ The default `console` backend requires a sync call stack. If you decorate a tool
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `enabled` | `bool` | `false` | Turn approval on/off |
+| `enabled` | `bool` | **`true`** | Turn approval on/off — safe by default |
 | `backend` | `str` | `"console"` | One of: `console`, `slack`, `telegram`, `discord`, `webhook`, `http`, `agent`, `auto`, `none` |
 | `approve_all_tools` | `bool` | `false` | If true, every tool needs approval (not just risky ones) |
 | `timeout` | `float` | `null` | Seconds to wait for a decision; `null` = no timeout |
-| `approve_level` | `str` | `null` | Auto-approve up to this risk level: `low`, `medium`, `high`, `critical` |
+| `approve_level` | `ApprovalLevel \| null` | `null` | Auto-approve up to this risk level: `low`, `medium`, `high`, `critical` |
 | `guardrails` | `str` | `null` | Free-text guardrail description |
+| `default_policy` | `"deny" \| "prompt" \| "allow"` | `"prompt"` | Policy when no per-tool entry matches |
+| `approve_tools` | `Dict[str, ApprovalLevel] \| null` | `null` | Per-tool granularity, e.g. `{"shell": "critical"}` |
 | `permissions` | `Dict[str, Any]` | `null` | Declarative allow/deny/ask rules. See [Declarative Permissions](/docs/features/declarative-permissions). |
 
 <Note>
@@ -109,6 +131,25 @@ agents:
       backend: slack
       timeout: 120
       approve_level: high
+      default_policy: prompt
+      approve_tools:
+        shell: critical
+        read_file: low
+```
+
+### Hook installation
+
+Register a `before_tool` hook that enforces the policy:
+
+```python
+from praisonai._approval_spec import ApprovalSpec
+
+spec = ApprovalSpec(
+    enabled=True,
+    default_policy="prompt",
+    approve_tools={"shell": "critical"},
+)
+spec.install_hook()
 ```
 
 Shorthands: `approval: true` (console), `approval: slack` (named backend), `approval: false` / `null` (off).

--- a/docs/features/async-bridge.mdx
+++ b/docs/features/async-bridge.mdx
@@ -407,7 +407,7 @@ graph LR
 |------------------|-----------|-------------|
 | `AsyncBridge` | `class AsyncBridge` | Per-instance async runner; create one per tenant or service. |
 | `AsyncBridge.run_sync` | `(self, coro, *, timeout=300) -> T` | Run a coroutine on this bridge's background loop. |
-| `AsyncBridge.shutdown` | `(self, timeout=5.0) -> None` | Cancel pending tasks and stop this bridge's loop. |
+| `AsyncBridge.shutdown` | `(self, timeout=5.0) -> None` | Cancel pending tasks and stop this bridge's loop. PR #2122: releases the bridge lock before awaiting cancellation and excludes the current task — safe to call from within an async tool on the bridge's loop. |
 | `AsyncBridge.submit` | `(self, coro) -> concurrent.futures.Future` | Submit without waiting; returns a `concurrent.futures.Future`. |
 | `AsyncBridge.get` | `(self) -> asyncio.AbstractEventLoop` | Get (lazily spawn) the bridge's event loop. |
 | `run_sync` (module-level) | `(coro, *, timeout=300) -> T` | Routes through the shared default `AsyncBridge`. Behaviour unchanged. |

--- a/docs/features/cli-backend-protocol.mdx
+++ b/docs/features/cli-backend-protocol.mdx
@@ -123,6 +123,27 @@ sequenceDiagram
 | 4 | Process | External CLI subprocess execution |
 | 5 | Result | Parsed response returned to Agent |
 
+### Permission modes (Claude Code backend)
+
+| Setting | Default (PR #2122) | Notes |
+|---------|-------------------|-------|
+| `--permission-mode` | `default` | Was `bypassPermissions` |
+| `ClaudeCodeBackend(unsafe=...)` | `False` | Set `True` + env var for bypass |
+
+To opt into bypass:
+
+```bash
+export PRAISONAI_CLAUDE_BYPASS_PERMISSIONS=1
+```
+
+```python
+from praisonai.cli_backends.claude import ClaudeCodeBackend
+
+backend = ClaudeCodeBackend(config={...}, unsafe=True)
+```
+
+With only `unsafe=True` or only the env var set, the backend overrides to `default` mode and logs a warning.
+
 ---
 
 ## Configuration Surfaces
@@ -248,7 +269,7 @@ The `claude-code` backend executes commands via the Claude Code CLI with these d
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `command` | `str` | `"claude"` | CLI command (must be on PATH) |
-| `args` | `List[str]` | `["-p", "--output-format", "stream-json", "--include-partial-messages", "--verbose", "--setting-sources", "user", "--permission-mode", "bypassPermissions"]` | Default arguments passed to CLI |
+| `args` | `List[str]` | `["-p", "--output-format", "stream-json", ..., "--permission-mode", "default"]` | Default permission mode is `default` (PR #2122; was `bypassPermissions`) |
 | `resume_args` | `List[str]` | `["-p", "--output-format", "stream-json", "--resume", "{session_id}"]` | Arguments for resuming sessions |
 | `output` | `str` | `"jsonl"` | Output format expected from CLI |
 | `input` | `str` | `"stdin"` | How to pass prompts to CLI |

--- a/docs/features/cloud-databases.mdx
+++ b/docs/features/cloud-databases.mdx
@@ -39,6 +39,29 @@ graph LR
     class Scale scale
 ```
 
+## Supported URL Schemes
+
+`PraisonAIDB._detect_backend` recognises these schemes:
+
+| Scheme | Backend |
+|--------|---------|
+| `sqlite://` | SQLite |
+| `postgres://`, `postgresql://` | PostgreSQL |
+| `mysql://` | MySQL |
+| `redis://` | Redis |
+| `libsql://` | LibSQL / Turso |
+| `http://`, `https://` | Cloud DB hosts (Neon, Supabase, etc.) |
+
+Hostname heuristics also detect Qdrant and Weaviate URLs.
+
+<Warning>
+**PR #2122:** Passing a URL whose scheme cannot be inferred now raises `ValueError` instead of falling back to SQLite:
+
+`Unable to infer DB backend from URL '...'; supported schemes: postgres://, mysql://, sqlite://, redis://, libsql://, http(s)://`
+
+Set the URL explicitly, e.g. `sqlite:///mydata.db`.
+</Warning>
+
 ## Quick Start
 
 <Steps>

--- a/docs/features/fail-loud-defaults.mdx
+++ b/docs/features/fail-loud-defaults.mdx
@@ -1,0 +1,119 @@
+---
+title: "Fail-Loud Defaults"
+sidebarTitle: "Fail-Loud Defaults"
+description: "PraisonAI raises clear errors instead of silently picking a default when configuration is ambiguous"
+icon: "triangle-exclamation"
+---
+
+PraisonAI raises clear errors instead of silently picking a default when configuration is ambiguous.
+
+```mermaid
+graph LR
+    subgraph Before
+        A1[Ambiguous config] --> B1[Silent fallback]
+    end
+    subgraph After
+        A2[Ambiguous config] --> B2[ValueError with fix hint]
+    end
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef warn fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A1,A2 agent
+    class B1 warn
+    class B2 ok
+```
+
+<Warning>
+**Behaviour change (PR #2122):** Several subsystems that previously fell back silently now raise explicit errors. Review the table below when upgrading.
+</Warning>
+
+## What Changed
+
+| Area | Old behaviour | New behaviour | Deep dive |
+|------|---------------|---------------|-----------|
+| Database URL | Unknown scheme → SQLite fallback | `ValueError` | [Cloud Databases](/docs/features/cloud-databases) |
+| Model string | Unrecognised name → OpenAI | `ValueError` | [Multi-Provider Advanced](/docs/features/multi-provider-advanced) |
+| Daytona sandbox | Appeared available with client | `NotImplementedError` | [Sandbox](/docs/features/sandbox) |
+| LazyCache | Cached `None` on `ImportError` | Re-raises `ImportError` | Optional deps docs |
+| Approval | `enabled: false` by default | `enabled: true` by default | [Approval](/docs/features/approval) |
+| Claude CLI backend | `bypassPermissions` default | `default` mode; bypass requires opt-in | [CLI Backend Protocol](/docs/features/cli-backend-protocol) |
+
+## Quick Start
+
+<Steps>
+
+<Step title="Grep your logs for new errors">
+
+```bash
+grep -r "Unable to infer DB backend\|Cannot infer provider\|Daytona backend not yet implemented" logs/
+```
+
+</Step>
+
+<Step title="Fix database URLs explicitly">
+
+```python
+# Was silently SQLite — now raises ValueError
+db_url = "sqlite:///mydata.db"  # explicit scheme required
+```
+
+</Step>
+
+<Step title="Use provider/model form">
+
+```python
+from praisonaiagents import Agent
+
+# Was OpenAI fallback — now raises ValueError
+agent = Agent(name="assistant", llm="ollama/llama3")
+```
+
+</Step>
+
+</Steps>
+
+## Migrating
+
+| Exception text | Fix |
+|----------------|-----|
+| `Unable to infer DB backend from URL '...'; supported schemes: postgres://, mysql://, sqlite://, redis://, libsql://, http(s)://` | Prefix URL with a supported scheme, e.g. `sqlite:///path.db` |
+| `Cannot infer provider from model '...'. Use the 'provider/model' form, e.g. 'ollama/llama3', 'bedrock/anthropic.claude-3-sonnet'.` | Use `provider/model` or a recognised prefix (`gpt-`, `claude-`, `gemini-`) |
+| `Daytona backend not yet implemented. Use 'subprocess', 'docker', or 'e2b' sandbox instead.` | Switch `sandbox_type` to a supported backend |
+| Approval prompts where none expected | Set `approval=False` or `approval: {enabled: false}` in YAML |
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Prefer explicit configuration">
+When in doubt, spell out schemes, provider prefixes, and backend names — silent fallbacks are gone.
+</Accordion>
+
+<Accordion title="Disable approval only when intended">
+Approval is on by default (PR #2122). Use `approval=False` for fully autonomous runs.
+</Accordion>
+
+<Accordion title="Never use BYPASS without env gate">
+Claude Code bypass requires `unsafe=True` **and** `PRAISONAI_CLAUDE_BYPASS_PERMISSIONS=1`.
+</Accordion>
+
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Approval" icon="shield-check" href="/docs/features/approval">
+    Safe-by-default approval gates
+  </Card>
+  <Card title="Cloud Databases" icon="cloud" href="/docs/features/cloud-databases">
+    Supported DB URL schemes
+  </Card>
+  <Card title="Multi-Provider" icon="shuffle" href="/docs/features/multi-provider-advanced">
+    Model string format
+  </Card>
+  <Card title="Sandbox" icon="box" href="/docs/features/sandbox">
+    Available sandbox backends
+  </Card>
+</CardGroup>

--- a/docs/features/mcp-lifecycle.mdx
+++ b/docs/features/mcp-lifecycle.mdx
@@ -48,6 +48,22 @@ finally:
 
 ## Lifecycle Methods
 
+### Authenticating the HTTP transport
+
+When `api_key` is configured on the MCP HTTP-stream server, **all** of GET, POST, and DELETE require:
+
+```
+Authorization: Bearer <key>
+```
+
+Comparison uses constant-time `hmac.compare_digest` (timing-attack resistant). Missing or wrong tokens return `401 Unauthorized` with `{"error": "Unauthorized"}`. DELETE returning 401 instead of 405 prevents information disclosure about whether sessions exist.
+
+```bash
+curl -H "Authorization: Bearer your-key" https://localhost:8080/mcp
+```
+
+---
+
 ### `__enter__` / `__exit__`
 
 Context manager protocol for automatic resource management:

--- a/docs/features/multi-provider-advanced.mdx
+++ b/docs/features/multi-provider-advanced.mdx
@@ -8,6 +8,21 @@ icon: "shuffle"
 
 While basic multi-provider support allows you to use different LLMs for different agents, PraisonAI's `ModelRouter` and `RouterAgent` provide sophisticated patterns for dynamic provider switching, cost optimization, and resilience.
 
+<Warning>
+**PR #2122:** A model string like `my-custom-model` no longer defaults to the OpenAI provider — it raises `ValueError`: *"Cannot infer provider from model '...'. Use the 'provider/model' form, e.g. 'ollama/llama3', 'bedrock/anthropic.claude-3-sonnet'."*
+</Warning>
+
+### Model string format
+
+Use either a recognised prefix (`gpt-`, `claude-`, `gemini-`) or explicit `provider/model` form:
+
+| Form | Example |
+|------|---------|
+| Prefix | `gpt-4o`, `claude-3-5-sonnet` |
+| Provider/model | `ollama/llama3`, `bedrock/anthropic.claude-3-sonnet`, `deepseek/deepseek-chat` |
+
+See [Fail-Loud Defaults](/docs/features/fail-loud-defaults) for migration guidance.
+
 ## Overview
 
 The advanced multi-provider system enables:

--- a/docs/features/permission-modes.mdx
+++ b/docs/features/permission-modes.mdx
@@ -153,7 +153,7 @@ print(mode.value)  # "dont_ask"
 
 <Accordion title="BYPASS - Skip All Checks">
 
-Bypasses all permission checks entirely.
+Bypasses all permission checks entirely. **Requires explicit opt-in (PR #2122)** — the Claude Code CLI backend no longer launches in `bypassPermissions` mode by default.
 
 ```python
 from praisonaiagents.permissions import PermissionMode
@@ -162,13 +162,15 @@ mode = PermissionMode.BYPASS
 print(mode.value)  # "bypass_permissions"
 ```
 
-**Behavior:**
-- No permission checks performed
-- All operations allowed
-- Maximum agent autonomy
+To opt into bypass for Claude Code backend:
+
+1. Construct with `ClaudeCodeBackend(unsafe=True)`
+2. Set `PRAISONAI_CLAUDE_BYPASS_PERMISSIONS=1`
+
+With only one set, the backend logs *"Overriding unsafe bypassPermissions to default mode"* and runs safely.
 
 <Danger>
-**Security Risk**: Only use in fully trusted environments. Agent can perform any operation without restriction.
+**Security Risk**: Only use in fully trusted environments with both opt-in steps above.
 </Danger>
 
 </Accordion>

--- a/docs/features/sandbox-backends.mdx
+++ b/docs/features/sandbox-backends.mdx
@@ -119,7 +119,7 @@ PR #2003 exposes all seven sandboxes through `SandboxRegistry` — selectable by
 | `sandlock` | `SandlockSandbox` | Hardened local sandbox |
 | `ssh` | `SSHSandbox` | Remote server execution |
 | `modal` | `ModalSandbox` | Modal cloud sandboxes |
-| `daytona` | `DaytonaSandbox` | Daytona dev environments |
+| `daytona` | `DaytonaSandbox` | **Not implemented** — use subprocess/docker/e2b |
 | `e2b` | `E2BSandbox` | E2B cloud code interpreter |
 
 ### Select by Name

--- a/docs/features/sandbox.mdx
+++ b/docs/features/sandbox.mdx
@@ -317,15 +317,11 @@ config = SandboxConfig(sandbox_type="modal")
 <Tab title="Daytona">
 **Daytona development workspaces**
 
-```python
-# Requires: Daytona client
-config = SandboxConfig(sandbox_type="daytona")
-```
+<Warning>
+**Not yet implemented (PR #2122):** `DaytonaSandbox.is_available` returns `False` and `DaytonaSandbox.start()` raises `NotImplementedError`: *"Daytona backend not yet implemented. Use 'subprocess', 'docker', or 'e2b' sandbox instead."*
+</Warning>
 
-| Requirements | Daytona client + workspace access |
-|--------------|-----------------------------------|
-| **Use case** | Daytona workspaces |
-| **Isolation** | ✅ Workspace isolation |
+Use `subprocess`, `docker`, or `e2b` instead.
 </Tab>
 </Tabs>
 
@@ -581,7 +577,7 @@ agent = Agent(
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `sandbox_type` | `str` | `"subprocess"` | Backend: subprocess, docker, e2b, native, sandlock, ssh, modal, daytona |
+| `sandbox_type` | `str` | `"subprocess"` | Backend: subprocess, docker, e2b, native, sandlock, ssh, modal (`daytona` not yet implemented) |
 | `image` | `str` | `"python:3.11-slim"` | Docker image (docker backend only) |
 | `working_dir` | `str` | `"/workspace"` | Working directory within sandbox |
 | `env` | `Dict[str, str]` | `{}` | Environment variables |

--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -529,7 +529,7 @@ The `ToolResolver` maintains two separate caches for performance:
 - **Per-tool caching**: Memoises `resolve(name)` results for each tool name
 - **Cacheable failures**: A tool genuinely absent from every source (local `tools.py`, `praisonaiagents.tools`, `praisonai-tools`, registry) is cached as `None` so repeated lookups don't walk the ladder again
 - **Transient failures are NOT cached**: If `praisonaiagents` fails to import (`ImportError`) or an entry in `TOOL_MAPPINGS` exists but its optional dependency failed to load, the lookup is retried on the next call. Install the missing package and the next `resolve()` picks it up — no `clear_cache()` needed
-- **`invalidate(name=None)`**: Clear one tool or the entire resolve cache. `ToolRegistry` changes auto-invalidate via `set_resolver()`.
+- **`invalidate(name=None)`**: Clear one tool or the entire resolve cache. `ToolRegistry.set_resolver()` **appends** to a weak-ref list (PR #2122) — all registered resolvers are notified on `register_function()` / `clear()`. Resolvers held only by `ToolRegistry` are GC'd; dead refs are cleaned lazily on each invalidation. Multi-tenant gateways can wire one resolver per tenant without overwriting each other.
 - **Thread safety**: Uses `_resolve_cache_lock` for concurrent access. Fixed in [PR #2147](https://github.com/MervinPraison/PraisonAI/pull/2147) — an earlier lock-free fast-path read could race with `ToolRegistry.invalidate()` and miss freshly-registered tools; the cache lookup now happens inside the lock.
 
 <Tip>


### PR DESCRIPTION
## Summary
- New `fail-loud-defaults.mdx` migration landing page
- Update approval (enabled default true), BYPASS opt-in, Daytona unimplemented
- DB URL schemes, model string format, MCP HTTP auth, tool resolver weak refs

Fixes #676

## Notes
- Skipped optional `multi-loop-concurrency.mdx` (advanced/internals)
- Did not edit `docs/concepts/managed-agents-daytona.mdx` (human-approved)

Made with [Cursor](https://cursor.com)