### PR TITLE
docs: sharpen sandbox lazy-loading note (PR #1992)

### DIFF
--- a/docs/features/sandbox.mdx
+++ b/docs/features/sandbox.mdx
@@ -326,7 +326,7 @@ Use `subprocess`, `docker`, or `e2b` instead.
 </Tabs>
 
 <Note>
-All backend imports are lazy-loaded. Importing the top-level package will not trigger heavy backend imports.
+**Zero import cost when unused.** The sandbox subsystem — including `SandboxConfig`, `SandboxManager`, security checks, and all backends — is lazy-loaded. `from praisonaiagents import Agent` does not load any sandbox module. Sandbox modules are only imported the first time you set `sandbox=True` (or pass a `SandboxConfig`) on an `Agent`, or call a sandbox method. This keeps the default `import Agent` path light for agents that never execute code.
 </Note>
 
 ---


### PR DESCRIPTION
## Summary

- Replaces the Sandbox Backends `<Note>` in `docs/features/sandbox.mdx` so lazy-loading covers the full sandbox subsystem (not only backends), matching upstream PR MervinPraison/PraisonAI#1992.

Fixes #624

## Test plan

- [x] Single surgical `<Note>` swap only — no examples, tables, or nav changes
- [x] Mintlify frontmatter untouched
- [ ] Mintlify preview (optional)

Upstream: https://github.com/MervinPraison/PraisonAI/pull/1992

Made with [Cursor](https://cursor.com)