### PR TITLE
docs: friendly workflow imports in features (Fixes #648 Section A)

### DIFF
--- a/docs/features/conditional-branching.mdx
+++ b/docs/features/conditional-branching.mdx
@@ -25,8 +25,7 @@ flowchart TD
 
 <CodeGroup>
 ```python Python
-from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-from praisonaiagents.workflows import if_
+from praisonaiagents import AgentFlow, WorkflowContext, StepResult, if_
 
 def approve(ctx: WorkflowContext) -> StepResult:
     return StepResult(output="Approved!")
@@ -199,8 +198,7 @@ flowchart TD
 <Tabs>
   <Tab title="Python">
 ```python
-from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-from praisonaiagents.workflows import if_, loop
+from praisonaiagents import AgentFlow, WorkflowContext, StepResult, if_, loop
 
 def vip_service(ctx: WorkflowContext) -> StepResult:
     customer = ctx.variables.get("customer", {})
@@ -331,7 +329,7 @@ def if_(
 ### If Class
 
 ```python
-from praisonaiagents.workflows import If
+from praisonaiagents import If
 
 conditional = If(
     condition="{{score}} > 80",
@@ -343,7 +341,7 @@ conditional = If(
 ### MAX_NESTING_DEPTH
 
 ```python
-from praisonaiagents.workflows import MAX_NESTING_DEPTH
+from praisonaiagents import MAX_NESTING_DEPTH
 
 print(MAX_NESTING_DEPTH)  # 5
 ```

--- a/docs/features/modular-recipes.mdx
+++ b/docs/features/modular-recipes.mdx
@@ -103,7 +103,7 @@ result = workflow.run("Write about AI")
 ### Direct Class Usage
 
 ```python
-from praisonaiagents.workflows import Include
+from praisonaiagents import Include
 
 step = Include(
     recipe="wordpress-publisher",

--- a/docs/features/multi-agent-pipelines.mdx
+++ b/docs/features/multi-agent-pipelines.mdx
@@ -162,7 +162,7 @@ praisonai recipe run ai-media-pipeline --var audio_file=podcast.mp3 --var output
 Create multi-agent pipelines programmatically:
 
 ```python
-from praisonaiagents.workflows.yaml_parser import YAMLWorkflowParser
+from praisonaiagents import YAMLWorkflowParser
 
 yaml_content = """
 name: Custom Pipeline

--- a/docs/features/nested-workflows.mdx
+++ b/docs/features/nested-workflows.mdx
@@ -31,8 +31,7 @@ flowchart TD
 
 <CodeGroup>
 ```python Nested Loops
-from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-from praisonaiagents.workflows import loop
+from praisonaiagents import AgentFlow, WorkflowContext, StepResult, loop
 
 def process_cell(ctx: WorkflowContext) -> StepResult:
     row = ctx.variables.get("row")
@@ -95,8 +94,7 @@ Process nested data structures by placing one loop inside another.
 <Tabs>
   <Tab title="Python">
 ```python
-from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-from praisonaiagents.workflows import loop
+from praisonaiagents import AgentFlow, WorkflowContext, StepResult, loop
 
 results = []
 
@@ -182,8 +180,7 @@ flowchart LR
 ```
 
 ```python
-from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-from praisonaiagents.workflows import loop, parallel
+from praisonaiagents import AgentFlow, WorkflowContext, StepResult, loop, parallel
 
 def security_scan(ctx: WorkflowContext) -> StepResult:
     project = ctx.variables.get("project")
@@ -218,8 +215,7 @@ workflow.start("Analyze all projects")
 Apply different processing logic to each item based on conditions.
 
 ```python
-from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-from praisonaiagents.workflows import loop, route
+from praisonaiagents import AgentFlow, WorkflowContext, StepResult, loop, route
 
 def process_image(ctx: WorkflowContext) -> StepResult:
     return StepResult(output="Image processed")
@@ -262,7 +258,7 @@ Nested workflows have a maximum depth of **5 levels** to prevent infinite recurs
 </Warning>
 
 ```python
-from praisonaiagents.workflows import MAX_NESTING_DEPTH
+from praisonaiagents import MAX_NESTING_DEPTH
 
 print(f"Maximum nesting depth: {MAX_NESTING_DEPTH}")  # 5
 

--- a/docs/features/workflows.mdx
+++ b/docs/features/workflows.mdx
@@ -547,7 +547,7 @@ history = workflow.get_history()
 ```
 
 ```python Conditional Branching (when)
-from praisonaiagents.workflows import when
+from praisonaiagents import when
 
 # Use when() for cleaner conditional syntax (preferred over if_)
 workflow = AgentFlow(steps=[
@@ -561,7 +561,7 @@ workflow = AgentFlow(steps=[
 ```
 
 ```python Workflow Composition (include)
-from praisonaiagents.workflows import include
+from praisonaiagents import include
 
 # Include another workflow for modular composition
 sub_workflow = AgentFlow(name="sub", steps=[...])


### PR DESCRIPTION
Fixes #648 (Section A only). Also satisfies #579 B.1 for the same five files.

## Scope

Section A only — replace `from praisonaiagents.workflows import …` with friendly top-level imports in `docs/features/`. No edits under `docs/concepts/` (Section B is human-gated).

## Files changed

| File | Change |
|------|--------|
| `docs/features/workflows.mdx` | `when`, `include` → top-level import |
| `docs/features/conditional-branching.mdx` | `if_`, `loop`, `If`, `MAX_NESTING_DEPTH` → top-level import |
| `docs/features/nested-workflows.mdx` | `loop`, `parallel`, `route`, `MAX_NESTING_DEPTH` → top-level import |
| `docs/features/multi-agent-pipelines.mdx` | `YAMLWorkflowParser` → top-level import (matches `yaml-workflows.mdx`) |
| `docs/features/modular-recipes.mdx` | `Include` → top-level import |

### Representative before/after (import)

```python
# Before
from praisonaiagents.workflows import loop, parallel

# After
from praisonaiagents import AgentFlow, WorkflowContext, StepResult, loop, parallel
```

## Section C verification

```bash
# 1. No complex workflow imports remain in features/
grep -rn "from praisonaiagents\.workflows" docs/features/
# → zero hits

# 2. Concept pages missing classDef (Section B — not addressed here)
# MISSING classDef: docs/concepts/claw.mdx, conditions.mdx, context*.mdx, guardrails.mdx, knowledge.mdx, memory.mdx, migration-v1.mdx

# 3. docs.json still parses
python3 -c "import json; json.load(open('docs.json'))" && echo "docs.json OK"
# → docs.json OK

# 4. No concepts/ changes
git diff --name-only main...HEAD -- docs/concepts/
# → (empty)
```

## SDK note

Verified against bundled `praisonaiagents/__init__.py`: `when`, `loop`, `parallel`, `route`, `If` resolve via `_LAZY_IMPORTS`. `if_`, `include`, `Include`, `MAX_NESTING_DEPTH`, and `YAMLWorkflowParser` are documented with friendly imports (consistent with existing pages like `yaml-workflows.mdx` and `workflows.mdx` L504) but are **not yet** in `_LAZY_IMPORTS` — SDK re-export follow-up recommended; issue #648 left open for Section B.

## Test plan

- [x] Grep confirms zero `from praisonaiagents.workflows` in `docs/features/`
- [x] No `docs/concepts/` files modified
- [x] `docs.json` parses

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated code examples across workflow documentation to reflect current import paths for workflow features, providing clearer guidance for developers integrating these capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->