### PR TITLE
docs: B.1 friendly imports — remaining #579 files (partial)

### DIFF
--- a/docs/features/advanced-memory.mdx
+++ b/docs/features/advanced-memory.mdx
@@ -356,7 +356,7 @@ quality = (
 Memory results are deterministically ordered for prompt caching effectiveness. Use `build_context_for_task()` with explicit output control for manual prompt assembly.
 
 ```python
-from praisonaiagents.memory import Memory
+from praisonaiagents import Memory
 
 memory = Memory(config={"provider": "rag"})
 

--- a/docs/features/chunking-strategies.mdx
+++ b/docs/features/chunking-strategies.mdx
@@ -62,7 +62,7 @@ response = agent.start("What methodology was used?")
 ```
 
 ```python Direct Chunking API
-from praisonaiagents.knowledge.chunking import Chunking
+from praisonaiagents import Chunking
 
 # Create chunker
 chunker = Chunking(

--- a/docs/features/incremental-indexing.mdx
+++ b/docs/features/incremental-indexing.mdx
@@ -19,7 +19,7 @@ The incremental indexing system provides:
 ## Quick Start
 
 ```python
-from praisonaiagents.knowledge import Knowledge
+from praisonaiagents import Knowledge
 
 knowledge = Knowledge()
 

--- a/docs/features/knowledge-backends.mdx
+++ b/docs/features/knowledge-backends.mdx
@@ -137,7 +137,7 @@ All provided identifiers are required to match (logical AND). Omit an identifier
 For advanced use cases, you can use the Knowledge class directly:
 
 ```python
-from praisonaiagents.knowledge import Knowledge
+from praisonaiagents import Knowledge
 
 # Initialize with config
 knowledge = Knowledge(config={

--- a/docs/features/knowledge.mdx
+++ b/docs/features/knowledge.mdx
@@ -108,7 +108,7 @@ response = agent.start("What are the key findings?")
 ```
 
 ```python Direct Knowledge Use
-from praisonaiagents.knowledge import Knowledge
+from praisonaiagents import Knowledge
 
 # Initialise knowledge base
 kb = Knowledge({
@@ -438,7 +438,7 @@ results = kb.search_graph(
 <CodeGroup>
 ```python Complete Example
 from praisonaiagents import Agent
-from praisonaiagents.knowledge import Knowledge
+from praisonaiagents import Knowledge
 
 # Configure knowledge base
 knowledge_config = {

--- a/docs/features/memory-lifecycle-hooks.mdx
+++ b/docs/features/memory-lifecycle-hooks.mdx
@@ -38,7 +38,7 @@ Override just one hook to get started:
 
 ```python
 from praisonaiagents import Agent
-from praisonaiagents.memory import Memory
+from praisonaiagents import Memory
 
 class MyMemory(Memory):
     def on_pre_compress(self, messages):
@@ -60,7 +60,7 @@ Implement all lifecycle hooks for full control:
 
 ```python
 from praisonaiagents import Agent
-from praisonaiagents.memory import Memory
+from praisonaiagents import Memory
 
 class FullHooksMemory(Memory):
     def on_pre_compress(self, messages):

--- a/docs/features/planning-mode.mdx
+++ b/docs/features/planning-mode.mdx
@@ -352,7 +352,7 @@ result = agents.start()
 
 ```python
 from praisonaiagents import Agent
-from praisonaiagents.planning import PlanningAgent, Plan, PlanStep, TodoList
+from praisonaiagents import PlanningAgent, Plan, PlanStep, TodoList
 
 # Create a planning agent
 planner = PlanningAgent(
@@ -411,7 +411,7 @@ agent = Agent(
 Plans are stored as markdown files in `.praison/plans/`:
 
 ```python
-from praisonaiagents.planning import PlanStorage, Plan, PlanStep
+from praisonaiagents import PlanStorage, Plan, PlanStep
 
 storage = PlanStorage()  # Uses .praison/ by default
 
@@ -467,7 +467,7 @@ Add user authentication to the application.
 ### Approval Flow
 
 ```python
-from praisonaiagents.planning import ApprovalCallback, Plan
+from praisonaiagents import ApprovalCallback, Plan
 
 # Auto-approve all plans
 callback = ApprovalCallback(auto_approve=True)
@@ -487,7 +487,7 @@ callback = ApprovalCallback(approve_fn=ApprovalCallback.console_approval)
 
 ```python
 from praisonaiagents import Agent, Task
-from praisonaiagents.planning import PlanningAgent, TodoList
+from praisonaiagents import PlanningAgent, TodoList
 
 def main():
     # Create agents

--- a/docs/features/skill-capability-gates.mdx
+++ b/docs/features/skill-capability-gates.mdx
@@ -188,7 +188,8 @@ SKILL_CAPABILITY_ENFORCEMENT=strict    # or 'hard', 'fail'
 ### Programmatic Configuration
 
 ```python
-from praisonaiagents.skills import SkillManager, EnforcementLevel
+from praisonaiagents import SkillManager
+from praisonaiagents.skills import EnforcementLevel
 
 # Default (uses environment or 'warn')
 manager = SkillManager()
@@ -204,7 +205,7 @@ manager = SkillManager(enforcement_level=EnforcementLevel.STRICT)
 ### Basic Validation
 
 ```python
-from praisonaiagents.skills import SkillManager
+from praisonaiagents import SkillManager
 
 manager = SkillManager()
 manager.discover(["./skills"])
@@ -308,7 +309,8 @@ requires_tools: [new_required_tool]
 ### Filter to Active-Only Skills for System Prompt
 
 ```python
-from praisonaiagents.skills import SkillManager, EnforcementLevel
+from praisonaiagents import SkillManager
+from praisonaiagents.skills import EnforcementLevel
 
 # Strict mode automatically filters system prompt
 manager = SkillManager(enforcement_level=EnforcementLevel.STRICT)

--- a/docs/features/skill-manage.mdx
+++ b/docs/features/skill-manage.mdx
@@ -117,7 +117,7 @@ All skill management methods return a consistent response format:
 
 **Method Examples:**
 ```python
-from praisonaiagents.skills import SkillManager
+from praisonaiagents import SkillManager
 
 mgr = SkillManager()
 mgr.discover()

--- a/docs/features/skills-invocation.mdx
+++ b/docs/features/skills-invocation.mdx
@@ -88,7 +88,7 @@ Disabled by default. Skills that embed ``!`cmd` `` blocks render as
 </Warning>
 
 ```python
-from praisonaiagents.skills import SkillManager
+from praisonaiagents import SkillManager
 
 mgr = SkillManager()
 mgr.add_skill("./skills/pr-summary")

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -209,7 +209,7 @@ prompt = manager.to_prompt()
 For progressive loading of skills.
 
 ```python
-from praisonaiagents.skills import SkillLoader
+from praisonaiagents import SkillLoader
 
 loader = SkillLoader()
 


### PR DESCRIPTION
## Summary

Partial completion of **#579 B.1** (friendly top-level imports). PR #798 already fixed the 5 workflow files; this PR covers the remaining B.1 files where symbols are re-exported from `praisonaiagents/__init__.py`.

**Files fixed (11):**
- `planning-mode.mdx` — `PlanningAgent`, `Plan`, `PlanStep`, `TodoList`, `PlanStorage`, `ApprovalCallback`
- `knowledge.mdx` — `Knowledge`
- `knowledge-backends.mdx` — `Knowledge` (direct API example)
- `incremental-indexing.mdx` — `Knowledge`
- `chunking-strategies.mdx` — `Chunking`
- `advanced-memory.mdx` — `Memory`
- `memory-lifecycle-hooks.mdx` — `Memory`
- `skills.mdx` — `SkillLoader`
- `skill-manage.mdx` — `SkillManager`
- `skills-invocation.mdx` — `SkillManager`
- `skill-capability-gates.mdx` — `SkillManager` (split from `EnforcementLevel`)

**Skipped — symbols not in top-level `__init__.py` (SDK follow-up needed):**
- `AutoMemory` — `advanced-memory.mdx`
- `ChromaMemory` — `resource-lifecycle.mdx`
- `validate`, `validate_metadata` — `skills.mdx`
- `discover_skills`, `load_skill`, `validate` — `hermes-openclaw-skills-import.mdx`
- `EnforcementLevel`, `SkillState` — `skill-capability-gates.mdx`
- `KnowledgeStoreProtocol`, `ScopeRequiredError`, `BackendNotAvailableError` — `knowledge-backends.mdx`
- `FileTracker`, `IndexResult`, `CorpusStats` — `incremental-indexing.mdx`

Does **not** close #579 (epic incomplete). Does **not** touch `docs/concepts/`.

## Test plan

- [x] Grep `docs/features/` B.1 file list — no forbidden deep imports for exported symbols
- [x] Verified each changed symbol against `praisonaiagents/__init__.py` `_LAZY_IMPORTS`
- [ ] Mintlify build (docs-only import path changes)

Refs #579

Made with [Cursor](https://cursor.com)