### PR TITLE
docs: complete #579 B.1 friendly imports (remaining 7 files)

### DIFF
--- a/docs/features/advanced-memory.mdx
+++ b/docs/features/advanced-memory.mdx
@@ -692,7 +692,7 @@ agent.start("I prefer Python for data science and I'm based in London")
 ### Custom Patterns
 
 ```python
-from praisonaiagents.memory.auto_memory import AutoMemory
+from praisonaiagents import AutoMemory
 
 # Create with custom patterns
 auto_mem = AutoMemory(

--- a/docs/features/hermes-openclaw-skills-import.mdx
+++ b/docs/features/hermes-openclaw-skills-import.mdx
@@ -32,7 +32,7 @@ Import an existing Hermes/OpenClaw skill into your PraisonAI project:
 
 ```python
 from praisonaiagents import Agent
-from praisonaiagents.skills import discover_skills
+from praisonaiagents import discover_skills
 
 # Discover skills from custom directory
 skills = discover_skills(["/path/to/hermes-skills"])
@@ -52,7 +52,7 @@ Validate and safely import skills with error handling:
 
 ```python
 from praisonaiagents import Agent
-from praisonaiagents.skills import validate, load_skill
+from praisonaiagents import validate, load_skill
 
 # Validate skill before import
 skill_path = "/path/to/hermes-skills/data-processor"
@@ -233,7 +233,7 @@ def import_skill(source_path: str, target_dir: str = None) -> str:
 Verify the skill is discoverable by PraisonAI:
 
 ```python
-from praisonaiagents.skills import discover_skills
+from praisonaiagents import discover_skills
 
 def test_discovery(skills_dir: str) -> bool:
     """Test if imported skills are discoverable."""
@@ -320,7 +320,7 @@ Skills coexist with tools through layered integration:
 ```python
 from praisonaiagents import Agent
 from praisonaiagents.tools import tool
-from praisonaiagents.skills import load_skill
+from praisonaiagents import load_skill
 
 # Load Hermes skill
 hermes_skill = load_skill("data-processor", ["/path/to/skills"])
@@ -364,7 +364,7 @@ Use consistent naming to avoid conflicts:
 Review and sanitize script execution:
 
 ```python
-from praisonaiagents.skills import validate
+from praisonaiagents import validate
 
 # Always validate before importing
 def safe_import(skill_path: str) -> bool:

--- a/docs/features/incremental-indexing.mdx
+++ b/docs/features/incremental-indexing.mdx
@@ -47,7 +47,7 @@ print(f"Indexed: {result2.files_indexed}, Skipped: {result2.files_skipped}")
 The `FileTracker` class maintains state about indexed files:
 
 ```python
-from praisonaiagents.knowledge.indexing import FileTracker
+from praisonaiagents import FileTracker
 
 tracker = FileTracker(state_file=".praison/.index_state.json")
 tracker.load()
@@ -126,7 +126,7 @@ praisonai knowledge index ./docs --verbose
 The `IndexResult` dataclass provides detailed statistics:
 
 ```python
-from praisonaiagents.knowledge.indexing import IndexResult
+from praisonaiagents import IndexResult
 
 result = knowledge.index("./docs", memory={"user_id": "my_user"})
 
@@ -142,7 +142,7 @@ print(f"Errors: {result.errors}")
 Get statistics about your indexed corpus:
 
 ```python
-from praisonaiagents.knowledge.indexing import CorpusStats
+from praisonaiagents import CorpusStats
 
 # From directory scan
 stats = CorpusStats.from_directory("./docs")

--- a/docs/features/knowledge-backends.mdx
+++ b/docs/features/knowledge-backends.mdx
@@ -179,7 +179,7 @@ for result in results['results']:
 All backends implement the `KnowledgeStoreProtocol`:
 
 ```python
-from praisonaiagents.knowledge import KnowledgeStoreProtocol
+from praisonaiagents import KnowledgeStoreProtocol
 
 class MyCustomBackend:
     """Custom backend implementing the protocol."""
@@ -227,7 +227,7 @@ config = {
 ## Error Handling
 
 ```python
-from praisonaiagents.knowledge import (
+from praisonaiagents import (
     ScopeRequiredError,
     BackendNotAvailableError,
 )

--- a/docs/features/resource-lifecycle.mdx
+++ b/docs/features/resource-lifecycle.mdx
@@ -119,7 +119,7 @@ graph TB
 ### Using with shared memory
 ```python
 from praisonaiagents import Agent, Task, PraisonAIAgents
-from praisonaiagents.memory import ChromaMemory
+from praisonaiagents import ChromaMemory
 
 researcher = Agent(name="Researcher", instructions="Research and remember findings")
 task = Task(description="Research renewable energy trends", agent=researcher)

--- a/docs/features/skill-capability-gates.mdx
+++ b/docs/features/skill-capability-gates.mdx
@@ -188,8 +188,7 @@ SKILL_CAPABILITY_ENFORCEMENT=strict    # or 'hard', 'fail'
 ### Programmatic Configuration
 
 ```python
-from praisonaiagents import SkillManager
-from praisonaiagents.skills import EnforcementLevel
+from praisonaiagents import SkillManager, EnforcementLevel
 
 # Default (uses environment or 'warn')
 manager = SkillManager()
@@ -234,7 +233,7 @@ for name, result in diagnostics.items():
 ### Filter Skills by State
 
 ```python
-from praisonaiagents.skills import SkillState
+from praisonaiagents import SkillState
 
 # Get only active skills
 active_skills = manager.get_available_skills_by_state(SkillState.ACTIVE)
@@ -309,8 +308,7 @@ requires_tools: [new_required_tool]
 ### Filter to Active-Only Skills for System Prompt
 
 ```python
-from praisonaiagents import SkillManager
-from praisonaiagents.skills import EnforcementLevel
+from praisonaiagents import SkillManager, EnforcementLevel
 
 # Strict mode automatically filters system prompt
 manager = SkillManager(enforcement_level=EnforcementLevel.STRICT)

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -229,7 +229,7 @@ assets = loader.load_assets(skill)
 ### Validation
 
 ```python
-from praisonaiagents.skills import validate, validate_metadata
+from praisonaiagents import validate, validate_metadata
 
 # Validate a skill directory
 errors = validate("./my-skill")


### PR DESCRIPTION
## Summary

Completes **#579 B.1** friendly top-level imports for the 7 files blocked on SDK re-exports (PR #799 partial). Depends on SDK lazy exports in `praisonaiagents/__init__.py` (branch `fix/sdk-lazy-exports-579-b1` in praisonai-package).

**Files fixed:**
- `advanced-memory.mdx` — `AutoMemory`
- `resource-lifecycle.mdx` — `ChromaMemory`
- `skills.mdx` — `validate`, `validate_metadata`
- `hermes-openclaw-skills-import.mdx` — `discover_skills`, `validate`, `load_skill`
- `skill-capability-gates.mdx` — `EnforcementLevel`, `SkillState`
- `knowledge-backends.mdx` — `KnowledgeStoreProtocol`, `ScopeRequiredError`, `BackendNotAvailableError`
- `incremental-indexing.mdx` — `FileTracker`, `IndexResult`, `CorpusStats`

Follows PR #798 (workflow files) and PR #799 (partial B.1). Does **not** touch `docs/concepts/`.

## Test plan

- [x] Grep 7 B.1 files — no `praisonaiagents.memory|skills|knowledge` deep imports remain
- [x] Symbols verified against `praisonaiagents/__init__.py` `_LAZY_IMPORTS`
- [ ] Mintlify build

Refs #579

Made with [Cursor](https://cursor.com)