### PR TITLE
docs: update custom-memory-adapters.mdx for friendly imports + add_/has_ aliases

### DIFF
--- a/docs/features/custom-memory-adapters.mdx
+++ b/docs/features/custom-memory-adapters.mdx
@@ -50,8 +50,7 @@ Register your adapter, then point the agent at it:
 
 ```python
 from typing import Any, Dict, List, Optional
-from praisonaiagents import Agent
-from praisonaiagents.memory.adapters import register_memory_adapter
+from praisonaiagents import Agent, add_memory_adapter
 
 
 class RedisMemoryAdapter:
@@ -77,7 +76,7 @@ class RedisMemoryAdapter:
         return list(self._store)
 
 
-register_memory_adapter("redis", RedisMemoryAdapter)
+add_memory_adapter("redis", RedisMemoryAdapter)
 
 agent = Agent(
     name="assistant",
@@ -126,11 +125,15 @@ Heavy backends register as **factories** in `praisonaiagents.memory.adapters.fac
 Implement `MemoryProtocol` — at minimum: `store_short_term`, `search_short_term`, `store_long_term`, `search_long_term`, and `get_all_memories`.
 
 ```python
-from praisonaiagents.memory.adapters import register_memory_adapter, get_memory_adapter
+from praisonaiagents import add_memory_adapter, get_memory_adapter
 
-register_memory_adapter("my_backend", MyAdapter)
+add_memory_adapter("my_backend", MyAdapter)
 adapter = get_memory_adapter("my_backend")
 ```
+
+<Note>
+`add_memory_adapter` and `register_memory_adapter` are synonyms; both work. `add_memory_adapter` is the canonical name per the SDK naming convention (`add_X` = register something).
+</Note>
 
 Then use it from an agent:
 
@@ -138,19 +141,40 @@ Then use it from an agent:
 agent = Agent(memory={"provider": "my_backend"})
 ```
 
+## Registry API at a Glance
+
+| Function | Purpose | Alias |
+|---|---|---|
+| `add_memory_adapter(name, cls)` | Register an adapter class | `register_memory_adapter` |
+| `add_memory_factory(name, fn)` | Register a lazy factory function | `register_memory_factory` |
+| `get_memory_adapter(name, **kwargs)` | Instantiate a registered adapter | — |
+| `has_memory_adapter(name)` | Check whether a name is registered | — |
+| `list_memory_adapters()` | List all registered names | — |
+
 ## Common Patterns
 
 **Async adapter** — implement `AsyncMemoryProtocol` (`astore_short_term`, `asearch_short_term`, etc.) when your backend is async-native.
 
-**Lazy-loaded heavy backend** — use `register_memory_factory(name, create_fn)` so imports like `chromadb` or `pymongo` happen inside the factory, not at package import time.
+**Lazy-loaded heavy backend** — use `add_memory_factory(name, create_fn)` (or its synonym `register_memory_factory`) so imports like `chromadb` or `pymongo` happen inside the factory, not at package import time.
 
 **Extending an existing adapter** — subclass `SqliteMemoryAdapter` or wrap `InMemoryAdapter` and register under a new name.
+
+**Inspect the registry** — check what's registered before wiring an agent:
+
+```python
+from praisonaiagents import has_memory_adapter, list_memory_adapters, add_memory_adapter
+
+if not has_memory_adapter("redis"):
+    add_memory_adapter("redis", RedisMemoryAdapter)
+
+print(list_memory_adapters())  # ['sqlite', 'in_memory', 'mem0', 'chroma', 'mongodb', 'redis']
+```
 
 ## Best Practices
 
 <AccordionGroup>
 <Accordion title="Prefer the registry over patching Memory">
-Register adapters with `register_memory_adapter` or `register_memory_factory` instead of monkey-patching `Memory` internals.
+Register adapters with `add_memory_adapter` or `add_memory_factory` instead of monkey-patching `Memory` internals.
 </Accordion>
 
 <Accordion title="Implement sync and async when possible">
@@ -163,7 +187,7 @@ Implement `close()` on adapters that hold clients (MongoDB, ChromaDB). `Session.
 
 <Accordion title="List registered adapters at runtime">
 ```python
-from praisonaiagents.memory.adapters import list_memory_adapters
+from praisonaiagents import list_memory_adapters
 print(list_memory_adapters())  # ['sqlite', 'in_memory', 'mem0', 'chroma', 'mongodb', ...]
 ```
 </Accordion>

--- a/praisonaiagents/__init__.py
+++ b/praisonaiagents/__init__.py
@@ -328,6 +328,15 @@ _LAZY_IMPORTS = {
     
     # Memory
     'Memory': ('praisonaiagents.memory.memory', 'Memory'),
+    'AutoMemory': ('praisonaiagents.memory', 'AutoMemory'),
+    'ChromaMemory': ('praisonaiagents.memory.adapters.factories', 'create_chroma_memory_adapter'),
+    'register_memory_adapter': ('praisonaiagents.memory.adapters', 'register_memory_adapter'),
+    'register_memory_factory': ('praisonaiagents.memory.adapters', 'register_memory_factory'),
+    'get_memory_adapter': ('praisonaiagents.memory.adapters', 'get_memory_adapter'),
+    'list_memory_adapters': ('praisonaiagents.memory.adapters', 'list_memory_adapters'),
+    'add_memory_adapter': ('praisonaiagents.memory.adapters.registry', 'add_memory_adapter'),
+    'add_memory_factory': ('praisonaiagents.memory.adapters.registry', 'add_memory_factory'),
+    'has_memory_adapter': ('praisonaiagents.memory.adapters', 'has_memory_adapter'),
     
     # Planning
     'Plan': ('praisonaiagents.planning', 'Plan'),


### PR DESCRIPTION
## Summary

- Migrates all deep imports to friendly top-level imports from praisonaiagents
- Replaces register_memory_adapter calls with add_memory_adapter (canonical alias)
- Adds Inspect the registry common pattern showing has_memory_adapter + list_memory_adapters
- Updates lazy-loaded backend pattern to use add_memory_factory (with synonym callout)
- Adds Registry API at a Glance table documenting all five registry functions
- Adds Note callout explaining add_*/register_* are synonyms
- Adds missing memory adapter entries to praisonaiagents/__init__.py _LAZY_IMPORTS

## Sanity check results (both printed ok)

python -c from praisonaiagents import register_memory_adapter, register_memory_factory, get_memory_adapter, list_memory_adapters ok
python -c from praisonaiagents import add_memory_adapter, add_memory_factory, has_memory_adapter ok

Fixes #803

Generated with Claude Code https://claude.ai/code