### PR TITLE
docs: update scheduler cost tracking and LLM provider aliases (fixes #807)

### DIFF
--- a/docs/cli/cost-tracking.mdx
+++ b/docs/cli/cost-tracking.mdx
@@ -246,6 +246,26 @@ DEFAULT_PRICING["my-custom-model"] = ModelPricing(
 tracker.track_request("my-custom-model", 1000, 500)
 ```
 
+## Scheduler Integration
+
+`AgentScheduler` and `AsyncAgentScheduler` price every run through `ModelPricing` (since [PR #2171](https://github.com/MervinPraison/PraisonAI/pull/2171)). Any model you register here becomes spendable from the scheduler's `max_cost` brake:
+
+```python
+from praisonai.cli.features.cost_tracker import ModelPricing, DEFAULT_PRICING
+from praisonai.scheduler import AsyncAgentScheduler
+
+DEFAULT_PRICING["my-org/custom-llm"] = ModelPricing(
+    model_name="my-org/custom-llm",
+    input_price_per_1m=0.80,
+    output_price_per_1m=2.40,
+    context_window=32000,
+)
+
+scheduler = AsyncAgentScheduler(agent, task="Hourly digest", max_cost=5.00)
+```
+
+Models that are **not** in `DEFAULT_PRICING` are priced at $0 — they still run, but `total_cost_usd` will under-report and the `max_cost` brake won't trip. See [Async Agent Scheduler](/docs/features/async-agent-scheduler) for the full budget pattern.
+
 ## Real-Time Monitoring
 
 ### Display During Operations

--- a/docs/cli/scheduler.mdx
+++ b/docs/cli/scheduler.mdx
@@ -354,8 +354,7 @@ praisonai schedule agents.yaml --verbose
 Budget limit: $0.50
 Timeout per execution: 120s
 ...
-Estimated cost this run: $0.0002, Total: $0.0002
-Budget remaining: $0.4998
+Run cost: $0.0034 (model=gpt-4o-mini, in=2100, out=480). Total: $0.0034 / $0.5
 ...
 Budget limit reached: $0.5001 >= $0.50
 Stopping scheduler to prevent additional costs
@@ -455,6 +454,10 @@ scheduler.start("hourly", max_retries=3, run_immediately=True)
 - **🛡️ Budget Protection**: Auto-stops when cost limit reached
 - **🔄 Retry Logic**: Exponential backoff prevents rapid failures
 
+<Note>
+**Real cost tracking ([PR #2171](https://github.com/MervinPraison/PraisonAI/pull/2171)):** `--max-cost` is now enforced against the real per-token spend pulled from each agent response. Previously the scheduler added a fixed `$0.0001` per run, so the default `$1.00` brake required ~10,000 executions to trip. Set `--max-cost` to your actual budget, and ensure your model is in `DEFAULT_PRICING` (or register it — see [Cost Tracking](/docs/cli/cost-tracking#custom-pricing)) so runs aren't silently priced at $0.
+</Note>
+
 ## Output
 
 The scheduler provides detailed logging with cost tracking:
@@ -471,8 +474,7 @@ Agent scheduler started successfully
 Attempt 1/3
 Agent execution successful on attempt 1
 Result: [agent output]
-Estimated cost this run: $0.0001, Total: $0.0001
-Budget remaining: $0.9999
+Run cost: $0.0034 (model=gpt-4o-mini, in=2100, out=480). Total: $0.0034 / $1.0
 Next execution in 3600 seconds (1.0 hours)
 ```
 

--- a/docs/features/async-agent-scheduler.mdx
+++ b/docs/features/async-agent-scheduler.mdx
@@ -386,23 +386,34 @@ async def main():
 asyncio.run(main())
 ```
 
+<Note>
+**Real cost tracking ([PR #2171](https://github.com/MervinPraison/PraisonAI/pull/2171)):** Before #2171, both schedulers added a fixed `$0.0001` to `total_cost` per run, so the default `max_cost=1.00` only tripped after ~10,000 runs regardless of model. The scheduler now pulls `usage` (input/output tokens) and `model` off the agent response and prices it through `praisonai.cli.features.cost_tracker.ModelPricing`. Responses with no `usage` metadata contribute **$0** — the brake errs on the side of running rather than tripping on missing data. Negative token counts are clamped to `0` so they can never bypass the brake.
+</Note>
+
 ```mermaid
 graph TB
     Start[Execution Start] --> Check{total_cost >= max_cost?}
     Check -->|Yes| Stop[stop_event.set] --> Halt[Scheduler Halts]
     Check -->|No| Run[Run Agent]
-    Run --> AddCost[total_cost += ~$0.0001]
+    Run --> Extract[Extract usage from result]
+    Extract --> HasUsage{usage present?}
+    HasUsage -->|Yes| Price[ModelPricing.calculate_cost in + out tokens]
+    HasUsage -->|No| Zero[run_cost = $0.00]
+    Price --> AddCost[total_cost += run_cost]
+    Zero --> AddCost
     AddCost --> NextLoop[Wait for next interval]
-    
+
     classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
     classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef stop fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef run fill:#10B981,stroke:#7C90A0,color:#fff
-    
+    classDef calc fill:#189AB4,stroke:#7C90A0,color:#fff
+
     class Start start
-    class Check check
+    class Check,HasUsage check
     class Stop,Halt stop
-    class Run,AddCost,NextLoop run
+    class Run,NextLoop run
+    class Extract,Price,Zero,AddCost calc
 ```
 
 ---
@@ -481,17 +492,19 @@ scheduler.start("hourly")
 </Accordion>
 
 <Accordion title="Budget Control">
-The default `max_cost=1.00` is intentional — it caps unattended cost runaway. For long-running production deployments, raise it explicitly to the budget you've approved, or set `max_cost=None` only when an external billing system enforces limits.
+The default `max_cost=1.00` caps unattended cost runaway. Since [PR #2171](https://github.com/MervinPraison/PraisonAI/pull/2171), `total_cost_usd` is the real per-token spend computed from each response's `usage` field — pick a value that matches your approved budget, not a multiple chosen to compensate for an undercount.
 
 ```python
 # Production with explicit budget
 scheduler = AsyncAgentScheduler(agent, task, max_cost=50.00)
 
-# Disable budget (only when external limits exist)
+# Disable budget (only when external limits enforce it)
 scheduler = AsyncAgentScheduler(agent, task, max_cost=None)
 ```
 
 When the budget triggers, the scheduler logs a warning and calls `stop_event.set()` internally — `stats["is_running"]` flips to `False`.
+
+If your model is missing from `DEFAULT_PRICING`, the run is priced at `$0` and `total_cost_usd` will under-report — register it via the [custom pricing](/docs/cli/cost-tracking#custom-pricing) snippet so the brake stays meaningful.
 </Accordion>
 
 <Accordion title="Timeout Configuration">

--- a/docs/features/async-scheduler.mdx
+++ b/docs/features/async-scheduler.mdx
@@ -284,23 +284,34 @@ async def main():
 asyncio.run(main())
 ```
 
+<Note>
+**Real cost tracking ([PR #2171](https://github.com/MervinPraison/PraisonAI/pull/2171)):** Before #2171, both schedulers added a fixed `$0.0001` to `total_cost` per run, so the default `max_cost=1.00` only tripped after ~10,000 runs regardless of model. The scheduler now pulls `usage` (input/output tokens) and `model` off the agent response and prices it through `praisonai.cli.features.cost_tracker.ModelPricing`. Responses with no `usage` metadata contribute **$0** — the brake errs on the side of running rather than tripping on missing data. Negative token counts are clamped to `0` so they can never bypass the brake.
+</Note>
+
 ```mermaid
 graph TB
     Start[Execution Start] --> Check{total_cost >= max_cost?}
     Check -->|Yes| Stop[stop_event.set] --> Halt[Scheduler Halts]
     Check -->|No| Run[Run Agent]
-    Run --> AddCost[total_cost += ~$0.0001]
+    Run --> Extract[Extract usage from result]
+    Extract --> HasUsage{usage present?}
+    HasUsage -->|Yes| Price[ModelPricing.calculate_cost in + out tokens]
+    HasUsage -->|No| Zero[run_cost = $0.00]
+    Price --> AddCost[total_cost += run_cost]
+    Zero --> AddCost
     AddCost --> NextLoop[Wait for next interval]
-    
+
     classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
     classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef stop fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef run fill:#10B981,stroke:#7C90A0,color:#fff
-    
+    classDef calc fill:#189AB4,stroke:#7C90A0,color:#fff
+
     class Start start
-    class Check check
+    class Check,HasUsage check
     class Stop,Halt stop
-    class Run,AddCost,NextLoop run
+    class Run,NextLoop run
+    class Extract,Price,Zero,AddCost calc
 ```
 
 ---
@@ -367,17 +378,19 @@ finally:
 </Accordion>
 
 <Accordion title="Budget Control">
-The default `max_cost=1.00` is intentional — it caps unattended cost runaway. For long-running production deployments, raise it explicitly to the budget you've approved, or set `max_cost=None` only when an external billing system enforces limits.
+The default `max_cost=1.00` caps unattended cost runaway. Since [PR #2171](https://github.com/MervinPraison/PraisonAI/pull/2171), `total_cost_usd` is the real per-token spend computed from each response's `usage` field — pick a value that matches your approved budget, not a multiple chosen to compensate for an undercount.
 
 ```python
 # Production with explicit budget
 scheduler = AsyncAgentScheduler(agent, task, max_cost=50.00)
 
-# Disable budget (only when external limits exist)
+# Disable budget (only when external limits enforce it)
 scheduler = AsyncAgentScheduler(agent, task, max_cost=None)
 ```
 
 When the budget triggers, the scheduler logs a warning and calls `stop_event.set()` internally — `stats["is_running"]` flips to `False`.
+
+If your model is missing from `DEFAULT_PRICING`, the run is priced at `$0` and `total_cost_usd` will under-report — register it via the [custom pricing](/docs/cli/cost-tracking#custom-pricing) snippet so the brake stays meaningful.
 </Accordion>
 
 <Accordion title="Timeout Configuration">

--- a/docs/models/custom-provider.mdx
+++ b/docs/models/custom-provider.mdx
@@ -10,6 +10,8 @@ The Custom Provider Registry allows you to register custom LLM providers that ex
 
 <Note>
 **Updated in PR #1624**: Built-in providers (`openai`, `anthropic`, `google`) plus aliases (`oai`, `claude`, `gemini`, `google_genai`) are now auto-registered and backed by LiteLLM. You add custom providers when you need a non-LiteLLM backend or a custom routing/caching/mocking layer.
+
+**Verified end-to-end in [PR #2171](https://github.com/MervinPraison/PraisonAI/pull/2171):** alias registration previously checked the resolved-provider cache (empty at init) instead of the loader map, so `oai`, `claude`, `gemini`, and `google_genai` silently raised `ValueError`. Resolving via any of these prefixes now succeeds.
 </Note>
 
 ## Built-in providers


### PR DESCRIPTION
## Summary

- Replace outdated `total_cost += ~$0.0001` Mermaid nodes in `async-agent-scheduler.mdx` and `async-scheduler.mdx` with the real `ModelPricing` cost flow introduced in PR #2171
- Add `<Note>` callouts explaining the before/after behavior for cost tracking in both scheduler feature docs
- Update Budget Control accordions to accurately reflect per-token spend
- Replace sample log lines in `scheduler.mdx` (`Estimated cost this run: $0.0001`) with the real `Run cost: $X (model=..., in=..., out=...)` format
- Add Safety Features `<Note>` in `scheduler.mdx` about `--max-cost` accuracy
- Add `## Scheduler Integration` H2 section to `cost-tracking.mdx` showing how `ModelPricing`/`DEFAULT_PRICING` connects to the scheduler `max_cost` brake
- Append alias verification note to `custom-provider.mdx` confirming `oai`/`claude`/`gemini`/`google_genai` now resolve correctly

Fixes #807

Generated with [Claude Code](https://claude.ai/code)