### PR TITLE
docs: add praisonai init page + update agent/command/custom-agents pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1259,6 +1259,7 @@
                 "group": "Core Commands",
                 "icon": "play",
                 "pages": [
+                  "docs/cli/init",
                   "docs/cli/run",
                   "docs/cli/agent",
                   "docs/cli/command",
@@ -1271,7 +1272,6 @@
                   "docs/cli/acp",
                   "docs/cli/auth",
                   "docs/cli/auto",
-                  "docs/cli/init",
                   "docs/cli/serve",
                   "docs/cli/dashboard",
                   "docs/cli/mcp-server",

--- a/docs/cli/agent.mdx
+++ b/docs/cli/agent.mdx
@@ -28,6 +28,10 @@ praisonai agent list --verbose
 praisonai agent show researcher
 ```
 
+<Tip>
+No agents yet? Run [`praisonai init`](/docs/cli/init) to scaffold a working starter agent in `.praisonai/agents/assistant.md`.
+</Tip>
+
 ## Related
 
 <CardGroup cols={2}>
@@ -36,5 +40,8 @@ praisonai agent show researcher
   </Card>
   <Card title="Run" icon="play" href="/docs/cli/run">
     Run with --agent
+  </Card>
+  <Card title="Init" icon="wand-magic-sparkles" href="/docs/cli/init">
+    Scaffold a starter agent in one command
   </Card>
 </CardGroup>

--- a/docs/cli/command.mdx
+++ b/docs/cli/command.mdx
@@ -29,6 +29,10 @@ praisonai command show summarise
 praisonai command show summarise --preview
 ```
 
+<Tip>
+No commands yet? Run [`praisonai init`](/docs/cli/init) to scaffold a working starter command in `.praisonai/commands/review.md`.
+</Tip>
+
 ## Related
 
 <CardGroup cols={2}>
@@ -37,5 +41,8 @@ praisonai command show summarise --preview
   </Card>
   <Card title="Run" icon="play" href="/docs/cli/run">
     Run with --command
+  </Card>
+  <Card title="Init" icon="wand-magic-sparkles" href="/docs/cli/init">
+    Scaffold a starter command in one command
   </Card>
 </CardGroup>

--- a/docs/cli/init.mdx
+++ b/docs/cli/init.mdx
@@ -1,102 +1,213 @@
 ---
 title: "Init"
 sidebarTitle: "Init"
-description: "Initialize agents.yaml with intelligent tool discovery"
-icon: "play"
+description: "Scaffold the .praisonai/ project convention in one command"
+icon: "wand-magic-sparkles"
 ---
 
-The `--init` flag initializes a new agents.yaml configuration file with **intelligent tool discovery** - automatically assigning the most appropriate tools based on your task description.
+`praisonai init` creates a working `.praisonai/` project — config, a starter agent, and a starter command — so the next two commands you type already run.
+
+```mermaid
+graph LR
+    subgraph "praisonai init"
+        I[⚡ praisonai init] --> S[📁 .praisonai/]
+        S --> C[📝 config.yaml]
+        S --> A[🤖 agents/assistant.md]
+        S --> CMD[🛠 commands/review.md]
+    end
+
+    classDef cmd fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef dir fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef file fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class I cmd
+    class S dir
+    class C,A,CMD file
+```
 
 ## Quick Start
 
-```bash
-praisonai --init "Research stock prices and create a financial report"
-```
+<Steps>
 
-## Usage
+<Step title="Scaffold the project">
 
 ```bash
-praisonai --init [topic] [options]
+praisonai init
 ```
 
-## Options
+This writes three files under `.praisonai/` — skipping any that already exist.
 
-| Option | Description |
-|--------|-------------|
-| `--init` | Initialize agents with optional topic |
-| `--framework` | Framework to use (crewai, autogen, praisonai) |
-| `--merge` | Merge with existing agents.yaml |
+</Step>
 
-## Intelligent Tool Discovery
+<Step title="Run the scaffolded agent">
 
-The init command analyzes your task and automatically assigns tools from 9 categories:
-
-| Category | Example Tools | Keywords |
-|----------|---------------|----------|
-| **Web Search** | `internet_search`, `tavily_search` | search, find, look up |
-| **Web Scraping** | `scrape_page`, `crawl` | scrape, crawl, extract |
-| **File Operations** | `read_file`, `write_file` | read, save, load |
-| **Code Execution** | `execute_command` | execute, run, script |
-| **Data Processing** | `read_csv`, `write_csv` | csv, excel, json |
-| **Research** | `search_arxiv`, `wiki_search` | research, paper, academic |
-| **Finance** | `get_stock_price` | stock, price, financial |
-| **Math** | `evaluate`, `solve_equation` | calculate, math |
-| **Database** | `query`, `find_documents` | database, sql, mongodb |
-
-## Examples
-
-### Financial Research
 ```bash
-praisonai --init "Research stock prices and create a financial report"
+praisonai agent run assistant "hello"
 ```
 
-**Generated agents.yaml:**
-```yaml
-framework: praisonai
-topic: Research stock prices and create a financial report
-roles:
-  financial_researcher:
-    role: Financial Analyst
-    goal: Research stock prices and compile a detailed financial report
-    tools:
-    - internet_search
-    - get_stock_price
-    - get_stock_info
-    - get_historical_data
-    - write_file
-```
+</Step>
 
-### Web Scraping Pipeline
+<Step title="Run the scaffolded command">
+
 ```bash
-praisonai --init "Scrape websites for product data and save to CSV"
+praisonai command run review "src/foo.py"
 ```
 
-**Generated agents.yaml:**
-```yaml
-roles:
-  data_scraper:
-    role: Web Scraping Specialist
-    tools: [scrape_page, extract_links, crawl, extract_text]
-  data_processor:
-    role: Data Processing Specialist
-    tools: [write_csv, read_csv, analyze_csv]
-```
+</Step>
 
-### With Framework
-```bash
-praisonai --init "Data Pipeline" --framework praisonai
-```
+</Steps>
 
 ## How It Works
 
-1. **Task Analysis**: Analyzes complexity (simple → 1 agent, complex → 3-4 agents)
-2. **Keyword Matching**: Identifies relevant tool categories
-3. **Tool Assignment**: Assigns appropriate tools from 50+ available
-4. **YAML Generation**: Creates ready-to-use agents.yaml
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as praisonai init
+    participant FS as File system
 
-## Next Steps
+    User->>CLI: praisonai init
+    CLI->>FS: Resolve target (git root or cwd)
+    CLI->>FS: Write config.yaml / agents/ / commands/
+    FS-->>CLI: Created / Skipped per file
+    CLI-->>User: Next-step commands
+```
 
-After initialization:
-1. Review the generated `agents.yaml`
-2. Customize agents if needed
-3. Run with `praisonai agents.yaml`
+| Step | What happens |
+|------|-------------|
+| Resolve target | Walks up to the git root (or uses cwd) and sets `.praisonai/` as the base |
+| Write files | Creates `config.yaml`, `agents/assistant.md`, `commands/review.md` |
+| Report | Prints `Created <path>` or `Skipped (already exists, use --force): <path>` per file |
+| Next steps | Prints the exact `agent run` and `command run` commands you can copy |
+
+## Project vs global
+
+```mermaid
+graph TB
+    Q{Where should agents/commands live?}
+    Q -->|Share with the team via git| P[praisonai init]
+    Q -->|Personal across all projects| G[praisonai init --global]
+    P --> PD[./.praisonai/]
+    G --> GD[~/.praisonai/]
+
+    classDef pick fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef cmd fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef dir fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Q pick
+    class P,G cmd
+    class PD,GD dir
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--global` | `bool` | `False` | Scaffold the user-global `~/.praisonai/` instead of the project directory |
+| `--force` / `-f` | `bool` | `False` | Overwrite existing files (otherwise existing files are skipped) |
+
+## Scaffolded files
+
+**`config.yaml`** — project-wide defaults:
+
+```yaml
+# PraisonAI project configuration
+# Defaults applied to scaffolded agents and commands.
+model: gpt-4o-mini
+output: text
+```
+
+**`agents/assistant.md`** — ready-to-run starter agent:
+
+```markdown
+---
+model: gpt-4o-mini
+role: Assistant
+goal: Help the user accomplish tasks accurately and concisely
+instructions: |
+  You are a helpful assistant. Answer clearly and concisely.
+  When you are unsure, say so instead of guessing.
+---
+You are a helpful assistant for this project.
+
+Be concise, accurate, and practical. Prefer actionable answers.
+```
+
+**`commands/review.md`** — starter command using `$ARGUMENTS` and `@file`:
+
+```markdown
+---
+description: Review the provided code or file and suggest improvements
+---
+Review the following and suggest concrete improvements
+(correctness, readability, performance, and security):
+
+$ARGUMENTS
+
+If a file path is provided, here are its contents:
+
+@$ARGUMENTS
+```
+
+## Common Patterns
+
+### Scaffold a fresh project
+
+```bash
+praisonai init
+praisonai agent run assistant "hello"
+```
+
+### Re-init after editing a file
+
+`praisonai init` is idempotent — it skips files that already exist. To overwrite with the original starters:
+
+```bash
+praisonai init --force
+```
+
+### Set up personal shortcuts
+
+```bash
+praisonai init --global
+```
+
+Agents and commands land in `~/.praisonai/` and are available in every project. Project-level definitions override global ones on name collision.
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Commit .praisonai/ to git">
+Check in `.praisonai/agents/` and `.praisonai/commands/` so the whole team shares the same agents and commands without any extra setup.
+</Accordion>
+
+<Accordion title="Keep ~/.praisonai/ personal">
+Use `--global` for shortcuts that are specific to you. Team-shared agents belong in the project directory — project files override global on name collision.
+</Accordion>
+
+<Accordion title="Edit the starter files, don't replace them">
+The scaffolded files match the exact shape `CustomDefinitionsDiscovery` parses: frontmatter fields for agents, `$ARGUMENTS` / `@file` substitutions for commands. Keep that structure when customising.
+</Accordion>
+
+<Accordion title="Use --force carefully">
+`--force` overwrites existing files without prompting. Commit or back up your edits first.
+</Accordion>
+
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Custom Agents & Commands" icon="file-code" href="/docs/features/custom-agents-commands">
+    Agent frontmatter fields, command template syntax, and discovery rules
+  </Card>
+  <Card title="Agent CLI" icon="robot" href="/docs/cli/agent">
+    List and inspect custom agents
+  </Card>
+  <Card title="Command CLI" icon="terminal" href="/docs/cli/command">
+    List and preview custom commands
+  </Card>
+  <Card title="Config CLI" icon="sliders" href="/docs/cli/config">
+    Manage project and global configuration
+  </Card>
+</CardGroup>

--- a/docs/features/custom-agents-commands.mdx
+++ b/docs/features/custom-agents-commands.mdx
@@ -27,6 +27,14 @@ graph LR
 
 ## Quick Start
 
+<Note>
+Skip the boilerplate — [`praisonai init`](/docs/cli/init) scaffolds a working `.praisonai/` with a starter agent and command, then read on to customise.
+</Note>
+
+```bash
+praisonai init
+```
+
 <Steps>
 
 <Step title="Create an agent file">
@@ -187,5 +195,8 @@ Use `~/.praisonai/` for personal shortcuts that should not override team agents.
   </Card>
   <Card title="Slash Commands" icon="slash" href="/docs/cli/slash-commands">
     Interactive custom commands
+  </Card>
+  <Card title="Init CLI" icon="wand-magic-sparkles" href="/docs/cli/init">
+    Scaffold .praisonai/ in one command
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

- Rewrites `docs/cli/init.mdx` for the new `praisonai init` scaffold subcommand (replaces old `--init` flag content): hero diagram, Quick Start Steps, How It Works sequence diagram, project-vs-global decision diagram, Flags table, Scaffolded files, Common Patterns, Best Practices AccordionGroup, Related CardGroup
- Adds `<Note>` callout + Step 0 `praisonai init` + Init card to `docs/features/custom-agents-commands.mdx`
- Adds `<Tip>` callout + Init card to `docs/cli/agent.mdx`
- Adds `<Tip>` callout + Init card to `docs/cli/command.mdx`
- Moves `docs/cli/init` to top of Core Commands group in `docs.json`

Fixes #809

Generated with [Claude Code](https://claude.ai/code)