### PR TITLE
docs: document memory backend fallback behavior

### DIFF
--- a/docs/features/advanced-memory.mdx
+++ b/docs/features/advanced-memory.mdx
@@ -317,6 +317,64 @@ memory_config = {
 }
 ```
 
+## Backend Fallback
+
+PraisonAI automatically falls back to SQLite when a configured backend (Redis, Valkey, Postgres) is unavailable, so your agent keeps working without crashing.
+
+```python
+from praisonaiagents import Agent, MemoryConfig
+
+# Configure Redis — if redis-py isn't installed,
+# PraisonAI falls back to SQLite automatically.
+agent = Agent(
+    name="Assistant",
+    instructions="You remember user preferences.",
+    memory=MemoryConfig(backend="redis", user_id="user_123")
+)
+
+agent.start("Remember I prefer dark mode")
+```
+
+```mermaid
+graph LR
+    Config[📋 MemoryConfig backend=redis] --> Try{🔍 Redis available?}
+    Try -->|Yes| Redis[(🗃️ Redis)]
+    Try -->|No| Adapter[💾 SqliteMemoryAdapter]
+    Adapter --> Tables[(short_term_memory<br/>long_term_memory)]
+
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef storage fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Config config
+    class Try decision
+    class Redis,Adapter,Tables storage
+```
+
+| Configured backend | Fallback when unavailable | Search/store path |
+|---|---|---|
+| `redis` | SQLite (adapter) | `memory_adapter.search_*` / `store_*` |
+| `valkey` | SQLite (adapter) | `memory_adapter.search_*` / `store_*` |
+| `postgres` | SQLite (adapter) | `memory_adapter.search_*` / `store_*` |
+| `sqlite` | n/a (native) | `memory_adapter.*` (direct) |
+| `file` | n/a (native) | FileMemory (direct) |
+| `mem0` | raises `ImportError` | direct Mem0 client |
+| `mongodb` | raises error | direct Mongo client |
+
+<Note>
+Before the fix in PraisonAI PR #2190, configuring `backend="redis"` without `redis-py` installed produced `sqlite3.OperationalError: no such table: short_mem` on the first memory call. The SQLite adapter now owns the correct schema (`short_term_memory` / `long_term_memory`), so fallback is transparent.
+</Note>
+
+<AccordionGroup>
+<Accordion title="Symptom: sqlite3.OperationalError: no such table: short_mem">
+**Cause:** You are running a version of PraisonAI before PR #2190. A non-default backend (e.g. `redis`) was configured but its dependency was not installed, causing a silent fallback to SQLite — which then queried the legacy `short_mem` table that no longer exists.
+
+**Fix:** Upgrade PraisonAI to the release that includes PR #2190, or install the dependency for your configured backend (e.g. `pip install redis` for Redis).
+</Accordion>
+</AccordionGroup>
+
+---
+
 ## Quality Scoring System
 
 ### Quality Metrics


### PR DESCRIPTION
## Summary

- Adds a new **Backend Fallback** section to `docs/features/advanced-memory.mdx` between "Configuration Options" and "Quality Scoring System"
- Documents the automatic SQLite fallback when a configured backend (Redis, Valkey, Postgres) is unavailable
- Includes a Mermaid diagram, behavior table, runnable code example, `<Note>` callout about PR #2190, and a troubleshooting `<AccordionGroup>`
- Does NOT touch `docs/concepts/` (HUMAN-ONLY per AGENTS.md rule 1.8)

Fixes #820

Upstream fix: MervinPraison/PraisonAI#2190

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for automatic memory backend fallback behavior, including examples and troubleshooting guidance for scenarios when primary backends (Redis/Valkey/Postgres) are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->