### PR TITLE
docs: update installer pages for frictionless uv/pipx/venv install

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -47,6 +47,15 @@
             ]
           },
           {
+            "group": "Install",
+            "icon": "download",
+            "pages": [
+              "docs/install/quickstart",
+              "docs/install/installer",
+              "docs/install/isolation-backends"
+            ]
+          },
+          {
             "group": "Core Concepts",
             "icon": "lightbulb",
             "pages": [

--- a/docs/developers/scripts.mdx
+++ b/docs/developers/scripts.mdx
@@ -11,7 +11,7 @@ The `src/praisonai/scripts/` folder contains automation scripts for development,
 
 | Script | Purpose |
 |--------|---------|
-| `install.sh` | One-liner installer for macOS/Linux |
+| `install.sh` | Frictionless, environment-isolated one-liner installer (uv tool → pipx → venv fallback) |
 | `install.ps1` | One-liner installer for Windows |
 | `bump_and_release.py` | Automated version bump and release |
 | `bump_version.py` | Version management utility |
@@ -38,11 +38,13 @@ iwr -useb https://praison.ai/install.ps1 | iex
 ### Features
 
 - **OS Detection** - Automatically detects macOS, Linux (various distros), Windows, WSL
-- **Python Management** - Installs Python 3.10+ if not available
+- **Isolation Backend** - Auto-selects `uv tool` → `pipx` → venv fallback; override with `--backend`
+- **Python Management** - Installs Python 3.10+ if not available (venv path only)
 - **Package Manager Support** - brew, apt, dnf, pacman, winget, chocolatey
-- **Virtual Environment** - Creates isolated venv at `~/.praisonai/`
-- **PATH Configuration** - Adds to shell profile automatically
-- **Interactive Onboarding** - Prompts for bot setup after installation
+- **PATH Shim** - Drops `~/.local/bin/praisonai` so the CLI is available without activating a venv
+- **Idempotent PATH Block** - Appends a clearly-marked `# >>> PraisonAI PATH >>>` block to shell rc; skip with `--no-modify-path`
+- **Shell Completions** - Offers to install bash/zsh/fish completions via `praisonai completion <shell>`
+- **Interactive Onboarding** - Prompts for LLM setup and bot configuration after installation
 - **Dry Run Mode** - Preview changes before applying
 
 ### Environment Variables
@@ -50,25 +52,34 @@ iwr -useb https://praison.ai/install.ps1 | iex
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PRAISONAI_VERSION` | `latest` | Specific version to install |
-| `PRAISONAI_EXTRAS` | `""` | Comma-separated extras (ui,chat,api) |
-| `PRAISONAI_SKIP_VENV` | `0` | Skip virtual environment |
+| `PRAISONAI_EXTRAS` | `""` | Comma-separated extras (defaults to `all`) |
+| `PRAISONAI_BACKEND` | `auto` | Force backend: `uv` / `pipx` / `venv` / `system` / `auto` |
+| `PRAISONAI_INSTALL_DIR` | `~/.praisonai` | Base dir for the venv fallback |
+| `PRAISONAI_NO_MODIFY_PATH` | `0` | Skip shell rc PATH modification (`1` to enable) |
+| `PRAISONAI_SKIP_VENV` | `0` | Skip isolation entirely (`1` to enable) |
 | `PRAISONAI_DRY_RUN` | `0` | Preview mode |
 | `PRAISONAI_NO_ONBOARD` | `0` | Skip interactive onboarding entirely |
 
 ### Examples
 
 ```bash
-# Install specific version
-PRAISONAI_VERSION=2.2.0 curl -fsSL https://praison.ai/install.sh | bash
+# Basic install (isolated: uv tool -> pipx -> venv)
+curl -fsSL https://praison.ai/install.sh | bash
+
+# Force pipx backend
+curl -fsSL https://praison.ai/install.sh | bash -s -- --backend pipx
 
 # Install with extras
 PRAISONAI_EXTRAS=ui,chat curl -fsSL https://praison.ai/install.sh | bash
+
+# Don't touch shell rc
+curl -fsSL https://praison.ai/install.sh | bash -s -- --no-modify-path
 
 # Dry run (preview only)
 PRAISONAI_DRY_RUN=1 curl -fsSL https://praison.ai/install.sh | bash
 
 # Non-interactive for CI/CD
-curl -fsSL https://praison.ai/install.sh | bash -s -- --no-interactive
+curl -fsSL https://praison.ai/install.sh | bash -s -- --no-prompt
 ```
 
 ---

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -82,11 +82,24 @@ mode: "custom"
       ```bash
       curl -fsSL https://praison.ai/install.sh | bash
       ```
+      Isolated install via `uv tool` → `pipx` → venv fallback. CLI available at `~/.local/bin/praisonai`.
     </Tab>
     <Tab title="Windows (PowerShell)">
       ```powershell
       iwr -useb https://praison.ai/install.ps1 | iex
       ```
+    </Tab>
+    <Tab title="uvx (zero-install)">
+      ```bash
+      uvx praisonai "2+2"
+      ```
+      Runs PraisonAI without a permanent install. Requires [uv](https://github.com/astral-sh/uv).
+    </Tab>
+    <Tab title="pipx">
+      ```bash
+      pipx install praisonai
+      ```
+      Isolated persistent install. Requires [pipx](https://pipx.pypa.io/).
     </Tab>
     <Tab title="pip">
       ```bash

--- a/docs/install/installer.mdx
+++ b/docs/install/installer.mdx
@@ -1,82 +1,99 @@
 ---
 title: "Installer Internals"
-description: "How the PraisonAI installer scripts work"
+sidebarTitle: "Installer"
+description: "How the PraisonAI install.sh works — three isolation backends, shell completions, and PATH management"
 icon: "gear"
 ---
 
-<Info>
-This page explains how `install.sh` and `install.ps1` work under the hood.
-</Info>
+The PraisonAI installer automatically picks the best isolation backend (`uv tool` → `pipx` → venv fallback) so you get a working `praisonai` CLI without touching your global Python environment.
 
 ```mermaid
 flowchart TD
-    A[Start]:::agent --> B{Detect OS}:::tool
-    B -->|macOS| C[Homebrew]:::tool
-    B -->|Linux| D[apt/dnf/pacman]:::tool
-    B -->|Windows| E[winget/choco]:::tool
-    C --> F{Python 3.10+?}:::agent
-    D --> F
-    E --> F
-    F -->|No| G[Install Python]:::tool
-    F -->|Yes| H[Create venv]:::tool
+    A[curl praison.ai/install.sh | bash]:::tool --> B{Detect Backend}:::agent
+    B -->|uv found| C[uv tool install praisonai\[all\]]:::tool
+    B -->|pipx found| D[pipx install praisonai\[all\]]:::tool
+    B -->|neither| E[Create venv at ~/.praisonai/venv]:::tool
+    E --> F[pip install praisonai\[all\]]:::tool
+    F --> G[Shim → ~/.local/bin/praisonai]:::process
+    C --> H[Ensure ~/.local/bin on PATH]:::process
+    D --> H
     G --> H
-    H --> I[pip install]:::tool
-    I --> J[Setup PATH]:::tool
-    J --> K[Verify]:::agent
-    K --> L[Setup wizard]:::process
-    L --> M{Onboard?}:::agent
-    M -->|Yes| N[Bot onboarding]:::process
-    M -->|No| O[Next Steps]:::success
-    N --> P[✅ Done panel]:::success
-    
-    classDef agent fill:#8B0000,color:#fff
-    classDef tool fill:#189AB4,color:#fff
-    classDef process fill:#F59E0B,color:#fff
-    classDef success fill:#10B981,color:#fff
+    H --> I[Verify install]:::agent
+    I --> J[Offer shell completions]:::process
+    J --> K[Interactive onboarding]:::process
+    K --> L[✅ Ready]:::success
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
 ```
 
-## install.sh (macOS/Linux)
+## install.sh (macOS / Linux / WSL)
 
-### What It Does
+### How It Works
 
 <Steps>
   <Step title="Detect OS">
-    Identifies macOS, Linux distro, or WSL
+    Identifies macOS, Linux distro, or WSL via `uname -s` and `/proc/version`.
   </Step>
-  <Step title="Check Python">
-    Looks for Python 3.10+ in common locations
+  <Step title="Detect isolation backend">
+    Checks `PRAISONAI_BACKEND` / `--backend` first. In `auto` mode (default), prefers `uv tool` → `pipx` → venv fallback.
   </Step>
-  <Step title="Install Python (if needed)">
-    - **macOS**: Homebrew (`brew install python@3.12`)
-    - **Ubuntu/Debian**: apt (`apt install python3`)
-    - **Fedora/RHEL**: dnf (`dnf install python3`)
-    - **Arch**: pacman (`pacman -S python`)
-    - **Alpine**: apk (`apk add python3`)
+  <Step title="Build package spec">
+    Defaults to `praisonai[all]` for a full install. Respects `PRAISONAI_EXTRAS` / `--extras` and `PRAISONAI_VERSION` / `--version`.
   </Step>
-  <Step title="Create Virtual Environment">
-    Creates isolated environment at `~/.praisonai/venv`
+  <Step title="Install via chosen backend">
+    - **uv**: `uv tool install --force praisonai[all]` + `uv tool update-shell`
+    - **pipx**: `pipx install --force praisonai[all]` + `pipx ensurepath`
+    - **venv**: Python check → `python -m venv ~/.praisonai/venv` → `pip install praisonai[all]` → symlink `~/.local/bin/praisonai → ~/.praisonai/venv/bin/praisonai`
   </Step>
-  <Step title="Install PraisonAI">
-    Runs `pip install praisonaiagents`
+  <Step title="Ensure ~/.local/bin on PATH">
+    Adds `~/.local/bin` to the current shell session and appends an idempotent block to your shell rc (unless `--no-modify-path`):
+    ```
+    # >>> PraisonAI PATH >>>
+    export PATH="$HOME/.local/bin:$PATH"
+    # <<< PraisonAI PATH <<<
+    ```
   </Step>
-  <Step title="Configure PATH">
-    Adds venv to shell rc file (`.zshrc`, `.bashrc`, etc.)
+  <Step title="Verify installation">
+    - **venv backend**: imports `praisonaiagents` via the venv python.
+    - **uv / pipx backends**: checks that the resolved `praisonai` CLI runs (isolated env, not system Python).
   </Step>
-  <Step title="Verify Installation">
-    Tests import and CLI availability
+  <Step title="Offer shell completions">
+    Prompts once (TTY only, skipped under `--no-prompt` / `--no-onboard` / `--dry-run`) to install tab-completions for bash, zsh, or fish.
   </Step>
-  <Step title="Interactive Setup">
-    Runs `praisonai setup` for LLM configuration
-  </Step>
-  <Step title="Bot Onboarding">
-    Optional `praisonai onboard` for messaging bots — asks 4 questions to configure Telegram/Discord/Slack/WhatsApp
-  </Step>
-  <Step title="Final Summary">
-    Shows either onboard wizard's ✅ Done panel or installer's Next Steps
+  <Step title="Interactive onboarding">
+    Runs `praisonai setup` for LLM API key configuration, then offers `praisonai onboard` for Telegram / Discord / Slack / WhatsApp bot setup.
   </Step>
 </Steps>
 
-### CLI Flags
+---
+
+## User Interaction Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant I as Installer
+    participant B as Backend (uv/pipx/venv)
+    participant S as Shell rc
+
+    U->>I: curl praison.ai/install.sh | bash
+    I->>I: detect_backend() → uv / pipx / venv
+    I->>B: install praisonai[all]
+    B-->>I: binary at ~/.local/bin/praisonai
+    I->>S: append PraisonAI PATH block (idempotent)
+    I->>I: verify_installation()
+    I->>U: Install shell completions? [Y/n]
+    I->>U: praisonai setup (LLM key wizard)
+    I->>U: Set up messaging bot? [Y/n]
+    I-->>U: ✅ Done
+```
+
+---
+
+## CLI Flags
 
 ```bash
 curl -fsSL https://praison.ai/install.sh | bash -s -- --help
@@ -84,88 +101,98 @@ curl -fsSL https://praison.ai/install.sh | bash -s -- --help
 
 | Flag | Description |
 |------|-------------|
-| `--version VERSION` | Install specific version |
-| `--extras EXTRAS` | Install with extras (e.g., `ui,chat`) |
-| `--no-venv` | Skip virtual environment |
-| `--python PATH` | Use specific Python |
-| `--dry-run` | Preview without changes |
-| `--no-prompt` | Non-interactive mode |
-| `--no-onboard` | Skip interactive onboarding |
+| `--version VERSION` | Install specific version (default: `latest`) |
+| `--extras EXTRAS` | Install with extras, e.g. `ui,chat` (default: `all`) |
+| `--backend BACKEND` | Force isolation backend: `uv`, `pipx`, `venv`, `system`, or `auto` |
+| `--install-dir DIR` | Base dir for the venv fallback (default: `~/.praisonai`) |
+| `--no-modify-path` | Do not append a PATH block to your shell rc |
+| `--no-venv` | Skip isolation — install into the active Python environment |
+| `--no-onboard` | Skip interactive onboarding after install |
+| `--python PATH` | Use a specific Python executable |
+| `--dry-run` | Print what would happen without making any changes |
+| `--no-prompt` | Non-interactive mode — skip all prompts |
 | `-h, --help` | Show help |
 
-### Environment Variables
+---
 
-| Variable | Description |
-|----------|-------------|
-| `PRAISONAI_VERSION` | Version to install |
-| `PRAISONAI_EXTRAS` | Comma-separated extras |
-| `PRAISONAI_SKIP_VENV` | Skip venv (`1` to enable) |
-| `PRAISONAI_PYTHON` | Python executable path |
-| `PRAISONAI_DRY_RUN` | Dry run mode (`1` to enable) |
-| `PRAISONAI_NO_PROMPT` | Skip prompts (`1` to enable) |
-| `PRAISONAI_NO_ONBOARD` | Skip onboarding (`1` to enable) |
+## Environment Variables
 
-## install.ps1 (Windows)
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PRAISONAI_VERSION` | `latest` | Version to install |
+| `PRAISONAI_EXTRAS` | `""` | Comma-separated extras (defaults to `all`) |
+| `PRAISONAI_BACKEND` | `auto` | Force backend: `uv` / `pipx` / `venv` / `system` / `auto` |
+| `PRAISONAI_INSTALL_DIR` | `~/.praisonai` | Base dir for the venv fallback |
+| `PRAISONAI_NO_MODIFY_PATH` | `0` | Skip shell rc PATH modification (`1` to enable) |
+| `PRAISONAI_SKIP_VENV` | `0` | Skip isolation entirely (`1` to enable, same as `--no-venv`) |
+| `PRAISONAI_PYTHON` | auto-detect | Path to Python executable |
+| `PRAISONAI_DRY_RUN` | `0` | Preview mode (`1` to enable) |
+| `PRAISONAI_NO_PROMPT` | `0` | Skip all prompts (`1` to enable) |
+| `PRAISONAI_NO_ONBOARD` | `0` | Skip interactive onboarding (`1` to enable) |
 
-### What It Does
+---
 
-<Steps>
-  <Step title="Detect Package Manager">
-    Checks for winget, Chocolatey, or Scoop
-  </Step>
-  <Step title="Check Python">
-    Looks for Python 3.10+ using `py` launcher
-  </Step>
-  <Step title="Install Python (if needed)">
-    - **winget**: `winget install Python.Python.3.12`
-    - **Chocolatey**: `choco install python`
-    - **Scoop**: `scoop install python`
-  </Step>
-  <Step title="Create Virtual Environment">
-    Creates at `%USERPROFILE%\.praisonai\venv`
-  </Step>
-  <Step title="Install PraisonAI">
-    Runs `pip install praisonaiagents`
-  </Step>
-  <Step title="Configure PATH">
-    Adds venv Scripts folder to user PATH
-  </Step>
-</Steps>
+## Power-User Alternatives (No Installer Needed)
 
-### PowerShell Parameters
+These are first-class supported paths — no installer required:
 
-```powershell
-& ([scriptblock]::Create((iwr -useb https://praison.ai/install.ps1))) -Help
+```bash
+# Zero-install one-shot via uv
+uvx praisonai "2+2"
+
+# Isolated persistent install
+pipx install praisonai
+
+# Install into the active Python environment
+pip install praisonai
 ```
 
-| Parameter | Description |
-|-----------|-------------|
-| `-Version` | Install specific version |
-| `-Extras` | Install with extras |
-| `-NoVenv` | Skip virtual environment |
-| `-Python` | Use specific Python |
-| `-DryRun` | Preview without changes |
-| `-Help` | Show help |
+---
 
-## Post-Install Flow
+## Shell Completions
 
-After successful installation and verification, the installer runs an interactive onboarding sequence:
+The installer offers to install tab-completions after a successful install:
 
-1. **Setup wizard** (`praisonai setup`) - Configure LLM API keys
-2. **Bot onboarding** (`praisonai onboard`) - Asks 4 questions to set up messaging bots (default: Yes). See the [onboard guide](/docs/features/onboard) for details.
-3. **Final summary** - Either the onboard wizard's ✅ Done panel or installer's Next Steps
+```
+Install bash shell completions for praisonai? [Y/n]
+```
 
-**Two possible end states:**
-- **Onboarding completed**: Shows the ✅ Done panel with dashboard URL, bot commands, and gateway endpoints
-- **Onboarding skipped**: Shows the installer's Next Steps block
+The prompt is **auto-skipped** when any of the following apply: `--no-onboard`, `--no-prompt`, `--dry-run`, or no TTY is available (e.g. CI).
+
+Re-run anytime:
+
+```bash
+praisonai completion bash    # append to ~/.bashrc
+praisonai completion zsh     # append to ~/.zshrc
+praisonai completion fish    # write ~/.config/fish/completions/praisonai.fish
+```
+
+**Idempotency**: bash/zsh completions are only appended if `_praisonai_completion` or `#compdef praisonai` is not already present. Fish completions are overwritten.
+
+---
+
+## Choosing a Backend
 
 <Note>
-PR #1486 ensures only one summary appears - never both. The onboard wizard's ✅ Done panel is the canonical final summary when onboarding completes.
+Not sure which backend to pick? The installer chooses the best one automatically. Read more in [Isolation Backends](/docs/install/isolation-backends).
 </Note>
 
-<Note>
-If you skip the setup wizard during install (for example with `--no-prompt`), the next `praisonai` or `praisonai run` invocation will detect the missing credentials and offer to launch the wizard for you (or exit with a clear error in CI). See [First-run Onboarding](/docs/features/first-run-onboarding) for details.
-</Note>
+```mermaid
+graph TB
+    Start([Which backend?]):::agent
+    Start --> Q1{Have uv?}
+    Q1 -->|Yes| UV[uv tool — fastest,\nzero extra install]:::success
+    Q1 -->|No| Q2{Have pipx?}
+    Q2 -->|Yes| PIPX[pipx — well-known,\nbroad ecosystem]:::tool
+    Q2 -->|No| VENV[venv fallback —\nalways available]:::process
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+```
+
+---
 
 ## CI/CD Usage
 
@@ -173,8 +200,7 @@ If you skip the setup wizard during install (for example with `--no-prompt`), th
   <Tab title="GitHub Actions">
     ```yaml
     - name: Install PraisonAI
-      run: |
-        curl -fsSL https://praison.ai/install.sh | bash -s -- --no-prompt
+      run: curl -fsSL https://praison.ai/install.sh | bash -s -- --no-prompt
       env:
         PRAISONAI_SKIP_VENV: "1"
     ```
@@ -196,64 +222,30 @@ If you skip the setup wizard during install (for example with `--no-prompt`), th
   </Tab>
 </Tabs>
 
-## Troubleshooting
-
-<AccordionGroup>
-  <Accordion title="praisonai not found after install">
-    The installer adds the venv to your shell rc file. Either:
-    1. **Restart your terminal**, or
-    2. **Source the rc file**: `source ~/.zshrc` (or `.bashrc`)
-    3. **Activate manually**: `source ~/.praisonai/venv/bin/activate`
-  </Accordion>
-  
-  <Accordion title="Python version too old">
-    The installer requires Python 3.10+. If auto-install fails:
-    ```bash
-    # macOS
-    brew install python@3.12
-    
-    # Ubuntu/Debian
-    sudo apt install python3.12
-    
-    # Then re-run installer
-    curl -fsSL https://praison.ai/install.sh | bash
-    ```
-  </Accordion>
-  
-  <Accordion title="Permission denied on Linux">
-    If npm/pip global install fails with permission errors, the installer creates a user-local venv. If you still have issues:
-    ```bash
-    # Use --no-venv and install to user site
-    pip install --user praisonaiagents
-    ```
-  </Accordion>
-  
-  <Accordion title="Windows: Script execution disabled">
-    Enable script execution in PowerShell:
-    ```powershell
-    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
-    ```
-  </Accordion>
-</AccordionGroup>
+---
 
 ## Uninstall
 
 <Tabs>
-  <Tab title="macOS/Linux">
+  <Tab title="uv">
     ```bash
-    # Remove venv
-    rm -rf ~/.praisonai
-    
-    # Remove PATH entry from shell rc
-    # Edit ~/.zshrc or ~/.bashrc and remove the PraisonAI line
+    uv tool uninstall praisonai
     ```
   </Tab>
-  <Tab title="Windows">
-    ```powershell
-    # Remove venv
-    Remove-Item -Recurse -Force "$env:USERPROFILE\.praisonai"
-    
-    # Remove from PATH (System Properties > Environment Variables)
+  <Tab title="pipx">
+    ```bash
+    pipx uninstall praisonai
+    ```
+  </Tab>
+  <Tab title="venv">
+    ```bash
+    # Remove venv and shim
+    rm -rf ~/.praisonai
+    rm -f ~/.local/bin/praisonai
+
+    # Remove the PATH block from your shell rc
+    # Edit ~/.zshrc or ~/.bashrc and remove the lines between:
+    # # >>> PraisonAI PATH >>> ... # <<< PraisonAI PATH <<<
     ```
   </Tab>
   <Tab title="pip only">
@@ -262,3 +254,145 @@ If you skip the setup wizard during install (for example with `--no-prompt`), th
     ```
   </Tab>
 </Tabs>
+
+---
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="praisonai not found after install">
+    Restart your terminal or source your shell rc:
+    ```bash
+    source ~/.zshrc   # zsh
+    source ~/.bashrc  # bash
+    ```
+    Or add `~/.local/bin` to PATH manually:
+    ```bash
+    export PATH="$HOME/.local/bin:$PATH"
+    ```
+  </Accordion>
+
+  <Accordion title="Force a specific backend">
+    ```bash
+    # Via flag
+    curl -fsSL https://praison.ai/install.sh | bash -s -- --backend pipx
+
+    # Via env var
+    PRAISONAI_BACKEND=pipx curl -fsSL https://praison.ai/install.sh | bash
+    ```
+  </Accordion>
+
+  <Accordion title="Don't want PATH modified">
+    ```bash
+    curl -fsSL https://praison.ai/install.sh | bash -s -- --no-modify-path
+    # or
+    PRAISONAI_NO_MODIFY_PATH=1 curl -fsSL https://praison.ai/install.sh | bash
+    ```
+    Then add `~/.local/bin` to PATH manually in your shell rc.
+  </Accordion>
+
+  <Accordion title="I have both uv and pipx — which runs?">
+    The installer picks `uv` first in `auto` mode. Override with `--backend pipx` or `PRAISONAI_BACKEND=pipx`.
+  </Accordion>
+
+  <Accordion title="Python version too old">
+    The installer requires Python 3.10+. If auto-install fails:
+    ```bash
+    # macOS
+    brew install python@3.12
+
+    # Ubuntu/Debian
+    sudo apt install python3.12
+
+    # Then re-run installer
+    curl -fsSL https://praison.ai/install.sh | bash
+    ```
+  </Accordion>
+
+  <Accordion title="Permission denied on Linux">
+    ```bash
+    # Install into active env without root
+    curl -fsSL https://praison.ai/install.sh | bash -s -- --no-venv
+    # or
+    pip install --user praisonai
+    ```
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## install.ps1 (Windows)
+
+### What It Does
+
+<Steps>
+  <Step title="Detect Package Manager">
+    Checks for winget, Chocolatey, or Scoop.
+  </Step>
+  <Step title="Check Python">
+    Looks for Python 3.10+ using the `py` launcher.
+  </Step>
+  <Step title="Install Python (if needed)">
+    - **winget**: `winget install Python.Python.3.12`
+    - **Chocolatey**: `choco install python`
+    - **Scoop**: `scoop install python`
+  </Step>
+  <Step title="Create Virtual Environment">
+    Creates at `%USERPROFILE%\.praisonai\venv`.
+  </Step>
+  <Step title="Install PraisonAI">
+    Runs `pip install praisonai[all]`.
+  </Step>
+  <Step title="Configure PATH">
+    Adds venv Scripts folder to user PATH.
+  </Step>
+</Steps>
+
+### PowerShell Parameters
+
+```powershell
+& ([scriptblock]::Create((iwr -useb https://praison.ai/install.ps1))) -Help
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `-Version` | Install specific version |
+| `-Extras` | Install with extras |
+| `-NoVenv` | Skip virtual environment |
+| `-Python` | Use specific Python |
+| `-DryRun` | Preview without changes |
+| `-Help` | Show help |
+
+---
+
+## Post-Install Flow
+
+After installation and verification, the installer runs an interactive onboarding sequence:
+
+1. **Shell completions** — offered once, idempotent
+2. **Setup wizard** (`praisonai setup`) — configure LLM API keys
+3. **Bot onboarding** (`praisonai onboard`) — set up Telegram / Discord / Slack / WhatsApp (default: Yes). See the [onboard guide](/docs/features/onboard).
+4. **Final summary** — the onboard wizard's ✅ Done panel, or the installer's Next Steps block if onboarding was skipped.
+
+<Note>
+If you skip the setup wizard (`--no-prompt`), the next `praisonai` invocation will detect missing credentials and offer to launch the wizard — or exit with a clear error in CI.
+</Note>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Quick Install" icon="bolt" href="/docs/install/quickstart">
+    One-liner install with options
+  </Card>
+  <Card title="Isolation Backends" icon="box" href="/docs/install/isolation-backends">
+    Choose between uv, pipx, and venv
+  </Card>
+  <Card title="Onboarding" icon="rocket" href="/docs/features/onboard">
+    Bot setup wizard
+  </Card>
+  <Card title="Scripts Reference" icon="terminal" href="/docs/developers/scripts">
+    All developer scripts
+  </Card>
+</CardGroup>

--- a/docs/install/isolation-backends.mdx
+++ b/docs/install/isolation-backends.mdx
@@ -1,0 +1,173 @@
+---
+title: "Isolation Backends"
+sidebarTitle: "Isolation Backends"
+description: "Choose between uv tool, pipx, and venv for installing PraisonAI"
+icon: "box"
+---
+
+PraisonAI's installer keeps the CLI isolated from your global Python environment. Pick the backend that fits your workflow.
+
+```mermaid
+graph TB
+    Start([Which backend should I use?]):::agent
+    Start --> Q1{Is uv installed?}
+    Q1 -->|Yes| UV[uv tool\nFastest. Zero extra deps.]:::success
+    Q1 -->|No| Q2{Is pipx installed?}
+    Q2 -->|Yes| PIPX[pipx\nWell-known. Broad ecosystem.]:::tool
+    Q2 -->|No| Q3{Need isolation?}
+    Q3 -->|Yes| VENV[venv fallback\nAlways available.]:::process
+    Q3 -->|No| SYS[--no-venv\nActive Python env.]:::agent
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+```
+
+## Backend Comparison
+
+| | **uv tool** | **pipx** | **venv** | **--no-venv** |
+|---|---|---|---|---|
+| **Isolation** | ✅ Isolated | ✅ Isolated | ✅ Isolated | ❌ None |
+| **Persistence** | ✅ Permanent | ✅ Permanent | ✅ Permanent | ✅ Permanent |
+| **Speed** | ⚡ Fastest | 🐢 Slower | 🐢 Slower | ⚡ Fast |
+| **PATH management** | `uv tool update-shell` | `pipx ensurepath` | `~/.local/bin` shim | Depends on active env |
+| **Extra install** | [uv](https://github.com/astral-sh/uv) | [pipx](https://pipx.pypa.io/) | None | None |
+| **Who manages env** | uv | pipx | Installer | You |
+| **When to pick** | You use uv already | You use pipx already | No uv/pipx available | CI, Docker, scripts |
+
+## Using Each Backend
+
+### uv tool (recommended)
+
+`uv tool install` creates a fully isolated environment managed by uv. The fastest option.
+
+```bash
+# Auto-detected if uv is installed
+curl -fsSL https://praison.ai/install.sh | bash
+
+# Force explicitly
+curl -fsSL https://praison.ai/install.sh | bash -s -- --backend uv
+
+# Or directly (no installer needed)
+uv tool install praisonai
+```
+
+### pipx
+
+`pipx install` creates an isolated venv managed by pipx. Familiar to Python developers.
+
+```bash
+# Auto-detected if uv is absent and pipx is installed
+curl -fsSL https://praison.ai/install.sh | bash
+
+# Force explicitly
+curl -fsSL https://praison.ai/install.sh | bash -s -- --backend pipx
+
+# Or directly (no installer needed)
+pipx install praisonai
+```
+
+### venv (fallback)
+
+The installer creates `~/.praisonai/venv` and symlinks `~/.local/bin/praisonai → venv/bin/praisonai`.
+
+```bash
+# Auto-selected when uv and pipx are absent
+curl -fsSL https://praison.ai/install.sh | bash
+
+# Force explicitly
+curl -fsSL https://praison.ai/install.sh | bash -s -- --backend venv
+
+# Custom install directory
+curl -fsSL https://praison.ai/install.sh | bash -s -- --backend venv --install-dir /opt/praisonai
+```
+
+### No isolation (--no-venv)
+
+Installs directly into the active Python environment. Useful in Docker, CI, or when you manage your own venv.
+
+```bash
+curl -fsSL https://praison.ai/install.sh | bash -s -- --no-venv
+
+# Or directly
+pip install "praisonai[all]"
+```
+
+### uvx (zero-install one-shot)
+
+Runs PraisonAI in a temporary environment without a persistent install. Good for one-off commands.
+
+```bash
+uvx praisonai "2+2"
+```
+
+## Environment Variable
+
+Override the backend without changing the install command:
+
+```bash
+PRAISONAI_BACKEND=pipx curl -fsSL https://praison.ai/install.sh | bash
+PRAISONAI_BACKEND=venv curl -fsSL https://praison.ai/install.sh | bash
+PRAISONAI_BACKEND=uv   curl -fsSL https://praison.ai/install.sh | bash
+```
+
+Valid values: `uv`, `pipx`, `venv`, `system`, `auto` (default).
+
+## PATH Management
+
+All backends expose the CLI at `~/.local/bin/praisonai`. The installer appends an idempotent block to your shell rc (unless `--no-modify-path`):
+
+```bash
+# >>> PraisonAI PATH >>>
+export PATH="$HOME/.local/bin:$PATH"
+# <<< PraisonAI PATH <<<
+```
+
+Fish shell variant:
+```fish
+# >>> PraisonAI PATH >>>
+set -gx PATH $HOME/.local/bin $PATH
+# <<< PraisonAI PATH <<<
+```
+
+Skip PATH modification:
+```bash
+curl -fsSL https://praison.ai/install.sh | bash -s -- --no-modify-path
+# or
+PRAISONAI_NO_MODIFY_PATH=1 curl -fsSL https://praison.ai/install.sh | bash
+```
+
+## Uninstalling
+
+<Tabs>
+  <Tab title="uv">
+    ```bash
+    uv tool uninstall praisonai
+    ```
+  </Tab>
+  <Tab title="pipx">
+    ```bash
+    pipx uninstall praisonai
+    ```
+  </Tab>
+  <Tab title="venv">
+    ```bash
+    rm -rf ~/.praisonai
+    rm -f ~/.local/bin/praisonai
+    ```
+  </Tab>
+</Tabs>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Quick Install" icon="bolt" href="/docs/install/quickstart">
+    One-liner install command
+  </Card>
+  <Card title="Installer Internals" icon="gear" href="/docs/install/installer">
+    Full install.sh reference
+  </Card>
+</CardGroup>

--- a/docs/install/quickstart.mdx
+++ b/docs/install/quickstart.mdx
@@ -1,29 +1,35 @@
 ---
 title: "Quick Install"
-description: "Install PraisonAI with a single command"
+sidebarTitle: "Quick Install"
+description: "Install PraisonAI with a single command — isolated via uv tool, pipx, or venv fallback"
 icon: "bolt"
 ---
 
 <Info>
-**One command. Everything installed. You're welcome. 🚀**
+**One command. Everything installed. Isolated from your system Python. You're welcome. 🚀**
 </Info>
 
 ```mermaid
 graph LR
-    A[curl install.sh]:::tool --> B[Detect OS]:::agent
-    B --> C[Install Python]:::tool
-    C --> D[Create venv]:::tool
-    D --> E[pip install]:::tool
-    E --> F[Ready!]:::agent
-    
-    classDef agent fill:#8B0000,color:#fff
-    classDef tool fill:#189AB4,color:#fff
+    A[curl praison.ai/install.sh | bash]:::tool --> B{Detect backend}:::agent
+    B -->|uv found| C[uv tool]:::success
+    B -->|pipx found| D[pipx]:::tool
+    B -->|neither| E[venv fallback]:::process
+    C --> F[~/.local/bin/praisonai]:::success
+    D --> F
+    E --> F
+    F --> G[✅ Ready]:::success
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
 ```
 
 ## One-Liner Install
 
 <Tabs>
-  <Tab title="macOS/Linux">
+  <Tab title="macOS / Linux / WSL">
     ```bash
     curl -fsSL https://praison.ai/install.sh | bash
     ```
@@ -33,9 +39,21 @@ graph LR
     iwr -useb https://praison.ai/install.ps1 | iex
     ```
   </Tab>
+  <Tab title="uvx (zero-install)">
+    ```bash
+    uvx praisonai "2+2"
+    ```
+    Runs PraisonAI in a temporary isolated environment — no install required. Powered by [uv](https://github.com/astral-sh/uv).
+  </Tab>
+  <Tab title="pipx">
+    ```bash
+    pipx install praisonai
+    ```
+    Isolated persistent install managed by [pipx](https://pipx.pypa.io/).
+  </Tab>
   <Tab title="pip">
     ```bash
-    pip install praisonaiagents
+    pip install "praisonai[all]"
     ```
   </Tab>
   <Tab title="npm">
@@ -48,35 +66,38 @@ graph LR
 <Check>
 The installer automatically:
 - Detects your OS (macOS, Linux, Windows WSL)
-- Installs Python 3.10+ if needed
-- Creates a virtual environment
-- Installs PraisonAI
-- Configures your PATH
+- Picks the best isolation backend: `uv tool` → `pipx` → venv fallback
+- Installs Python 3.10+ if needed (venv path only)
+- Creates an isolated environment for PraisonAI
+- Drops a `~/.local/bin/praisonai` shim on your PATH
+- Offers shell tab-completions for bash, zsh, or fish
 </Check>
 
 ## What Gets Installed
 
 | Component | Description |
 |-----------|-------------|
-| **praisonaiagents** | Core SDK for building AI agents |
-| **Python 3.10+** | If not already installed |
-| **Virtual environment** | Isolated at `~/.praisonai/venv` |
+| **praisonai[all]** | Full PraisonAI package with all extras |
+| **Python 3.10+** | If not already installed (venv path only) |
+| **Isolation backend** | `uv tool`, `pipx`, or venv at `~/.praisonai/venv` |
+| **`~/.local/bin/praisonai`** | CLI shim on PATH (all backends) |
+| **Shell rc PATH block** | `~/.zshrc` / `~/.bashrc` / `~/.config/fish/config.fish` |
 
 <Info>
-The installer ends with an interactive bot-onboarding prompt:
+The installer ends with an interactive onboarding prompt:
 
 ```
 Set up a messaging bot (Telegram / Discord / Slack / WhatsApp) now? [Y/n]
 ```
 
-- **Default is Yes** - Safe to accept on desktop installations
-- **Skip with `n`** or use `--no-onboard` / `PRAISONAI_NO_ONBOARD=1`  
+- **Default is Yes** — safe to accept on desktop installs
+- **Skip with `n`** or use `--no-onboard` / `PRAISONAI_NO_ONBOARD=1`
 - **Auto-skipped** in CI/headless environments (no TTY detected)
 </Info>
 
 ## Quick Start
 
-After installation, try this:
+After installation:
 
 ```python
 from praisonaiagents import Agent
@@ -87,7 +108,7 @@ print(response)
 ```
 
 <Warning>
-Don't forget to set your API key:
+Set your API key first:
 ```bash
 export OPENAI_API_KEY=your_key
 ```
@@ -96,25 +117,46 @@ export OPENAI_API_KEY=your_key
 ## Install Options
 
 <AccordionGroup>
+  <Accordion title="Force a specific backend">
+    ```bash
+    curl -fsSL https://praison.ai/install.sh | bash -s -- --backend pipx
+    curl -fsSL https://praison.ai/install.sh | bash -s -- --backend uv
+    curl -fsSL https://praison.ai/install.sh | bash -s -- --backend venv
+    ```
+  </Accordion>
+
+  <Accordion title="Custom install directory">
+    ```bash
+    curl -fsSL https://praison.ai/install.sh | bash -s -- --install-dir /opt/praisonai
+    ```
+    Sets the base directory for the venv fallback (default: `~/.praisonai`).
+  </Accordion>
+
+  <Accordion title="Don't modify PATH">
+    ```bash
+    curl -fsSL https://praison.ai/install.sh | bash -s -- --no-modify-path
+    ```
+    The installer still exports `~/.local/bin` for the current session, but skips writing to your shell rc. Add it manually afterward.
+  </Accordion>
+
   <Accordion title="Install with extras">
     ```bash
-    # Install with UI support
     curl -fsSL https://praison.ai/install.sh | bash -s -- --extras ui,chat
     ```
   </Accordion>
-  
+
   <Accordion title="Install specific version">
     ```bash
     curl -fsSL https://praison.ai/install.sh | bash -s -- --version 0.14.0
     ```
   </Accordion>
-  
-  <Accordion title="Skip virtual environment">
+
+  <Accordion title="Skip isolation (install into active env)">
     ```bash
     curl -fsSL https://praison.ai/install.sh | bash -s -- --no-venv
     ```
   </Accordion>
-  
+
   <Accordion title="Dry run (preview)">
     ```bash
     curl -fsSL https://praison.ai/install.sh | bash -s -- --dry-run
@@ -124,14 +166,17 @@ export OPENAI_API_KEY=your_key
 
 ## Environment Variables
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `PRAISONAI_VERSION` | Version to install | `latest` |
-| `PRAISONAI_EXTRAS` | Comma-separated extras | - |
-| `PRAISONAI_SKIP_VENV` | Skip venv creation | `0` |
-| `PRAISONAI_PYTHON` | Python executable path | auto-detect |
-| `PRAISONAI_DRY_RUN` | Preview mode | `0` |
-| `PRAISONAI_NO_ONBOARD` | Skip onboarding | `0` |
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PRAISONAI_VERSION` | `latest` | Version to install |
+| `PRAISONAI_EXTRAS` | `""` | Comma-separated extras (defaults to `all`) |
+| `PRAISONAI_BACKEND` | `auto` | Force backend: `uv` / `pipx` / `venv` / `system` / `auto` |
+| `PRAISONAI_INSTALL_DIR` | `~/.praisonai` | Base dir for the venv fallback |
+| `PRAISONAI_NO_MODIFY_PATH` | `0` | Skip shell rc PATH modification (`1` to enable) |
+| `PRAISONAI_SKIP_VENV` | `0` | Skip isolation entirely (`1` to enable) |
+| `PRAISONAI_PYTHON` | auto-detect | Python executable path |
+| `PRAISONAI_DRY_RUN` | `0` | Preview mode (`1` to enable) |
+| `PRAISONAI_NO_ONBOARD` | `0` | Skip onboarding (`1` to enable) |
 
 ## Next Steps
 
@@ -139,13 +184,13 @@ export OPENAI_API_KEY=your_key
   <Card title="Build Your First Agent" icon="robot" href="/code/quickstart">
     Create an AI agent in 3 lines of code
   </Card>
+  <Card title="Isolation Backends" icon="box" href="/docs/install/isolation-backends">
+    Compare uv, pipx, and venv
+  </Card>
+  <Card title="Installer Internals" icon="gear" href="/docs/install/installer">
+    How install.sh works
+  </Card>
   <Card title="Add Tools" icon="wrench" href="/tools">
     Give your agent superpowers
-  </Card>
-  <Card title="Multi-Agent Workflows" icon="users" href="/features/workflows">
-    Coordinate multiple agents
-  </Card>
-  <Card title="API Reference" icon="code" href="/api/praisonaiagents/index">
-    Explore the full API
   </Card>
 </CardGroup>

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -149,6 +149,10 @@ You can also use other LLM providers like Anthropic, Google, etc. Please refer t
 
 ## Quick Install
 
+<Note>
+The one-liner installer uses an isolated backend (`uv tool` → `pipx` → venv fallback) and exposes `praisonai` via a `~/.local/bin/praisonai` shim — your global Python environment is untouched. See [Isolation Backends](/docs/install/isolation-backends) for details.
+</Note>
+
 <Tabs>
   <Tab title="macOS/Linux">
     ```bash
@@ -178,7 +182,7 @@ You can also use other LLM providers like Anthropic, Google, etc. Please refer t
 </Tabs>
 
 <Check>
-The installer automatically detects your OS, installs Python if needed, creates a virtual environment, and configures your PATH.
+The installer automatically detects your OS, picks the best isolation backend (`uv tool` → `pipx` → venv fallback), installs Python if needed, and drops a `~/.local/bin/praisonai` shim on your PATH.
 </Check>
 
 <Note>


### PR DESCRIPTION
## Summary

- **Major rewrite** of `docs/install/installer.mdx`: documents all three isolation backends (uv tool → pipx → venv fallback), all new CLI flags (`--backend`, `--install-dir`, `--no-modify-path`), all new env vars, shell completions section, `~/.local/bin/praisonai` shim, sequence diagram, power-user alternatives, updated uninstall/troubleshooting
- **Updated** `docs/install/quickstart.mdx`: adds `uvx` and `pipx install` as first-class tabs, new flags/env var accordions, updated What Gets Installed table
- **Updated** `docs/installation.mdx`: isolation note + link to new backends page
- **Updated** `docs/index.mdx`: isolation copy under macOS/Linux tab + uvx/pipx install tabs
- **Updated** `docs/developers/scripts.mdx`: new description, features list, env vars, and examples for multi-backend installer
- **New page** `docs/install/isolation-backends.mdx`: backend decision diagram, side-by-side comparison table (uv / pipx / venv / --no-venv), per-backend install examples, PATH block docs
- **Updated** `docs.json`: added Install group (quickstart, installer, isolation-backends)

Fixes #824

Generated with [Claude Code](https://claude.ai/code)