### PR TITLE
docs: update context files pages for AGENTS.md walk-up discovery + layered merge

### DIFF
--- a/docs/cli/rules.mdx
+++ b/docs/cli/rules.mdx
@@ -147,7 +147,12 @@ PraisonAI automatically discovers instruction files from your project root and g
 | `.windsurf/rules/*.md` | Windsurf modular rules | Medium |
 | `.cursor/rules/*.mdc` | Cursor modular rules | Medium |
 | `.praison/rules/*.md` | Workspace rules | Medium |
-| `~/.praisonai/rules/*.md` | Global rules | Low |
+| `~/.praisonai/rules/*.md` | Global modular rules | Low |
+| `~/.praisonai/AGENTS.md` | Global single-file instructions (loaded by `load_context_files()`) | Lowest |
+
+<Note>
+`~/.praisonai/AGENTS.md` is loaded by `load_context_files()` as the lowest-precedence layer whenever `walk_up=True` (the default). It is separate from the modular `~/.praisonai/rules/*.md` files loaded by `RulesManager`. See [Context Files](/docs/features/context-files) for details on layered merge behaviour.
+</Note>
 
 ## Rule File Format
 

--- a/docs/features/context-files.mdx
+++ b/docs/features/context-files.mdx
@@ -5,13 +5,13 @@ description: "Inject markdown context files into your agent's instructions autom
 icon: "file-text"
 ---
 
-Context files allow you to automatically inject markdown content into your agent's instructions using AGENTS.md-style files.
+Context files automatically inject markdown content into your agent's instructions — drop an `AGENTS.md` in your project root and every run sees it, no config needed.
 
 ```mermaid
 graph LR
     subgraph "Context Injection Flow"
-        A[📄 Context Files] --> B[📝 Load Content]
-        B --> C[🔗 Merge Instructions]
+        A[📄 AGENTS.md<br/>CLAUDE.md] --> B[🔍 Walk-up Discovery]
+        B --> C[🔗 Layer & Merge]
         C --> D[🤖 Enhanced Agent]
     end
     
@@ -27,9 +27,7 @@ graph LR
 ## Quick Start
 
 <Steps>
-<Step title="Create Context Files">
-
-Create markdown files with context information:
+<Step title="Drop an AGENTS.md in your project root">
 
 ```markdown
 # AGENTS.md
@@ -42,14 +40,22 @@ Create markdown files with context information:
 Our main products include:
 - AI Assistant Platform
 - Workflow Automation Tools
-- Data Analytics Dashboard
 ```
 
 </Step>
 
-<Step title="Configure Context Injection">
+<Step title="Run from any subdirectory — instructions load automatically">
 
-Use `context_paths` to inject the content:
+```bash
+# From the project root
+praisonai run "Help a customer"
+
+# Or from a nested package — the root AGENTS.md is still found
+cd packages/frontend
+praisonai run "Build a login form"
+```
+
+Or use the Python API:
 
 ```python
 from praisonaiagents import Agent
@@ -60,11 +66,8 @@ agent = Agent(
     instructions="Help customers with their questions"
 )
 
-configure_host(
-    agents=[agent],
-    context_paths=["AGENTS.md", "STYLE.md"],
-    style="dashboard"
-)
+# No context_paths needed — auto-discovery picks up AGENTS.md
+configure_host(agents=[agent], style="dashboard")
 ```
 
 </Step>
@@ -74,30 +77,36 @@ configure_host(
 
 ## How It Works
 
-Context files are merged into agent instructions during host configuration:
+`load_context_files()` walks up from your current directory to the git root, collecting candidates at each level and concatenating them with the nearest file winning (appended last):
 
 ```mermaid
-sequenceDiagram
-    participant User
-    participant Host as configure_host()
-    participant Loader as Context Loader
-    participant Agent as Agent Instance
+graph TB
+    subgraph "Discovery Layers (low → high precedence)"
+        GLOBAL["🌐 ~/.praisonai/AGENTS.md<br/>(user-global)"]
+        ROOT["📁 git root /<br/>AGENTS.md · CLAUDE.md · agents.md · .agents/AGENTS.md"]
+        MID["📁 intermediate dirs<br/>(each level)"]
+        CWD["📁 cwd /<br/>AGENTS.md · CLAUDE.md · agents.md · .agents/AGENTS.md"]
+    end
 
-    User->>Host: context_paths=["AGENTS.md"]
-    Host->>Loader: load_context_files()
-    Loader->>Loader: Read markdown files
-    Loader-->>Host: Combined context text
-    Host->>Agent: Prepend to instructions
-    Note over Agent: {instructions}\n\nContext:\n{context}
+    GLOBAL --> ROOT --> MID --> CWD --> MERGE["🔗 Concatenate<br/>global → root → cwd"]
+    MERGE --> AGENT["🤖 Agent"]
+
+    classDef layer fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef merge fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef agent fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class GLOBAL,ROOT,MID,CWD layer
+    class MERGE merge
+    class AGENT agent
 ```
 
-The content is merged using this pattern:
+The merged content is prepended to the agent's instructions:
 
 ```
 {original_instructions}
 
 Context:
-{context_file_content}
+{layered_context_from_all_levels}
 ```
 
 ---
@@ -106,17 +115,40 @@ Context:
 
 ### Default File Discovery
 
-If no `context_paths` specified, these files are automatically checked:
+When no `context_paths` is given, these filenames are checked at every directory level:
 
 | Path | Description |
 |------|-------------|
-| `AGENTS.md` | Primary agent context file |
-| `agents.md` | Alternative naming |
+| `AGENTS.md` | Primary agent context file (Codex CLI compatible) |
+| `agents.md` | Alternative casing |
 | `.agents/AGENTS.md` | Hidden directory structure |
+| `CLAUDE.md` | Claude Code memory file |
 
-### Custom Context Paths
+### Discovery Scope
 
-Specify your own context files:
+| Layer | Location | Precedence |
+|-------|----------|------------|
+| User-global | `~/.praisonai/AGENTS.md` | Lowest (loaded first) |
+| Git/project root | Root-level candidates | Low |
+| Intermediate dirs | Each dir between root and cwd | Medium |
+| cwd | Current working directory candidates | Highest (loaded last) |
+
+<Note>
+When no git root is found, the walk-up is **capped at 10 levels** to avoid scanning unrelated system directories.
+</Note>
+
+### `walk_up` Parameter
+
+| Value | Behavior |
+|-------|----------|
+| `True` _(default)_ | Walk up to git/project root, include `~/.praisonai/AGENTS.md` |
+| `False` | Read only from `cwd`, skip global file |
+
+The `walk_up` parameter is ignored when you pass an explicit `paths` list.
+
+### Explicit Paths (Backward Compatible)
+
+Pass `context_paths` to skip auto-discovery entirely — files are read from `cwd` only:
 
 ```python
 configure_host(
@@ -128,17 +160,41 @@ configure_host(
 )
 ```
 
+### Choosing a Mode
+
+```mermaid
+graph TB
+    START["Which mode do I need?"] --> Q1{"Explicit file list?"}
+    Q1 -->|Yes| EXPLICIT["Pass context_paths=[...]<br/>cwd-only, no walk-up"]
+    Q1 -->|No| Q2{"Restrict to cwd only?"}
+    Q2 -->|Yes| WALKFALSE["walk_up=False<br/>cwd-only, no global"]
+    Q2 -->|No| AUTO["Default auto-discovery<br/>walk_up=True<br/>global → root → cwd"]
+
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef choice fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class START start
+    class Q1,Q2 decision
+    class EXPLICIT,WALKFALSE,AUTO choice
+```
+
 ### Context Loading Behavior
 
 ```python
-# Silent fallback when module unavailable
-try:
-    from praisonai.integration.context_files import load_context_files
-    context = load_context_files(paths)
-except ImportError:
-    # No-op when context_files not available
-    context = ""
+from praisonai.integration.context_files import load_context_files
+
+# Auto-discovery (default): walks up, includes global file
+context = load_context_files()
+
+# Restrict to cwd only (no walk-up, no global)
+context = load_context_files(walk_up=False)
+
+# Explicit paths: cwd-only, no walk-up (backward compatible)
+context = load_context_files(paths=["AGENTS.md", "STYLE.md"])
 ```
+
+De-duplication is automatic: if `cwd` equals the git root, the same file is read only once (matched by inode, safe on case-insensitive volumes).
 
 ---
 
@@ -163,28 +219,43 @@ You are a customer support specialist with deep knowledge of our products.
 - Account management procedures
 ```
 
-### Multi-File Setup
+### Monorepo Layering
+
+Place org-wide guidelines at the repo root and package-specific overrides closer to the working directory:
 
 ```
-project/
-├── AGENTS.md          # Primary context
-├── STYLE.md           # Communication guidelines  
-├── docs/
-│   └── products.md    # Product information
-└── .agents/
-    └── internal.md    # Internal guidelines
+monorepo/
+├── AGENTS.md              # Org-wide guidelines (lowest project precedence)
+├── packages/
+│   ├── frontend/
+│   │   └── AGENTS.md      # Frontend overrides (higher precedence)
+│   └── backend/
+│       └── AGENTS.md      # Backend overrides (higher precedence)
 ```
 
-```python
-configure_host(
-    context_paths=[
-        "AGENTS.md",
-        "STYLE.md", 
-        "docs/products.md",
-        ".agents/internal.md"
-    ]
-)
+Running from inside `packages/frontend/` automatically merges both files — root guidelines first, frontend overrides last (winning):
+
+```bash
+cd packages/frontend
+praisonai run "Add a login form"
+# Loads: monorepo/AGENTS.md → packages/frontend/AGENTS.md
 ```
+
+No `context_paths` configuration needed.
+
+### User-Global Instructions
+
+`~/.praisonai/AGENTS.md` applies across all your projects as the lowest-priority layer:
+
+```markdown
+# ~/.praisonai/AGENTS.md
+## Personal Preferences
+- Always respond in British English
+- Prefer async/await over callbacks
+- Include type hints in all Python code
+```
+
+Every project you work in inherits these preferences unless overridden by a project-level file.
 
 ---
 
@@ -194,17 +265,20 @@ configure_host(
 
 ```python
 import os
+from praisonaiagents import Agent
+from praisonai.integration import configure_host
 
+agent = Agent(name="Assistant", instructions="You are helpful.")
+
+env = os.getenv("ENVIRONMENT", "development")
 context_files = ["AGENTS.md"]
 
-# Add environment-specific context
-env = os.getenv("ENVIRONMENT", "development")
 if env == "production":
     context_files.append("production-guidelines.md")
 else:
     context_files.append("dev-guidelines.md")
 
-configure_host(context_paths=context_files)
+configure_host(agents=[agent], context_paths=context_files)
 ```
 
 ### Conditional Context Loading
@@ -220,25 +294,18 @@ def get_context_files(agent_type):
     
     return base_files
 
-configure_host(
-    context_paths=get_context_files("support")
-)
+configure_host(context_paths=get_context_files("support"))
 ```
 
-### Hierarchical Context
+### CI / Snapshot Testing
 
-```markdown
-# base-context.md
-## Universal Guidelines
-All agents should follow these principles...
+When you don't want ancestor files to influence a test run, disable walk-up:
 
-# specialized-context.md
-## Support-Specific Guidelines
-When handling support tickets...
+```python
+from praisonai.integration.context_files import load_context_files
 
-# team-context.md  
-## Team Information
-Our support team includes...
+# Only reads files in the current test directory
+context = load_context_files(walk_up=False)
 ```
 
 ---
@@ -286,6 +353,14 @@ Sample interactions or responses when helpful
 ```
 </Accordion>
 
+<Accordion title="When to use walk_up=False">
+Disable walk-up for isolated CI jobs, snapshot tests, or any run where you want to guarantee only the files in the current directory are loaded — no ancestor directories, no global user file.
+
+```python
+context = load_context_files(walk_up=False)
+```
+</Accordion>
+
 <Accordion title="Content Management">
 Version control your context files:
 
@@ -303,10 +378,9 @@ git diff HEAD~1 context/
 Validate context injection in development:
 
 ```python
-# Test context loading
 from praisonai.integration.context_files import load_context_files
 
-context = load_context_files(["AGENTS.md", "STYLE.md"])
+context = load_context_files()
 print("Loaded context length:", len(context))
 print("Preview:", context[:200])
 ```
@@ -322,7 +396,7 @@ print("Preview:", context[:200])
 <Card title="Host Integration" icon="plug" href="/docs/features/host-integration">
   Configure context injection
 </Card>
-<Card title="Integration Patterns" icon="diagram-project" href="/docs/features/integration-patterns">
-  Deployment patterns
+<Card title="Rules & Instructions" icon="scroll" href="/docs/features/rules">
+  Auto-discovered instruction files
 </Card>
 </CardGroup>

--- a/docs/features/host-integration.mdx
+++ b/docs/features/host-integration.mdx
@@ -134,7 +134,7 @@ graph TB
 | `sidebar` | `bool` | `True` | Show navigation sidebar |
 | `page_header` | `bool` | `True` | Show page header |
 | `style` | `str` | `"dashboard"` | UI layout: `"dashboard"` or `"chat"` |
-| `context_paths` | `Sequence[str]` | `None` | Paths to context files (AGENTS.md-style) prepended to agent instructions |
+| `context_paths` | `Sequence[str]` | `None` | Explicit paths to context files prepended to agent instructions. When omitted (`None`), `load_context_files()` runs in auto-discovery mode and walks up from cwd to the git root collecting `AGENTS.md` / `CLAUDE.md` / `agents.md` / `.agents/AGENTS.md` at each level, layered on top of `~/.praisonai/AGENTS.md`. When an explicit list is given, discovery is skipped and paths are read from cwd only (backward compatible). |
 | `theme` | `Dict[str, Any]` | `None` | Custom theme settings |
 | `agents` | `List[Any]` | `None` | Pre-configured agents |
 | `agent_kwargs` | `Dict[str, Any]` | `None` | Default agent parameters |

--- a/docs/features/rules.mdx
+++ b/docs/features/rules.mdx
@@ -63,7 +63,12 @@ PraisonAI automatically loads these files from your project root and git root:
 | `.windsurf/rules/*.md` | Windsurf modular rules | Medium (50) |
 | `.cursor/rules/*.mdc` | Cursor modular rules | Medium (50) |
 | `.praison/rules/*.md` | Workspace rules | Medium (0) |
-| `~/.praisonai/rules/*.md` | Global rules | Low (-1000) |
+| `~/.praisonai/rules/*.md` | Global modular rules | Low (-1000) |
+| `~/.praisonai/AGENTS.md` | Global single-file instructions | Lowest (loaded by `load_context_files()`) |
+
+<Note>
+`~/.praisonai/AGENTS.md` is the global single-file layer used by `load_context_files()`. It is separate from the modular `~/.praisonai/rules/*.md` files managed by `RulesManager` and has the lowest precedence — project-level files always override it.
+</Note>
 
 <Note>
 **Local Override Files**: `CLAUDE.local.md` and `PRAISON.local.md` are personal overrides that should be gitignored. They have higher priority than the main files, allowing you to customize rules without affecting the shared project configuration.
@@ -215,6 +220,8 @@ monorepo/                    # Git root
 ```
 
 Rules closer to the current working directory have higher priority than rules at the git root.
+
+The wrapper-layer `load_context_files()` (used by `configure_host` / `context_paths`) uses the same git-root walk-up and adds layered merge semantics — collecting `AGENTS.md`, `CLAUDE.md`, `agents.md`, and `.agents/AGENTS.md` at every directory level from `~/.praisonai/AGENTS.md` (lowest) up through the git root to `cwd` (highest). See [Context Files](/docs/features/context-files) for the full layered merge details.
 
 ## Storage Structure
 


### PR DESCRIPTION
## Summary

Updates four documentation pages to reflect the new `load_context_files()` behaviour introduced in PraisonAI PR #2206:

- **`docs/features/context-files.mdx`** (major rewrite): documents walk-up discovery from cwd to git root, `~/.praisonai/AGENTS.md` as the lowest-precedence global layer, `CLAUDE.md` as a default candidate, the `walk_up` parameter, precedence order (global → root → intermediate → cwd), de-duplication by inode, a monorepo layering example (no `context_paths` needed), and a Mermaid decision diagram for choosing between auto / `walk_up=False` / explicit paths modes.
- **`docs/cli/rules.mdx`**: adds `~/.praisonai/AGENTS.md` row to the Auto-Discovered Files table with an explanatory Note distinguishing it from modular rules.
- **`docs/features/rules.mdx`**: adds `~/.praisonai/AGENTS.md` row to the Supported Instruction Files table and a cross-reference paragraph in the Git Root Discovery section linking to the Context Files page for layered merge details.
- **`docs/features/host-integration.mdx`**: updates the `context_paths` table row description to explain auto-discovery vs explicit-paths semantics.

## Test plan

- [ ] Verify all four modified MDX files render correctly in Mintlify preview
- [ ] Confirm Mermaid diagrams use the standard color palette (`#6366F1`/`#F59E0B`/`#10B981`, white text)
- [ ] Confirm no changes to `docs/concepts/` or `docs.json`
- [ ] Confirm all code blocks are copy-paste runnable

Fixes #835

Generated with [Claude Code](https://claude.ai/code)