### PR TITLE
docs: add Bot Session Compaction page and update related docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -329,6 +329,7 @@
                       "docs/features/linear-bot",
                       "docs/features/bot-commands",
                       "docs/features/bot-session-reset",
+                      "docs/features/bot-session-compaction",
                       "docs/features/bot-command-access-control",
                       "docs/features/bot-run-control",
                       "docs/features/bot-gateway",

--- a/docs/features/bot-session-compaction.mdx
+++ b/docs/features/bot-session-compaction.mdx
@@ -1,0 +1,210 @@
+---
+title: "Bot Session Compaction"
+sidebarTitle: "Session Compaction"
+description: "Summarise older turns in long-lived bot sessions instead of dropping them"
+icon: "compress"
+---
+
+Long-lived bot conversations get a compact summary of older turns instead of having them silently dropped.
+
+```mermaid
+graph LR
+    subgraph "Bot Session Compaction"
+        H[📚 Long history] --> C{🗜 Over budget?}
+        C -->|No| K[📚 Keep verbatim]
+        C -->|Yes| S[📝 Summary + recent tail]
+        S --> P[💾 Persist compacted form]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class H input
+    class C decision
+    class K,S,P result
+```
+
+## Quick Start
+
+<Steps>
+
+<Step title="Enable with one line">
+
+```yaml
+channels:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+    session:
+      compaction:
+        enabled: true
+```
+
+</Step>
+
+<Step title="Tune the budget">
+
+```yaml
+channels:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+    session:
+      max_history: 500           # hard cap
+      compaction:
+        enabled: true
+        strategy: summarize       # or truncate / sliding / smart / prune / llm_summarize
+        max_messages: 100         # approximate compaction threshold
+        keep_recent: 10           # keep the last 10 turns verbatim
+```
+
+</Step>
+
+</Steps>
+
+---
+
+## Agent-Centric Example
+
+```python
+from praisonaiagents import Agent
+from praisonai.bots import TelegramBot
+
+bot = TelegramBot(
+    token="YOUR_BOT_TOKEN",
+    agent=Agent(name="Assistant", instructions="Help users."),
+    session={
+        "compaction": {
+            "enabled": True,
+            "strategy": "summarize",
+            "max_messages": 100,
+            "keep_recent": 10,
+        }
+    },
+)
+bot.run()
+```
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Bot
+    participant Manager as BotSessionManager
+    participant Compactor as ContextCompactor
+    participant Store
+
+    User->>Bot: Message #500
+    Bot->>Manager: _save_history(history)
+    Manager->>Compactor: needs_compaction(history)?
+    alt Over budget
+        Compactor-->>Manager: yes
+        Manager->>Compactor: compact(history)
+        Compactor-->>Manager: [summary, …recent tail]
+        Manager->>Store: set_chat_history(compacted)
+    else Under budget
+        Compactor-->>Manager: no
+        Manager->>Store: set_chat_history(history)
+    end
+```
+
+Compaction runs at save time. When history exceeds the budget, the manager summarises older turns into a single system message, appends the most-recent verbatim tail, and persists the compacted form. Bot restarts preserve the same memory.
+
+<Note>
+The manager builds a fresh `ContextCompactor` per save call rather than sharing one instance. This prevents per-conversation summary state from leaking between users under concurrent saves.
+</Note>
+
+---
+
+## Choosing a Strategy
+
+```mermaid
+graph TB
+    Q{What matters most?} -->|Long-term continuity| Summarize[summarize<br/>default]
+    Q -->|Speed + low cost| Truncate[truncate<br/>opt-out]
+    Q -->|Fixed window| Sliding[sliding]
+    Q -->|Balanced production| Smart[smart]
+    Q -->|Drop tool noise| Prune[prune]
+    Q -->|Highest quality summary| LLM[llm_summarize]
+
+    classDef question fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef option fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Q question
+    class Summarize,Truncate,Sliding,Smart,Prune,LLM option
+```
+
+| Strategy | Use when |
+|----------|----------|
+| `summarize` (default) | Long-running support bots / personal assistants. |
+| `truncate` | Explicit opt-out — same behaviour as no compaction config. |
+| `sliding` | Fixed-window conversations (e.g. customer chat queues). |
+| `smart` | Production default when you want a balanced trade-off. |
+| `prune` | Tool-heavy agents that produce noisy intermediate messages. |
+| `llm_summarize` | Highest fidelity summary; uses an extra LLM call. |
+
+---
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Master switch. When `false` the legacy tail-slice truncation runs. |
+| `strategy` | `str` | `"summarize"` | One of `truncate`, `sliding`, `summarize`, `smart`, `prune`, `llm_summarize`. Invalid values raise at schema-validation time. |
+| `max_messages` | `int` | `100` | Approximate compaction threshold. Converted to a token budget (`max_messages × 80`) when `max_tokens` is not set. Must be ≥ 1. |
+| `max_tokens` | `int` | `null` | Optional explicit token budget. Overrides `max_messages` when set. |
+| `keep_recent` | `int` | `10` | Number of most-recent messages kept verbatim (tail). Must be ≥ 0. |
+
+Configure under `session.compaction` inside any channel block in `gateway.yaml` or `bot.yaml`.
+
+---
+
+## User Interaction Flow
+
+> *A 3-week-old Telegram support bot conversation. Messages 1–400 covered the customer's account setup, billing decisions, and ongoing tickets. Message #500 arrives. **Without compaction:** the bot loads the most recent 100 messages and has no memory of the original setup — the customer has to re-explain everything. **With compaction:** the bot loads a one-line summary of decisions/facts from messages 1–490 followed by the last 10 verbatim turns. The agent answers the new question with full historical context. The compacted form is also persisted, so a bot restart preserves the memory.*
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Pair with session.reset and max_history">
+Reset clears context on idle or daily schedule. Compaction keeps context across long sessions. `max_history × 4` is the hard cap in compaction mode — history cannot grow past that ceiling even if the token threshold has not tripped yet. Use all three together for production bots.
+</Accordion>
+
+<Accordion title="Start with defaults">
+`enabled: true` alone is enough for most bots. The defaults (`strategy: summarize`, `max_messages: 100`, `keep_recent: 10`) work well out of the box.
+</Accordion>
+
+<Accordion title="Raise keep_recent for handoff flows">
+When the most recent turns carry the context that matters — a multi-step purchase flow or live escalation — increase `keep_recent` so more verbatim turns survive the compaction cycle.
+</Accordion>
+
+<Accordion title="No cross-user leakage">
+The manager builds a fresh compactor per save call, so per-conversation summary state never leaks between users sharing the same bot instance. This is safe for concurrent, high-traffic bots.
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Bot Session Reset" icon="rotate" href="/features/bot-session-reset">
+    Clear history on idle or daily schedule
+  </Card>
+  <Card title="Session Persistence" icon="database" href="/features/session-persistence">
+    How bot sessions are stored and restored
+  </Card>
+  <Card title="Messaging Bots" icon="robot" href="/features/messaging-bots">
+    Multi-platform bot setup and YAML config
+  </Card>
+  <Card title="Context Compaction" icon="compress" href="/features/context-compaction">
+    Agent-level context compaction (core ContextCompactor API)
+  </Card>
+</CardGroup>

--- a/docs/features/bot-session-reset.mdx
+++ b/docs/features/bot-session-reset.mdx
@@ -175,8 +175,8 @@ session:
 **Session Reaper** (`session_ttl` on `BotConfig`) prunes the *in-memory session record* of stale users. They solve different problems; use both for long-running bots.
 </Accordion>
 
-<Accordion title="Pair with max_history">
-Combine `session.max_history` with reset policies to cap context size and cost. Reset clears history entirely; `max_history` trims retained turns during an active session.
+<Accordion title="Pair with max_history and session compaction">
+Combine `session.max_history` with reset policies to cap context size and cost. Reset clears history entirely; `max_history` trims retained turns during an active session; `session.compaction` summarises older turns instead of dropping them. See [Bot Session Compaction](/features/bot-session-compaction).
 </Accordion>
 
 <Accordion title="Manual /new command">
@@ -201,5 +201,8 @@ Users can always send `/new` for an immediate reset. Manual reset works alongsid
   </Card>
   <Card title="Session Persistence" icon="database" href="/docs/features/session-persistence">
     Persisting session state to disk
+  </Card>
+  <Card title="Bot Session Compaction" icon="compress" href="/docs/features/bot-session-compaction">
+    Summarise old turns instead of dropping them
   </Card>
 </CardGroup>

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -302,7 +302,7 @@ Every entry under `channels:` is validated by `ChannelConfigSchema`:
 | `home_channel` | `str` | `None` | Default channel ID for this platform. |
 | `aliases` | `dict[str, str]` | `{}` | Friendly name → channel ID map. |
 | `outbound_resilience` | `object` | `None` | Retry/DLQ settings (`enabled`, `initial_ms`, `max_ms`, `factor`, `max_attempts`, `jitter`, `dlq_path`). |
-| `session` | `object` | `None` | Session config (`max_history`, `reset` policy). |
+| `session` | `object` | `None` | Session config (`max_history`, `reset` policy, `compaction` policy). |
 | `max_history` | `int` | `None` | Legacy alias for `session.max_history`. |
 | `phone_number_id` | `str` | `None` | WhatsApp Cloud API phone number ID. |
 | `verify_token` | `str` | `None` | WhatsApp webhook verify token. |
@@ -313,6 +313,27 @@ Every entry under `channels:` is validated by `ChannelConfigSchema`:
 | `smtp_server` | `str` | `None` | Email SMTP server. |
 | `inbox_id` | `str` | `None` | AgentMail inbox ID. |
 | `domain` | `str` | `None` | AgentMail domain. |
+
+### Session Compaction
+
+Long-lived sessions can summarise older turns instead of dropping them. Enable per-channel via `session.compaction.enabled: true` in `gateway.yaml`.
+
+<Card icon="compress" href="/features/bot-session-compaction">
+  Configure per-channel compaction strategy, budget, and recent-tail
+</Card>
+
+```yaml
+channels:
+  telegram:
+    token: "${TELEGRAM_BOT_TOKEN}"
+    session:
+      compaction:
+        enabled: true
+    routing:
+      default: support
+```
+
+---
 
 ### Agent Configuration Reference
 
@@ -819,5 +840,8 @@ praisonai gateway channels --config gateway.yaml
   </Card>
   <Card title="Gateway Error Handling" icon="triangle-alert" href="/features/gateway-error-handling">
     Error handling patterns for the gateway
+  </Card>
+  <Card title="Bot Session Compaction" icon="compress" href="/features/bot-session-compaction">
+    Summarise old turns instead of dropping them
   </Card>
 </CardGroup>

--- a/docs/features/messaging-bots.mdx
+++ b/docs/features/messaging-bots.mdx
@@ -1367,6 +1367,10 @@ channels:
       reset:
         mode: idle
         idle_minutes: 60
+      compaction:
+        enabled: true
+        strategy: summarize
+        keep_recent: 10
     routing:
       dm: "personal"
       group: "support"
@@ -2031,5 +2035,8 @@ bot.run()
   </Card>
   <Card title="Bot Platform Capabilities" icon="sliders" href="/docs/features/bot-platform-capabilities">
     How platform capabilities drive this feature
+  </Card>
+  <Card title="Bot Session Compaction" icon="compress" href="/features/bot-session-compaction">
+    Summarise old turns instead of dropping them
   </Card>
 </CardGroup>

--- a/docs/features/session-persistence.mdx
+++ b/docs/features/session-persistence.mdx
@@ -355,14 +355,23 @@ graph TB
     A -->|not set| B[session.max_history in YAML]
     B -->|set?| E[Use session.max_history]
     B -->|not set| C[Default: 100]
+    D --> CP{session.compaction.enabled?}
+    E --> CP
+    C --> CP
+    CP -->|No| TR[Tail-slice truncate]
+    CP -->|Yes| CO[Compact older turns<br/>max_history × 4 hard cap]
 
     classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
     classDef fallback fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef compact fill:#8B0000,stroke:#7C90A0,color:#fff
 
     class A,B config
     class C fallback
     class D,E result
+    class CP fallback
+    class TR result
+    class CO compact
 ```
 
 ### Bot Session Configuration
@@ -376,6 +385,15 @@ Configure these settings in your `bot.yaml` under each channel:
 | Session reset mode | `session.reset.mode` | `string` | `"none"` | `none`, `idle`, `daily`, or `both`. |
 | Idle reset threshold | `session.reset.idle_minutes` | `int` | `60` | Minutes of inactivity before reset (when mode includes `idle`). |
 | Daily reset hour | `session.reset.at_hour` | `int` | — | Hour (0–23) for daily reset (required when mode includes `daily`). |
+| Compaction enabled | `session.compaction.enabled` | `bool` | `false` | Master switch for summarising older turns. |
+| Compaction strategy | `session.compaction.strategy` | `string` | `"summarize"` | `truncate`, `sliding`, `summarize`, `smart`, `prune`, `llm_summarize`. |
+| Compaction message threshold | `session.compaction.max_messages` | `int` | `100` | Approximate threshold (converted to a token budget). |
+| Compaction token budget | `session.compaction.max_tokens` | `int` | — | Optional explicit budget. Overrides `max_messages`. |
+| Recent tail kept verbatim | `session.compaction.keep_recent` | `int` | `10` | Most-recent messages kept un-summarised. |
+
+<Note>
+When compaction is enabled, `max_history` becomes a hard upper bound (`max_history × 4`) instead of the primary trim mechanism. See [Bot Session Compaction](/features/bot-session-compaction) for the full flow.
+</Note>
 
 <Note>
 `max_history` at the channel level takes precedence over `session.max_history`. Use `session.max_history` for new configs — it is the preferred form.
@@ -465,3 +483,7 @@ assert isinstance(get_default_session_store(), SessionStoreProtocol)
 | `list_sessions(limit)` | List all sessions |
 | `session_exists(session_id)` | Check if session exists |
 | `invalidate_cache(session_id)` | Drop the in-memory cache entry (no-op for reads; reads always reload) |
+
+<Card icon="compress" href="/features/bot-session-compaction">
+  Summarise older bot session turns instead of dropping them
+</Card>


### PR DESCRIPTION
## Summary

- **New page**: `docs/features/bot-session-compaction.mdx` — complete documentation for the `session.compaction` config block introduced in PR #2205
- **Updated**: `docs/features/gateway.mdx` — `session` row updated to mention compaction, new Session Compaction section with YAML example and card link, new Related card
- **Updated**: `docs/features/bot-session-reset.mdx` — expanded "Pair with max_history" accordion to mention compaction, new Related card
- **Updated**: `docs/features/session-persistence.mdx` — 5 compaction rows added to Bot Session Configuration table, new `<Note>` on max_history precedence in compaction mode, updated precedence diagram with compaction branch, new Related card
- **Updated**: `docs/features/messaging-bots.mdx` — compaction added to gateway YAML example, new Related card
- **Updated**: `docs.json` — `docs/features/bot-session-compaction` added to Features group next to `bot-session-reset`

## Test plan

- [ ] New page renders correctly at `/features/bot-session-compaction`
- [ ] All cross-links resolve
- [ ] Mermaid diagrams render (hero, sequence, strategy decision)
- [ ] docs.json valid JSON (verified)
- [ ] `strategy` values match schema: `truncate`, `sliding`, `summarize`, `smart`, `prune`, `llm_summarize`
- [ ] Defaults match: `enabled=false`, `strategy="summarize"`, `max_messages=100`, `max_tokens=null`, `keep_recent=10`

Fixes #844

Generated with [Claude Code](https://claude.ai/code)