### PR TITLE
docs(cli): add docs/cli/models.mdx and fix CLI reference command tree gaps

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1283,6 +1283,7 @@
                   "docs/cli/agents",
                   "docs/cli/acp",
                   "docs/cli/auth",
+                  "docs/cli/models",
                   "docs/cli/auto",
                   "docs/cli/serve",
                   "docs/cli/dashboard",

--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -195,6 +195,38 @@ praisonai
 │   ├── ci                       # CI mode
 │   └── selftest                 # Agent functionality
 │
+├── agent                        # Custom agent definitions
+│   ├── list [--verbose]         # List discovered custom agents
+│   └── show <name>              # Show agent details
+│
+├── auth                         # Credential management
+│   ├── login <provider>         # Store provider key (interactive or --key)
+│   ├── list                     # List stored providers (redacted)
+│   ├── status [provider]        # Validate stored credentials
+│   └── logout [provider|--all]  # Remove credentials
+│
+├── command                      # Custom command templates
+│   ├── list [--verbose]         # List discovered commands
+│   └── show <name> [--preview]  # Show / preview a command template
+│
+├── models                       # LLM model catalogue
+│   ├── list [SEARCH]            # List/filter models by provider or name
+│   ├── describe <model>         # Full capabilities/limits/cost
+│   └── validate <model>         # Validate an ID; suggests alternatives on miss
+│
+├── permissions                  # Tool approval rules
+│   ├── list                     # List rules
+│   ├── allow|deny|ask <pattern> # Add a rule
+│   ├── remove <id-prefix>       # Remove a rule
+│   ├── reset                    # Delete all rules (confirm)
+│   ├── export                   # Print rules as JSON
+│   └── import <file>            # Import rules from JSON
+│
+├── validate                     # YAML configuration validation
+│   ├── <file>                   # Validate one file
+│   ├── check [directory]        # Validate all YAML in directory
+│   └── schema                   # Print the YAML schema
+│
 ├── agents                       # Agent management
 ├── run                          # Run agents
 ├── thinking                     # Thinking budget config

--- a/docs/cli/models.mdx
+++ b/docs/cli/models.mdx
@@ -1,0 +1,149 @@
+---
+title: "Models"
+sidebarTitle: "Models"
+description: "List, describe, and validate available LLM models from the CLI"
+icon: "microchip"
+---
+
+`praisonai models` browses every model your install knows about — provider, capabilities, context window, and cost — so you pick the right one before you run.
+
+```mermaid
+graph LR
+    subgraph "Models CLI"
+        T[💻 Terminal] --> CLI[praisonai models]
+        CLI --> CAT[Model Catalogue]
+        CAT --> LIVE[litellm live data]
+        CAT --> FB[Static fallback list]
+        CAT --> OUT[✅ Capabilities · Limits · Cost]
+    end
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef data fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class T input
+    class CLI,CAT process
+    class LIVE,FB data
+    class OUT output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="List all models">
+
+```bash
+praisonai models list
+```
+
+</Step>
+
+<Step title="Filter by provider or name">
+
+```bash
+praisonai models list --provider openai
+praisonai models list gpt
+```
+
+</Step>
+
+<Step title="Inspect a specific model">
+
+```bash
+praisonai models describe gpt-4o
+```
+
+</Step>
+
+<Step title="Validate a model ID before using it">
+
+```bash
+praisonai models validate gpt-4o
+```
+
+</Step>
+</Steps>
+
+## Agent-centric example
+
+```python
+from praisonaiagents import Agent
+
+# `praisonai models describe gpt-4o` confirmed this model supports vision
+agent = Agent(
+    name="Vision Agent",
+    instructions="Describe what's in the image.",
+    llm="gpt-4o",
+)
+agent.start("Describe this screenshot.")
+```
+
+## Subcommands
+
+| Command | Purpose |
+|---|---|
+| `models list [SEARCH] [--provider P] [--json]` | List available models grouped by provider |
+| `models describe <model>` | Full capabilities, limits, cost, and notes for one model |
+| `models validate <model>` | Check whether an ID is valid; suggests alternatives on a miss |
+
+## Flags
+
+### `praisonai models list`
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `search` (positional) | `str` | `None` | Substring filter on model ID |
+| `--provider` / `-p` | `str` | `None` | Filter to one provider |
+| `--json` | `bool` | `False` | Emit JSON instead of a Rich table |
+
+### `praisonai models describe <model>`
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `model` (positional) | `str` | — | Model ID (e.g. `gpt-4o`) |
+
+### `praisonai models validate <model>`
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `model` (positional) | `str` | — | Model ID to validate |
+
+## Fallback behaviour
+
+If `litellm` is not installed, the CLI falls back to a curated static list covering OpenAI, Anthropic, Google, Groq, and Ollama models. All three subcommands work against the static list. Install `litellm` for the full live catalogue:
+
+```bash
+pip install 'praisonai[litellm]'
+```
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Validate model IDs before running agents">
+Catch typos in `llm=` before the agent fails on the first API call — `praisonai models validate <id>` exits 1 and suggests similar IDs on a miss.
+</Accordion>
+<Accordion title="Use --json for scripting">
+Pipe `praisonai models list --json` into `jq` to filter by capability or cost in CI pipelines.
+</Accordion>
+<Accordion title="Install litellm for the full catalogue">
+The static fallback covers only a handful of common models. Install `praisonai[litellm]` to unlock 100+ models with live pricing data.
+</Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card icon="microchip" title="Model Catalogue" href="/docs/features/models-cli">
+    Long-form feature article with output samples and caching details
+  </Card>
+  <Card icon="brain" title="Models Overview" href="/docs/models">
+    Picking the right model for your workload
+  </Card>
+  <Card icon="key" title="Auth" href="/docs/cli/auth">
+    Store provider API keys before running agents
+  </Card>
+  <Card icon="play" title="Run" href="/docs/cli/run">
+    Run agents with the model you picked
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- **Create `docs/cli/models.mdx`**: New CLI reference page for `praisonai models` following the exact pattern of `agent.mdx`, `auth.mdx`, `command.mdx`, `permissions.mdx`, and `validate.mdx`. Covers all three subcommands (`list`, `describe`, `validate`) with flag tables, an agent-centric Python example, fallback behaviour note, Best Practices accordion group, and Related card group.
- **Patch `docs/cli/cli-reference.mdx`**: Added all 6 previously-missing top-level commands (`agent`, `auth`, `command`, `models`, `permissions`, `validate`) to the Command Tree section as top-level entries with their subcommands.
- **Patch `docs.json`**: Registered `docs/cli/models` under CLI → Core Commands (alphabetically after `auth`). JSON validated.

## Changes

- `docs/cli/models.mdx` — new file
- `docs/cli/cli-reference.mdx` — additions only (no deletions)
- `docs.json` — one line added, JSON remains valid

Fixes #848

Generated with [Claude Code](https://claude.ai/code)