### PR TITLE
docs: document fail-loud schema-validated config + updated init scaffold

### DIFF
--- a/docs/cli/config.mdx
+++ b/docs/cli/config.mdx
@@ -76,10 +76,27 @@ praisonai config show --sources                # Include contributing layers
 
 ### `validate`
 
+Validates discovered config files against the schema, catching typos with `difflib`-based suggestions.
+
 ```bash
-praisonai config validate                      # Validate resolved config
-praisonai config validate .praisonai/config.yaml  # Validate a specific file
+praisonai config validate                          # Validate discovered configs (warn-by-default)
+praisonai config validate .praisonai/config.yaml   # Validate a specific file
+praisonai config validate --strict-config          # Treat warnings as errors (exit 1)
+praisonai config validate --json                   # Machine-readable output
 ```
+
+Example output for a typo:
+
+```
+⚠ Unknown config key 'temprature' in .praisonai/config.yaml (section: agent). Did you mean 'temperature'?
+⚠ Configuration loaded with 1 warning(s).
+ℹ Use --strict-config (or PRAISONAI_STRICT_CONFIG=1) to fail on these.
+```
+
+| Flag | Type | Default | Behaviour |
+|------|------|---------|-----------|
+| `--strict-config` / `--strict` | `bool` | `False` | Treat unknown/typo keys as errors (exit `1`) |
+| `--json` | `bool` | `False` | Emit `{valid, warnings, sources, hint}` JSON |
 
 ### `sources`
 
@@ -103,6 +120,28 @@ praisonai config path --scope user
 |-------|------|-------------|
 | `user` (default) | `~/.praisonai/config.yaml` | `0600` |
 | `project` | `./.praisonai/config.yaml` | `0644` |
+
+---
+
+## Strict Validation
+
+Unknown or mistyped keys are reported with the closest valid match. By default they are **warnings** — your valid keys still apply. Opt into **strict** mode to fail-fast.
+
+| Mode | Trigger | Behaviour |
+|------|---------|-----------|
+| Warn (default) | — | Logs `UserWarning` per unknown key, run continues |
+| Strict (per-call) | `--strict-config` on `config validate` or `ConfigResolver(strict=True)` | Raises `ValueError` on first unknown key |
+| Strict (global) | `PRAISONAI_STRICT_CONFIG=1` env var | All resolver calls run in strict mode |
+
+```bash
+# Catch typos in CI:
+PRAISONAI_STRICT_CONFIG=1 praisonai config validate
+
+# Or per-call:
+praisonai config validate --strict-config
+```
+
+The validator inspects the **raw** discovered config (before normalisation through `ResolvedConfig`), so nested mistakes like `agent.temprature` surface instead of being silently dropped.
 
 ---
 
@@ -155,6 +194,10 @@ From `cwd`, the resolver walks up to the git root searching:
 | `agent.max_tokens` | `int` | `16000` | Max output tokens |
 
 Store API keys via env vars or [`praisonai auth`](/docs/cli/auth) — `api_key` is never written to YAML.
+
+<Note>
+Editor autocomplete: `praisonai init` writes a `# yaml-language-server: $schema=...` pointer to [`config.schema.json`](https://raw.githubusercontent.com/MervinPraison/PraisonAI/main/src/praisonai/praisonai/cli/configuration/config.schema.json). VS Code (YAML extension) and other LSP editors validate against the published schema.
+</Note>
 
 ---
 

--- a/docs/cli/init.mdx
+++ b/docs/cli/init.mdx
@@ -110,11 +110,17 @@ graph TB
 **`config.yaml`** — project-wide defaults:
 
 ```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/MervinPraison/PraisonAI/main/src/praisonai/praisonai/cli/configuration/config.schema.json
 # PraisonAI project configuration
 # Defaults applied to scaffolded agents and commands.
-model: gpt-4o-mini
-output: text
+# Sections are nested exactly as the resolver consumes them.
+agent:
+  model: gpt-4o-mini
+output:
+  format: text
 ```
+
+The `# yaml-language-server:` line enables editor autocomplete and inline error highlighting in VS Code (YAML extension) and other LSP-aware editors. The nested `agent:` / `output:` shape is exactly what `ConfigResolver` reads — flat top-level `model:` / `output:` keys will now produce a warning.
 
 **`agents/assistant.md`** — ready-to-run starter agent:
 

--- a/docs/features/cli-configuration.mdx
+++ b/docs/features/cli-configuration.mdx
@@ -177,6 +177,46 @@ Other top-level sections (`output`, `mcp`, `rules`, `traces`, `session`) are unc
 
 ---
 
+## Validation
+
+Configuration is validated against a published JSON Schema. Unknown keys produce actionable warnings with typo suggestions; opt into strict mode to fail fast.
+
+```mermaid
+graph LR
+    L[📄 .praisonai/config.yaml] --> R[🔍 Schema check]
+    R -->|Known keys| OK[✅ Applied]
+    R -->|Unknown key| W[⚠ Warn + suggest]
+    R -->|Strict mode| E[❌ Raise ValueError]
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef warn fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef err fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class L input
+    class R process
+    class OK ok
+    class W warn
+    class E err
+```
+
+| Mode | Enable via | Behaviour on unknown key |
+|------|------------|-------------------------|
+| Warn (default) | — | Logs `UserWarning`, valid keys still apply |
+| Strict (per-call) | `--strict-config` / `ConfigResolver(strict=True)` | Raises `ValueError` |
+| Strict (global) | `PRAISONAI_STRICT_CONFIG=1` | All resolver calls strict |
+
+Typo example:
+
+```
+Unknown config key 'temprature' in .praisonai/config.yaml (section: agent). Did you mean 'temperature'?
+```
+
+The `# yaml-language-server: $schema=...` line written by `praisonai init` enables real-time autocomplete and inline errors in VS Code (YAML extension) and other LSP-aware editors against the [published schema](https://raw.githubusercontent.com/MervinPraison/PraisonAI/main/src/praisonai/praisonai/cli/configuration/config.schema.json).
+
+---
+
 ## Environment Variables
 
 | Variable | Maps to | Notes |
@@ -201,7 +241,7 @@ Other top-level sections (`output`, `mcp`, `rules`, `traces`, `session`) are unc
 | Command | Flags | Behaviour |
 |---------|-------|-----------|
 | `praisonai config show` | `--format yaml\|json\|table`, `--sources/-s` | Prints fully resolved config; with `--sources`, lists contributing layers |
-| `praisonai config validate [FILE]` | optional FILE | Validates YAML syntax + schema; no arg validates resolved config |
+| `praisonai config validate [FILE]` | `--strict-config`, `--json`, optional FILE | Validates schema; warn-by-default, strict opts into raise |
 | `praisonai config sources` | none | Prints precedence hierarchy and active layers |
 | `praisonai config list` | `--scope all\|user\|project` | Lists resolved values; verbose shows sources |
 | `praisonai config get KEY` | dotted path | e.g. `agent.model` |


### PR DESCRIPTION
## Summary

- **`docs/cli/init.mdx`**: Replace old flat `config.yaml` scaffold with the correct nested `agent:` / `output:` shape plus `# yaml-language-server: $schema=...` pointer and LSP editor note
- **`docs/cli/config.mdx`**: Expand `validate` section with `--strict-config`/`--json` flags and typo suggestion example output; add new `## Strict Validation` section with mode table and CI usage; add schema link callout to `agent.*` Schema section
- **`docs/features/cli-configuration.mdx`**: Add `## Validation` section with mermaid diagram (warn/strict flow), mode table, typo example; update subcommand table `validate` row with new flags

## Context

Documents PraisonAI PR #2222 (merged) which adds fail-loud schema validation, typo suggestions via `difflib`, a published JSON Schema, an updated `praisonai init` scaffold, and the `--strict-config` / `PRAISONAI_STRICT_CONFIG=1` strict mode.

Fixes #866

Generated with [Claude Code](https://claude.ai/code)