### PR TITLE
docs(bots): fix HealthResult field names in botos.mdx

### DIFF
--- a/docs/features/botos.mdx
+++ b/docs/features/botos.mdx
@@ -359,9 +359,13 @@ botos = BotOS(agent=agent, platforms=["telegram", "discord"])
 async def check():
     health_by_platform = await botos.health()
     # {"telegram": HealthResult(...), "discord": HealthResult(...)}
-    print(health_by_platform["telegram"].ok)
-    print(health_by_platform["telegram"].reason)
-    print(health_by_platform["telegram"].last_activity)
+    tg = health_by_platform["telegram"]
+    print(tg.ok)             # bool — overall pass/fail
+    print(tg.is_running)     # bool — adapter loop alive
+    print(tg.uptime_seconds) # float | None
+    print(tg.probe.ok)       # bool — platform API reachable
+    print(tg.sessions)       # int — active sessions
+    print(tg.error)          # str | None — populated when probe fails
 
     status = botos.get_supervisor_status()
     # supervisor + health-monitor snapshot for /healthz or metrics
@@ -420,8 +424,11 @@ print(result.latency)   # Response time in seconds
 # Get detailed health after running
 health = asyncio.run(bot.health())
 print(health.ok)
-print(health.uptime)
-print(health.sessions_active)
+print(health.platform)
+print(health.is_running)
+print(health.uptime_seconds)
+print(health.sessions)
+print(health.error)
 ```
 
 <Tip>


### PR DESCRIPTION
## Summary

Fixes two pre-existing field-name discrepancies in `docs/features/botos.mdx` that reference non-existent fields on the `HealthResult` dataclass.

**Edit 1 — Aggregated Health snippet:**
- Removed `.reason` (no such field) → show `.error` instead
- Removed `.last_activity` (no such field) → show `.is_running`, `.uptime_seconds`, `.probe.ok`, `.sessions`, `.error`

**Edit 2 — Health Checks snippet:**
- `.uptime` → `.uptime_seconds`
- `.sessions_active` → `.sessions`
- Added `.platform`, `.is_running`, `.error` to match full `HealthResult` dataclass

Verified against `praisonaiagents/bots/protocols.py::HealthResult` field list. No other pages have the same drift.

Closes #878

Generated with [Claude Code](https://claude.ai/code)