### PR TITLE
docs: clarify workflow action templating — auto-append, substitution order, {{input}} support

### DIFF
--- a/docs/api-reference/workflow-manager.mdx
+++ b/docs/api-reference/workflow-manager.mdx
@@ -766,13 +766,17 @@ def reload() -> None
 
 ## Variable Substitution
 
-Workflows support variable substitution using `{{variable}}` syntax:
+Every `action` string supports `{{placeholder}}` substitution, applied in this order:
 
-| Variable | Description |
-|----------|-------------|
-| `{{variable_name}}` | User-defined variable |
-| `{{previous_output}}` | Output from previous step |
-| `{{step_name_output}}` | Output from specific step |
+| Placeholder | Resolves to | Notes |
+|---|---|---|
+| `{{your_variable}}` | Value from `variables={}` or an earlier step's `output_variable` | Substituted first |
+| `{{previous_output}}` | Output of the immediately previous step | Auto-appended as `"Context from previous step:"` if omitted and a previous output exists |
+| `{{step_name_output}}` | Output of a specific named step (set via `output_variable`) | Resolved in the same pass as `{{your_variable}}` |
+| `{{input}}` | Value passed to `workflow.start(...)` | Substituted last; available in every step |
+
+For the full substitution pipeline and auto-append behaviour, see [How Action Templating Works](/features/workflows#how-action-templating-works).
+For date/time/UUID placeholders (`{{today}}`, `{{now}}`, `{{uuid}}`), see [Dynamic Variables](/features/dynamic-variables) — a separate mechanism.
 
 ### Example
 

--- a/docs/features/workflows.mdx
+++ b/docs/features/workflows.mdx
@@ -976,13 +976,96 @@ result = manager.execute(
 )
 ```
 
+## How Action Templating Works
+
+Every `action` string is processed through three substitution steps — in this exact order — before the step runs.
+
+```mermaid
+graph TB
+    A["📥 action string"] --> B["🔄 Replace {{your_variable}}<br/>from all_variables"]
+    B --> C{Previous output exists?}
+    C -->|No| F["🔁 Replace {{input}}"]
+    C -->|Yes| D{"action contains<br/>{{previous_output}}?"}
+    D -->|Yes| E1["✏️ Replace in place"]
+    D -->|No| E2["➕ Append:<br/>'Context from previous step:'"]
+    E1 --> F
+    E2 --> F
+    F --> G["✅ Final prompt sent to agent"]
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef decision fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A input
+    class B,E1,E2,F process
+    class C,D decision
+    class G output
+```
+
+### Supported Placeholders
+
+| Placeholder | Resolves to | Substituted when |
+|---|---|---|
+| `{{your_variable}}` | Value from `variables={}` or an earlier step's `output_variable` | First |
+| `{{previous_output}}` | Output of the immediately previous step | Second — auto-appended if omitted and a previous output exists |
+| `{{step_name_output}}` | Output of a specific named step (set via `output_variable`) | Same pass as `{{your_variable}}` |
+| `{{input}}` | Value passed to `workflow.start(...)` | Last — available in every step |
+
+### Auto-Append Fallback
+
+If a previous step produced output **and** the action does **not** contain `{{previous_output}}`, the workflow automatically appends the prior output:
+
+```
+<your action>
+
+Context from previous step:
+<previous_output>
+```
+
+This means every step automatically sees the prior output as context — even when you don't reference it explicitly.
+
+<Tip>
+**When to use which form:**
+- Use `{{previous_output}}` explicitly when you want to **embed** the prior output inside a sentence:
+  `"Summarise: {{previous_output}}"`
+- Omit it and let the auto-append do the work when you just need the next step to **see** the prior output as background context:
+  `"Now write a tweet about this."`
+</Tip>
+
+### Example — Explicit vs Auto-Append
+
+```python
+from praisonaiagents import Agent, AgentFlow, Task
+
+researcher = Agent(name="Researcher", instructions="Research the topic.")
+writer = Agent(name="Writer", instructions="Write a short summary.")
+
+workflow = AgentFlow(steps=[
+    Task(name="research", agent=researcher, action="Research {{input}}"),
+    Task(name="summary", agent=writer, action="Summarise: {{previous_output}}"),
+    Task(name="tweet", agent=writer, action="Now write a one-line tweet."),
+])
+
+workflow.start("AI agents")
+```
+
+- `research` — `{{input}}` is replaced with `"AI agents"`.
+- `summary` — `{{previous_output}}` is replaced in place with the research output.
+- `tweet` — no `{{previous_output}}` token, so the research output is auto-appended under `"Context from previous step:"`.
+
+<Note>
+`{{input}}`, `{{previous_output}}`, and `{{your_variable}}` are workflow-level templating. For date/time/UUID substitution (`{{today}}`, `{{now}}`, `{{uuid}}`), see [Dynamic Variables](/features/dynamic-variables) — that is a separate mechanism.
+</Note>
+
 ## Context Passing
 
 Workflow steps automatically pass context to subsequent steps. Use special variables to access previous outputs:
 
 | Variable | Description |
 |----------|-------------|
-| `{{previous_output}}` | Output from the immediately previous step |
+| `{{previous_output}}` | Output from the immediately previous step (auto-appended if not referenced — see [How Action Templating Works](#how-action-templating-works)) |
+| `{{input}}` | Value passed to `workflow.start(...)` — available in every step |
 | `{{step_name_output}}` | Output from a specific step (e.g., `{{research_output}}`) |
 
 ```python
@@ -1342,16 +1425,16 @@ manager.delete_checkpoint("research-checkpoint")
 
 ### Variable Substitution
 
-Workflows support `{{variable}}` placeholders with dynamic providers:
+Workflows support `{{placeholder}}` substitution in every `action` string, applied in this order:
 
-| Variable | Value |
-|----------|-------|
-| `{{previous_output}}` | Output of the previous step |
-| `{{step_name_output}}` | Output of a specific named step |
-| `{{now}}` | Current datetime |
-| `{{today}}` | Today's date |
-| `{{uuid}}` | Unique identifier |
-| Custom variables | Passed via `variables={}` dict |
+| Placeholder | Resolves to | Notes |
+|---|---|---|
+| `{{your_variable}}` | Value from `variables={}` or an earlier step's `output_variable` | Substituted first |
+| `{{previous_output}}` | Output of the immediately previous step | Auto-appended as `"Context from previous step:"` if omitted and a previous output exists |
+| `{{step_name_output}}` | Output of a specific named step (set via `output_variable`) | Resolved in the same pass as `{{your_variable}}` |
+| `{{input}}` | Value passed to `workflow.start(...)` / `manager.execute(...)` | Substituted last; available in every step |
+
+`{{now}}`, `{{today}}`, and `{{uuid}}` are provided by the separate [Dynamic Variables](/features/dynamic-variables) mechanism.
 
 ### Async Execution
 

--- a/docs/features/yaml-configuration-reference.mdx
+++ b/docs/features/yaml-configuration-reference.mdx
@@ -449,16 +449,18 @@ All options available at the root level of your YAML file.
         - Computer Vision
     ```
     
-    Use variables in steps with `{{variable_name}}` syntax.
+    Use variables in steps with `{{variable_name}}` syntax. Substitutions are applied in this order:
     
-    | Pattern | Description |
-    |---------|-------------|
-    | `{{input}}` | Workflow input |
-    | `{{topic}}` | Topic field value |
-    | `{{previous_output}}` | Previous step result |
-    | `{{variable_name}}` | Custom variable |
-    | `{{item}}` | Current loop item |
-    | `{{item.field}}` | Field in loop item |
+    | Placeholder | Resolves to | Notes |
+    |---|---|---|
+    | `{{your_variable}}` | Value from `variables:` or an earlier step's `output_variable` | Substituted first |
+    | `{{previous_output}}` | Output of the immediately previous step | Auto-appended as `"Context from previous step:"` if omitted and a previous output exists |
+    | `{{step_name_output}}` | Output of a specific named step (set via `output_variable`) | Resolved in the same pass as `{{your_variable}}` |
+    | `{{input}}` | Value of the top-level `input:` field | Substituted last; available in every step |
+    | `{{item}}` | Current loop item | Set by `loop_over` steps |
+    | `{{item.field}}` | Field in loop item | Set by `loop_over` steps |
+
+    For date/time/UUID placeholders (`{{today}}`, `{{now}}`, `{{uuid}}`), see [Dynamic Variables](/features/dynamic-variables) — that is a separate mechanism.
   </Accordion>
 
   <Accordion title="Runtime Selection" icon="play">

--- a/docs/features/yaml-workflows.mdx
+++ b/docs/features/yaml-workflows.mdx
@@ -93,7 +93,12 @@ steps:
 </Note>
 
 <Tip>
-Use `{{input}}` to reference the workflow input and `{{previous_output}}` to get the result from the previous step.
+**Action templating** — every `action` string supports three placeholders, processed in order:
+1. `{{your_variable}}` — replaced with values from `variables:` or earlier `output_variable` fields.
+2. `{{previous_output}}` — replaced in place **or auto-appended** as `"Context from previous step: …"` if the token is absent and a previous output exists.
+3. `{{input}}` — replaced with the top-level `input:` value, available in every step.
+
+For the full substitution order, auto-append rules, and examples, see [How Action Templating Works](/features/workflows#how-action-templating-works).
 </Tip>
 
 ## Field Names Reference (A-I-G-S)

--- a/docs/sdk/praisonaiagents/workflows/workflow-manager.mdx
+++ b/docs/sdk/praisonaiagents/workflows/workflow-manager.mdx
@@ -760,13 +760,17 @@ def reload() -> None
 
 ## Variable Substitution
 
-Workflows support variable substitution using `{{variable}}` syntax:
+Every `action` string supports `{{placeholder}}` substitution, applied in this order:
 
-| Variable | Description |
-|----------|-------------|
-| `{{variable_name}}` | User-defined variable |
-| `{{previous_output}}` | Output from previous step |
-| `{{step_name_output}}` | Output from specific step |
+| Placeholder | Resolves to | Notes |
+|---|---|---|
+| `{{your_variable}}` | Value from `variables={}` or an earlier step's `output_variable` | Substituted first |
+| `{{previous_output}}` | Output of the immediately previous step | Auto-appended as `"Context from previous step:"` if omitted and a previous output exists |
+| `{{step_name_output}}` | Output of a specific named step (set via `output_variable`) | Resolved in the same pass as `{{your_variable}}` |
+| `{{input}}` | Value passed to `workflow.start(...)` | Substituted last; available in every step |
+
+For the full substitution pipeline and auto-append behaviour, see [How Action Templating Works](/features/workflows#how-action-templating-works).
+For date/time/UUID placeholders (`{{today}}`, `{{now}}`, `{{uuid}}`), see [Dynamic Variables](/features/dynamic-variables) — a separate mechanism.
 
 ### Example
 


### PR DESCRIPTION
## Summary

Closes #881.

- **`docs/features/workflows.mdx`** — New **"How action templating works"** section with:
  - Mermaid `graph TB` flow diagram (standard color scheme) showing the full substitution pipeline
  - Supported placeholders table with substitution order
  - Auto-append fallback explanation
  - Beginner-friendly example contrasting explicit `{{previous_output}}` vs implicit auto-append
  - Cross-link to Dynamic Variables for `{{today}}` / `{{now}}` / `{{uuid}}`
  - Updated Context Passing table to include `{{input}}`
  - Updated WorkflowManager Variable Substitution table with full placeholder set

- **`docs/features/yaml-workflows.mdx`** — Replaced one-line Tip with a callout covering all three placeholders, substitution order, auto-append behavior, and link to canonical section.

- **`docs/features/yaml-configuration-reference.mdx`** — Updated Variables accordion table: added `{{input}}`, `{{step_name_output}}`, auto-append note, and Dynamic Variables cross-link.

- **`docs/api-reference/workflow-manager.mdx`** — Updated Variable Substitution table with the unified four-row placeholder set and cross-links.

- **`docs/sdk/praisonaiagents/workflows/workflow-manager.mdx`** — Same unified Variable Substitution table update.

No files under `docs/concepts/` or `docs/sdk/reference/` were touched.
`_substitute_action_variables` (private API) is not mentioned anywhere.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how workflow action templating and variable substitution work across the product.
  * Added a clear, ordered explanation of supported placeholders, including explicit values, previous output, named step output, and input.
  * Documented the auto-append behavior for previous step context when no placeholder is provided.
  * Added references to Dynamic Variables for date/time/UUID-style values.
  * Expanded examples and updated YAML/workflow docs to match the latest templating behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->