### PR TITLE
docs: document learn_skill / /learn / praisonai skills learn

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -846,6 +846,7 @@
                   "docs/features/zep-memory",
                   "docs/features/skill-manage",
                   "docs/features/skill-lifecycle",
+                  "docs/features/learn-skill",
                   "docs/features/self-improve",
                   "docs/features/bot-default-tools",
                   "docs/features/todo-planning",

--- a/docs/cli/skills.mdx
+++ b/docs/cli/skills.mdx
@@ -49,6 +49,24 @@ Available Skills:
     └── Metadata: author=scraping-team, version=1.5
 ```
 
+### Learn a Skill from Sources
+
+Distil a grounded `SKILL.md` from sources you describe (a repo, docs, PDFs, configs, or a URL). Uses the existing skill tools — no manual content authoring required.
+
+```bash
+praisonai skills learn "Read ./my-repo and make a 'deploy-flow' skill"
+```
+
+```bash
+praisonai skills learn "deploy steps from ./repo and the runbook PDF"
+```
+
+```bash
+praisonai skills learn "the API in ./openapi.yaml as a 'stripe-billing' skill" --llm gpt-4o
+```
+
+This is distinct from `praisonai memory learn` (captures a recall note into the memory store — not a skill) and from `self_improve` (auto-curates from conversation, unprompted).
+
 ### Validate a Skill
 
 Validate that a skill directory conforms to the Agent Skills specification.

--- a/docs/features/bot-commands.mdx
+++ b/docs/features/bot-commands.mdx
@@ -12,17 +12,19 @@ graph TB
     Q --> C[Change LLM]
     Q --> D[See cost/tokens]
     Q --> E[Queue a follow-up]
+    Q --> F[Author a skill from sources]
     A --> A1[/stop]
     B --> B1[/compress]
     C --> C1[/model]
     D --> D1[/usage]
     E --> E1[/queue]
+    F --> F1[/learn]
 
     classDef decision fill:#6366F1,stroke:#7C90A0,color:#fff
     classDef result fill:#10B981,stroke:#7C90A0,color:#fff
 
     class Q decision
-    class A1,B1,C1,D1,E1 result
+    class A1,B1,C1,D1,E1,F1 result
 ```
 
 Every PraisonAI bot comes with built-in chat commands. Just type a command in your chat — no setup required.
@@ -59,6 +61,9 @@ Every PraisonAI bot comes with built-in chat commands. Just type a command in yo
   </Card>
   <Card title="/queue" icon="list-ol">
     Queue a follow-up message to run after the current task.
+  </Card>
+  <Card title="/learn" icon="graduation-cap">
+    Distil a grounded skill from sources you describe (repo, docs, PDFs, or this chat). Authored via `skill_manage` — same approval gate as other agent-created skills. Gated by the same per-command access-control system as other built-ins. See [Learn a Skill from Sources](/docs/features/learn-skill).
   </Card>
 </CardGroup>
 

--- a/docs/features/learn-skill.mdx
+++ b/docs/features/learn-skill.mdx
@@ -1,0 +1,239 @@
+---
+title: "Learn a Skill from Sources"
+sidebarTitle: "Learn Skill"
+description: "Point your agent at a repo, docs, PDFs, configs, or this chat — and it authors one grounded, reusable SKILL.md in a single command."
+icon: "graduation-cap"
+---
+
+Learn-skill turns real source material — code, docs, PDFs, configs, or this chat — into one grounded, reusable `SKILL.md` in a single command.
+
+```mermaid
+graph LR
+    subgraph "Learn a Skill from Sources"
+        SRC[📂 Sources<br/>repo / docs / PDFs / chat] --> A[🤖 Agent]
+        A --> G[🔍 Gather]
+        G --> D[🧠 Distil]
+        D --> S[✅ SKILL.md]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class SRC input
+    class A agent
+    class G,D process
+    class S result
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Learn from a repo">
+```python
+from praisonaiagents import Agent
+
+agent = Agent()
+agent.learn_skill(
+    "Read ./my-repo and make a 'deploy-flow' skill"
+)
+```
+</Step>
+
+<Step title="Learn from multiple sources">
+```python
+from praisonaiagents import Agent
+
+agent = Agent()
+agent.learn_skill(
+    "Read ./my-repo and the docs in ./docs/*.pdf and make a 'deploy-flow' skill"
+)
+```
+</Step>
+
+<Step title="Learn from the current chat">
+```python
+from praisonaiagents import Agent
+
+agent = Agent()
+agent.start("Walk me through deploying this service: …")
+agent.learn_skill("Save what we just figured out as a 'deploy-flow' skill")
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Tools as File / PDF / Fetch
+    participant Skills as skill_manage
+
+    User->>Agent: agent.learn_skill("read ./repo, make 'deploy-flow' skill")
+    Agent->>Tools: gather only the named sources
+    Tools-->>Agent: source content (verbatim)
+    Agent->>Agent: distil SKILL.md (verbatim flags/paths only, ~100-200 lines)
+    Agent->>Skills: skill_manage(action="create", name="deploy-flow", content=…)
+    Skills-->>Agent: status: pending (approval gate) or live
+    Agent-->>User: "✅ Authored 'deploy-flow' skill — <summary>"
+```
+
+The agent follows three rules when authoring a skill:
+
+| Rule | What it means |
+|---|---|
+| **Verbatim only** | Only flags, paths, commands, env vars, and API names that appear **verbatim** in the gathered sources end up in the skill. Never invented. |
+| **Tight body** | `SKILL.md` is kept to ~100–200 lines. Long material moves to supporting files referenced by relative path. |
+| **Named sources only** | The agent reads only the sources you name. It does not browse unrelated material. |
+| **YAML frontmatter** | Every generated skill has at least `name` + `description`. |
+
+---
+
+## Three Surfaces
+
+<Tabs>
+<Tab title="Python SDK">
+```python
+from praisonaiagents import Agent
+
+agent = Agent()
+agent.learn_skill("Read ./my-repo and make a 'deploy-flow' skill")
+```
+</Tab>
+<Tab title="CLI">
+```bash
+praisonai skills learn "the API in ./openapi.yaml as a 'stripe-billing' skill"
+```
+</Tab>
+<Tab title="Bot Chat">
+```
+/learn deploy steps from this repo and the runbook PDF
+```
+</Tab>
+</Tabs>
+
+---
+
+## Async
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent()
+result = await agent.alearn_skill(
+    "Read ./my-repo and make a 'deploy-flow' skill"
+)
+```
+
+<Note>
+`alearn_skill` is the async equivalent of `learn_skill`. Use it inside `async` functions or notebooks.
+</Note>
+
+---
+
+## Approval Gate
+
+<Note>
+Skills authored by `learn_skill` go through the **same human approval gate** as any other agent-created skill. By default the tool returns `{"status": "pending", "id": "skl-…"}` and disk is not touched until a human approves. See [Skill Manage](/docs/features/skill-manage).
+</Note>
+
+---
+
+## Common Patterns
+
+### From a single repo
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent()
+agent.learn_skill("Read ./my-repo and make a 'deploy-flow' skill")
+```
+
+### Multi-source (repo + PDFs + URL)
+
+The agent picks the right tool per source — file read, PDF read, or fetch — automatically.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent()
+agent.learn_skill(
+    "Read ./my-repo, the runbook at ./docs/runbook.pdf, "
+    "and https://docs.example.com/api — make a 'deploy-flow' skill"
+)
+```
+
+### From the current chat
+
+Phrases like `"what we just figured out"` or `"this conversation"` route the agent to use the chat as the source.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent()
+agent.start("Walk me through deploying this service to AWS…")
+agent.learn_skill("Save what we just figured out as a 'deploy-flow' skill")
+```
+
+### CLI with model override
+
+```bash
+praisonai skills learn "the API in ./openapi.yaml as a 'stripe-billing' skill" --llm gpt-4o
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Name sources explicitly">
+    Saying "read `./my-repo` and `./docs/*.pdf`" beats "learn about deploys" because the agent only reads what you name. Explicit paths give better, more grounded skills.
+  </Accordion>
+  <Accordion title="Pick a kebab-case skill name in the request">
+    Include a quoted name like `"… make a 'deploy-flow' skill"`. If you omit it, the agent derives one from the content — which may be less predictable.
+  </Accordion>
+  <Accordion title="Prefer learn_skill over learn in new code">
+    `learn` / `alearn` are kept as backward-compat aliases. The canonical names are `learn_skill` / `alearn_skill` to avoid confusion with the memory `learn=` constructor param on `Agent`.
+  </Accordion>
+  <Accordion title="Don't pre-wire skill_manage yourself">
+    `learn_skill` automatically adds `skill_manage`, `read_skill_file`, and `list_skill_scripts` to `agent.tools` if they are missing. The call is idempotent — running it multiple times does not double-register tools.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Backward-compat Aliases
+
+`learn` and `alearn` are aliases for `learn_skill` and `alearn_skill`:
+
+```python
+agent.learn("Read ./my-repo and make a 'deploy-flow' skill")
+await agent.alearn("Read ./my-repo and make a 'deploy-flow' skill")
+```
+
+Prefer `learn_skill` / `alearn_skill` in new code.
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Skill Manage" icon="shield-check" href="/docs/features/skill-manage">
+    The approval gate the authored skill flows through
+  </Card>
+  <Card title="Agent Skills" icon="puzzle-piece" href="/docs/features/skills">
+    Invoking and discovering skills
+  </Card>
+  <Card title="Self-Improving Agents" icon="rotate" href="/docs/features/self-improve">
+    Auto-curate skills from conversation (different mechanism)
+  </Card>
+  <Card title="Bot Chat Commands" icon="terminal" href="/docs/features/bot-commands">
+    /learn slash command in Telegram, Discord, and Slack
+  </Card>
+</CardGroup>

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -11,6 +11,10 @@ Skills extend agents with specialized knowledge and instructions loaded on deman
 **Agent-created skills are staged for approval by default.** When an agent calls `skill_manage` to create, edit, or delete a skill, the mutation is held in a pending store until a human approves it — disk is not touched. Reading and using existing skills is unaffected. See [Skill Manage](/docs/features/skill-manage) for the full approval gate docs.
 </Note>
 
+<Tip>
+**Want to generate a skill from your own repo or docs?** See [Learn a Skill from Sources](/docs/features/learn-skill) — one command turns code/docs/PDFs into a grounded `SKILL.md`.
+</Tip>
+
 ```mermaid
 graph LR
     subgraph "Progressive Loading"


### PR DESCRIPTION
## Summary

Documents the new `Agent.learn_skill()` / `/learn` / `praisonai skills learn` feature introduced in upstream PraisonAI #2266.

### Changes

- **NEW** `docs/features/learn-skill.mdx` — Primary feature page with hero Mermaid diagram, agent-centric Quick Start (3 steps), sequence diagram, trust-contract rules table, three surfaces (Python/CLI/Bot), async variant, common patterns, best practices, and cross-references
- **UPDATED** `docs/features/skills.mdx` — Added Tip callout pointing to the new learn-skill page
- **UPDATED** `docs/features/bot-commands.mdx` — Added /learn to decision diagram + new Card in Built-in Commands section
- **UPDATED** `docs/cli/skills.mdx` — Added Learn a Skill from Sources section with CLI examples
- **UPDATED** `docs.json` — Added docs/features/learn-skill under the Advanced Features group, adjacent to other skill pages (after skill-lifecycle)

Closes #891

Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new “Learn a Skill from Sources” workflow, including examples for creating a skill from repos, docs, PDFs, configs, chat, or a URL.
  * Updated CLI and bot command docs to cover the new `/learn` command and how it fits into the existing skill tools.
  * Added navigation and cross-links so the new feature is easier to find from the skills and advanced features docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->