### PR TITLE
docs: Add Vector Store feature page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -612,6 +612,7 @@
                   "docs/features/checkpoints",
                   "docs/features/database-persistence",
                   "docs/features/advanced-memory",
+                  "docs/features/vector-store",
                   "docs/features/prompt-caching",
                   "docs/features/memory-advanced-search",
                   "docs/features/memory-troubleshooting",

--- a/docs/features/advanced-memory.mdx
+++ b/docs/features/advanced-memory.mdx
@@ -804,4 +804,7 @@ agent = Agent(
   <Card title="Prompt Caching" icon="database" href="/docs/features/prompt-caching">
     Optimise memory context for prompt caching
   </Card>
+  <Card title="Vector Store" icon="database" href="/docs/features/vector-store">
+    Store and query embeddings with a pluggable, namespace-aware backend
+  </Card>
 </CardGroup>

--- a/docs/features/knowledge-backends.mdx
+++ b/docs/features/knowledge-backends.mdx
@@ -354,4 +354,7 @@ class MyBackend:
   <Card title="Knowledge" icon="book" href="/features/knowledge">
     Core knowledge retrieval and agent integration
   </Card>
+  <Card title="Vector Store" icon="database" href="/docs/features/vector-store">
+    Store and query embeddings with a pluggable, namespace-aware backend
+  </Card>
 </CardGroup>

--- a/docs/features/knowledge.mdx
+++ b/docs/features/knowledge.mdx
@@ -499,4 +499,7 @@ for paper in papers:
   <Card icon="magnifying-glass" href="/features/rag">
     Build RAG applications
   </Card>
+  <Card title="Vector Store" icon="database" href="/docs/features/vector-store">
+    Store and query embeddings with a pluggable, namespace-aware backend
+  </Card>
 </CardGroup>

--- a/docs/features/rag.mdx
+++ b/docs/features/rag.mdx
@@ -351,6 +351,9 @@ agent.start("What is KAG in one line?") # Retrieval
   <Card title="Mini Agents" icon="microchip" href="./mini">
     Explore lightweight, focused AI agents
   </Card>
+  <Card title="Vector Store" icon="database" href="/docs/features/vector-store">
+    Store and query embeddings with a pluggable, namespace-aware backend
+  </Card>
 </CardGroup>
 
 <Note>

--- a/docs/features/retrieval.mdx
+++ b/docs/features/retrieval.mdx
@@ -222,3 +222,4 @@ agent = Agent(
 - [CLI Retrieval Commands](/docs/cli/retrieval) - Use retrieval from the command line
 - [Knowledge Concepts](/docs/concepts/knowledge) - Learn about knowledge bases
 - [Memory](/docs/concepts/memory) - Combine with agent memory
+- [Vector Store](/docs/features/vector-store) - Pluggable embedding store with namespace support

--- a/docs/features/vector-store.mdx
+++ b/docs/features/vector-store.mdx
@@ -1,0 +1,237 @@
+---
+title: "Vector Store"
+sidebarTitle: "Vector Store"
+description: "Store and query embeddings with a pluggable, namespace-aware backend"
+icon: "database"
+---
+
+Store and retrieve text embeddings using a simple, pluggable backend — no external infrastructure needed to get started.
+
+```mermaid
+graph LR
+    subgraph "Vector Store"
+        Text[📝 Text] --> Embed[🧠 Embed]
+        Embed --> Store[(💾 Store)]
+        Query[🔍 Query] --> Sim[📐 Similarity]
+        Store --> Sim
+        Sim --> Results[✅ Top K]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef store fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Text,Query input
+    class Embed,Sim process
+    class Store store
+    class Results output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Agent with Knowledge">
+The simplest way to use a vector store is through an agent's `knowledge` parameter — PraisonAI handles indexing and retrieval automatically.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Researcher",
+    instructions="Answer using the indexed documents",
+    knowledge=["docs/manual.pdf"]
+)
+
+agent.start("How do I configure authentication?")
+```
+</Step>
+
+<Step title="Direct API Usage">
+Access the in-memory store directly to add and query vectors.
+
+```python
+from praisonaiagents.knowledge.vector_store import get_vector_store_registry
+
+store = get_vector_store_registry().get("memory")
+
+store.add(
+    texts=["PraisonAI builds agentic systems"],
+    embeddings=[[0.1, 0.2, 0.3]],
+    metadatas=[{"source": "readme"}],
+)
+
+results = store.query(embedding=[0.1, 0.2, 0.3], top_k=5)
+for r in results:
+    print(r.text, r.score)
+```
+</Step>
+
+<Step title="Register a Custom Store">
+Swap in any vector database by registering a factory function.
+
+```python
+from praisonaiagents.knowledge.vector_store import get_vector_store_registry
+
+def make_my_store(config=None, namespace=None):
+    return MyStore(config=config, namespace=namespace)
+
+get_vector_store_registry().register("my_store", make_my_store)
+
+store = get_vector_store_registry().get("my_store")
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+A user question flows through the agent to the vector store, which finds the closest matching content using cosine similarity.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Embed as Embedder
+    participant VS as Vector Store
+
+    User->>Agent: "How do I deploy?"
+    Agent->>Embed: Embed question
+    Embed-->>Agent: Vector
+    Agent->>VS: query(vector, top_k=5)
+    VS-->>Agent: Top matches
+    Agent-->>User: Answer grounded in matches
+```
+
+---
+
+## Configuration Options
+
+<Card title="Vector Store API Reference" icon="code" href="/docs/sdk/praisonaiagents/knowledge/vector-store-module">
+  Full API reference for `VectorRecord`, `VectorStoreProtocol`, `VectorStoreRegistry`, and `InMemoryVectorStore`
+</Card>
+
+### VectorRecord Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `id` | `str` | — | Unique identifier |
+| `text` | `str` | — | Text content |
+| `embedding` | `List[float]` | — | Vector embedding |
+| `metadata` | `Dict[str, Any]` | `{}` | Optional metadata |
+| `score` | `Optional[float]` | `None` | Similarity score (set on query results) |
+
+### VectorStoreProtocol Methods
+
+| Method | Description |
+|--------|-------------|
+| `add(texts, embeddings, metadatas, ids, namespace)` | Add vectors; returns list of IDs |
+| `query(embedding, top_k, namespace, filter)` | Find similar vectors; returns `List[VectorRecord]` |
+| `delete(ids, namespace, filter, delete_all)` | Remove vectors; returns count deleted |
+| `count(namespace)` | Number of stored vectors |
+| `get(ids, namespace)` | Retrieve vectors by ID |
+
+---
+
+## Common Patterns
+
+### Filter by Metadata
+
+Narrow query results to records that match specific metadata fields.
+
+```python
+from praisonaiagents.knowledge.vector_store import get_vector_store_registry
+
+store = get_vector_store_registry().get("memory")
+
+store.add(
+    texts=["Chapter 1: Introduction", "Chapter 2: Advanced"],
+    embeddings=[[0.1, 0.2], [0.3, 0.4]],
+    metadatas=[{"chapter": 1}, {"chapter": 2}],
+)
+
+results = store.query(
+    embedding=[0.1, 0.2],
+    top_k=5,
+    filter={"chapter": 1},
+)
+```
+
+### Multi-Tenant Namespaces
+
+Isolate data for different users or projects within the same store.
+
+```python
+from praisonaiagents.knowledge.vector_store import get_vector_store_registry
+
+store = get_vector_store_registry().get("memory")
+
+store.add(
+    texts=["Alice's note"],
+    embeddings=[[0.1, 0.2]],
+    namespace="user:alice",
+)
+
+store.add(
+    texts=["Bob's note"],
+    embeddings=[[0.3, 0.4]],
+    namespace="user:bob",
+)
+
+alice_results = store.query(embedding=[0.1, 0.2], namespace="user:alice")
+```
+
+### Delete Vectors
+
+Remove specific records, filter-matched records, or all records in a namespace.
+
+```python
+from praisonaiagents.knowledge.vector_store import get_vector_store_registry
+
+store = get_vector_store_registry().get("memory")
+
+# Delete by ID
+store.delete(ids=["record-123"])
+
+# Delete by metadata filter
+store.delete(filter={"chapter": 1})
+
+# Clear an entire namespace
+store.delete(namespace="user:alice", delete_all=True)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="When to use the in-memory store">
+`InMemoryVectorStore` (registered as `"memory"`) is ideal for development, testing, and short-lived agents. It requires no external dependencies and resets on process restart. Switch to a persistent backend (Chroma, Pinecone, pgvector) when you need data to survive restarts or to scale beyond a single process.
+</Accordion>
+
+<Accordion title="Namespace strategy">
+Use namespaces to isolate data by user, project, or run — `"user:alice"`, `"project:docs-v2"`, `"run:abc123"`. A well-chosen namespace strategy lets you share a single store instance while keeping data strictly separated, and makes bulk deletion straightforward.
+</Accordion>
+
+<Accordion title="Cosine similarity and vector normalisation">
+`InMemoryVectorStore` ranks results by cosine similarity. Cosine similarity measures angle, not magnitude, so two vectors pointing in the same direction score `1.0` regardless of length. If your embedding model already normalises output vectors (most do), results will be reliable. If it does not, normalise manually before calling `add` and `query` to avoid misleading scores.
+</Accordion>
+
+<Accordion title="Registering custom backends">
+Any object that satisfies `VectorStoreProtocol` can be registered. Implement the five methods (`add`, `query`, `delete`, `count`, `get`) and a `name` attribute, then call `registry.register("my_backend", factory)`. The registry caches instances per `name:namespace` key, so the factory is called only once per combination.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Knowledge" icon="book" href="/docs/concepts/knowledge">
+  How agents load and search knowledge sources
+</Card>
+<Card title="Store Types" icon="database" href="/docs/concepts/store-types">
+  Compare vector, graph, and relational storage backends
+</Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Creates `docs/features/vector-store.mdx` — a full, AGENTS.md-compliant user-facing feature page for the Vector Store API
- Adds the page to `docs.json` under the **Features → State & Sessions** group
- Adds cross-reference links from `rag.mdx`, `retrieval.mdx`, `advanced-memory.mdx`, `knowledge.mdx`, `knowledge-backends.mdx`

## What's in the page

- **Hero Mermaid diagram** with standard colour palette (`#6366F1`, `#F59E0B`, `#189AB4`, `#10B981`, white text)
- **Agent-centric Quick Start** (`Agent` + `knowledge=`) followed by direct registry usage and custom store registration
- **Sequence diagram** showing user → agent → embedder → vector store flow
- **Configuration Options** table covering all `VectorRecord` fields and `VectorStoreProtocol` methods (no SDK duplication)
- **3 Common Patterns**: metadata filtering, multi-tenant namespaces, delete strategies
- **4 Best Practices** as `AccordionGroup` entries
- **Related** `CardGroup` linking to `concepts/knowledge` and `concepts/store-types`

Fixes #898

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Vector Store documentation page covering embedding storage and search, quick start guidance, API usage, and custom backend examples.
  * Updated related documentation and navigation links so the new page is easier to discover from knowledge, retrieval, RAG, and advanced memory docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->