### PR TITLE
docs: update session resume CLI docs for deterministic resume

### DIFF
--- a/docs/cli/session.mdx
+++ b/docs/cli/session.mdx
@@ -97,26 +97,81 @@ praisonai session list --project a1b2c3d4
 
 ### Resume a Session
 
+`session resume` restores chat history, model, and agent name from a previous session.
+
 ```bash
 praisonai session resume my-project
 ```
 
 **Expected Output:**
 ```
-▶️  Resuming session: my-project
+🔄 Session Resumed
+┌─────────────────────────────────────────────┐
+│ Session: my-project                         │
+│ Model:   gpt-4o                             │
+│ Messages restored: 12                       │
+└─────────────────────────────────────────────┘
 
-Session restored successfully!
-┌─────────────────────┬────────────────────────────┐
-│ Property            │ Value                      │
-├─────────────────────┼────────────────────────────┤
-│ Session ID          │ my-project                 │
-│ Messages            │ 12                         │
-│ Last Message        │ "Can you explain..."       │
-│ Context Size        │ 2,456 tokens               │
-└─────────────────────┴────────────────────────────┘
-
-Session context loaded. Continue your conversation:
+--- Restored Conversation ---
+[user] Can you explain the authentication flow?
+[assistant] Based on the code...
 ```
+
+#### Resume and continue with a prompt
+
+```bash
+praisonai session resume my-project "Now refactor the auth module"
+```
+
+State is rehydrated, then the prompt runs through the shared `praisonai run --session <id>` path. The resume panel is suppressed when a prompt is provided — the run pipeline emits the only top-level output.
+
+#### Show transcript only (legacy view)
+
+```bash
+praisonai session resume my-project --transcript
+```
+
+Use `--transcript` to inspect a session without restoring state. The panel title shows "Session Transcript".
+
+#### Cross-store lookup
+
+`session resume` finds a session whether it was created via `praisonai run --continue` (project store) or via the gateway/TUI (global store). See [Storage Backends](/docs/storage/backends).
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as praisonai CLI
+    participant PS as Project Store
+    participant GS as Global Store
+    participant Run as run pipeline
+
+    User->>CLI: session resume <id> ["prompt"]
+    CLI->>PS: session_exists(<id>)?
+    alt found in project store
+        PS-->>CLI: RehydratedSession
+    else fall back
+        CLI->>GS: session_exists(<id>)?
+        GS-->>CLI: RehydratedSession or not found
+    end
+    alt prompt provided
+        CLI->>Run: _run_prompt(prompt, model, session=<id>)
+        Run-->>User: continuation output
+    else no prompt
+        CLI-->>User: "Session Resumed" panel + last 10 messages
+    end
+
+    classDef cli fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef store fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef run fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class User,CLI cli
+    class PS,GS store
+    class Run run
+```
+
+<Note>
+When you pass a continuation prompt, the resume panel is suppressed — the run pipeline emits the only top-level output. To inspect a session without continuing, use `--transcript` or omit the prompt.
+</Note>
 
 ### Show Session Details
 
@@ -179,7 +234,8 @@ Session Commands:
 
   praisonai session start <name>    - Start a new session
   praisonai session list            - List all sessions
-  praisonai session resume <name>   - Resume a session
+  praisonai session resume <id> [prompt]      - Resume a session, optionally with a prompt
+                                --transcript  - Show transcript only (legacy view)
   praisonai session show <name>     - Show session details
   praisonai session delete <name>   - Delete a session
   praisonai session help            - Show this help
@@ -197,6 +253,8 @@ The same project-scoped store powers `--continue` and `--session` on `praisonai 
 | Prompt mode (`praisonai run "..."`) | Yes | Yes (unless `--no-save`) |
 | YAML / file mode (`praisonai run agents.yaml`) | Yes | Yes (unless `--no-save`) |
 | Actions mode (`--output actions`) | Yes | Yes (unless `--no-save`) |
+
+As of [PR #2277](https://github.com/MervinPraison/PraisonAI/pull/2277), `--session <id>` and `--continue` now persist `model` and `agent_name` into session metadata so a later `session resume` reproduces the same configuration deterministically. For advanced programmatic use, the `rehydrate_session` helper in `praisonai.cli.session` returns a `RehydratedSession` with `session_id`, `chat_history`, `model`, `agent_name`, `metadata`, and `found` fields — see the [SDK reference](/docs/sdk/reference/praisonai/modules/session) for details.
 
 ```bash
 praisonai run --continue "Add tests for the new endpoint"

--- a/docs/features/session-persistence.mdx
+++ b/docs/features/session-persistence.mdx
@@ -26,6 +26,30 @@ PraisonAI Agents provides automatic session persistence with zero configuration.
 
 ## Quick Start
 
+Start an agent with a session, then resume from the CLI with a follow-up prompt:
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Reviewer",
+    instructions="Review the codebase and answer follow-ups",
+    memory={"session_id": "review-2026-06-25"},
+)
+
+agent.start("Summarise the auth module")
+```
+
+Continue the session from the terminal without writing any more Python:
+
+```bash
+praisonai session resume review-2026-06-25 "Now suggest test cases for the same module"
+```
+
+---
+
+## Agent Session Persistence
+
 ```python
 from praisonaiagents import Agent
 
@@ -43,6 +67,26 @@ agent = Agent(
 )
 agent.start("What is my name?")  # Agent remembers: "Alice"
 ```
+
+## Deterministic Resume
+
+As of [PR #2277](https://github.com/MervinPraison/PraisonAI/pull/2277), `praisonai session resume` is a first-class restore — not a transcript display.
+
+What is restored:
+- **Chat history** — full conversation messages
+- **Model** — the LLM used in the session (read from `metadata["model"]`, falls back to `metadata["llm"]`)
+- **Agent name** — the name of the agent that ran the session
+
+New CLI options:
+- `praisonai session resume <id>` — restores state and shows a "Session Resumed" panel
+- `praisonai session resume <id> "<prompt>"` — restores state and continues with a new prompt
+- `praisonai session resume <id> --transcript` — opt-in to the old transcript-only view (panel title: "Session Transcript")
+
+Session lookup checks the project store first, then falls back to the global default store — so sessions created via `praisonai run --continue` or via the gateway/TUI are all reachable.
+
+For the full CLI reference, see [Session Command](/docs/cli/session#resume-a-session).
+
+---
 
 ## How It Works
 

--- a/docs/guides/persistence/overview.mdx
+++ b/docs/guides/persistence/overview.mdx
@@ -49,6 +49,16 @@ agent.start("What did we talk about?")  # Remembers previous context
 | Redis | High-performance | `persistence="redis"` |
 | MongoDB | Document storage | `persistence="mongodb"` |
 
+## CLI Session Resume
+
+`praisonai session resume <id>` is a first-class restore — it brings back chat history, model, and agent name. Use a follow-up prompt to continue immediately:
+
+```bash
+praisonai session resume my-session "What did we discuss?"
+```
+
+See [Session Command](/docs/cli/session#resume-a-session) for the full reference including `--transcript` and cross-store lookup behaviour.
+
 ## Related
 
 - [Database Setup](/docs/guides/persistence/databases) - Configure backends

--- a/docs/persistence/overview.mdx
+++ b/docs/persistence/overview.mdx
@@ -84,7 +84,7 @@ The persistence registry provides user-friendly aliases for common databases:
 ## Key Features
 
 - **Zero Config**: SQLite works out of the box with `memory=True`
-- **Session Resume**: Same `session_id` = continue conversation
+- **Session Resume**: `praisonai session resume <id>` is a first-class restore — it brings back chat history, model, and agent name, not just a transcript. Pass a follow-up prompt to continue immediately: `praisonai session resume <id> "<prompt>"`.
 - **Runtime State Mirroring**: lightweight per-turn artefacts for native↔plugin handoff (opt-in via `SessionConfig.mirror_runtime_state`)
 - **Lazy Loading**: No performance impact until used
 - **CLI Support**: `praisonai persistence doctor/run/resume`

--- a/docs/persistence/quickstart.mdx
+++ b/docs/persistence/quickstart.mdx
@@ -121,6 +121,14 @@ praisonai persistence run \
     "Hello, my name is Bob"
 ```
 
+## Continue a Session from the CLI
+
+`praisonai session resume` restores chat history, model, and agent name — then optionally continues with a new prompt:
+
+```bash
+praisonai session resume cli-session "What was my name again?"
+```
+
 ## Serverless Database Tuning
 
 For serverless databases that may experience cold starts, tune the retry parameters:


### PR DESCRIPTION
## Summary

Updates documentation across 5 files to reflect the new deterministic `session resume` behaviour from [PraisonAI PR #2277](https://github.com/MervinPraison/PraisonAI/pull/2277) (merged 2026-06-25).

### Changes

**`docs/cli/session.mdx`** (primary):
- Rewrites "Resume a Session" section with new expected output panel showing `🔄 Session Resumed` + model/messages-restored fields
- Adds three sub-sections: continue with prompt, `--transcript` legacy view, cross-store lookup
- Adds sequence diagram showing project store → global store fallback and prompt vs. no-prompt paths
- Adds `<Note>` about JSON-mode caveat (resume panel suppressed when prompt is passed)
- Updates help block to show new `[prompt]` and `--transcript` signature
- Adds note to "Working with `praisonai run`" about `model`/`agent_name` persistence and `rehydrate_session` helper

**`docs/features/session-persistence.mdx`**:
- Adds agent-centric Quick Start with `Agent(memory={"session_id": ...})` + CLI continuation example
- Adds "Deterministic Resume" subsection documenting what is restored, `llm` metadata key fallback, new flags, cross-store lookup

**`docs/persistence/overview.mdx`**:
- Updates "Session Resume" bullet to describe first-class restore behaviour

**`docs/persistence/quickstart.mdx`**:
- Adds "Continue a Session from the CLI" section with 2-line code block

**`docs/guides/persistence/overview.mdx`**:
- Adds "CLI Session Resume" section with example and link to CLI reference

### Files NOT modified (per issue instructions)
- `docs/concepts/session-management.mdx` — HUMAN-APPROVED-ONLY folder, flagged for human review
- `docs/code/external-agents.mdx`, `docs/code/cursor-cli.mdx` — grep confirmed no old transcript references
- `docs.json` — no new pages added

Fixes #900

Generated with [Claude Code](https://claude.ai/code)