### PR TITLE
docs: add Vector Store feature page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -616,6 +616,7 @@
                   "docs/features/memory-advanced-search",
                   "docs/features/memory-troubleshooting",
                   "docs/features/rag-scoping",
+                  "docs/features/vector-store",
                   "docs/features/platform-workspace-context",
                   "docs/features/context-compaction",
                   "docs/features/context-compaction-policy",

--- a/docs/features/vector-store.mdx
+++ b/docs/features/vector-store.mdx
@@ -1,0 +1,297 @@
+---
+title: "Vector Store"
+sidebarTitle: "Vector Store"
+description: "Store and search embeddings to give agents long-term semantic recall"
+icon: "database"
+---
+
+Vector stores let an agent remember and retrieve information by meaning, not by exact match.
+
+```mermaid
+graph LR
+    subgraph "Vector Store"
+        Docs[📚 Documents] --> Embed[🧠 Embed]
+        Embed --> Store[(💾 Vector Store)]
+        Query[❓ Query] --> EmbedQ[🧠 Embed]
+        EmbedQ --> Store
+        Store --> TopK[🎯 Top-k Chunks]
+        TopK --> Answer[✅ Answer]
+    end
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Docs,Query input
+    class Embed,EmbedQ process
+    class Store config
+    class TopK,Answer result
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Agent with Knowledge (auto vector store)">
+Three lines — PraisonAI creates the vector store automatically:
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Research Assistant",
+    instructions="Answer questions using stored knowledge",
+    knowledge=["docs/handbook.pdf"]
+)
+
+agent.start("What's our refund policy?")
+```
+</Step>
+
+<Step title="Choose a vector store provider">
+Pass `knowledge_config` to pick a specific backend:
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Research Assistant",
+    instructions="Answer questions using stored knowledge",
+    knowledge=["docs/handbook.pdf"],
+    knowledge_config={
+        "vector_store": {
+            "provider": "chroma",
+            "config": {
+                "collection_name": "handbook",
+                "path": ".praison/vectors"
+            }
+        }
+    }
+)
+
+agent.start("What's our refund policy?")
+```
+</Step>
+
+<Step title="Use KnowledgeConfig for full control">
+```python
+from praisonaiagents import Agent, KnowledgeConfig
+
+agent = Agent(
+    name="Research Assistant",
+    instructions="Answer questions using stored knowledge",
+    knowledge=KnowledgeConfig(
+        sources=["docs/handbook.pdf"],
+        retrieval_k=5,
+        rerank=True,
+        vector_store={
+            "provider": "chroma",
+            "config": {
+                "collection_name": "handbook",
+                "path": ".praison/vectors"
+            }
+        }
+    )
+)
+
+agent.start("What's our refund policy?")
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant VectorStore
+    participant LLM
+
+    User->>Agent: "What's our refund policy?"
+    Agent->>VectorStore: Embed + search (top-k)
+    VectorStore-->>Agent: Matching chunks from handbook.pdf
+    Agent->>LLM: Question + chunks as context
+    LLM-->>Agent: Drafted answer with citation
+    Agent-->>User: "Refunds within 30 days… (handbook §4.2)"
+```
+
+| Step | What happens |
+|------|--------------|
+| 1. Ingest | Documents are split into chunks, embedded, and stored |
+| 2. Query | The user's question is embedded into a vector |
+| 3. Search | Top-k most similar chunks are retrieved |
+| 4. Answer | The LLM answers using those chunks as context |
+
+---
+
+## Choosing a Vector Store
+
+```mermaid
+graph TB
+    Start([Which vector store?]) --> Local{Local dev?}
+    Local -->|Yes| Chroma[Chroma\nDefault, zero config]
+    Local -->|No| Scale{Production scale?}
+    Scale -->|Self-hosted| SH{Preference}
+    Scale -->|Managed cloud| Pinecone[Pinecone\nZero ops]
+    SH --> Qdrant[Qdrant\nFast, Rust-native]
+    SH --> Milvus[Milvus\nBig data]
+    SH --> Weaviate[Weaviate\nGraphQL]
+    Scale -->|Already on Postgres| PGVector[pgvector\nNo extra infra]
+
+    classDef start fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef store fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Start start
+    class Local,Scale,SH decision
+    class Chroma,Qdrant,Milvus,Weaviate,Pinecone,PGVector store
+```
+
+| Provider | Best for | Docs |
+|----------|----------|------|
+| `chroma` | Local dev, zero setup | [ChromaDB](/docs/databases/chroma) |
+| `qdrant` | Self-hosted, fast similarity search | [Qdrant](/docs/databases/qdrant) |
+| `milvus` | High-volume, distributed | [Milvus](/docs/databases/milvus) |
+| `weaviate` | GraphQL + vector search | [Weaviate](/docs/databases/weaviate) |
+| `pinecone` | Managed cloud, zero ops | [Pinecone](/docs/databases/pinecone) |
+| `pgvector` | Already on PostgreSQL | [pgvector](/docs/databases/pgvector) |
+| `lancedb` | Embedded, columnar storage | [LanceDB](/docs/databases/lancedb) |
+
+---
+
+## Configuration Options
+
+`KnowledgeConfig` controls the full vector store pipeline:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `sources` | `List[str]` | `[]` | Files, directories, or URLs to ingest |
+| `embedder` | `str` | `"openai"` | Embedding model provider |
+| `embedder_config` | `dict` | `None` | Provider-specific embedder settings |
+| `chunking_strategy` | `str` | `"semantic"` | How to split documents (`fixed`, `semantic`, `sentence`, `paragraph`) |
+| `chunk_size` | `int` | `1000` | Target chunk size in tokens |
+| `chunk_overlap` | `int` | `200` | Overlap between consecutive chunks |
+| `retrieval_k` | `int` | `5` | Number of chunks to retrieve per query |
+| `retrieval_threshold` | `float` | `0.0` | Minimum similarity score to include |
+| `rerank` | `bool` | `False` | Enable reranking of retrieved chunks |
+| `rerank_model` | `str` | `None` | Reranker model (uses default if None) |
+| `auto_retrieve` | `bool` | `True` | Automatically inject retrieved context |
+| `vector_store` | `dict` | `None` | Vector database config (provider + settings) |
+
+The `vector_store` dict uses this structure:
+
+```python
+vector_store={
+    "provider": "chroma",   # chroma | qdrant | pinecone | weaviate | milvus | pgvector
+    "config": {
+        "collection_name": "my_collection",
+        "path": ".praison/vectors"   # local path (chroma only)
+    }
+}
+```
+
+---
+
+## Common Patterns
+
+### Persist across runs
+
+Give the vector store a fixed path so documents are not re-embedded on every restart:
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Support Bot",
+    instructions="Answer questions about our product",
+    knowledge=["docs/"],
+    knowledge_config={
+        "vector_store": {
+            "provider": "chroma",
+            "config": {
+                "collection_name": "support_docs",
+                "path": ".praison/vectors"
+            }
+        }
+    }
+)
+```
+
+### Swap providers without changing agent code
+
+Use a config dict so only the `provider` key changes between environments:
+
+```python
+import os
+from praisonaiagents import Agent
+
+vs_config = {
+    "provider": os.getenv("VECTOR_STORE", "chroma"),
+    "config": {
+        "collection_name": "my_docs"
+    }
+}
+
+agent = Agent(
+    name="Assistant",
+    instructions="Answer from the knowledge base",
+    knowledge=["docs/"],
+    knowledge_config={"vector_store": vs_config}
+)
+```
+
+### Combine with memory for short-term + long-term recall
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Research Assistant",
+    instructions="Answer questions using both stored documents and conversation history",
+    knowledge=["docs/handbook.pdf"],
+    memory=True
+)
+
+agent.start("Summarise the return policy and remember I asked about it")
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Choose the right chunk size">
+    Smaller chunks (`chunk_size=256`) give precise retrieval; larger chunks (`chunk_size=1024`) give more context per result. Start at `500–1000` and tune based on your documents.
+  </Accordion>
+  <Accordion title="Enable reranking for higher accuracy">
+    Set `rerank=True` when precision matters more than speed. Reranking re-scores the initial top-k results with a cross-encoder model, filtering out false positives.
+  </Accordion>
+  <Accordion title="Use namespaces for multi-tenant isolation">
+    Each user or tenant should have their own namespace so searches don't bleed across users. Pass `namespace` in the vector store config when using Qdrant or Pinecone.
+  </Accordion>
+  <Accordion title="Set a similarity threshold">
+    Use `retrieval_threshold=0.7` to skip low-confidence chunks. Without a threshold, even unrelated chunks can be injected into the context and confuse the LLM.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card icon="book" href="/docs/concepts/knowledge">
+    Feed documents into an agent
+  </Card>
+  <Card icon="brain" href="/docs/concepts/memory">
+    Long-term recall across sessions
+  </Card>
+  <Card icon="search" href="/docs/concepts/rag">
+    RAG retrieval pipeline
+  </Card>
+  <Card icon="database" href="/docs/databases/overview">
+    Per-database setup guides
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Creates `docs/features/vector-store.mdx` — the last undocumented Python SDK category per `docs/features/DOCS_PARITY.md`
- Adds the page to `docs.json` under the **Features > State & Sessions** group (never Concepts)
- Brings Python parity from 98.5% (65/66) to 100% (66/66)

## What's included

- **Hero Mermaid diagram** with AGENTS.md color palette (`#8B0000`, `#189AB4`, `#6366F1`, `#10B981`)
- **Sequence diagram** showing the full user → agent → vector store → LLM → user flow
- **Decision diagram** helping users choose between chroma, qdrant, milvus, weaviate, pinecone, pgvector
- **3-step Quick Start** using `from praisonaiagents import Agent` (agent-centric, friendly import)
- **KnowledgeConfig.vector_store** options table sourced directly from `praisonaiagents/config/feature_configs.py`
- **3 common patterns**: persist across runs, swap providers, combine with memory
- **AccordionGroup** Best Practices, **CardGroup** Related section
- Links out to per-database pages in `docs/databases/` rather than duplicating them

## Acceptance checklist

- [x] New file `docs/features/vector-store.mdx` exists
- [x] Frontmatter has all four required fields (`title`, `sidebarTitle`, `description`, `icon`)
- [x] Page opens with agent-centric Quick Start (`from praisonaiagents import Agent`)
- [x] Hero Mermaid diagram with AGENTS.md color palette
- [x] `<Steps>`, `<AccordionGroup>`, `<CardGroup>` components used
- [x] Decision diagram for choosing a vector store provider
- [x] `sequenceDiagram` showing user interaction flow
- [x] Config options from actual SDK source (no invented params)
- [x] No content in `docs/concepts/`
- [x] `docs.json` updated under "Features" group and is valid JSON
- [x] No forbidden phrases from AGENTS.md §6.3

Fixes #901

Generated with [Claude Code](https://claude.ai/code)