### PR TITLE
docs: create Vector Store feature page (closes #904)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -615,6 +615,7 @@
                   "docs/features/prompt-caching",
                   "docs/features/memory-advanced-search",
                   "docs/features/memory-troubleshooting",
+                  "docs/features/vector-store",
                   "docs/features/rag-scoping",
                   "docs/features/platform-workspace-context",
                   "docs/features/context-compaction",

--- a/docs/features/advanced-memory.mdx
+++ b/docs/features/advanced-memory.mdx
@@ -804,4 +804,7 @@ agent = Agent(
   <Card title="Prompt Caching" icon="database" href="/docs/features/prompt-caching">
     Optimise memory context for prompt caching
   </Card>
+  <Card title="Vector Store" icon="database" href="/features/vector-store">
+    Pluggable embedding backend for semantic search
+  </Card>
 </CardGroup>

--- a/docs/features/knowledge-backends.mdx
+++ b/docs/features/knowledge-backends.mdx
@@ -354,4 +354,7 @@ class MyBackend:
   <Card title="Knowledge" icon="book" href="/features/knowledge">
     Core knowledge retrieval and agent integration
   </Card>
+  <Card title="Vector Store" icon="database" href="/features/vector-store">
+    Low-level embedding store with namespace and filter support
+  </Card>
 </CardGroup>

--- a/docs/features/knowledge.mdx
+++ b/docs/features/knowledge.mdx
@@ -499,4 +499,7 @@ for paper in papers:
   <Card icon="magnifying-glass" href="/features/rag">
     Build RAG applications
   </Card>
+  <Card title="Vector Store" icon="database" href="/features/vector-store">
+    Store and search embeddings with a pluggable backend
+  </Card>
 </CardGroup>

--- a/docs/features/rag.mdx
+++ b/docs/features/rag.mdx
@@ -351,6 +351,9 @@ agent.start("What is KAG in one line?") # Retrieval
   <Card title="Mini Agents" icon="microchip" href="./mini">
     Explore lightweight, focused AI agents
   </Card>
+  <Card title="Vector Store" icon="database" href="/features/vector-store">
+    Pluggable embedding store behind every RAG workflow
+  </Card>
 </CardGroup>
 
 <Note>

--- a/docs/features/retrieval.mdx
+++ b/docs/features/retrieval.mdx
@@ -221,4 +221,5 @@ agent = Agent(
 
 - [CLI Retrieval Commands](/docs/cli/retrieval) - Use retrieval from the command line
 - [Knowledge Concepts](/docs/concepts/knowledge) - Learn about knowledge bases
+- [Vector Store](/features/vector-store) - Low-level embedding store powering retrieval
 - [Memory](/docs/concepts/memory) - Combine with agent memory

--- a/docs/features/vector-store.mdx
+++ b/docs/features/vector-store.mdx
@@ -1,0 +1,348 @@
+---
+title: "Vector Store"
+sidebarTitle: "Vector Store"
+description: "Store and search embeddings with a pluggable, namespace-aware backend"
+icon: "database"
+---
+
+A vector store keeps your text and its embeddings together so an agent can find the closest match by meaning.
+
+```mermaid
+graph LR
+    subgraph "Vector Store"
+        Text[📝 Text] --> Embed[🧠 Embed]
+        Embed --> Store[(💾 Store)]
+        Query[🔍 Query] --> Sim[📐 Similarity]
+        Store --> Sim
+        Sim --> Results[✅ Top-K]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef store fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Text,Query input
+    class Embed,Sim process
+    class Store store
+    class Results output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Agent with knowledge (recommended)">
+
+The simplest way — pass files or text to `knowledge=` and PraisonAI handles embedding and storage automatically with the built-in in-memory store.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    instructions="Answer questions using the knowledge provided.",
+    knowledge=["docs/faq.pdf", "docs/guide.txt"],
+)
+
+response = agent.start("How do I reset my password?")
+print(response)
+```
+
+</Step>
+
+<Step title="Choose a backend">
+
+Use the `vector_store` key inside `knowledge=` to pick a backend:
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    instructions="Answer questions using the knowledge provided.",
+    knowledge={
+        "sources": ["docs/faq.pdf"],
+        "vector_store": {
+            "provider": "memory",
+        },
+    },
+)
+
+response = agent.start("How do I reset my password?")
+print(response)
+```
+
+Switch `"provider": "memory"` to `"chroma"`, `"pinecone"`, or any registered backend for production use.
+
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Embed as Embedder
+    participant VS as Vector Store
+
+    User->>Agent: "How do I deploy?"
+    Agent->>Embed: Embed question
+    Embed-->>Agent: vector
+    Agent->>VS: query(vector, top_k=5)
+    VS-->>Agent: Top matches
+    Agent-->>User: Answer grounded in matches
+```
+
+| Step | What happens |
+|------|-------------|
+| 1. Embed | Text is converted to a float vector by an embedding model |
+| 2. Store | The vector + original text + metadata are saved in the store |
+| 3. Query | At runtime, the question is embedded and compared to stored vectors |
+| 4. Rank | Cosine similarity scores rank results; top-K are returned |
+
+---
+
+## Direct API (Advanced)
+
+For full control, access the registry directly:
+
+```python
+from praisonaiagents.knowledge import (
+    get_vector_store_registry,
+    VectorRecord,
+)
+
+registry = get_vector_store_registry()
+store = registry.get("memory")
+
+ids = store.add(
+    texts=["PraisonAI supports multi-agent workflows."],
+    embeddings=[[0.1, 0.2, 0.3]],
+    metadatas=[{"source": "docs"}],
+)
+
+results = store.query(embedding=[0.1, 0.2, 0.3], top_k=3)
+for r in results:
+    print(r.text, r.score)
+```
+
+<Tabs>
+<Tab title="add()">
+
+```python
+ids = store.add(
+    texts=["Hello world"],
+    embeddings=[[0.1, 0.2, 0.3]],
+    metadatas=[{"source": "readme"}],
+    ids=["doc-001"],
+    namespace="project-x",
+)
+```
+
+</Tab>
+<Tab title="query()">
+
+```python
+results = store.query(
+    embedding=[0.1, 0.2, 0.3],
+    top_k=5,
+    namespace="project-x",
+    filter={"source": "readme"},
+)
+```
+
+</Tab>
+<Tab title="delete()">
+
+```python
+deleted = store.delete(
+    ids=["doc-001"],
+    namespace="project-x",
+)
+
+all_deleted = store.delete(delete_all=True, namespace="project-x")
+```
+
+</Tab>
+<Tab title="count() / get()">
+
+```python
+n = store.count(namespace="project-x")
+
+records = store.get(ids=["doc-001"], namespace="project-x")
+```
+
+</Tab>
+</Tabs>
+
+---
+
+## Configuration Options
+
+### VectorRecord fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `id` | `str` | required | Unique identifier |
+| `text` | `str` | required | The original text content |
+| `embedding` | `List[float]` | required | The vector embedding |
+| `metadata` | `Dict[str, Any]` | `{}` | Optional key-value metadata |
+| `score` | `Optional[float]` | `None` | Similarity score (set on query results) |
+
+<CardGroup cols={2}>
+  <Card title="VectorStoreProtocol SDK Reference" icon="code" href="/docs/sdk/praisonaiagents/knowledge/vector-store-module">
+    Full API: add, query, delete, count, get
+  </Card>
+  <Card title="Knowledge SDK Reference" icon="book" href="/docs/sdk/praisonaiagents/knowledge/knowledge">
+    Knowledge class configuration options
+  </Card>
+</CardGroup>
+
+---
+
+## Common Patterns
+
+### Namespaces for multi-tenant isolation
+
+Separate data per user or project with the `namespace` parameter — no separate stores needed.
+
+```python
+from praisonaiagents.knowledge import get_vector_store_registry
+
+registry = get_vector_store_registry()
+store = registry.get("memory")
+
+store.add(
+    texts=["Alice's document"],
+    embeddings=[[0.1, 0.2, 0.3]],
+    namespace="user-alice",
+)
+
+store.add(
+    texts=["Bob's document"],
+    embeddings=[[0.4, 0.5, 0.6]],
+    namespace="user-bob",
+)
+
+alice_results = store.query(embedding=[0.1, 0.2, 0.3], namespace="user-alice")
+```
+
+### Metadata filtering at query time
+
+Filter results by exact metadata values to narrow results without re-embedding.
+
+```python
+results = store.query(
+    embedding=[0.1, 0.2, 0.3],
+    top_k=10,
+    filter={"source": "docs", "version": "v2"},
+)
+```
+
+<Note>
+`filter` is **exact match** on metadata keys. Pre-normalise values (e.g. lowercase) before storing.
+</Note>
+
+### Registering a custom backend
+
+Any class satisfying `VectorStoreProtocol` can be registered:
+
+```python
+from praisonaiagents.knowledge import (
+    get_vector_store_registry,
+    VectorStoreProtocol,
+    VectorRecord,
+)
+
+class MyVectorStore:
+    name = "my_store"
+
+    def add(self, texts, embeddings, metadatas=None, ids=None, namespace=None):
+        ...
+        return ids
+
+    def query(self, embedding, top_k=10, namespace=None, filter=None):
+        ...
+        return []
+
+    def delete(self, ids=None, namespace=None, filter=None, delete_all=False):
+        return 0
+
+    def count(self, namespace=None):
+        return 0
+
+    def get(self, ids, namespace=None):
+        return []
+
+registry = get_vector_store_registry()
+registry.register("my_store", lambda **kw: MyVectorStore())
+
+store = registry.get("my_store")
+```
+
+---
+
+## Which Backend Should I Use?
+
+```mermaid
+graph TB
+    Start([Start]) --> Q1{Need persistence?}
+    Q1 -->|No| Mem[memory\nbuilt-in, no deps]
+    Q1 -->|Yes| Q2{Single user?}
+    Q2 -->|Yes| Chroma[chroma\nlocal file store]
+    Q2 -->|No| Q3{Cloud / multi-tenant?}
+    Q3 -->|Yes| Prod[pinecone / qdrant\ncustom registry]
+    Q3 -->|Team / self-hosted| Weaviate[weaviate / milvus]
+
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef backend fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class Q1,Q2,Q3 decision
+    class Mem,Chroma,Prod,Weaviate backend
+    class Start start
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Use namespaces, not separate stores, for multi-tenant apps">
+A single `InMemoryVectorStore` (or any backend) can hold data from many tenants by passing `namespace="user-123"` to every `add`, `query`, and `delete` call. This avoids the overhead of spinning up one store per user.
+</Accordion>
+
+<Accordion title="Match embedding dimensions between add and query">
+Every vector passed to `add` and every query vector must come from the **same embedding model**. Mixing models (e.g. `text-embedding-3-small` at ingest, `text-embedding-ada-002` at query time) will produce incorrect similarity scores. The `InMemoryVectorStore` returns `0.0` for mismatched-length vectors without raising an error.
+</Accordion>
+
+<Accordion title="filter is exact-match — pre-normalise metadata values">
+The `filter` argument to `query` and `delete` performs exact dict-key comparison on stored metadata. If you store `{"source": "Docs"}` but filter by `{"source": "docs"}`, nothing will match. Normalise values (lowercase, strip whitespace) before storing.
+</Accordion>
+
+<Accordion title="Pre-compute embeddings in batches when ingesting large corpora">
+Call `store.add()` with a full batch of `texts` and `embeddings` at once rather than one record at a time. The in-memory store processes all items in a single pass, and production backends (Pinecone, Chroma) also benefit from batched upserts.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Knowledge Backends" icon="database" href="/features/knowledge-backends">
+    Configure mem0, Chroma, and other knowledge backends
+  </Card>
+  <Card title="RAG Quick Start" icon="magnifying-glass" href="/features/rag">
+    Build retrieval-augmented generation workflows
+  </Card>
+  <Card title="Chunking Strategies" icon="scissors" href="/features/chunking-strategies">
+    Split documents before embedding for better recall
+  </Card>
+  <Card title="Knowledge" icon="book" href="/features/knowledge">
+    Full knowledge base system with document processing
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Creates `docs/features/vector-store.mdx` — the missing user-facing Vector Store page that closes the last Python parity gap (Vector Store, 0 docs → 1 doc)
- Adds the page to `docs.json` under **Features > State & Sessions** group
- Adds cross-links from `knowledge.mdx`, `knowledge-backends.mdx`, `rag.mdx`, `retrieval.mdx`, and `advanced-memory.mdx`

### Page structure (per AGENTS.md)
- **Frontmatter**: `title`, `sidebarTitle`, `description`, `icon: "database"`
- **Hero Mermaid diagram** (`graph LR`) with standard AGENTS.md colour scheme
- **Quick Start** with `<Steps>` — agent-centric example first, then backend selection
- **How It Works** sequence diagram
- **Direct API** with `<Tabs>` for `add`, `query`, `delete`, `count/get`
- **Configuration Options** — VectorRecord fields table + SDK reference cards
- **Common Patterns** — namespaces, metadata filtering, custom backend registration
- **Decision diagram** (`graph TB`) for backend selection
- **Best Practices** (`<AccordionGroup>`)
- **Related** (`<CardGroup cols={2}>`)

### SDK verification
All methods and fields are verified against `praisonaiagents/knowledge/vector_store.py` (416 lines). All imports use the friendly `from praisonaiagents.knowledge import …` path as required by AGENTS.md §6.1.

Fixes #904

Generated with [Claude Code](https://claude.ai/code)