### PR TITLE
docs: document conversation-control bot commands (/undo, /sessions, /resume, /retry, /reasoning)

### DIFF
--- a/docs/features/bot-command-access-control.mdx
+++ b/docs/features/bot-command-access-control.mdx
@@ -37,6 +37,8 @@ graph LR
 
 **Privileged commands** (`/learn` today) are admin-only by default whenever any policy is configured. They stay open when neither `admin_users` nor `user_allowed_commands` is set, so existing deployments are unaffected. To grant a regular user a privileged command, add it explicitly to `user_allowed_commands`.
 
+The conversation-control commands (`/undo`, `/sessions`, `/resume`, `/retry`, `/reasoning`) are **not** privileged — they follow the same rules as `/stop`, `/model`, and `/usage`. Regular users can run them whenever the policy allows non-privileged commands.
+
 | Group | What's allowed by default when a policy is configured |
 |---|---|
 | **Admins** (`admin_users`) | Every command, always. |

--- a/docs/features/bot-commands.mdx
+++ b/docs/features/bot-commands.mdx
@@ -13,18 +13,26 @@ graph TB
     Q --> D[See cost/tokens]
     Q --> E[Queue a follow-up]
     Q --> F[Author a skill from sources]
+    Q --> G[Rewind the last turn]
+    Q --> H[List or switch sessions]
+    Q --> I[Re-run your last message]
+    Q --> J[Toggle reasoning visibility]
     A --> A1[/stop]
     B --> B1[/compress]
     C --> C1[/model]
     D --> D1[/usage]
     E --> E1[/queue]
     F --> F1[/learn]
+    G --> G1[/undo]
+    H --> H1[/sessions, /resume]
+    I --> I1[/retry]
+    J --> J1[/reasoning]
 
     classDef decision fill:#6366F1,stroke:#7C90A0,color:#fff
     classDef result fill:#10B981,stroke:#7C90A0,color:#fff
 
     class Q decision
-    class A1,B1,C1,D1,E1,F1 result
+    class A1,B1,C1,D1,E1,F1,G1,H1,I1,J1 result
 ```
 
 Every PraisonAI bot comes with built-in chat commands. Just type a command in your chat — no setup required.
@@ -64,6 +72,21 @@ Every PraisonAI bot comes with built-in chat commands. Just type a command in yo
   </Card>
   <Card title="/learn" icon="graduation-cap">
     Distil a grounded skill from sources you describe (repo, docs, PDFs, or this chat). **Privileged** — admin-only by default when a policy is configured. Authored via `skill_manage` with the same approval gate as other agent-created skills. See [Learn a Skill from Sources](/docs/features/learn-skill) and [Command Access Control](/docs/features/bot-command-access-control).
+  </Card>
+  <Card title="/undo" icon="rotate-left">
+    Undo the last turn's file changes. Requires the agent to track changes (`autonomy` with `track_changes`).
+  </Card>
+  <Card title="/sessions" icon="folder-open">
+    List the caller's saved sessions/checkpoints. Scoped to the requesting user — never enumerates other users' sessions.
+  </Card>
+  <Card title="/resume" icon="play">
+    Switch to a saved session: `/resume &lt;id&gt;`. Use `/sessions` to list available IDs.
+  </Card>
+  <Card title="/retry" icon="rotate-right">
+    Re-run your last message through the normal chat path.
+  </Card>
+  <Card title="/reasoning" icon="brain">
+    Toggle whether extended-thinking output is shown in this conversation (per user).
   </Card>
 </CardGroup>
 
@@ -371,6 +394,72 @@ No follow-up queued. Use /queue <message> to add one while a task is running.
 <Note>
 `/queue` requires [Bot Run Control](/docs/features/bot-run-control) to be enabled with `busy_mode`. Without it, the bot replies: `"ℹ️ Message queuing isn't enabled for this bot. Just send your message and it will be processed."`
 </Note>
+
+### /undo
+
+Rewinds the last turn's file changes via `Agent.undo()`.
+
+- Requires change tracking — enable `autonomy` with `track_changes` on the agent
+- Returns `"✅ Reverted the last turn."` when files were restored, `"ℹ️ Nothing to undo."` when there is nothing to revert
+- Degrades gracefully when undo is unavailable: `"❌ This agent does not support undo (change tracking not enabled)."`
+
+### /sessions
+
+Lists recent saved sessions for the **requesting user only**. Session lookups are scoped via the per-user storage key so one caller cannot enumerate another user's sessions.
+
+Example output:
+
+```
+📁 Recent sessions:
+• telegram:123456789
+• telegram:123456789:project-a
+
+Use /resume <id> to switch to one.
+```
+
+Returns `"No saved sessions yet."` when nothing is stored.
+
+### /resume
+
+Switches to a previously saved session.
+
+```
+/resume telegram:123456789:project-a
+✅ Resumed session telegram:123456789:project-a.
+```
+
+- Usage: `/resume <id>` — run `/sessions` first to see IDs
+- Returns `"❌ Session {id} not found."` when the ID is unknown
+- When the session manager lacks a `resume_session` primitive, the bot reports honestly rather than claiming a switch succeeded
+
+### /retry
+
+Re-runs your most recent user message through the normal `session.chat(...)` path.
+
+```
+🔁 Retrying your last message:
+Summarise the deployment runbook in three bullets.
+```
+
+Returns `"ℹ️ Nothing to retry — no previous message found."` when the history is empty.
+
+### /reasoning
+
+Toggles whether extended-thinking output is shown for **this user** in this conversation. The preference is stored per user on the session manager.
+
+```
+/reasoning
+🧠 Reasoning output will be shown for this conversation.
+```
+
+Run again to hide:
+
+```
+/reasoning
+🙈 Reasoning output will be hidden for this conversation.
+```
+
+Defaults to hidden when no preference is set. Adapters consult `is_reasoning_visible()` when rendering responses.
 
 ### /learn
 


### PR DESCRIPTION
## Summary
- Extends `docs/features/bot-commands.mdx` with five new built-in commands from PraisonAI PR #2284
- Clarifies in `docs/features/bot-command-access-control.mdx` that these commands are non-privileged

Fixes #897

## Test plan
- [x] Mermaid decision diagram includes new branches
- [x] CardGroup lists all five commands
- [x] Command detail sections match SDK handlers in `_commands.py`

Made with [Cursor](https://cursor.com)