### PR TITLE
docs: webhook verification (fail-closed HMAC + platform updates)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -325,6 +325,7 @@
                     "pages": [
                       "docs/features/message-steering",
                       "docs/features/messaging-bots",
+                      "docs/features/webhook-verification",
                       "docs/features/bot-streaming-replies",
                       "docs/features/channel-capabilities",
                       "docs/features/bot-status-reactions",

--- a/docs/features/bot-platform-capabilities.mdx
+++ b/docs/features/bot-platform-capabilities.mdx
@@ -107,8 +107,14 @@ sequenceDiagram
 | `max_files_per_message` | `int` | `1` | Attachments per message |
 | `max_file_size_mb` | `int` | `10` | Max file size in MB |
 | `supported_file_types` | `List[str]` | `["*"]` | Allowed mime types or extensions |
+| `accepts_webhooks` | `bool` | `False` | Channel receives inbound HTTP webhooks |
+| `verifies_webhook_signature` | `bool` | `False` | Adapter exposes a webhook verifier |
 
 Methods: `to_dict()` and `from_dict(data)`.
+
+### Webhook-based platforms
+
+Platforms that set `accepts_webhooks=True` must also expose a `webhook_verifier` so `enforce_webhook_verification` can enforce signatures fail-closed. See [Webhook Verification](/docs/features/webhook-verification).
 
 ## Built-in platform defaults
 

--- a/docs/features/email-bot.mdx
+++ b/docs/features/email-bot.mdx
@@ -203,6 +203,18 @@ await bot.start()  # starts HTTP server, registers webhook
 ```
 ````
 
+### Webhook Verification
+
+When using `mode: webhook`, set `AGENTMAIL_WEBHOOK_SECRET` in production. An unset secret causes all inbound webhooks to be **rejected with HTTP 401** (fail-closed).
+
+<Warning>
+The AgentMail API token is **no longer** used as a fallback signing secret. Configure `AGENTMAIL_WEBHOOK_SECRET` explicitly.
+</Warning>
+
+Accepted signature headers: `X-AgentMail-Signature`, `X-Webhook-Signature`, `X-Signature`.
+
+For local development without a real AgentMail webhook, set `PRAISONAI_INSECURE_WEBHOOKS=true` — never in production. See [Webhook Verification](/docs/features/webhook-verification).
+
 ---
 
 ## Inbox Lifecycle Management

--- a/docs/features/linear-bot.mdx
+++ b/docs/features/linear-bot.mdx
@@ -269,10 +269,10 @@ The Linear bot includes these slash commands:
 ## Webhook Security
 
 <Warning>
-Always set `LINEAR_WEBHOOK_SECRET` for production deployments. Missing secrets disable signature verification and log security warnings.
+Always set `LINEAR_WEBHOOK_SECRET` for production deployments. Missing secrets cause inbound webhooks to be **rejected with HTTP 401** (fail-closed). Set `PRAISONAI_INSECURE_WEBHOOKS=true` only for local development.
 </Warning>
 
-The bot implements Linear's recommended security measures:
+The bot implements Linear's recommended security measures via the shared [Webhook Verification](/docs/features/webhook-verification) stack:
 - **HMAC-SHA256 signature verification** using webhook secret
 - **60-second replay protection** via timestamp validation  
 - **HTTPS enforcement** recommended for production webhooks
@@ -354,7 +354,7 @@ channels:
 
 <AccordionGroup>
 <Accordion title="Always Configure Webhook Secrets">
-Use `LINEAR_WEBHOOK_SECRET` to enable HMAC signature verification. This prevents replay attacks and ensures webhook authenticity.
+Set `LINEAR_WEBHOOK_SECRET` for HMAC verification. Without it, webhooks are rejected with HTTP 401. Use `PRAISONAI_INSECURE_WEBHOOKS=true` only for local development. See [Webhook Verification](/docs/features/webhook-verification).
 </Accordion>
 
 <Accordion title="Scope OAuth Tokens Appropriately">

--- a/docs/features/webhook-verification.mdx
+++ b/docs/features/webhook-verification.mdx
@@ -1,0 +1,181 @@
+---
+title: "Webhook Verification"
+sidebarTitle: "Webhook Verification"
+description: "Fail-closed HMAC signature verification for inbound bot webhooks"
+icon: "shield-check"
+---
+
+Inbound webhooks are verified by default — misconfigured secrets return HTTP 401 instead of silently accepting unsigned traffic.
+
+```mermaid
+graph LR
+    WH[Inbound Webhook] --> Gate[enforce_webhook_verification]
+    Gate -->|verified| Agent[Agent run]
+    Gate -->|rejected| Deny[HTTP 401]
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef gate fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef deny fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class WH input
+    class Gate gate
+    class Agent ok
+    class Deny deny
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Set your signing secret">
+```bash
+export LINEAR_WEBHOOK_SECRET=your-linear-secret
+# or for AgentMail:
+export AGENTMAIL_WEBHOOK_SECRET=your-agentmail-secret
+```
+</Step>
+
+<Step title="Run the bot — verification is on by default">
+```bash
+praisonai bot linear --token $LINEAR_OAUTH_TOKEN
+```
+</Step>
+
+<Step title="Local dev without a real platform">
+<Warning>
+Never set this in production.
+</Warning>
+
+```bash
+PRAISONAI_INSECURE_WEBHOOKS=true praisonai bot linear --token $LINEAR_OAUTH_TOKEN
+```
+</Step>
+</Steps>
+
+## Which mode am I in?
+
+```mermaid
+flowchart TB
+    Start{Secret set?} -->|Yes| Prod[Fail-closed verification — production]
+    Start -->|No| Dev{PRAISONAI_INSECURE_WEBHOOKS?}
+    Dev -->|true| Skip[Skip verification — dev only, logs warning]
+    Dev -->|unset/false| Reject[Reject all webhooks — HTTP 401]
+
+    classDef cfg fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef warn fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef deny fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class Start,Dev cfg
+    class Skip warn
+    class Prod ok
+    class Reject deny
+```
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Platform
+    participant Bot
+    participant Gate as enforce_webhook_verification
+    participant Verifier as HmacWebhookVerifier
+    participant Agent
+
+    Platform->>Bot: POST webhook
+    Bot->>Gate: headers + raw body
+    alt verified
+        Gate->>Verifier: verify()
+        Verifier-->>Gate: true
+        Gate->>Agent: dispatch
+    else rejected
+        Gate-->>Bot: false
+        Bot-->>Platform: HTTP 401
+    end
+```
+
+| accepts_webhooks | Verifier configured | PRAISONAI_INSECURE_WEBHOOKS | Outcome |
+|------------------|---------------------|-------------------------------|---------|
+| false | — | — | No verification gate |
+| true | yes | unset | Verify; 401 on failure |
+| true | no | unset | **401** (fail-closed) |
+| true | — | true | Skip with warning |
+
+## Configuration Options
+
+| Variable | Purpose |
+|----------|---------|
+| `PRAISONAI_INSECURE_WEBHOOKS` | Set to `true` / `1` / `yes` to disable verification globally (local dev only) |
+| `LINEAR_WEBHOOK_SECRET` | HMAC secret for Linear webhooks |
+| `AGENTMAIL_WEBHOOK_SECRET` | HMAC secret for AgentMail webhooks (required in production; API token is **not** a fallback) |
+| `WHATSAPP_APP_SECRET` | Meta app secret for Cloud-mode WhatsApp webhooks |
+
+| PlatformCapabilities field | Default | Meaning |
+|----------------------------|---------|---------|
+| `accepts_webhooks` | `False` | Channel receives inbound HTTP webhooks |
+| `verifies_webhook_signature` | `False` | Adapter exposes a verifier implementation |
+
+## Common Patterns
+
+**Built-in adapter, secret only** — set the platform env var and run the bot; no code required.
+
+**Custom adapter with `HmacWebhookVerifier`:**
+
+```python
+from praisonai.bots.webhook_security import HmacWebhookVerifier
+
+verifier = HmacWebhookVerifier(
+    secret="your-secret",
+    signature_headers=["X-Hub-Signature-256"],
+    prefix="sha256=",
+)
+```
+
+**Custom ingress with the shared gate:**
+
+```python
+from praisonai.bots.webhook_security import enforce_webhook_verification
+
+ok = enforce_webhook_verification(
+    accepts_webhooks=True,
+    verifier=verifier,
+    headers=dict(request.headers),
+    raw_body=await request.body(),
+    platform="mychat",
+)
+if not ok:
+    return Response(status_code=401)
+```
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Never set PRAISONAI_INSECURE_WEBHOOKS in production">
+The override logs a warning on every request and disables all signature checks.
+</Accordion>
+
+<Accordion title="Use the shared helper instead of rolling your own HMAC">
+`verify_hmac` and `HmacWebhookVerifier` fail closed on missing secrets, unknown digest algorithms, and verifier exceptions.
+</Accordion>
+
+<Accordion title="Rotate signing secrets with the platform">
+Update both the platform webhook config and your env var at the same time.
+</Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Linear Bot" icon="list" href="/docs/features/linear-bot">
+  Linear webhook setup and secrets
+</Card>
+<Card title="Email Bot" icon="envelope" href="/docs/features/email-bot">
+  AgentMail webhook mode
+</Card>
+<Card title="WhatsApp Bot" icon="message-circle" href="/docs/features/whatsapp-bot">
+  Cloud-mode webhooks
+</Card>
+<Card title="Platform Capabilities" icon="sliders" href="/docs/features/bot-platform-capabilities">
+  accepts_webhooks and verifies_webhook_signature
+</Card>
+</CardGroup>

--- a/docs/features/whatsapp-bot.mdx
+++ b/docs/features/whatsapp-bot.mdx
@@ -317,6 +317,10 @@ graph TB
     class WA,WH,NC,WS,AG infra
 ```
 
+<Note>
+**Cloud-mode webhook verification:** inbound Meta webhooks are HMAC-verified via the shared helper. Set `WHATSAPP_APP_SECRET` (see [Messaging Bots](/docs/features/messaging-bots)). Details: [Webhook Verification](/docs/features/webhook-verification).
+</Note>
+
 ### Key Components
 
 | Component | Role |

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -252,6 +252,10 @@ be reconfigured to write inside the sandbox root.
 
 ## Best Practices
 
+### Webhook Verification
+
+Bot adapters that accept inbound webhooks verify HMAC signatures **fail-closed** by default — missing secrets or invalid signatures return HTTP 401. Set `PRAISONAI_INSECURE_WEBHOOKS=true` only for local development. See [Webhook Verification](/docs/features/webhook-verification).
+
 <Tabs>
   <Tab title="API Key Management">
     <Note>


### PR DESCRIPTION
## Summary
- New `docs/features/webhook-verification.mdx` with Quick Start, decision flow, and configuration tables
- Corrects stale Linear fail-open wording; adds AgentMail/WhatsApp verification callouts
- Updates `bot-platform-capabilities.mdx`, `security.mdx`, and `docs.json` nav

Fixes #902

## Test plan
- [x] `docs.json` validates as JSON
- [x] No edits to `docs/concepts/*`

Made with [Cursor](https://cursor.com)