### PR TITLE
docs: update call.mdx for PRAISONAI_CALL_AUTH=disabled + PRAISONAI_CALL_BIND_HOST requirement

### DIFF
--- a/docs/call.mdx
+++ b/docs/call.mdx
@@ -57,15 +57,30 @@ curl -H "Authorization: Bearer your-secure-token-here" \
 
 ### Option 2: Disable Authentication (Local Development Only)
 
-For local development, you can explicitly disable authentication:
+For local development on your own machine, you can disable authentication. The CLI sets the bind-host env var for you, so this is enough when launching via `praisonai call`:
 
 ```bash
 export PRAISONAI_CALL_AUTH=disabled
-praisonai call --public
+praisonai call
+```
+
+If you launch the server programmatically (custom `uvicorn`, embedding `praisonai.api.agent_invoke` in another app, or any path that does NOT go through `praisonai call` / `praisonai serve`), you must also pin the bind host:
+
+```bash
+export PRAISONAI_CALL_AUTH=disabled
+export PRAISONAI_CALL_BIND_HOST=127.0.0.1
+```
+
+Without `PRAISONAI_CALL_BIND_HOST` set to a localhost value, every request is rejected with:
+
+```
+503 Service Unavailable
+PRAISONAI_CALL_AUTH=disabled is only permitted for localhost binding;
+set PRAISONAI_CALL_BIND_HOST to 127.0.0.1 when binding locally
 ```
 
 <Warning>
-Never use `PRAISONAI_CALL_AUTH=disabled` in production environments.
+Never use `PRAISONAI_CALL_AUTH=disabled` in production. It is rejected outright unless the server is bound to localhost, and even then it bypasses all caller verification.
 </Warning>
 
 ### Authentication Flow
@@ -75,18 +90,20 @@ graph LR
     A[📝 Request] --> B{🔐 Has Bearer Token?}
     B -->|Yes| C[✅ 200 Success]
     B -->|No| D{⚙️ Auth Disabled?}
-    D -->|Yes| C
+    D -->|Yes| H{🏠 Bind host is localhost?}
+    H -->|Yes| C
+    H -->|No| G[❌ 503 Service Unavailable]
     D -->|No| E{🔧 Token Configured?}
     E -->|Yes| F[❌ 401 Unauthorized]
-    E -->|No| G[❌ 503 Service Unavailable]
-    
+    E -->|No| G
+
     classDef request fill:#6366F1,stroke:#7C90A0,color:#fff
     classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef success fill:#10B981,stroke:#7C90A0,color:#fff
     classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
-    
+
     class A request
-    class B,D,E check
+    class B,D,E,H check
     class C success
     class F,G error
 ```
@@ -97,6 +114,22 @@ When `CALL_SERVER_TOKEN` is not configured and the environment is not developmen
 503 Service Unavailable
 CALL_SERVER_TOKEN is not configured. Set CALL_SERVER_TOKEN or PRAISONAI_CALL_AUTH=disabled to run without authentication.
 ```
+
+When `PRAISONAI_CALL_AUTH=disabled` is set but the bind host is not localhost:
+
+```
+503 Service Unavailable
+PRAISONAI_CALL_AUTH=disabled is only permitted for localhost binding;
+set PRAISONAI_CALL_BIND_HOST to 127.0.0.1 when binding locally
+```
+
+### Environment Variables
+
+| Env var | Required when | Effect |
+|---|---|---|
+| `CALL_SERVER_TOKEN` | Production / any non-local exposure | Server requires `Authorization: Bearer <token>` |
+| `PRAISONAI_CALL_AUTH=disabled` | Local development only | Bypasses auth — **only honored if `PRAISONAI_CALL_BIND_HOST` is localhost** |
+| `PRAISONAI_CALL_BIND_HOST` | Whenever you launch without the `praisonai call`/`praisonai serve` CLI | Declares the real bind host so the auth-disabled guard can verify it |
 
 ## Binding & Network Access
 


### PR DESCRIPTION
## Summary

Updates `docs/call.mdx` to reflect the new auth-disabled behavior introduced in [MervinPraison/PraisonAI#2280](https://github.com/MervinPraison/PraisonAI/pull/2280).

**Changes:**
- **Option 2 (Disable Auth)**: Removed misleading `--public` flag from example; added two-env-var pairing for non-CLI launch paths
- **Authentication Flow diagram**: Added `🏠 Bind host is localhost?` guard node between "Auth Disabled?" and "200 Success"
- **503 error examples**: Added second 503 message for the new `PRAISONAI_CALL_BIND_HOST` unset/non-localhost code path
- **Environment variables table**: Added quick-reference table for `CALL_SERVER_TOKEN`, `PRAISONAI_CALL_AUTH`, and `PRAISONAI_CALL_BIND_HOST`

Fixes #918

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to disable authentication for voice calls during local development.
  * Added guidance that programmatic server startup must also use a localhost bind host setting.
  * Documented the error shown when authentication is disabled without a localhost-only bind.
  * Strengthened the warning that this configuration is rejected outside localhost-bound setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->