### PR TITLE
docs: update budget pages for pre-call hard ceiling behaviour

### DIFF
--- a/docs/configuration/agent-config.mdx
+++ b/docs/configuration/agent-config.mdx
@@ -76,10 +76,12 @@ result = agent.start("Research AI trends")
 
 **Benefits**:
 - Simpler than using `ExecutionConfig` for basic budget control
-- Prevents runaway costs in production
+- Prevents runaway costs in production — the guard fires **before** each LLM call in `stop` mode (default), so the over-budget call is never dispatched
 - Clean error handling in CLI mode
 
 **Precedence**: When both `max_budget` and `execution.max_budget` are provided, the top-level parameter takes precedence and a warning is emitted.
+
+**Mode behaviour**: `stop` (default) enforces a pre-call hard ceiling; `warn` and callable modes check post-call and always let the call run. Pass `on_budget_exceeded` via `ExecutionConfig` to change the mode.
 
 ### Context Management
 

--- a/docs/configuration/execution-config.mdx
+++ b/docs/configuration/execution-config.mdx
@@ -115,7 +115,7 @@ config = ExecutionConfig(
 | `max_tool_calls_per_turn` | `int` | `10` | Maximum tool calls allowed in a single chat turn. When exceeded, execution stops with a clear message instead of looping forever. |
 | `context_compaction` | `bool \| ContextCompactionPolicy` | `False` | Proactive context-overflow protection. `True` uses the `BALANCED_POLICY` preset. Pass a `ContextCompactionPolicy` instance for custom routing. **Default flips to `True` in the next release** — a `DeprecationWarning` is emitted today when left at `False`. See [Context Compaction Policy](/features/context-compaction-policy). |
 | `max_budget` | `float \| None` | `None` | Hard USD cap per agent run. `None` = no limit. |
-| `on_budget_exceeded` | `str \| callable` | `"stop"` | Action when limit is hit: `"stop"` raises `BudgetExceededError`, `"warn"` logs and continues, or a `callable(total_cost, max_budget)`. |
+| `on_budget_exceeded` | `str \| callable` | `"stop"` | Action when limit is hit. `"stop"` raises `BudgetExceededError` **before** the next LLM call is dispatched (pre-call hard ceiling). `"warn"` logs after the call returns and continues. `callable(total_cost, max_budget)` runs after the call returns; return value is ignored. |
 
 <Note>
 For simple budget limits, use the `Agent(max_budget=...)` convenience parameter instead of importing `ExecutionConfig`. See [Agent max_budget](/docs/features/agent-max-budget) for details.

--- a/docs/features/agent-max-budget.mdx
+++ b/docs/features/agent-max-budget.mdx
@@ -47,7 +47,7 @@ agent = Agent(
 agent.start("Research the history of AI")
 ```
 
-When spend reaches $0.50, the run stops with `BudgetExceededError` including agent name and totals.
+When spend reaches $0.50, the run stops with `BudgetExceededError` including agent name and totals. In `stop` mode (the default), the guard runs **before** each call — the over-budget call is never dispatched.
 
 </Step>
 
@@ -68,7 +68,7 @@ agent = Agent(
 agent.start("Summarise this quarterly report")
 ```
 
-With `on_budget_exceeded="warn"`, the agent logs a warning but continues. Default is `"stop"`.
+With `on_budget_exceeded="warn"`, the agent logs a warning but continues. `warn` and callable modes stay reactive (post-call) — the call always runs, then the warning fires. Default is `"stop"`.
 
 </Step>
 </Steps>
@@ -79,20 +79,32 @@ With `on_budget_exceeded="warn"`, the agent logs a warning but continues. Defaul
 sequenceDiagram
     participant User
     participant Agent
-    participant LLM
     participant Budget
+    participant LLM
 
     User->>Agent: start(prompt)
     loop Each LLM call
-        Agent->>LLM: chat completion
-        LLM-->>Agent: response + usage
-        Agent->>Budget: add cost
-        Budget-->>Agent: total vs max_budget
+        Agent->>Budget: estimate call cost
+        Budget-->>Agent: estimate
+        alt stop mode AND total + estimate >= max_budget
+            Agent-->>User: BudgetExceededError (call not dispatched)
+        else within budget
+            Agent->>LLM: chat completion
+            LLM-->>Agent: response + usage
+            Agent->>Budget: record actual cost
+            alt warn / callable AND total >= max_budget
+                Budget-->>Agent: trigger warn / handler
+            end
+        end
     end
-    Agent-->>User: result or BudgetExceededError
+    Agent-->>User: result
 ```
 
-Budget tracking adds zero overhead when `max_budget` is `None` (the default).
+Budget tracking adds zero overhead when `max_budget` is `None` (the default). In `stop` mode and callable modes, the check timing differs: `stop` is pre-call while `warn` and callable stay post-call.
+
+## Estimation
+
+Before each LLM call in `stop` mode, the agent estimates the minimum call cost: input tokens ≈ total characters ÷ 4, plus the configured `max_tokens` output reservation. If the running total plus this estimate meets or exceeds `max_budget`, the call is blocked before dispatch — the LLM is never billed and `$0` is recorded for that turn.
 
 ## Configuration Options
 

--- a/docs/features/cli-budget-handling.mdx
+++ b/docs/features/cli-budget-handling.mdx
@@ -74,24 +74,29 @@ sequenceDiagram
     participant User
     participant CLI
     participant Agent
+    participant Budget
     participant LLM
     
     User->>CLI: praisonai "task"
     CLI->>Agent: agent.start(prompt)
-    Agent->>LLM: API call
-    LLM-->>Agent: Response + cost
-    Agent-->>Agent: Check budget
-    
-    alt Budget OK
-        Agent-->>CLI: Success
-        CLI-->>User: Results
-    else Budget Exceeded
-        Agent->>Agent: Raise BudgetExceededError
-        CLI->>CLI: Catch exception
-        CLI->>CLI: Print clean message
-        CLI->>User: Exit code 1
+    loop Each LLM call
+        Agent->>Budget: estimate call cost
+        Budget-->>Agent: estimate
+        alt stop mode AND total + estimate >= max_budget
+            Agent->>CLI: BudgetExceededError (call not dispatched)
+            CLI->>CLI: Print clean message
+            CLI->>User: Exit code 1
+        else within budget
+            Agent->>LLM: API call
+            LLM-->>Agent: Response + cost
+            Agent->>Budget: record actual cost
+        end
     end
+    Agent-->>CLI: Success
+    CLI-->>User: Results
 ```
+
+In `stop` mode, the guard fires **before** the LLM is called, so the CLI exits with `1` without spending on the over-budget turn.
 
 The `praisonai` CLI wraps every `agent.start(...)` / `agent.chat(...)` call in a budget handler. When the agent raises `BudgetExceededError`, the CLI:
 


### PR DESCRIPTION
## Summary

Updates four documentation pages to reflect the new pre-call hard ceiling enforcement for `max_budget` in `stop` mode, introduced by MervinPraison/PraisonAI#2315 (merged 2026-06-26).

- **`docs/features/agent-max-budget.mdx`**: Replace single post-call-only sequence diagram with dual-path diagram (pre-call guard for `stop`, post-call reactive for `warn`/callable). Add new "Estimation" subsection explaining the ~4 chars/token input + `max_tokens` reservation formula. Append stop/warn timing notes to Quick Start steps.
- **`docs/features/cli-budget-handling.mdx`**: Update sequence diagram to show pre-call budget guard in `stop` mode; add sentence clarifying CLI exits without billing on the over-budget turn.
- **`docs/configuration/execution-config.mdx`**: Expand `on_budget_exceeded` row description to distinguish pre-call (`stop`) from post-call (`warn`/callable) enforcement.
- **`docs/configuration/agent-config.mdx`**: Add pre-call timing note and mode behaviour summary to `max_budget` parameter docs.

> **Note**: `docs/concepts/budget.mdx` is HUMAN-APPROVED ONLY (AGENTS.md §1.8) and has not been touched. A separate sub-issue (#927) tracks the required human review for that page.

## Test plan

- [ ] Verify all four `.mdx` files render without errors in Mintlify
- [ ] Confirm sequence diagrams display correctly (pre-call guard path visible)
- [ ] Review prose changes for accuracy against upstream PR #2315

Fixes #926
Upstream: MervinPraison/PraisonAI#2315

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how budget limits work across agent and CLI workflows.
  * Explained when budget checks happen in each mode: `stop` blocks calls before they run, while `warn` and callable modes act after a call completes.
  * Added clearer examples and diagrams showing budget estimation, over-budget handling, and CLI exit behavior.
  * Documented that default `stop` mode prevents spending on calls that would exceed the limit, and that existing budget precedence rules still apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->