### PR TITLE
docs: update budget docs for pre-call hard ceiling (fixes #928)

### DIFF
--- a/docs/configuration/agent-config.mdx
+++ b/docs/configuration/agent-config.mdx
@@ -58,7 +58,7 @@ agent = Agent(
 #### `max_budget`
 - **Type**: `float | None`
 - **Default**: `None`
-- **Description**: Convenience alias for `ExecutionConfig(max_budget=...)`. Set a hard USD cap on the agent run without importing `ExecutionConfig`. If both this and `execution.max_budget` are set with different values, this one wins and a `UserWarning` is emitted.
+- **Description**: Convenience alias for `ExecutionConfig(max_budget=...)`. Set a hard USD cap on the agent run without importing `ExecutionConfig`. In `stop` mode (default), the guard fires **before** each LLM call — the over-budget call is never dispatched. In `warn` and callable modes, the check stays post-call (reactive). If both this and `execution.max_budget` are set with different values, this one wins and a `UserWarning` is emitted.
 
 Set a dollar limit directly on the agent without needing to configure `ExecutionConfig`:
 

--- a/docs/configuration/execution-config.mdx
+++ b/docs/configuration/execution-config.mdx
@@ -115,7 +115,7 @@ config = ExecutionConfig(
 | `max_tool_calls_per_turn` | `int` | `10` | Maximum tool calls allowed in a single chat turn. When exceeded, execution stops with a clear message instead of looping forever. |
 | `context_compaction` | `bool \| ContextCompactionPolicy` | `False` | Proactive context-overflow protection. `True` uses the `BALANCED_POLICY` preset. Pass a `ContextCompactionPolicy` instance for custom routing. **Default flips to `True` in the next release** — a `DeprecationWarning` is emitted today when left at `False`. See [Context Compaction Policy](/features/context-compaction-policy). |
 | `max_budget` | `float \| None` | `None` | Hard USD cap per agent run. `None` = no limit. |
-| `on_budget_exceeded` | `str \| callable` | `"stop"` | Action when limit is hit: `"stop"` raises `BudgetExceededError`, `"warn"` logs and continues, or a `callable(total_cost, max_budget)`. |
+| `on_budget_exceeded` | `str \| callable` | `"stop"` | Action when limit is hit. `"stop"` raises `BudgetExceededError` **before** the next LLM call is dispatched (pre-call hard ceiling). `"warn"` logs after the call returns and continues. `callable(total_cost, max_budget)` runs after the call returns; return value is ignored. |
 
 <Note>
 For simple budget limits, use the `Agent(max_budget=...)` convenience parameter instead of importing `ExecutionConfig`. See [Agent max_budget](/docs/features/agent-max-budget) for details.

--- a/docs/features/agent-max-budget.mdx
+++ b/docs/features/agent-max-budget.mdx
@@ -47,7 +47,7 @@ agent = Agent(
 agent.start("Research the history of AI")
 ```
 
-When spend reaches $0.50, the run stops with `BudgetExceededError` including agent name and totals.
+When spend reaches $0.50, the run stops with `BudgetExceededError` including agent name and totals. In `stop` mode (the default), the guard runs **before** each call — the over-budget call is never dispatched.
 
 </Step>
 
@@ -68,7 +68,7 @@ agent = Agent(
 agent.start("Summarise this quarterly report")
 ```
 
-With `on_budget_exceeded="warn"`, the agent logs a warning but continues. Default is `"stop"`.
+With `on_budget_exceeded="warn"`, the agent logs a warning but continues. `warn` and callable modes stay reactive (post-call) — the call always runs, then the warning fires. Default is `"stop"`.
 
 </Step>
 </Steps>
@@ -79,20 +79,32 @@ With `on_budget_exceeded="warn"`, the agent logs a warning but continues. Defaul
 sequenceDiagram
     participant User
     participant Agent
-    participant LLM
     participant Budget
+    participant LLM
 
     User->>Agent: start(prompt)
     loop Each LLM call
-        Agent->>LLM: chat completion
-        LLM-->>Agent: response + usage
-        Agent->>Budget: add cost
-        Budget-->>Agent: total vs max_budget
+        Agent->>Budget: estimate call cost
+        Budget-->>Agent: estimate
+        alt stop mode AND total + estimate >= max_budget
+            Agent-->>User: BudgetExceededError (call not dispatched)
+        else within budget
+            Agent->>LLM: chat completion
+            LLM-->>Agent: response + usage
+            Agent->>Budget: record actual cost
+            alt warn / callable AND total >= max_budget
+                Budget-->>Agent: trigger warn / handler
+            end
+        end
     end
-    Agent-->>User: result or BudgetExceededError
+    Agent-->>User: result
 ```
 
-Budget tracking adds zero overhead when `max_budget` is `None` (the default).
+Budget tracking adds zero overhead when `max_budget` is `None` (the default). In `stop` mode, the guard runs before each call — the over-budget call is never dispatched.
+
+## Estimation
+
+Before each LLM call in `stop` mode, PraisonAI estimates the minimum call cost using input token count (≈ chars ÷ 4) plus the configured `max_tokens` output reservation. If `total_cost + estimate >= max_budget`, the call is blocked and `BudgetExceededError` is raised with `$0` recorded for that turn.
 
 ## Configuration Options
 

--- a/docs/features/cli-budget-handling.mdx
+++ b/docs/features/cli-budget-handling.mdx
@@ -74,24 +74,30 @@ sequenceDiagram
     participant User
     participant CLI
     participant Agent
+    participant Budget
     participant LLM
     
     User->>CLI: praisonai "task"
     CLI->>Agent: agent.start(prompt)
-    Agent->>LLM: API call
-    LLM-->>Agent: Response + cost
-    Agent-->>Agent: Check budget
-    
-    alt Budget OK
-        Agent-->>CLI: Success
-        CLI-->>User: Results
-    else Budget Exceeded
-        Agent->>Agent: Raise BudgetExceededError
-        CLI->>CLI: Catch exception
-        CLI->>CLI: Print clean message
-        CLI->>User: Exit code 1
+    loop Each LLM call
+        Agent->>Budget: estimate call cost (stop mode)
+        Budget-->>Agent: estimate
+        alt stop mode AND total + estimate >= max_budget
+            Agent->>CLI: BudgetExceededError (call not dispatched)
+            CLI->>CLI: Catch exception
+            CLI->>CLI: Print clean message
+            CLI->>User: Exit code 1
+        else within budget
+            Agent->>LLM: API call
+            LLM-->>Agent: Response + cost
+            Agent->>Budget: record actual cost
+        end
     end
+    Agent-->>CLI: Success
+    CLI-->>User: Results
 ```
+
+In `stop` mode, the guard fires *before* the LLM is called, so the CLI exits with `1` without spending on the over-budget turn.
 
 The `praisonai` CLI wraps every `agent.start(...)` / `agent.chat(...)` call in a budget handler. When the agent raises `BudgetExceededError`, the CLI:
 


### PR DESCRIPTION
## Summary

Updates the AI-editable budget documentation pages to reflect the new pre-call hard ceiling behaviour introduced in MervinPraison/PraisonAI#2315.

**`docs/concepts/budget.mdx` is NOT modified** — it is HUMAN-APPROVED ONLY per AGENTS.md §1.8. Changes for that file are tracked as a human-review item in the parent issue #926.

### Changes

- **`docs/features/agent-max-budget.mdx`**: Replaced "How It Works" sequence diagram to show pre-call guard in `stop` mode vs post-call path for `warn`/callable. Added new "Estimation" subsection explaining the ~4 chars/token + `max_tokens` formula. Updated Quick Start prose for both modes.

- **`docs/features/cli-budget-handling.mdx`**: Replaced sequence diagram to show pre-call guard in `stop` mode. Added sentence clarifying the CLI exits *before* spending on the over-budget turn.

- **`docs/configuration/execution-config.mdx`**: Expanded `on_budget_exceeded` table description to clarify `stop` = pre-call hard ceiling, `warn`/callable = post-call reactive.

- **`docs/configuration/agent-config.mdx`**: Added pre-call vs post-call timing note to `max_budget` description.

## References

Fixes #928 (human-review sub-issue for #926)
Parent issue: #926
Upstream SDK change: MervinPraison/PraisonAI#2315

Generated with [Claude Code](https://claude.ai/code)