### PR TITLE
docs: document LiteLLM fallback for AutoGenerator structured output

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -288,6 +288,7 @@
                       "docs/features/structured",
                       "docs/features/mini",
                       "docs/features/autoagents",
+                      "docs/features/auto-generator-providers",
                       "docs/features/onboard",
                       "docs/features/first-run-onboarding",
                       "docs/features/installation-extras",

--- a/docs/cli/auto.mdx
+++ b/docs/cli/auto.mdx
@@ -165,6 +165,10 @@ flowchart TD
   </Step>
 </Steps>
 
+<Card title="Auto Mode Providers" icon="plug" href="/docs/features/auto-generator-providers">
+  LiteLLM unlocks 100+ providers for auto mode, with automatic OpenAI fallback. Learn how provider selection works.
+</Card>
+
 ## Generated Output
 
 The auto mode creates an `agents.yaml` file with:

--- a/docs/features/auto-generator-providers.mdx
+++ b/docs/features/auto-generator-providers.mdx
@@ -1,0 +1,331 @@
+---
+title: "Auto Mode Providers"
+sidebarTitle: "Auto Mode Providers"
+description: "Use any of 100+ LLM providers with praisonai --auto via LiteLLM, with automatic OpenAI fallback"
+icon: "plug"
+---
+
+Auto mode picks a provider for you: LiteLLM first (100+ providers), OpenAI as a safety net.
+
+```mermaid
+graph LR
+    subgraph "Auto Mode Provider Selection"
+        T["📝 Topic"] --> AG["🤖 AutoGenerator"]
+        AG --> LIT{"LiteLLM\ninstalled?"}
+        LIT -->|Yes| LL["⚡ LiteLLM\n100+ providers"]
+        LIT -->|No| OAI["🔑 OpenAI SDK"]
+        LL -->|Success| YAML["✅ agents.yaml"]
+        LL -->|Error| FB["⚠️ Fallback\nto OpenAI"]
+        FB --> OAI
+        OAI --> YAML
+    end
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef litellm fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef fallback fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef decision fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class T,AG input
+    class LL litellm
+    class FB fallback
+    class OAI fallback
+    class YAML output
+    class LIT decision
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Default (OpenAI only)">
+
+Install PraisonAI and set your OpenAI key:
+
+```bash
+pip install "praisonai[crewai]"
+```
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+Run auto mode:
+
+```bash
+praisonai --auto "research AI trends"
+```
+
+Or programmatically:
+
+```python
+from praisonai import AutoGenerator
+
+generator = AutoGenerator(topic="research AI trends")
+result = generator.generate()
+print(result)
+```
+
+</Step>
+
+<Step title="Unlock 100+ Providers with LiteLLM">
+
+Install LiteLLM to use Anthropic, Google, Azure, Bedrock, Ollama, and more:
+
+```bash
+pip install litellm
+```
+
+Switch to Anthropic Claude:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_MODEL_NAME=anthropic/claude-sonnet-4
+praisonai --auto "research AI trends"
+```
+
+Switch to Google Gemini:
+
+```bash
+export GEMINI_API_KEY=...
+export OPENAI_MODEL_NAME=gemini/gemini-2.0-flash
+praisonai --auto "research AI trends"
+```
+
+Switch to a local Ollama model:
+
+```bash
+export OPENAI_MODEL_NAME=ollama/llama3
+praisonai --auto "research AI trends"
+```
+
+</Step>
+
+<Step title="Programmatic Use (Sync & Async)">
+
+Both sync and async paths honour the LiteLLM → OpenAI fallback:
+
+```python
+from praisonai import AutoGenerator
+
+generator = AutoGenerator(topic="summarise recent AI papers")
+agents_yaml = generator.generate()
+print(agents_yaml)
+```
+
+Async version:
+
+```python
+import asyncio
+from praisonai import AutoGenerator
+
+async def main():
+    generator = AutoGenerator(topic="summarise recent AI papers")
+    agents_yaml = await generator.agenerate()
+    print(agents_yaml)
+
+asyncio.run(main())
+```
+
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant AutoGenerator
+    participant LiteLLM
+    participant OpenAI
+
+    User->>CLI: praisonai --auto "topic"
+    CLI->>AutoGenerator: generate(topic)
+    AutoGenerator->>LiteLLM: completion(model, response_format)
+    alt LiteLLM succeeds
+        LiteLLM-->>AutoGenerator: structured JSON
+        AutoGenerator-->>CLI: agents.yaml
+        CLI-->>User: agents created & executed
+    else LiteLLM raises exception
+        LiteLLM-->>AutoGenerator: Exception (auth/timeout/unsupported)
+        AutoGenerator->>AutoGenerator: log warning + continue
+        AutoGenerator->>OpenAI: beta.chat.completions.parse(...)
+        OpenAI-->>AutoGenerator: parsed Pydantic object
+        AutoGenerator-->>CLI: agents.yaml
+        CLI-->>User: agents created & executed
+    end
+```
+
+| Step | What happens |
+|------|-------------|
+| **1. LiteLLM attempt** | Calls `litellm.completion(model=..., response_format=PydanticModel)` |
+| **2. Runtime fallback** | If LiteLLM raises (auth error, timeout, unsupported model), logs a warning and continues |
+| **3. OpenAI fallback** | Calls `client.beta.chat.completions.parse(...)` using the OpenAI SDK |
+| **4. No providers** | Raises `ImportError` with install instructions |
+
+<Note>
+The fallback warning message is: `LiteLLM structured completion failed (...); falling back to OpenAI SDK.`
+Watch your logs for this — it means LiteLLM is degrading silently.
+</Note>
+
+---
+
+## Which Provider Should I Use?
+
+```mermaid
+graph TB
+    Start["Which provider for --auto?"] --> Q1{"Do you only need\nOpenAI or Azure?"}
+    Q1 -->|Yes| OPENAI["Install openai only\npip install openai"]
+    Q1 -->|No| Q2{"Anthropic, Gemini,\nBedrock, Ollama, etc.?"}
+    Q2 -->|Yes| LITELLM["Install litellm\npip install litellm"]
+    Q2 -->|Both| BOTH["Install both\npip install litellm openai\nLiteLLM preferred;\nOpenAI catches errors"]
+
+    classDef question fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef answer fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef both fill:#189AB4,stroke:#7C90A0,color:#fff
+
+    class Start,Q1,Q2 question
+    class OPENAI answer
+    class LITELLM answer
+    class BOTH both
+```
+
+---
+
+## Install Matrix
+
+| Installed | Auto mode behaviour |
+|-----------|---------------------|
+| `openai` only | OpenAI SDK used directly via `beta.chat.completions.parse` |
+| `litellm` only | LiteLLM used; if it raises, the call fails (no fallback) |
+| both | LiteLLM first; on runtime error, falls back to OpenAI with a warning |
+| neither | `ImportError: Structured output requires either litellm or openai...` |
+
+---
+
+## Configuration
+
+| Environment variable | What it does |
+|---------------------|-------------|
+| `OPENAI_API_KEY` | API key used by both LiteLLM and OpenAI paths |
+| `OPENAI_MODEL_NAME` | Model passed to whichever provider runs. For LiteLLM use prefixed names: `anthropic/claude-sonnet-4`, `gemini/gemini-2.0-flash`, `ollama/llama3` |
+| `OPENAI_API_BASE` | Forwarded as `base_url` to the OpenAI client (overrides default endpoint) |
+| `ANTHROPIC_API_KEY` | Required when `OPENAI_MODEL_NAME=anthropic/...` |
+| `GEMINI_API_KEY` | Required when `OPENAI_MODEL_NAME=gemini/...` |
+
+<Card title="Auto Module SDK Reference" icon="code" href="/docs/sdk/reference/praisonai/modules/auto">
+  Full API reference for AutoGenerator, WorkflowAutoGenerator, and BaseAutoGenerator
+</Card>
+
+---
+
+## Common Patterns
+
+**Switch from OpenAI to Anthropic:**
+
+```bash
+pip install litellm
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_MODEL_NAME=anthropic/claude-sonnet-4
+praisonai --auto "write a market analysis report"
+```
+
+**Run against a local Ollama model (no cloud keys needed):**
+
+```bash
+pip install litellm
+# Ollama must be running locally on port 11434
+export OPENAI_MODEL_NAME=ollama/llama3
+praisonai --auto "summarise today's news"
+```
+
+**Belt-and-braces production setup (LiteLLM + OpenAI fallback):**
+
+```bash
+pip install litellm openai
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...
+export OPENAI_MODEL_NAME=anthropic/claude-sonnet-4
+# LiteLLM runs first; transient errors fall back to OpenAI automatically
+praisonai --auto "generate a weekly status report"
+```
+
+**Async programmatic use:**
+
+```python
+import asyncio
+from praisonai import AutoGenerator
+
+async def run():
+    async with AutoGenerator(topic="competitor analysis") as gen:
+        yaml_config = await gen.agenerate()
+        print(yaml_config)
+
+asyncio.run(run())
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Install both litellm and openai in production">
+    Install both packages so transient LiteLLM failures (rate limits, network blips, provider outages) don't break agent generation:
+
+    ```bash
+    pip install litellm openai
+    ```
+
+    LiteLLM runs first; OpenAI silently catches any runtime errors.
+  </Accordion>
+
+  <Accordion title="Watch logs for the fallback warning">
+    The warning `LiteLLM structured completion failed (...); falling back to OpenAI SDK.` means LiteLLM silently degraded. Check:
+    - Is your provider API key set correctly?
+    - Does the model support `response_format` (structured output)?
+    - Is the provider having an outage?
+
+    Investigate before relying on the fallback long-term.
+  </Accordion>
+
+  <Accordion title="Pin model names in config_list for concurrent generators">
+    If your code runs multiple `AutoGenerator` instances in parallel, set model names in `config_list` rather than `OPENAI_MODEL_NAME` to avoid environment variable races:
+
+    ```python
+    from praisonai import AutoGenerator
+
+    gen = AutoGenerator(
+        topic="topic",
+        config_list=[{
+            "model": "anthropic/claude-sonnet-4",
+            "api_key": "sk-ant-...",
+        }]
+    )
+    ```
+  </Accordion>
+
+  <Accordion title="Do not import litellm at module scope">
+    Lazy loading is on by default — `litellm` is never imported at module load time. Do not add `import litellm` at the top of your files. Let `AutoGenerator` pull it in on demand. This keeps startup fast and avoids import-time side effects.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Auto Mode CLI" icon="terminal" href="/docs/cli/auto">
+    Command-line reference for `praisonai --auto`
+  </Card>
+  <Card title="AutoAgents" icon="robot" href="/docs/features/autoagents">
+    Automatically create and run agents from a prompt
+  </Card>
+  <Card title="Structured Output" icon="brackets-curly" href="/docs/features/structured">
+    Control agent output format with Pydantic models
+  </Card>
+  <Card title="YAML Workflows" icon="file-code" href="/docs/features/yaml-workflows">
+    The agents.yaml format generated by auto mode
+  </Card>
+</CardGroup>

--- a/docs/nocode/auto.mdx
+++ b/docs/nocode/auto.mdx
@@ -50,6 +50,8 @@ python -m praisonai --framework autogen --auto "research AI trends"
 3. Assigns relevant tools automatically
 4. Runs the agents immediately
 
+Auto uses LiteLLM if installed (100+ providers), with OpenAI as a fallback. See [Auto Mode Providers](/docs/features/auto-generator-providers).
+
 ## Init Only (No Run)
 
 To generate `agents.yaml` without running:


### PR DESCRIPTION
## Summary

- Creates docs/features/auto-generator-providers.mdx with full feature page
- Updates docs/cli/auto.mdx with cross-link card
- Updates docs/nocode/auto.mdx with inline note about LiteLLM fallback
- Updates docs.json to add new page under Features / Core Agent Features

Fixes #934

Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new documentation page for Auto Mode providers, including setup guidance, provider switching examples, fallback behavior, and best practices.
  * Added a navigation link to the new Auto Mode providers page in the docs menu.
* **Documentation**
  * Updated Auto-related docs to clarify that LiteLLM enables support for many providers, with OpenAI used as a fallback when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->