### PR TITLE
docs: document PRAISONAI_TOOL_TIMEOUT_WORKERS, background_work_may_continue, and atomic YAML writes

### DIFF
--- a/docs/configuration/tool-config.mdx
+++ b/docs/configuration/tool-config.mdx
@@ -160,10 +160,12 @@ When you set `tool_timeout` in YAML (`framework: praisonai`) **or** pass `--tool
 This means the `tool_timeout` knob is enforced even if the downstream SDK ignores it, even if the tool is a blocking C extension, and even if the tool is a subprocess that does not honour `CancelledError`.
 
 The wrapper handles **sync and async tools** differently:
-- **Sync tools** run in a daemon thread (`threading.Thread(daemon=True)`); on timeout the wrapper returns a JSON error dict and abandons the thread (daemon threads do not block process exit).
-- **Async tools** are wrapped with `asyncio.wait_for(...)`; on timeout the wrapper returns the same JSON error dict.
+- **Sync tools** run in a bounded `ThreadPoolExecutor` named `praisonai-tool-timeout`; on timeout the wrapper best-effort cancels the future and returns a JSON error dict. The pool size is controlled by `PRAISONAI_TOOL_TIMEOUT_WORKERS` (default `32`).
+- **Async tools** are wrapped with `asyncio.wait_for(...)`; on timeout the task is cancelled and the wrapper returns the same JSON error dict.
 
 The returned shape on wrapper-level timeout is a **JSON string** (because the wrapper boundary serialises) containing:
+
+**Async tools** (`asyncio.wait_for` cancelled):
 ```json
 {
   "error": "tool_timeout",
@@ -171,6 +173,18 @@ The returned shape on wrapper-level timeout is a **JSON string** (because the wr
   "timeout_seconds": 30
 }
 ```
+
+**Sync tools** (thread-pool future timed out):
+```json
+{
+  "error": "tool_timeout",
+  "tool": "<function name>",
+  "timeout_seconds": 30,
+  "background_work_may_continue": true
+}
+```
+
+`background_work_may_continue` is `true` when the future could **not** be cancelled — meaning the sync tool had already started executing on a worker thread and may still be running. Operators should not assume a timed-out sync tool has stopped — its side effects (network calls, file writes, etc.) may continue until the thread finishes naturally.
 
 If the worker thread exits without publishing a result (defensive fallback), the wrapper returns:
 ```json
@@ -650,6 +664,11 @@ agent = Agent(
 export PRAISONAI_TOOL_TIMEOUT="60"
 export PRAISONAI_TOOL_CONNECT_TIMEOUT="5"
 export PRAISONAI_TOOL_READ_TIMEOUT="55"
+
+# Worker pool for sync tool timeouts
+# Caps the ThreadPoolExecutor that enforces timeouts on synchronous tools.
+# Default: 32. Non-integer or non-positive values fall back to 32 with a warning.
+export PRAISONAI_TOOL_TIMEOUT_WORKERS="32"
 
 # Performance settings
 export PRAISONAI_TOOL_PARALLEL="true"

--- a/docs/nocode/auto.mdx
+++ b/docs/nocode/auto.mdx
@@ -50,6 +50,10 @@ python -m praisonai --framework autogen --auto "research AI trends"
 3. Assigns relevant tools automatically
 4. Runs the agents immediately
 
+<Note>
+Generated YAML files (`agents.yaml` and workflow files) are written atomically. A crash, disk-full error, or interruption during save will not corrupt the existing file.
+</Note>
+
 ## Init Only (No Run)
 
 To generate `agents.yaml` without running:


### PR DESCRIPTION
## Summary

Documents three user-visible additions from MervinPraison/PraisonAI#2318.

- `PRAISONAI_TOOL_TIMEOUT_WORKERS` — added to `docs/configuration/tool-config.mdx` Environment Variables section and inline in the wrapper-level timeout description. Default 32; non-int or non-positive values fall back to default with a warning.

- `background_work_may_continue` — updated the timeout response shape section in `docs/configuration/tool-config.mdx` to show separate JSON payloads for async vs sync tools, with an explanation that `background_work_may_continue: true` means the sync worker thread may still be running.

- Atomic YAML writes — added a Note to `docs/nocode/auto.mdx` explaining that generated YAML files are written atomically and a crash/interruption will not corrupt the existing file.

Fixes #945

Generated with [Claude Code](https://claude.ai/code)