### PR TITLE
docs: gateway tool policy — trust-tiered toolset scoping per inbound route

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -350,6 +350,7 @@
                       "docs/features/durable-delivery",
                       "docs/features/bot-routing",
                       "docs/features/gateway-route-bindings",
+                      "docs/features/gateway-tool-policy",
                       "docs/features/platform-aware-agents",
                       "docs/features/bot-pairing",
                       "docs/features/bot-unknown-user-pairing",

--- a/docs/features/approval.mdx
+++ b/docs/features/approval.mdx
@@ -7,6 +7,10 @@ icon: "shield-check"
 
 Approval pauses an agent before it runs a risky tool and asks a human (or another channel) to allow or deny it.
 
+<Note>
+**Two-layer defence for inbound bots:** [Gateway Tool Policy](/docs/features/gateway-tool-policy) runs *before* dispatch — dangerous tools are never even advertised to the model on untrusted routes. Approval runs *after* the model decides to call a tool, catching anything that slips through. Use both for defence in depth.
+</Note>
+
 <Warning>
 **Behaviour change (PR #2122):** Approval is **enabled by default**. YAML configs that omitted the `approval` key previously got `enabled: false`; they now get the prompting policy. Set `approval: false` to keep the old behaviour.
 </Warning>

--- a/docs/features/bot-routing.mdx
+++ b/docs/features/bot-routing.mdx
@@ -247,3 +247,16 @@ flowchart TD
 <Note>
 Routing is configured per channel. Each platform can have completely different routing rules — Telegram DMs can go to one agent while Discord DMs go to another.
 </Note>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Gateway Route Bindings" icon="route" href="/docs/features/gateway-route-bindings">
+    Advanced routing by peer, role, channel id, and bot account — with priority.
+  </Card>
+  <Card title="Gateway Tool Policy" icon="shield-check" href="/docs/features/gateway-tool-policy">
+    Scope the toolset per route — keep stranger DMs from running dangerous tools.
+  </Card>
+</CardGroup>

--- a/docs/features/gateway-route-bindings.mdx
+++ b/docs/features/gateway-route-bindings.mdx
@@ -93,6 +93,22 @@ channels:
 A user with id `12345678` always gets `vip`. A support-role member who DMs the bot gets `support` (role beats chat type). The `ops` channel routes to the ops agent. All other DMs go to `assistant`. Everything else falls back to `general`.
 
 </Step>
+
+<Step title="Restrict tools by trust tier">
+
+Add `trust:` to any binding to scope the toolset the model sees — strangers get a safe subset, your operator keeps full power.
+
+```yaml
+gateway:
+  routes:
+    - { chat_type: dm, agent: assistant, trust: untrusted }       # safe subset for strangers
+    - { peer: "operator-123", agent: assistant, trust: trusted }  # full toolset for the operator
+    - { channel_id: "ops", agent: assistant, deny_tools: [shell, delete_file] }
+```
+
+See [Gateway Tool Policy](/docs/features/gateway-tool-policy) for the full security reference.
+
+</Step>
 </Steps>
 
 ---
@@ -157,6 +173,9 @@ Each entry in the `bindings:` list is a `RouteBinding`:
 | `channel_id` | `Optional[str]` | `None` | Specific chat/channel id |
 | `account` | `Optional[str]` | `None` | Receiving bot account (multi-account channels) |
 | `priority` | `int` | `0` | Higher wins; ties broken by specificity then declaration order |
+| `trust` | `Optional[str]` | `None` | Trust tier — `"untrusted"` \| `"standard"` \| `"trusted"`. `untrusted` applies a conservative deny-list (no shell, no file mutation, no delegation, no self-scheduling). **Unknown values fail closed to `untrusted`**. |
+| `allow_tools` | `Optional[List[str]]` | `None` | Only these tool names are exposed on this route. Accepts a YAML scalar or list. |
+| `deny_tools` | `Optional[List[str]]` | `None` | Tool names removed before the run on this route. Layers on top of the trust tier's deny-list. Accepts a YAML scalar or list. |
 
 All non-`None` conditions in a binding must match the inbound message for that binding to apply. A binding with no conditions always matches.
 
@@ -234,6 +253,21 @@ channels:
 
 The `incident_responder` binding has `priority: 100` so it wins over the `peer` match for user `12345678`, even though `peer` has higher specificity. Use this for incident-mode overrides.
 
+**Lock down stranger DMs while keeping operator at full power**
+
+```yaml
+channels:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+    routes:
+      default: assistant
+    bindings:
+      - { chat_type: dm, agent: assistant, trust: untrusted }
+      - { peer: "operator-123", agent: assistant, trust: trusted }
+```
+
+Strangers who DM the bot never see shell, file-mutation, delegation, or scheduling tools. Your operator (`peer: "operator-123"`) retains the full toolset. See [Gateway Tool Policy](/docs/features/gateway-tool-policy) for the complete security reference.
+
 ---
 
 ## Best Practices
@@ -275,5 +309,11 @@ If your list grows past ~10 entries, consider grouping users by role at the plat
   </Card>
   <Card title="Multi-Channel Bots" icon="network-wired" href="/docs/features/multi-channel-bots">
     Run one bot per role on the same platform using multiple channel entries.
+  </Card>
+  <Card title="Gateway Tool Policy" icon="shield-check" href="/docs/features/gateway-tool-policy">
+    Full reference for trust-tiered toolset scoping — keep stranger DMs from running shell on your server.
+  </Card>
+  <Card title="Approval" icon="shield" href="/docs/features/approval">
+    Second line of defence — require human confirmation before risky tools run.
   </Card>
 </CardGroup>

--- a/docs/features/gateway-tool-policy.mdx
+++ b/docs/features/gateway-tool-policy.mdx
@@ -1,0 +1,273 @@
+---
+title: "Gateway Tool Policy"
+sidebarTitle: "Tool Policy"
+description: "Scope the toolset advertised to the model per inbound route — trust-tiered, fail-closed, prompt-injection-aware"
+icon: "shield-check"
+---
+
+Untrusted inbound routes never even see dangerous tools — the model is offered a scoped subset for that turn, then the agent's original toolset is restored.
+
+```mermaid
+graph LR
+    subgraph "Per-route Tool Policy"
+        M[📩 Inbound Message] --> R[🎯 Route Resolver]
+        R --> P{🛡️ Trust Tier}
+        P -->|untrusted| Deny[🚫 Deny-list:<br/>shell · file mut · delegate]
+        P -->|standard / trusted| Full[✅ Full Toolset]
+        Deny --> A[🤖 Agent Turn<br/>scoped tools]
+        Full --> A
+        A --> Restore[♻️ Restore Tools]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef gate fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef warn fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class M input
+    class R,P gate
+    class Deny warn
+    class Full,A,Restore ok
+```
+
+## Quick Start
+
+<Steps>
+
+<Step title="Lock down stranger DMs with one YAML line">
+
+Add `trust: untrusted` to any binding. Dangerous tools (shell, file mutation, delegation, scheduling) are automatically withheld from the model for that route.
+
+```yaml
+gateway:
+  routes:
+    - { chat_type: dm, agent: assistant, trust: untrusted }
+```
+
+</Step>
+
+<Step title="Give your operator full power">
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.gateway import RouteBinding
+
+assistant = Agent(name="assistant", instructions="Help users.")
+
+bindings = [
+    RouteBinding(agent="assistant", chat_type="dm", trust="untrusted"),
+    RouteBinding(agent="assistant", peer="operator-123", trust="trusted"),
+]
+```
+
+Stranger DMs get the safe subset. Your operator peer gets everything.
+
+</Step>
+
+<Step title="Add explicit allow/deny overrides">
+
+```python
+from praisonaiagents.gateway import RouteBinding
+
+RouteBinding(
+    agent="assistant",
+    channel_id="ops",
+    deny_tools=["shell", "delete_file"],
+)
+```
+
+Layer `deny_tools` on top of any trust tier for project-specific tools not covered by the default substrings.
+
+</Step>
+
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Msg as 📩 Inbound Message
+    participant Resolver as 🎯 Route Resolver
+    participant Policy as 🛡️ tool_policy()
+    participant Wrapper as _apply_tool_policy()
+    participant Agent as 🤖 Agent Turn
+    participant Restore as ♻️ Restore
+
+    Msg->>Resolver: Match binding
+    Resolver->>Policy: binding.tool_policy()
+    Policy-->>Wrapper: ToolPolicy (or None)
+    Wrapper->>Agent: agent.tools ← scoped subset (per-agent lock)
+    Agent-->>Restore: Turn complete (or raises)
+    Restore-->>Wrapper: agent.tools ← original (always restored)
+```
+
+The apply/restore step happens **inside the per-agent lock** and is guaranteed to run even when the agent turn raises an exception — so a failed run can never leave an agent permanently hobbled.
+
+| Step | What happens |
+|------|-------------|
+| Route resolver | Matches the binding with highest priority + specificity |
+| `tool_policy()` | Builds a `ToolPolicy` from `trust`, `allow_tools`, `deny_tools` |
+| `_apply_tool_policy()` | Swaps `agent.tools` to the allowed subset for this turn |
+| Agent turn | Model only sees the scoped tool list |
+| Restore | `agent.tools` reset to original regardless of outcome |
+
+---
+
+## Configuration Options
+
+### `RouteBinding` security fields
+
+For routing fields (`peer`, `role`, `channel_id`, `account`, `chat_type`, `priority`) see [Gateway Route Bindings](/docs/features/gateway-route-bindings).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `trust` | `Optional[str]` | `None` | `"untrusted"` \| `"standard"` \| `"trusted"`. Unknown values normalise to `"untrusted"` (fail-closed). |
+| `allow_tools` | `Optional[List[str]]` | `None` | Whitelist by exact tool name. `None` = allow all except deny rules. Accepts a YAML scalar or list. |
+| `deny_tools` | `Optional[List[str]]` | `None` | Exact tool names removed before the run. Layers on top of the trust tier's deny-list. Accepts a YAML scalar or list. |
+
+### `ToolPolicy` dataclass
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `allow_tools` | `Optional[Set[str]]` | `None` | Whitelist by exact name. `None` = allow all except deny rules. |
+| `deny_tools` | `Set[str]` | `set()` | Exact names removed. |
+| `deny_substrings` | `List[str]` | `[]` | Case-insensitive substrings; a tool whose name *contains* any of these is removed. Used by the `untrusted` tier. |
+
+### Module constants
+
+| Constant | Type | Description |
+|----------|------|-------------|
+| `UNTRUSTED_DENY_SUBSTRINGS` | `List[str]` | The 12 substrings the `untrusted` tier seeds: `shell`, `exec`, `command`, `subprocess`, `write_file`, `edit_file`, `delete_file`, `rm_file`, `delegate`, `handoff`, `cronjob`, `schedule`. |
+| `TRUST_TIERS` | `List[str]` | `["untrusted", "standard", "trusted"]` (least → most privileged). |
+
+Import from `praisonaiagents.gateway`:
+
+```python
+from praisonaiagents.gateway import (
+    RouteBinding, ToolPolicy, TRUST_TIERS, UNTRUSTED_DENY_SUBSTRINGS,
+)
+```
+
+---
+
+## Common Patterns
+
+**Lock down stranger DMs, keep operator at full power**
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.gateway import RouteBinding
+
+assistant = Agent(name="assistant", instructions="Help users.")
+
+bindings = [
+    RouteBinding(agent="assistant", chat_type="dm", trust="untrusted"),
+    RouteBinding(agent="assistant", peer="operator-123", trust="trusted"),
+]
+```
+
+Or in YAML:
+
+```yaml
+gateway:
+  routes:
+    - { chat_type: dm, agent: assistant, trust: untrusted }
+    - { peer: "operator-123", agent: assistant, trust: trusted }
+```
+
+**Channel-scoped policy — deny specific tools on #ops**
+
+```python
+from praisonaiagents.gateway import RouteBinding
+
+RouteBinding(
+    agent="assistant",
+    channel_id="ops",
+    deny_tools=["shell", "delete_file"],
+)
+```
+
+**Whitelist mode — only `search` on a public-facing route**
+
+```python
+from praisonaiagents.gateway import RouteBinding
+
+RouteBinding(
+    agent="assistant",
+    chat_type="group",
+    allow_tools=["search"],
+)
+```
+
+Only the `search` tool is offered. Everything else is withheld.
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Default new gateway routes to trust: untrusted">
+Opt *in* to power, not *out* of safety. Add `trust: untrusted` to every new route you create; promote to `standard` or `trusted` only when you have a clear need.
+
+```yaml
+gateway:
+  routes:
+    - { chat_type: dm, agent: assistant, trust: untrusted }   # safe by default
+```
+</Accordion>
+
+<Accordion title="Layer deny_tools on top of untrusted for project-specific tools">
+`UNTRUSTED_DENY_SUBSTRINGS` covers the 12 common dangerous families. Custom tools with names like `purge_cache` or `flush_queue` won't match any substring — add them explicitly.
+
+```python
+RouteBinding(
+    agent="assistant",
+    chat_type="dm",
+    trust="untrusted",
+    deny_tools=["purge_cache", "flush_queue"],
+)
+```
+</Accordion>
+
+<Accordion title="Never put your operator's peer on an untrusted binding">
+Pair `trust: trusted` (or omit `trust`) with your operator's stable `peer:` id. If you put an operator peer on `untrusted`, they will hit the conservative deny-list on every message.
+
+```yaml
+bindings:
+  - { peer: "operator-123", agent: assistant }          # trusted by default (no trust field)
+  - { chat_type: dm, agent: assistant, trust: untrusted }   # everyone else
+```
+</Accordion>
+
+<Accordion title="Audit UNTRUSTED_DENY_SUBSTRINGS for your tool families">
+Import the constant and check your tool names against it before deploying:
+
+```python
+from praisonaiagents.gateway import UNTRUSTED_DENY_SUBSTRINGS
+
+my_tools = ["search_web", "read_file", "send_email", "run_python"]
+for tool in my_tools:
+    blocked = any(sub in tool.lower() for sub in UNTRUSTED_DENY_SUBSTRINGS)
+    print(f"{tool}: {'BLOCKED on untrusted' if blocked else 'allowed'}")
+```
+
+Anything that bypasses the 12 substrings will leak through `trust: untrusted` unless you add an explicit `deny_tools` entry.
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Gateway Route Bindings" icon="route" href="/docs/features/gateway-route-bindings">
+    The routing surface this layers on — match by peer, role, channel, or chat type.
+  </Card>
+  <Card title="Approval" icon="shield" href="/docs/features/approval">
+    The second line of defence — require human confirmation before risky tool calls execute.
+  </Card>
+</CardGroup>

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -817,6 +817,12 @@ praisonai gateway channels --config gateway.yaml
 
 ---
 
+## Security
+
+Inbound gateway messages from strangers are the framework's largest prompt-injection surface. Use [Gateway Tool Policy](/docs/features/gateway-tool-policy) to scope the toolset advertised to the model per route — one line of YAML can prevent a stranger DM from triggering shell or file-mutation tools. Pair it with [Approval](/docs/features/approval) for a second line of defence on any tool that survives the policy.
+
+---
+
 ## Related
 
 <CardGroup cols={2}>

--- a/docs/features/platform-aware-agents.mdx
+++ b/docs/features/platform-aware-agents.mdx
@@ -304,4 +304,7 @@ Set `inject_session_context=False` when you don't want the agent to see platform
 <Card title="Messaging Bots" icon="robot" href="/docs/features/messaging-bots">
   Deploy AI agents to messaging platforms.
 </Card>
+<Card title="Gateway Tool Policy" icon="shield-check" href="/docs/features/gateway-tool-policy">
+  Scope the toolset per route — control what tools the model can use from different channels.
+</Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

- Creates `docs/features/gateway-tool-policy.mdx` — dedicated security page for the `ToolPolicy` / `UNTRUSTED_DENY_SUBSTRINGS` / `TRUST_TIERS` feature shipped in PraisonAI PR #2305
- Updates `docs/features/gateway-route-bindings.mdx` — adds `trust`, `allow_tools`, `deny_tools` to the config table; adds Quick Start step and Common Pattern for trust-tiered bindings
- Cross-link sweep: `gateway.mdx` (Security section), `bot-routing.mdx` (Related cards), `approval.mdx` (two-layer defence Note), `platform-aware-agents.mdx` (Related card)
- Adds `docs/features/gateway-tool-policy` to `docs.json` under Communication & Messaging group, after `gateway-route-bindings`

## What the new page covers

- Hero mermaid diagram following AGENTS.md §3.1 colour scheme
- Quick Start with 3 Steps (YAML, Python RouteBinding, explicit allow/deny)
- How It Works sequence diagram showing apply/restore flow
- Configuration tables for RouteBinding security fields, ToolPolicy dataclass, and module constants
- Common Patterns: lock down DMs, channel-scoped deny, whitelist mode
- Best Practices AccordionGroup: default to untrusted, layer deny_tools, protect operator peer, audit custom tool families
- Related CardGroup linking back to gateway-route-bindings and approval

Fixes #937

Generated with [Claude Code](https://claude.ai/code)