### PR TITLE
docs: surface checkpoint CLI, run rewind, multi-MCP, and custom commands

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -612,6 +612,7 @@
                   "docs/features/session-runtime-state",
                   "docs/features/stateful-agents",
                   "docs/features/checkpoints",
+                  "docs/features/run-rewind",
                   "docs/features/database-persistence",
                   "docs/features/advanced-memory",
                   "docs/features/vector-store",
@@ -714,6 +715,7 @@
                   "docs/features/mcp-tool-filtering",
                   "docs/features/mcp-client-protocol",
                   "docs/features/mcp-yaml-config",
+                  "docs/features/mcp-config",
                   "docs/features/runtime-mcp",
                   "docs/features/n8n-integration",
                   "docs/features/n8n-tools",
@@ -829,6 +831,7 @@
                 "group": "Advanced Features",
                 "icon": "gear",
                 "pages": [
+                  "docs/features/custom-commands",
                   "docs/features/cli",
                   "docs/features/run-stream-events",
                   "docs/features/cli-budget-handling",

--- a/docs/cli/checkpoint.mdx
+++ b/docs/cli/checkpoint.mdx
@@ -1,87 +1,268 @@
 ---
-title: "Checkpoints"
+title: "Checkpoint"
 sidebarTitle: "Checkpoint"
-description: "Shadow git checkpointing for file-level undo/restore"
+description: "Save, list, restore, diff, and delete file-level checkpoints of your workspace"
 icon: "clock-rotate-left"
 ---
 
-The `checkpoint` command manages file-level checkpoints using shadow git.
+Checkpoint snapshots your workspace so you can undo a bad run in one command.
+
+```mermaid
+graph LR
+    subgraph "Checkpoint workflow"
+        A[📋 Save checkpoint] --> B[🤖 Run agents]
+        B --> C{✅ Good result?}
+        C -->|Yes| D[Keep changes]
+        C -->|No| E[Restore checkpoint]
+        E --> F[⏮️ Back to safe state]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef proc fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef back fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class A input
+    class B,C proc
+    class D ok
+    class E,F back
+```
 
 ## Quick Start
 
+<Steps>
+<Step title="Save a checkpoint">
 ```bash
-# Save a checkpoint
-praisonai checkpoint save "Before refactoring"
+praisonai checkpoint save "before refactor"
 ```
+</Step>
 
-## Usage
-
-### Save Checkpoint
-
+<Step title="If something goes wrong, restore it">
 ```bash
-praisonai checkpoint save "Checkpoint message"
+praisonai checkpoint restore last
 ```
+</Step>
 
-**Expected Output:**
-```
-✅ Checkpoint saved: abc12345
-   Message: Before refactoring
-   Files changed: 3
-```
-
-### List Checkpoints
-
-```bash
-praisonai checkpoint list
-```
-
-**Expected Output:**
-```
-╭─ Checkpoints ────────────────────────────────────────────────────────────────╮
-│  1. [abc12345] Before refactoring (2024-12-24 07:30:00)                     │
-│  2. [def67890] Initial state (2024-12-24 07:25:00)                          │
-╰──────────────────────────────────────────────────────────────────────────────╯
-```
-
-### Show Diff
-
+<Step title="See what changed">
 ```bash
 praisonai checkpoint diff
-praisonai checkpoint diff abc12345
-praisonai checkpoint diff abc12345 def67890
 ```
+</Step>
+</Steps>
 
-### Restore Checkpoint
+---
+
+## Commands
+
+### `save`
+
+Snapshot the current workspace.
 
 ```bash
+praisonai checkpoint save <message> [OPTIONS]
+```
+
+| Argument / Flag | Type | Default | Description |
+|---|---|---|---|
+| `<message>` | string | required | Label for this checkpoint |
+| `--allow-empty` | bool | `false` | Save even when no files changed |
+| `--workspace, -w` | path | cwd | Directory to snapshot |
+
+```bash
+# Save with a message
+praisonai checkpoint save "before adding new feature"
+
+# Save even if nothing changed (useful for scripting)
+praisonai checkpoint save "baseline" --allow-empty
+
+# Save a specific directory
+praisonai checkpoint save "hotfix" --workspace /path/to/project
+```
+
+---
+
+### `list`
+
+Show checkpoints for the workspace, newest first.
+
+```bash
+praisonai checkpoint list [OPTIONS]
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--limit, -n` | int | `20` | Maximum number of checkpoints to show |
+| `--workspace, -w` | path | cwd | Workspace directory |
+
+```bash
+# List the last 20 checkpoints
+praisonai checkpoint list
+
+# Show more
+praisonai checkpoint list --limit 50
+
+# List checkpoints for a specific project
+praisonai checkpoint list -w /path/to/project
+```
+
+---
+
+### `restore`
+
+Restore the workspace to a checkpoint. **Destructive — overwrites current files.**
+
+```bash
+praisonai checkpoint restore <id|last> [OPTIONS]
+```
+
+| Argument / Flag | Type | Description |
+|---|---|---|
+| `<id\|last>` | string | Checkpoint to restore. See [Ref resolution](#ref-resolution) below |
+| `--workspace, -w` | path | Workspace directory (default: cwd) |
+
+```bash
+# Restore the most recent checkpoint
+praisonai checkpoint restore last
+
+# Restore by short ID
 praisonai checkpoint restore abc12345
+
+# Restore by unique ID prefix
+praisonai checkpoint restore abc12
 ```
 
-## Python API
+---
 
-```python
-import asyncio
-from praisonaiagents.checkpoints import CheckpointService
+### `diff`
 
-async def main():
-    service = CheckpointService(workspace_dir="/path/to/project")
-    await service.initialize()
-    
-    # Save checkpoint
-    result = await service.save("Before changes")
-    print(f"Saved: {result.checkpoint.short_id}")
-    
-    # List checkpoints
-    checkpoints = await service.list_checkpoints()
-    for cp in checkpoints:
-        print(f"{cp.short_id}: {cp.message}")
-    
-    # Restore
-    await service.restore(result.checkpoint.id)
+Show what changed between checkpoints or against the working directory.
 
-asyncio.run(main())
+```bash
+praisonai checkpoint diff [from] [to] [OPTIONS]
 ```
 
-## See Also
+| Argument / Flag | Description |
+|---|---|
+| `[from]` | Starting ref (default: previous checkpoint). Accepts same refs as `restore` |
+| `[to]` | Ending ref (default: working directory). Accepts same refs as `restore` |
+| `--workspace, -w` | Workspace directory (default: cwd) |
 
-- [Shadow Git Checkpointing Feature](/docs/features/checkpoints)
+```bash
+# Working dir vs. previous checkpoint
+praisonai checkpoint diff
+
+# Working dir vs. a specific checkpoint
+praisonai checkpoint diff abc12345
+
+# Between two checkpoints
+praisonai checkpoint diff abc12345 def67890
+
+# Using 'last' as ref
+praisonai checkpoint diff last
+```
+
+---
+
+### `delete`
+
+Delete **all** checkpoints for the workspace. Prompts for confirmation unless `--yes` is passed.
+
+```bash
+praisonai checkpoint delete [OPTIONS]
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--yes, -y` | bool | `false` | Skip confirmation prompt |
+| `--workspace, -w` | path | cwd | Workspace directory |
+
+```bash
+# Delete all checkpoints (prompts for confirmation)
+praisonai checkpoint delete
+
+# Delete without prompting (CI-safe)
+praisonai checkpoint delete --yes
+```
+
+<Warning>
+`delete` removes **all** checkpoints for the workspace — there is no per-checkpoint delete. Use with care.
+</Warning>
+
+---
+
+## Ref Resolution
+
+`restore` and `diff` both accept the same checkpoint references:
+
+| Ref | Resolves to |
+|---|---|
+| `last` or `latest` | The newest checkpoint in the workspace |
+| exact full ID | That checkpoint |
+| exact short ID | That checkpoint |
+| unique prefix | That checkpoint, if only one matches |
+| ambiguous prefix | **Rejected** — prints error, exits 1 |
+
+```bash
+# These all work (assuming unique matches)
+praisonai checkpoint restore last
+praisonai checkpoint restore abc12345678
+praisonai checkpoint restore abc12345
+praisonai checkpoint restore abc1
+```
+
+<Note>
+Ambiguous prefixes are always rejected. If `abc1` matches two checkpoints you get:
+```
+Error: Ambiguous checkpoint reference: abc1
+```
+Use more characters until the prefix is unique.
+</Note>
+
+---
+
+## Exit Codes
+
+All subcommands exit `0` on success and `1` on any error (missing checkpoint, ambiguous ref, I/O failure).
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Save before any risky operation">
+Run `praisonai checkpoint save "before X"` before bulk edits, code generation, or anything that touches many files. Then use `praisonai run --restore last` to undo if needed.
+</Accordion>
+
+<Accordion title="Use meaningful messages">
+`save "before adding payments module"` is more useful than `save "wip"` when you're scanning `checkpoint list` a week later.
+</Accordion>
+
+<Accordion title="Let YAML runs auto-checkpoint">
+`praisonai run agents.yaml` already auto-checkpoints before it runs (tagged `run:<run_id>`). You only need manual `save` when you want to snapshot mid-session or before a non-agent edit.
+</Accordion>
+
+<Accordion title="Use --yes only in CI">
+`checkpoint delete --yes` deletes everything with no way to undo. Reserve it for CI cleanup scripts.
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Rewind a Run" icon="clock-rotate-left" href="/docs/features/run-rewind">
+User-flow guide: auto-checkpoint, run, restore last.
+</Card>
+<Card title="Run Command" icon="play" href="/docs/cli/run">
+`--restore` and `--no-checkpoint` flags on `praisonai run`.
+</Card>
+<Card title="Shadow Git Checkpointing" icon="code-branch" href="/docs/features/checkpoints">
+SDK-level checkpoint service internals.
+</Card>
+<Card title="Session" icon="history" href="/docs/cli/session">
+Session continuity across runs.
+</Card>
+</CardGroup>

--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -45,6 +45,8 @@ praisonai run [OPTIONS] [TARGET]
 | `--permissions` | | Path to a YAML permission rules file | |
 | `--permission-default` | | Default action for unmatched patterns: `allow`, `deny`, or `ask` | |
 | `--approval` | | Approval backend mode: `console`, `plan`, `accept-edits`, `bypass` | |
+| `--restore` | | Rewind the workspace to a checkpoint (`last` or an ID) and exit | |
+| `--no-checkpoint` | | Skip the automatic pre-run snapshot for this run | |
 
 ## Output Modes
 
@@ -456,8 +458,96 @@ Sessions are scoped to the **current project** (git root, or current directory i
 Use `praisonai session list` to view saved sessions for the current project, or `praisonai session list --all` to see sessions across all projects.
 </Note>
 
+---
+
+## Rewind & Auto-Checkpoint
+
+`praisonai run agents.yaml` automatically snapshots your workspace **before** every YAML-file run, so any bad output can be undone in one command.
+
+```mermaid
+graph LR
+    subgraph "Run with safety net"
+        A[📋 praisonai run agents.yaml] --> B[💾 Auto-checkpoint]
+        B --> C[🤖 Agent runs]
+        C --> D{✅ Looks good?}
+        D -->|Yes| E[Keep changes]
+        D -->|No| F[praisonai run --restore last]
+        F --> G[⏮️ Back to pre-run state]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef proc fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef back fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class A input
+    class B,C proc
+    class D,E ok
+    class F,G back
+```
+
+### `--restore <id|last>`
+
+Rewinds the workspace to a checkpoint and **exits before the agent runs** — it is a pure undo, not a run.
+
+```bash
+# Undo the most recent auto-checkpoint
+praisonai run --restore last
+
+# Restore a specific checkpoint by ID or prefix
+praisonai run --restore abc12345
+```
+
+Accepts the same refs as `praisonai checkpoint restore`: `last`, `latest`, exact ID, short ID, or a unique prefix. Ambiguous prefixes are always rejected.
+
+### `--no-checkpoint`
+
+Skip the automatic pre-run snapshot for this run only.
+
+```bash
+praisonai run agents.yaml --no-checkpoint
+```
+
+### Auto-checkpoint behaviour
+
+| Behaviour | Detail |
+|---|---|
+| **Applies to** | YAML-file runs (`agents.yaml`, `*.yml`) only |
+| **Skipped for** | Plain-prompt runs (`praisonai run "do X"`) — they don't mutate project files |
+| **Label** | Tagged `run:<run_id>` so you can match it to log output |
+| **On failure** | Best-effort — any error (no git, protected path, no changes) is silently swallowed. Never blocks the run. With `--verbose`, failures are printed as info messages |
+| **Default** | On — disable globally with `checkpoints.auto: false` in project config, or per-run with `--no-checkpoint` |
+
+### Project config
+
+Control auto-checkpoint globally in `.praisonai/config.yaml`:
+
+```yaml
+checkpoints:
+  auto: true    # default — snapshot before every YAML-file run
+  # auto: false # opt out; --no-checkpoint does the same per-run
+```
+
+### User-flow example
+
+```bash
+# Day in the life:
+praisonai run agents.yaml          # auto-snapshot taken silently first
+
+# ...the agent wrote junk to your files...
+
+praisonai run --restore last       # undo — back to pre-run state
+
+# Inspect the history
+praisonai checkpoint list
+```
+
+---
+
 ## See Also
 
+- [Rewind a Run](/docs/features/run-rewind) - Full guide to auto-checkpoint + restore workflow
+- [Checkpoint](/docs/cli/checkpoint) - Manual checkpoint commands (save / list / diff / delete)
 - [Session](/docs/cli/session) - Session management commands
 - [Project-Scoped Sessions](/docs/features/project-sessions) - How project sessions work
 - [Agents](/docs/cli/agents) - Agent management

--- a/docs/features/custom-commands.mdx
+++ b/docs/features/custom-commands.mdx
@@ -1,0 +1,325 @@
+---
+title: "Custom Commands"
+sidebarTitle: "Custom Commands"
+description: "Reusable prompt templates in .praisonai/commands/ with variable interpolation and opt-in shell substitution"
+icon: "file-code"
+---
+
+Custom commands are Markdown templates stored in `.praisonai/commands/` that expand into full prompts when you run `praisonai run --command <name>`.
+
+```mermaid
+graph LR
+    subgraph "Custom command flow"
+        A[📋 praisonai run --command summarise] --> B[📄 Load template]
+        B --> C[🔧 Interpolate: $ARGUMENTS, @file, !cmd]
+        C --> D[🤖 Agent runs expanded prompt]
+        D --> E[✅ Result]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef proc fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A input
+    class B,C proc
+    class D,E ok
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Create a command template">
+```bash
+mkdir -p .praisonai/commands
+```
+
+```markdown
+# .praisonai/commands/summarise.md
+Summarise the following text in three bullet points:
+
+$ARGUMENTS
+```
+</Step>
+
+<Step title="Run the command">
+```bash
+praisonai run --command summarise "Long article text goes here"
+```
+
+`$ARGUMENTS` is replaced with the text you pass as `TARGET`.
+</Step>
+
+<Step title="Add frontmatter for metadata">
+```markdown
+---
+description: "Summarise text into three bullet points"
+---
+
+Summarise the following text in three bullet points:
+
+$ARGUMENTS
+```
+</Step>
+</Steps>
+
+---
+
+## Template Interpolation
+
+| Syntax | Behaviour |
+|---|---|
+| `$ARGUMENTS` | Replaced with the text passed as `TARGET` on the CLI |
+| `@path/to/file` | Replaced with the contents of that file (relative to the project root) |
+| `$(...)` | **Always escaped** — never executed (literal `\$(...)` in output) |
+| `` !`cmd` `` | Opt-in live shell output — **disabled by default** (see [Shell Substitution](#shell-substitution)) |
+
+### `$ARGUMENTS`
+
+```markdown
+Review this code:
+
+$ARGUMENTS
+```
+
+```bash
+praisonai run --command review "function foo() { return 42; }"
+```
+
+### `@file` inclusion
+
+Inline the contents of a file at template load time:
+
+```markdown
+Here is the current diff:
+
+@git-diff.txt
+
+Suggest a commit message.
+```
+
+File paths are resolved relative to the project root and sandboxed — paths that escape the root are left as-is.
+
+### `$(...)` escape
+
+`$(shell)` syntax is **always escaped** to prevent accidental command execution. The literal string `$(date)` in a template becomes `\$(date)` in the expanded prompt — safe to pass to the LLM as-is.
+
+---
+
+## Shell Substitution
+
+Live shell output can be embedded in templates with `` !`cmd` ``. This is **disabled by default** for security.
+
+```markdown
+---
+allow_shell: true
+---
+
+Here is the current git diff:
+
+!`git diff HEAD`
+
+Write a commit message for these changes.
+```
+
+### Enabling shell substitution
+
+Enable it with any of these (listed from lowest to highest precedence):
+
+| Method | How |
+|---|---|
+| **Project config** | Set `commands.allow_shell: true` in `.praisonai/config.yaml` |
+| **Environment variable** | `PRAISONAI_ALLOW_SHELL=true` |
+| **Per-command frontmatter** | `allow_shell: true` in the command's `.md` file |
+| **Programmatic** | `interpolate(..., allow_shell=True)` in Python |
+
+### Project config
+
+```yaml
+# .praisonai/config.yaml
+commands:
+  allow_shell: true
+```
+
+### Environment variable
+
+```bash
+PRAISONAI_ALLOW_SHELL=true praisonai run --command commit "wip"
+```
+
+### Per-command frontmatter
+
+```markdown
+---
+description: "Generate a commit message from the current diff"
+allow_shell: true
+---
+
+Here is the current diff:
+
+!`git diff HEAD`
+
+Write a conventional commit message for these changes.
+```
+
+### What happens when it's disabled?
+
+If a template contains `` !`cmd` `` but shell execution is not enabled, you get a clear error:
+
+```
+Error: Command template contains live shell substitution (!`...`) but
+shell execution is not enabled. Enable it with PRAISONAI_ALLOW_SHELL=true,
+the `commands.allow_shell` config flag, or `allow_shell: true` in the
+command's frontmatter.
+```
+
+The command does **not** silently escape or skip the substitution — the error is intentional.
+
+### Safety bounds
+
+| Bound | Value |
+|---|---|
+| **Timeout** | 30 seconds |
+| **Stdout cap** | 100 KB |
+| **Execution order** | Shell substitutions run on the original template, before `$ARGUMENTS` and `@file` injection — untrusted input can never introduce a `` !`cmd` `` that gets executed |
+
+---
+
+## File Layout
+
+```
+~/.praisonai/commands/          # user-global (all projects)
+  summarise.md
+  commit.md
+
+.praisonai/commands/            # project-level (this project)
+  review.md
+  changelog.md
+```
+
+**Discovery order:** user-global first, then project-level. Project-level wins on name collision.
+
+---
+
+## Frontmatter Fields
+
+```markdown
+---
+description: "Human-readable description shown in listings"
+allow_shell: true               # opt-in live !`cmd` execution (default: false)
+---
+
+Template body goes here.
+$ARGUMENTS
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `description` | string | — | Shown in `praisonai command list` |
+| `allow_shell` | bool | `false` | Enable `` !`cmd` `` substitution for this command |
+
+---
+
+## Examples
+
+### Commit message generator
+
+```markdown
+---
+description: "Generate a conventional commit message from the staged diff"
+allow_shell: true
+---
+
+Write a conventional commit message for the following diff:
+
+!`git diff --staged`
+
+Rules:
+- Use feat/fix/docs/chore/refactor prefix
+- One-line summary, 72 chars max
+- No body unless the change is complex
+```
+
+```bash
+git add -A
+praisonai run --command commit
+```
+
+### Code review
+
+```markdown
+---
+description: "Review a file or snippet for bugs and style issues"
+---
+
+Review this code for bugs, security issues, and style problems:
+
+$ARGUMENTS
+
+Provide specific, actionable feedback with line references where possible.
+```
+
+```bash
+praisonai run --command review "$(cat src/auth.py)"
+```
+
+### Changelog entry
+
+```markdown
+---
+description: "Draft a changelog entry from recent commits"
+allow_shell: true
+---
+
+Draft a changelog entry (keep-a-changelog format) based on these recent commits:
+
+!`git log --oneline -20`
+
+Group changes into Added / Changed / Fixed / Removed.
+```
+
+```bash
+praisonai run --command changelog
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Enable shell substitution only where needed">
+Use per-command `allow_shell: true` frontmatter rather than the project-wide config flag. This limits the scope of live shell execution to the specific commands that need it.
+</Accordion>
+
+<Accordion title="Keep shell commands simple and deterministic">
+`` !`git diff HEAD` `` is safe. `` !`curl https://...` `` in a shared config is a security risk. Prefer reading local files or running version-control commands.
+</Accordion>
+
+<Accordion title="Put user-global commands in ~/.praisonai/commands/">
+Commands useful across all projects (commit, review, summarise) belong in the user-global directory. Project-specific commands go in `.praisonai/commands/`.
+</Accordion>
+
+<Accordion title="Use $ARGUMENTS for the variable part, @file for static context">
+Pass the input the user provides via `$ARGUMENTS` and load static files (style guide, schema, existing code) via `@file`. This gives a clean separation between user input and template context.
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Run Command" icon="play" href="/docs/cli/run">
+`--command` flag and how `TARGET` maps to `$ARGUMENTS`.
+</Card>
+<Card title="Custom Agents" icon="user" href="/docs/cli/agent">
+Named agent definitions in `.praisonai/agents/`.
+</Card>
+<Card title="Command CLI" icon="terminal" href="/docs/cli/command">
+`praisonai command` — list and inspect defined commands.
+</Card>
+<Card title="Permissions" icon="shield" href="/docs/cli/permissions">
+Control what tools agents can use when running a command.
+</Card>
+</CardGroup>

--- a/docs/features/mcp-config.mdx
+++ b/docs/features/mcp-config.mdx
@@ -1,0 +1,232 @@
+---
+title: "MCP Project Config"
+sidebarTitle: "MCP Project Config"
+description: "Wire multiple local and remote MCP servers via project YAML config"
+icon: "plug"
+---
+
+Declare any number of MCP servers in `.praisonai/config.yaml` and every enabled one is wired automatically when you run `praisonai run`.
+
+```mermaid
+graph LR
+    subgraph "Multi-MCP run"
+        A[📋 praisonai run agents.yaml] --> B[🔧 Config loader]
+        B --> C[Local stdio server]
+        B --> D[Remote URL server]
+        C --> E[🤖 Agent]
+        D --> E
+        E --> F[✅ Result]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef proc fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A input
+    class B,C,D proc
+    class E,F ok
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Create .praisonai/config.yaml in your project">
+```yaml
+mcp:
+  servers:
+    filesystem:
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "."]
+      enabled: true
+```
+</Step>
+
+<Step title="Run — the MCP server is wired automatically">
+```bash
+praisonai run "List the files in src/"
+```
+
+No `--mcp` flag needed. All `enabled: true` servers from config are attached.
+</Step>
+
+<Step title="Add a remote server alongside it">
+```yaml
+mcp:
+  servers:
+    filesystem:
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "."]
+      enabled: true
+    notion:
+      type: remote
+      url: "https://mcp.notion.com/v1/sse"
+      headers:
+        Authorization: "Bearer ${NOTION_TOKEN}"
+      enabled: true
+```
+
+Both servers are wired on the next run.
+</Step>
+</Steps>
+
+---
+
+## Config Schema
+
+```yaml
+mcp:
+  servers:
+    <server-name>:            # arbitrary name — used in logs
+      # ── Local stdio server ──────────────────────────────────
+      command: "npx"          # executable (must be in allowed list)
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+      env:
+        FOO: "bar"            # injected into the server process
+      timeout: 30000          # milliseconds (converted to seconds internally)
+      enabled: true           # omit or set false to skip
+
+      # ── Remote URL server ───────────────────────────────────
+      type: remote            # or omit and just provide 'url'
+      url: "https://mcp.example.com/v1/sse"
+      headers:
+        Authorization: "Bearer ${MY_TOKEN}"
+      timeout: 60000
+      enabled: true
+```
+
+### Full example
+
+```yaml
+mcp:
+  servers:
+    filesystem:
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+      env:
+        FOO: "bar"
+      timeout: 30000
+      enabled: true
+    notion:
+      type: remote
+      url: "https://mcp.notion.com/v1/sse"
+      headers:
+        Authorization: "Bearer ${NOTION_TOKEN}"
+      timeout: 60000
+      enabled: true
+    github:
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-github"]
+      env:
+        GITHUB_TOKEN: "${GITHUB_TOKEN}"
+      enabled: true
+    disabled_server:
+      command: "npx"
+      args: ["-y", "@some/mcp-server"]
+      enabled: false          # skipped entirely
+```
+
+---
+
+## Server Types
+
+### Local stdio server
+
+Spawns a subprocess and communicates over stdin/stdout.
+
+```yaml
+filesystem:
+  command: "npx"                          # required
+  args: ["-y", "@modelcontextprotocol/server-filesystem", "."]
+  env:
+    API_KEY: "${MY_KEY}"                  # optional env vars
+  timeout: 30000                          # ms; default 30 s
+  enabled: true
+```
+
+**Allowed executables:** `npx`, `node`, `python`, `python3`, `uvx`, `uv`, `docker`, `deno`, `bun`, `pipx`.
+
+Inline code-execution flags (`python -c`, `node -e`, `deno eval`) are blocked for security.
+
+### Remote URL server
+
+Connects to an MCP server over HTTP-stream, SSE, or WebSocket.
+
+```yaml
+notion:
+  type: remote                            # or omit — just provide 'url'
+  url: "https://mcp.notion.com/v1/sse"
+  headers:
+    Authorization: "Bearer ${NOTION_TOKEN}"
+  timeout: 60000
+  enabled: true
+```
+
+<Note>
+Custom `headers` are not forwarded for legacy SSE URLs ending in `/sse`. The CLI prints a warning if headers are declared for such a URL.
+</Note>
+
+---
+
+## Mixing Config Servers and `--mcp`
+
+An explicit `--mcp` flag on the command line **merges alongside** config servers — it does not replace them.
+
+```bash
+# Config has two servers; this run adds a third on the fly
+praisonai run "do X" --mcp "npx -y @another/mcp-server"
+```
+
+---
+
+## Behaviour Reference
+
+| Property | Behaviour |
+|---|---|
+| **All enabled servers** | Both local stdio and remote URL servers are wired |
+| **disabled servers** | `enabled: false` skips the server entirely |
+| **`--mcp` flag** | Merged alongside config servers, not replaced |
+| **Timeout** | Config value is in ms; internally converted to seconds |
+| **Security** | Stdio commands are validated against the executable allowlist |
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Use environment variable references for secrets">
+Store tokens in env vars (`${NOTION_TOKEN}`) rather than hardcoding them in config. The config file is often committed to git.
+</Accordion>
+
+<Accordion title="Set enabled: false to temporarily disable a server">
+Comment-free way to switch a server off without deleting its config. Flip back to `true` when you need it.
+</Accordion>
+
+<Accordion title="Name servers descriptively">
+The name appears in log output. `notion` is easier to debug than `server1`.
+</Accordion>
+
+<Accordion title="Tune timeouts per server">
+Remote servers that do heavy processing may need a longer timeout (`timeout: 120000`). Local stdio servers usually work fine with the 30 s default.
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="MCP CLI" icon="terminal" href="/docs/cli/mcp">
+Ad-hoc `--mcp` flag and MCP CLI commands.
+</Card>
+<Card title="Run Command" icon="play" href="/docs/cli/run">
+`praisonai run` flags and project config integration.
+</Card>
+<Card title="MCP Feature" icon="plug" href="/docs/concepts/mcp">
+MCP protocol overview and SDK integration.
+</Card>
+<Card title="MCP YAML Config" icon="file-code" href="/docs/features/mcp-yaml-config">
+YAML-based MCP configuration for agent files.
+</Card>
+</CardGroup>

--- a/docs/features/run-rewind.mdx
+++ b/docs/features/run-rewind.mdx
@@ -1,0 +1,177 @@
+---
+title: "Rewind a Run"
+sidebarTitle: "Rewind a Run"
+description: "Auto-checkpoint before every YAML run and undo bad outputs with one command"
+icon: "clock-rotate-left"
+---
+
+`praisonai run agents.yaml` snapshots your workspace before the agent touches anything — restoring is one command.
+
+```mermaid
+graph LR
+    subgraph "Run with safety net"
+        A[📋 praisonai run agents.yaml] --> B[💾 Auto-checkpoint]
+        B --> C[🤖 Agent runs]
+        C --> D{✅ Looks good?}
+        D -->|Yes| E[Keep changes]
+        D -->|No| F[praisonai run --restore last]
+        F --> G[⏮️ Back to pre-run state]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef proc fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef back fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class A input
+    class B,C proc
+    class D,E ok
+    class F,G back
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Run your agents — a snapshot is taken automatically">
+```bash
+praisonai run agents.yaml
+```
+
+Before the agent starts, the CLI silently checkpoints the directory containing your YAML file, tagged `run:<run_id>`. No configuration needed.
+</Step>
+
+<Step title="Something went wrong? Undo it">
+```bash
+praisonai run --restore last
+```
+
+Restores every file in the workspace to the state it was in before the last run. The agent does **not** run — `--restore` exits after the undo.
+</Step>
+
+<Step title="Check the checkpoint history">
+```bash
+praisonai checkpoint list
+```
+
+Shows all saved snapshots, newest first. Auto-checkpoints are tagged `run:<run_id>` so you can tell them apart from manual saves.
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+Auto-checkpoint fires once per YAML-file run, **before** the first agent action.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Checkpoint as CheckpointService
+    participant Agent
+
+    User->>CLI: praisonai run agents.yaml
+    CLI->>Checkpoint: save("run:abc123", allow_empty=false, quiet=true)
+    Note over Checkpoint: Silently skips if nothing changed,<br/>no git, or protected path
+    Checkpoint-->>CLI: ok (or silently swallowed error)
+    CLI->>Agent: run agents.yaml
+    Agent-->>User: result
+
+    classDef user fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef cli fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef cp fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ag fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class User user
+    class CLI cli
+    class Checkpoint cp
+    class Agent ag
+```
+
+| Property | Behaviour |
+|---|---|
+| **When** | Before every `.yaml` / `.yml` run (YAML-file mode only) |
+| **Not triggered by** | Plain-prompt runs (`praisonai run "do X"`) — they don't touch project files |
+| **Scoped to** | The directory containing the YAML file, not the cwd |
+| **Best-effort** | Any error (no git, protected path, no changes) is swallowed silently |
+| **Verbose mode** | With `--verbose`, swallowed errors are printed as info |
+| **Tagged** | `run:<run_id>` to correlate with logs |
+
+---
+
+## Configuration
+
+### Disable auto-checkpoint for a single run
+
+```bash
+praisonai run agents.yaml --no-checkpoint
+```
+
+### Disable globally via project config
+
+Add a `checkpoints:` block to `.praisonai/config.yaml`:
+
+```yaml
+checkpoints:
+  auto: false   # opt out globally
+```
+
+`--no-checkpoint` does the same thing per-run and takes precedence over config.
+
+### Restore to a specific checkpoint
+
+```bash
+# Most recent checkpoint
+praisonai run --restore last
+
+# By short ID (from checkpoint list)
+praisonai run --restore abc12345
+
+# By unique prefix
+praisonai run --restore abc1
+```
+
+Ambiguous prefixes are always **rejected** — never a silent wrong restore.
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Don't disable auto-checkpoint unless you have a reason">
+The snapshot is silent and only fires when something changed. The cost is negligible; the undo value is high.
+</Accordion>
+
+<Accordion title="Manual save before risky non-agent edits">
+`praisonai run agents.yaml` auto-checkpoints before agent runs, but not before you manually edit files. Use `praisonai checkpoint save "before X"` before any risky manual operation.
+</Accordion>
+
+<Accordion title="Why ambiguous prefix matches are rejected">
+`--restore abc1` matching two checkpoints could silently restore the wrong one. The CLI always prints an error and exits 1 — use more characters until the prefix is unique, or use `last`.
+</Accordion>
+
+<Accordion title="Auto-checkpoint never blocks your run">
+If the snapshot fails (network drive, no write permission, no git, nothing changed), the CLI swallows the error and continues to the agent run. Use `--verbose` to surface the reason.
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Checkpoint CLI" icon="terminal" href="/docs/cli/checkpoint">
+Full reference: save, list, restore, diff, delete — all flags.
+</Card>
+<Card title="Run Command" icon="play" href="/docs/cli/run">
+All `praisonai run` options, including `--restore` and `--no-checkpoint`.
+</Card>
+<Card title="Shadow Git Checkpointing" icon="code-branch" href="/docs/features/checkpoints">
+SDK-level checkpoint internals.
+</Card>
+<Card title="Session Continuity" icon="history" href="/docs/features/project-sessions">
+Pick up where you left off across runs.
+</Card>
+</CardGroup>


### PR DESCRIPTION
Fixes #938

## Summary

Documentation for three CLI PRs that landed on 2026-06-26 (PRs #2309, #2311, #2306).

### Changes

- **docs/cli/checkpoint.mdx** — Complete rewrite with all subcommand flags, ref-resolution table, ambiguous-prefix rejection, exit codes, best-practices accordion, and related card group.

- **docs/cli/run.mdx** — New 'Rewind & Auto-Checkpoint' section with --restore and --no-checkpoint flags, auto-checkpoint behaviour table, checkpoints.auto project config, user-flow example, and Mermaid diagram.

- **docs/features/run-rewind.mdx** (new) — User-flow page: hero Mermaid, Steps quick start, sequence diagram, configuration section, AccordionGroup, CardGroup.

- **docs/features/mcp-config.mdx** (new) — Multi-MCP project YAML config: local stdio + remote URL schemas, full example, security notes.

- **docs/features/custom-commands.mdx** (new) — Full .praisonai/commands/ template system: interpolation patterns, opt-in shell substitution with all 4 enablement paths, safety bounds, examples.

- **docs.json** — Navigation: run-rewind in State & Sessions, mcp-config in Integrations, custom-commands in Advanced Features.

Generated with [Claude Code](https://claude.ai/code)