### PR TITLE
docs: update for gateway max_queued_frames, SLOW_CONSUMER close, and effectively-once delivery

### DIFF
--- a/docs/features/bot-platform-capabilities.mdx
+++ b/docs/features/bot-platform-capabilities.mdx
@@ -109,6 +109,8 @@ sequenceDiagram
 | `supported_file_types` | `List[str]` | `["*"]` | Allowed mime types or extensions |
 | `accepts_webhooks` | `bool` | `False` | Channel receives inbound HTTP webhooks |
 | `verifies_webhook_signature` | `bool` | `False` | Adapter exposes a webhook verifier |
+| `reconciles_unknown_send` | `bool` | `False` | Adapter can confirm whether a prior send actually landed (via `was_delivered(idempotency_key)`). Enables effectively-once delivery via the durable outbox. |
+| `supports_idempotency_token` | `bool` | `False` | **Informational** — transport accepts a provider-level idempotency token. Set `reconciles_unknown_send` as well if you need effectively-once. |
 
 Methods: `to_dict()` and `from_dict(data)`.
 
@@ -167,6 +169,9 @@ Keeps registry caching consistent when platforms override defaults.
 ## Related
 
 <CardGroup cols={2}>
+  <Card title="Durable Outbound Delivery" icon="shield-check" href="/docs/features/durable-delivery#effectively-once-delivery">
+    Effectively-once delivery via crash reconciliation
+  </Card>
   <Card title="Bot Platform Plugins" icon="puzzle-piece" href="/docs/features/bot-platform-plugins">
     Register custom adapters
   </Card>

--- a/docs/features/durable-delivery.mdx
+++ b/docs/features/durable-delivery.mdx
@@ -115,7 +115,105 @@ sequenceDiagram
     end
 ```
 
-Each message moves through statuses: `pending` → `sending` → `sent` (or `failed` / `permanent_failure`). On startup, stale `sending` entries are reset to `pending` automatically so crashes never leave orphaned rows.
+Each message moves through statuses: `pending` → `sending` → `sent` (or `failed` / `permanent_failure`).
+
+### State Machine
+
+The outbox tracks six statuses: `pending`, `sending`, `recovered`, `sent`, `failed`, and `permanent_failure`.
+
+On restart, stale `sending` entries transition to **`recovered`** instead of `pending`. This preserves the information that the send was in-flight when the crash occurred.
+
+```
+status = 'sending'  (crash)  ──►  status = 'recovered'  (on restart)
+```
+
+`recovered` entries are retryable like `pending`, but when a reconciler is supplied to `drain()`, they are offered to it first — allowing adapters that can check the platform to confirm delivery and avoid re-sending an already-delivered message (**effectively-once**). Without a reconciler, `recovered` entries are re-sent as normal (at-least-once, unchanged behaviour).
+
+<Note>
+Status-update writes (`mark_sent`, `mark_failed`, `_claim_entry`) now call `conn.commit()`. Without this, a terminal status could be lost on a crash, causing an already-delivered message to be redelivered. This is a reliability fix — no API change is required.
+</Note>
+
+---
+
+## Effectively-Once Delivery
+
+Adapters that can confirm whether a prior send actually landed can upgrade durable delivery from at-least-once to effectively-once.
+
+```mermaid
+sequenceDiagram
+    participant Adapter as 🤖 Adapter
+    participant Queue as 💾 OutboundQueue
+    participant Provider as 📱 Platform
+
+    Note over Queue: status = 'sending'
+    Adapter--xProvider: 💥 crash mid-send
+    Note over Queue: on restart → 'recovered'
+    Adapter->>Queue: drain_pending() (with reconciler)
+    Queue->>Adapter: reconciler(entry)
+    Adapter->>Provider: was_delivered(idempotency_key)
+    alt Provider says delivered
+        Provider-->>Adapter: True
+        Adapter-->>Queue: True → mark_sent (NO resend)
+    else Provider says not delivered
+        Provider-->>Adapter: False
+        Queue->>Provider: resend
+    end
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef queue fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef platform fill:#189AB4,stroke:#7C90A0,color:#fff
+```
+
+<Steps>
+<Step title="Declare the capability">
+Set `reconciles_unknown_send=True` on `PlatformCapabilities`:
+
+```python
+from praisonaiagents.bots import PlatformCapabilities
+
+class MyAdapter(DurableAdapterMixin):
+    platform_capabilities = PlatformCapabilities(
+        reconciles_unknown_send=True,
+    )
+```
+</Step>
+
+<Step title="Implement was_delivered">
+Add an async method that checks the platform for a prior send:
+
+```python
+async def was_delivered(self, idempotency_key: str) -> bool:
+    status = await my_provider.get_message_status(idempotency_key)
+    return status == "sent"
+```
+</Step>
+
+<Step title="Call drain_pending() at startup">
+`DurableDelivery` auto-wires the reconciler from the adapter's capability — no extra configuration required:
+
+```python
+from praisonaiagents.bots import PlatformCapabilities
+from praisonai.bots._adapter_base import DurableAdapterMixin
+
+
+class AcmeAdapter(DurableAdapterMixin):
+    platform_capabilities = PlatformCapabilities(
+        reconciles_unknown_send=True,
+    )
+
+    async def was_delivered(self, idempotency_key: str) -> bool:
+        status = await acme_client.messages.lookup(idempotency_key)
+        return status.delivered
+
+    async def send_message(self, channel_id: str, content: str) -> None:
+        await acme_client.messages.send(channel_id, content)
+
+
+# DurableDelivery picks up the reconciler automatically.
+succeeded, failed = await adapter.drain_outbox()
+```
+</Step>
+</Steps>
 
 ---
 
@@ -159,6 +257,24 @@ SQLite-backed outbox. All parameters after `path` are keyword-only.
 | `ttl_seconds` | `int` | `604800` (7 days) | Sent entries older than this are evicted. |
 | `max_attempts` | `int` | `5` | Max delivery attempts before marking permanent failure. |
 | `backoff` | `BackoffPolicy` | `BackoffPolicy()` | Retry backoff configuration. |
+
+#### `OutboundQueue.drain()` signature
+
+```python
+async def drain(
+    self,
+    sender: Callable[[str, Dict[str, Any]], Awaitable[bool]],
+    limit: Optional[int] = None,
+    *,
+    reconciler: Optional[Callable[[OutboundEntry], Awaitable[bool]]] = None,
+) -> Tuple[int, int]:
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `sender` | `async callable` | _(required)_ | Async callable that sends the message. |
+| `limit` | `int \| None` | `None` | Max entries to drain in this call. |
+| `reconciler` | `async callable \| None` | `None` | Called only for `recovered` entries. Returns `True` → mark sent without re-dispatch (effectively-once). Returns `False` → re-send as normal. Raises → falls back to re-send (logged at WARNING). |
 
 ```python
 from praisonai.bots import OutboundQueue
@@ -291,6 +407,14 @@ The drain replays oldest messages first, respects backoff delays between attempt
 ## Best Practices
 
 <AccordionGroup>
+<Accordion title="Set reconciles_unknown_send=True only if you can answer the question reliably">
+  A flaky `was_delivered` that returns `False` for an already-delivered message will cause a duplicate send. A reconciler that raises falls back to at-least-once re-send (safe, but logged at WARNING). Only opt in when your platform provides a reliable message-status API.
+</Accordion>
+
+<Accordion title="Don't rely on supports_idempotency_token alone for dedupe">
+  `supports_idempotency_token=True` is informational only — the outbox does not currently forward the token on resend. Adapters relying on provider-side deduplication should also set `reconciles_unknown_send=True` to get effectively-once delivery.
+</Accordion>
+
 <Accordion title="Always set platform= for accurate error classification">
 The `is_recoverable_error()` function checks platform-specific patterns (e.g., Telegram's HTTP 409 conflict, rate-limit "retry after" responses) when a platform name is provided. Without it, only generic patterns are checked and some transient errors may be misclassified as permanent.
 

--- a/docs/features/gateway-flow-control.mdx
+++ b/docs/features/gateway-flow-control.mdx
@@ -14,7 +14,7 @@ graph LR
         Inbox -->|No| Queue[✅ Queue Message]
         Inbox -->|Yes| Reject[⚠️ inbox_full error]
         Queue --> Agent[🤖 Agent]
-        Agent --> Buffer{📤 Buffer Full?}
+        Agent --> Buffer{📤 Byte / Frame ceiling exceeded?}
         Buffer -->|No| Send[✅ Send to Client]
         Buffer -->|Yes, droppable| Drop[💧 Drop Event]
         Buffer -->|Yes, critical| Close[🔌 Close 1013]
@@ -36,7 +36,7 @@ graph LR
 <Steps>
 
 <Step title="Defaults work out of the box">
-Flow control is enabled by default — no configuration needed. Every session gets a 256-message inbox and the gateway disconnects clients whose transport buffer exceeds 1 MB.
+Flow control is enabled by default — no configuration needed. Every session gets a 256-message inbox and the gateway disconnects clients whose transport buffer exceeds 1 MB or whose outbound frame queue exceeds 1000 frames.
 
 ```python
 from praisonaiagents import Agent, GatewayConfig
@@ -56,6 +56,7 @@ from praisonaiagents import Agent, GatewayConfig, SessionConfig
 
 config = GatewayConfig(
     max_buffered_bytes=4 * 1024 * 1024,
+    max_queued_frames=2000,            # NEW: frame-count ceiling
     session_config=SessionConfig(
         max_inbox=512,
     )
@@ -86,17 +87,19 @@ sequenceDiagram
     alt Inbox not full
         Gateway->>Agent: Route message
         Agent->>Gateway: Response
-        alt Buffer not full
+        alt Buffer not full (bytes and frames)
             Gateway-->>Client: Deliver response
         else Droppable event (presence/typing/status)
             Gateway->>Gateway: Silently drop
-        else Critical event
-            Gateway-->>Client: Close 1013 "slow consumer"
+        else Critical event — byte or frame ceiling exceeded
+            Gateway-->>Client: Close 1013 "slow_consumer"
         end
     else Inbox full
         Gateway-->>Client: Error — inbox_full
     end
 ```
+
+A frame is rejected when *either* ceiling would be exceeded, or a single frame already exceeds `max_buffered_bytes` on its own.
 
 | Event type | When buffer is full |
 |------------|---------------------|
@@ -112,15 +115,17 @@ sequenceDiagram
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `max_inbox` | `int` | `256` | Maximum queued messages per session. `0` = unlimited. Negative values raise `ValueError`. |
-| `max_buffered_bytes` | `int` | `1048576` | Maximum buffered bytes before a slow consumer is disconnected. `0` = disable slow-consumer checks. Negative values raise `ValueError`. |
+| `max_buffered_bytes` | `int` | `1048576` | Maximum buffered bytes before a slow consumer is disconnected. `0` = disable the byte ceiling. Negative values raise `ValueError`. |
+| `max_queued_frames` | `int` | `1000` | Maximum queued outbound frames per client. `0` = unlimited frame count (byte ceiling still applies). Negative values raise `ValueError`. |
 
-`max_inbox` is set on `SessionConfig`; `max_buffered_bytes` is set on `GatewayConfig`.
+`max_inbox` is set on `SessionConfig`; `max_buffered_bytes` and `max_queued_frames` are set on `GatewayConfig`.
 
 ```python
 from praisonaiagents import GatewayConfig, SessionConfig
 
 config = GatewayConfig(
     max_buffered_bytes=1024 * 1024,
+    max_queued_frames=1000,
     session_config=SessionConfig(
         max_inbox=256,
     )
@@ -132,6 +137,7 @@ These options are also available in `gateway.yaml`:
 ```yaml
 gateway:
   max_buffered_bytes: 1048576
+  max_queued_frames: 1000      # frame-count ceiling
   session_config:
     max_inbox: 256
 ```
@@ -150,12 +156,22 @@ When the inbox is full, the gateway sends this JSON frame before rejecting the m
 }
 ```
 
-When the transport buffer exceeds `max_buffered_bytes` for a critical event, the gateway closes the WebSocket with:
+When either transport ceiling is exceeded for a critical event, the gateway closes the WebSocket with:
 
 - **Code:** `1013` (Try Again Later)
-- **Reason:** `slow consumer`
+- **Reason:** `"slow_consumer"` (the value of `GatewayCloseCode.SLOW_CONSUMER`)
 
-Clients should reconnect and resume from the last known message.
+Use the typed enum from Python clients:
+
+```python
+from praisonaiagents.gateway import GatewayCloseCode
+
+if close.reason == GatewayCloseCode.SLOW_CONSUMER.value:
+    # reconnect and resume from the last known message
+    ...
+```
+
+Clients should reconnect and resume from the last known message. The gateway preserves session state during the `resume_window` (default 24 h), so conversation context is not lost.
 
 ---
 
@@ -180,6 +196,17 @@ from praisonaiagents import GatewayConfig, SessionConfig
 config = GatewayConfig(
     max_buffered_bytes=8 * 1024 * 1024,
     session_config=SessionConfig(max_inbox=1024)
+)
+```
+
+**Stream-heavy workloads** — Lower `max_queued_frames` to shed load on backpressure earlier:
+
+```python
+from praisonaiagents import GatewayConfig
+
+config = GatewayConfig(
+    max_buffered_bytes=4 * 1024 * 1024,
+    max_queued_frames=200,           # eager eviction for chatty streams
 )
 ```
 
@@ -212,7 +239,11 @@ config = GatewayConfig(
   </Accordion>
 
   <Accordion title="React to a 1013 slow-consumer close">
-    On receiving WebSocket close code `1013`, reconnect after a short delay and replay any messages that were in-flight. The gateway preserves session state during the `resume_window` (default 24 h), so conversation context is not lost.
+    On receiving WebSocket close code `1013` with reason `"slow_consumer"`, reconnect after a short delay and replay any messages that were in-flight. The gateway preserves session state during the `resume_window` (default 24 h), so conversation context is not lost.
+  </Accordion>
+
+  <Accordion title="Disable one ceiling without the other">
+    Set `max_queued_frames=0` to bound only by bytes (good for large but infrequent payloads); set `max_buffered_bytes=0` to bound only by frame count.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/features/gateway-handshake-protocol.mdx
+++ b/docs/features/gateway-handshake-protocol.mdx
@@ -133,7 +133,7 @@ Legacy nested `protocol: {min, max}` is also accepted; missing values fall back 
 |-------|------|-------------|
 | `protocol` | `int` | Negotiated protocol version |
 | `features` | `Dict[str, List[str]]` | Supported `methods` and `events` |
-| `policy` | `Dict[str, int]` | `max_payload`, `max_buffered_bytes`, `heartbeat_ms` |
+| `policy` | `Dict[str, int]` | `max_payload`, `max_buffered_bytes`, `max_queued_frames`, `heartbeat_ms` |
 | `session_id` | `str` | Session ID (new or resumed) |
 | `resumed` | `bool` | `True` if an existing session was resumed |
 | `cursor` | `int` | Current event cursor |
@@ -145,7 +145,7 @@ Example success frame:
   "type": "hello_ok",
   "protocol": 1,
   "features": {"methods": ["message", "leave"], "events": ["message", "error", "token_stream"]},
-  "policy": {"max_payload": 1048576, "max_buffered_bytes": 8388608, "heartbeat_ms": 30000},
+  "policy": {"max_payload": 1048576, "max_buffered_bytes": 8388608, "max_queued_frames": 1000, "heartbeat_ms": 30000},
   "session_id": "...",
   "resumed": false,
   "cursor": 0
@@ -230,9 +230,10 @@ Events are advertised only if the client requested the matching capability.
 |-----|---------|-------------|
 | `max_payload` | `1048576` (1 MB) | Maximum message payload size |
 | `max_buffered_bytes` | `8388608` (8 MB) | Maximum buffered bytes per connection |
+| `max_queued_frames` | `1000` | Maximum queued outbound frames per client. Clients can read this to pace their own sends. |
 | `heartbeat_ms` | `30000` | Heartbeat interval (`heartbeat_interval * 1000`, default 30 s) |
 
-Clients should self-configure from the `policy` object in `hello_ok`.
+Clients should self-configure from the `policy` object in `hello_ok`. See [Gateway Flow Control](/docs/features/gateway-flow-control) for tuning `max_buffered_bytes` and `max_queued_frames`.
 
 ---
 

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -107,6 +107,7 @@ config = GatewayConfig(
     max_connections=1000,
     heartbeat_interval=30,
     max_buffered_bytes=1024 * 1024,
+    max_queued_frames=1000,
     session_config=SessionConfig(
         timeout=3600,
         max_messages=1000,
@@ -126,7 +127,8 @@ config = GatewayConfig(
 | `max_connections` | `int` | `1000` | Maximum concurrent connections |
 | `heartbeat_interval` | `int` | `30` | Heartbeat interval in seconds |
 | `reconnect_timeout` | `int` | `60` | Reconnection timeout |
-| `max_buffered_bytes` | `int` | `1048576` | Slow-consumer disconnect threshold in bytes (`0` to disable) |
+| `max_buffered_bytes` | `int` | `1048576` | Slow-consumer disconnect threshold in bytes (`0` to disable). Negative values raise `ValueError`. |
+| `max_queued_frames` | `int` | `1000` | Maximum queued outbound frames per client before slow-consumer disconnect (`0` = unlimited frame count; byte ceiling still applies). Negative values raise `ValueError`. |
 | `ssl_cert` | `str` | `None` | SSL certificate path |
 | `ssl_key` | `str` | `None` | SSL key path |
 | `push` | `PushConfig` | `PushConfig()` | Push notification service configuration (disabled by default) |
@@ -176,6 +178,7 @@ gateway:
   host: "127.0.0.1"
   port: 8765
   max_buffered_bytes: 1048576       # 1 MB — slow-consumer disconnect threshold
+  max_queued_frames: 1000           # frame-count ceiling per client
   session_config:
     timeout: 3600
     max_messages: 1000
@@ -807,7 +810,7 @@ praisonai gateway channels --config gateway.yaml
   </Accordion>
   
   <Accordion title="Tune flow control for your workload">
-    `max_buffered_bytes` (default 1 MB) disconnects slow consumers before they degrade the gateway. `session_config.max_inbox` (default 256) caps the per-session message queue. See [Gateway Flow Control](/features/gateway-flow-control) for tuning guidance.
+    `max_buffered_bytes` (default 1 MB) and `max_queued_frames` (default 1000) disconnect slow consumers before they degrade the gateway. A client is evicted when either ceiling is exceeded. `session_config.max_inbox` (default 256) caps the per-session message queue. See [Gateway Flow Control](/features/gateway-flow-control) for tuning guidance.
   </Accordion>
   
   <Accordion title="Single instance per bot token">


### PR DESCRIPTION
## Summary

Updates documentation for two PraisonAI PRs merged on 2026-06-26:

**PR #2330 — gateway broadcast backpressure & slow-consumer eviction:**
- `gateway-flow-control.mdx`: adds `max_queued_frames` config option (type `int`, default `1000`), updates hero diagram to mention byte/frame ceiling, updates sequence diagram to note both ceilings, fixes slow-consumer close reason string to `"slow_consumer"` (underscore), adds `GatewayCloseCode.SLOW_CONSUMER` typed enum snippet, adds stream-heavy workloads pattern, adds "disable one ceiling without the other" best practice accordion
- `gateway-handshake-protocol.mdx`: adds `max_queued_frames` to policy example JSON and Policy Limits table with cross-link to flow-control page
- `gateway.mdx`: adds `max_queued_frames` to GatewayConfig code example, options table, and YAML example; updates flow-control best practice accordion

**PR #2331 — effectively-once outbound delivery via crash reconciliation:**
- `durable-delivery.mdx`: replaces outdated `sending→pending` sentence with new 6-status state machine description (adds `recovered` state), adds new "Effectively-Once Delivery" section with mermaid sequence diagram and Steps component, adds `drain()` reconciler parameter documentation, adds two new best-practice accordions, notes the `commit()` reliability fix
- `bot-platform-capabilities.mdx`: adds `reconciles_unknown_send` and `supports_idempotency_token` rows to configuration table, adds cross-link to durable-delivery effectively-once section in Related

Fixes #952

Generated with [Claude Code](https://claude.ai/code)