### PR TITLE
docs: document --no-save warm-runtime gating and chat-history isolation

### DIFF
--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -36,7 +36,7 @@ praisonai run [OPTIONS] [TARGET]
 | `--continue` | `-c` | Continue the most recent session for this project | `false` |
 | `--session` | `-s` | Resume a specific session ID | |
 | `--fork` | | Fork from the specified session (requires `--session`) | `false` |
-| `--no-save` | | Don't auto-save the session after execution | `false` |
+| `--no-save` | | Skip session auto-save **and** allow the warm runtime (`praisonai daemon`) to handle this prompt when one is running. Required to get warm-runtime acceleration; the default save path stays in-process. | `false` |
 | `--no-rules` | | Disable auto-injection of project instruction files (AGENTS.md, CLAUDE.md, etc.) | `false` |
 | `--agent` | `-a` | Use a named custom agent from `.praisonai/agents/` | |
 | `--command` | | Execute a named custom command; `TARGET` becomes `$ARGUMENTS` | |
@@ -45,6 +45,10 @@ praisonai run [OPTIONS] [TARGET]
 | `--permissions` | | Path to a YAML permission rules file | |
 | `--permission-default` | | Default action for unmatched patterns: `allow`, `deny`, or `ask` | |
 | `--approval` | | Approval backend mode: `console`, `plan`, `accept-edits`, `bypass` | |
+
+<Note>
+The warm runtime (`praisonai daemon`) only engages on `--no-save`. With auto-save on, `praisonai run` always runs in-process so session persistence is preserved. See [Warm Runtime (Daemon)](/docs/features/daemon) for details.
+</Note>
 
 ## Output Modes
 

--- a/docs/cli/session.mdx
+++ b/docs/cli/session.mdx
@@ -254,6 +254,8 @@ The same project-scoped store powers `--continue` and `--session` on `praisonai 
 | YAML / file mode (`praisonai run agents.yaml`) | Yes | Yes (unless `--no-save`) |
 | Actions mode (`--output actions`) | Yes | Yes (unless `--no-save`) |
 
+The default `praisonai run` (auto-save on) always uses the in-process execution path — the warm runtime daemon never bypasses session persistence and only engages when `--no-save` is explicitly set.
+
 As of [PR #2277](https://github.com/MervinPraison/PraisonAI/pull/2277), `--session <id>` and `--continue` now persist `model` and `agent_name` into session metadata so a later `session resume` reproduces the same configuration deterministically. For advanced programmatic use, the `rehydrate_session` helper in `praisonai.cli.session` returns a `RehydratedSession` with `session_id`, `chat_history`, `model`, `agent_name`, `metadata`, and `found` fields — see the [SDK reference](/docs/sdk/reference/praisonai/modules/session) for details.
 
 ```bash

--- a/docs/features/daemon.mdx
+++ b/docs/features/daemon.mdx
@@ -70,13 +70,13 @@ praisonai daemon start --background
 The daemon writes a project-local lockfile and binds to a free loopback port. All subsequent `praisonai run` calls in the same project directory automatically detect and attach to it.
 </Step>
 
-<Step title="Run prompts — no extra flags needed">
+<Step title="Run prompts with --no-save">
 ```bash
-praisonai run "Write a haiku about clouds"
-praisonai run "Now make it rhyme"
-praisonai run "Translate to Spanish"
+praisonai run --no-save "Write a haiku about clouds"
+praisonai run --no-save "Now make it rhyme"
+praisonai run --no-save "Translate to Spanish"
 ```
-Each call transparently attaches to the warm runtime. Provider and MCP clients are already initialised — only the prompt is forwarded.
+Each `--no-save` call attaches to the warm runtime. Provider and MCP clients are already initialised — only the prompt is forwarded. Omitting `--no-save` runs in-process so session auto-save is preserved.
 </Step>
 
 <Step title="Check status and stop">
@@ -95,6 +95,10 @@ praisonai daemon stop
 ```
 </Step>
 </Steps>
+
+<Warning>
+The warm runtime only engages when `praisonai run` is called with `--no-save`. By default, `praisonai run` auto-saves the session and the session-persistence path stays in-process so nothing is silently lost. Pass `--no-save` (suitable for stateless one-shot prompts) to get cold-start savings from the daemon.
+</Warning>
 
 ---
 
@@ -129,6 +133,12 @@ sequenceDiagram
 | **WarmRuntime** | Holds one warm `Agent` per model. Reuses it across calls. Evicts the agent on failure to prevent state bleed. |
 | **RuntimeClient** | Thin stdlib (`urllib`) HTTP client. Raises `RuntimeUnavailable` on any error — `run` then falls back in-process. |
 | **Idle watcher** | Background thread shuts down the server after `--idle-timeout` seconds of inactivity (default 30 min). |
+
+---
+
+## Run Isolation
+
+Every `praisonai run --no-save` call that hits the warm runtime is independent: the daemon clears the cached agent's chat history after every successful response, so prior prompts (and any secrets they included) cannot leak into the next invocation. The warm agent is reused only for client and MCP cold-start savings, never for conversation state. For conversation continuity, use the in-process path (`praisonai run` without `--no-save`, plus `--continue` or `--session <id>`).
 
 ---
 
@@ -198,10 +208,11 @@ graph TB
 
 ## When `run` Stays In-Process
 
-`praisonai run` skips the daemon and runs locally whenever you pass any of these flags:
+`praisonai run` skips the daemon and runs locally whenever auto-save is on (the default) **or** when you pass any of these flags:
 
 | Flag(s) | Why it stays in-process |
 |---------|------------------------|
+| *(default — auto-save on)* | Session persistence runs in-process so history is never lost. Pass `--no-save` to allow warm-runtime routing. |
 | `--mcp`, `--tools`, `--toolset` | Per-invocation tool overrides need in-process state. |
 | `--approval`, `--approve-all-tools` | Approval flow requires interactive in-process handling. |
 | `--memory` | Memory store is managed in-process. |
@@ -221,12 +232,12 @@ In all these cases, `praisonai run` behaves exactly as it did before the daemon 
 praisonai daemon start --background
 
 for topic in clouds mountains rivers; do
-  praisonai run "Write a haiku about $topic"
+  praisonai run --no-save "Write a haiku about $topic"
 done
 
 praisonai daemon stop
 ```
-Only the first call pays setup cost. The loop body is fast — just HTTP over loopback.
+Only the first call pays setup cost. The loop body is fast — just HTTP over loopback. Each run starts with a clean chat history; responses from earlier iterations never bleed into later ones.
 </Accordion>
 
 <Accordion title="Auto-shutdown at night with --idle-timeout">
@@ -258,8 +269,8 @@ The `--json` flag returns `{running, host, port, pid, base_url}` — safe for `j
 ```bash
 praisonai daemon start --background --model gpt-4o
 
-# All runs that don't specify --model will use gpt-4o from the warm agent
-praisonai run "summarize this document"
+# All --no-save runs that don't specify --model will use gpt-4o from the warm agent
+praisonai run --no-save "summarize this document"
 ```
 </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

Documents the two correctness fixes from [MervinPraison/PraisonAI#2325](https://github.com/MervinPraison/PraisonAI/pull/2325) across three existing pages:

- **`docs/features/daemon.mdx`**: Added `<Warning>` callout explaining the warm runtime only engages on `--no-save`; added "Run Isolation" subsection describing per-run chat history clearing; updated Quick Start steps and Common Patterns examples to use `--no-save`; added the default auto-save row to the "When run Stays In-Process" table
- **`docs/cli/run.mdx`**: Expanded `--no-save` flag description to cover its dual effect (skip auto-save + allow warm runtime); added `<Note>` callout cross-linking to the daemon docs
- **`docs/cli/session.mdx`**: Added one-line clarification after the auto-save table that the warm runtime never bypasses session persistence

No new pages created. No `docs.json` edits. No `docs/concepts/` changes.

Fixes #963

Generated with [Claude Code](https://claude.ai/code)