### PR TITLE
docs: add templates/web pages, fix AGENTS.md inconsistencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,14 +59,17 @@ Documentation MUST reflect SDK ground truth.
 
 | Content Type | SDK Location | Docs Location |
 |--------------|--------------|---------------|
-| Feature configs | `praisonaiagents/config/feature_configs.py` | `docs/concepts/*.mdx` |
-| Agent class | `praisonaiagents/agent/agent.py` | `docs/concepts/agents.mdx` |
-| MCP integration | `praisonaiagents/mcp/mcp.py` | `docs/concepts/mcp.mdx` |
-| Skills | `praisonaiagents/skills/` | `docs/concepts/skills.mdx` |
-| Memory | `praisonaiagents/memory/` | `docs/concepts/memory.mdx` |
-| Knowledge | `praisonaiagents/knowledge/` | `docs/concepts/knowledge.mdx` |
+| Feature configs | `praisonaiagents/config/feature_configs.py` | `docs/features/*.mdx` |
+| Agent class | `praisonaiagents/agent/agent.py` | `docs/features/` (new pages) or `docs/concepts/agents.mdx` (existing, human-only) |
+| MCP integration | `praisonaiagents/mcp/mcp.py` | `docs/features/` (new pages) or `docs/concepts/mcp.mdx` (existing, human-only) |
+| Skills | `praisonaiagents/skills/` | `docs/features/` (new pages) or `docs/concepts/skills.mdx` (existing, human-only) |
+| Memory | `praisonaiagents/memory/` | `docs/features/` (new pages) or `docs/concepts/memory.mdx` (existing, human-only) |
+| Knowledge | `praisonaiagents/knowledge/` | `docs/features/` (new pages) or `docs/concepts/knowledge.mdx` (existing, human-only) |
 
-In **PraisonAIDocs**, “SDK Location” paths are under **repo root** `praisonaiagents/` (not `src/`).
+> [!CAUTION]
+> **AI agents: always write new pages to `docs/features/`** — the `docs/concepts/*.mdx` paths listed above are existing human-approved pages (read-only for AI). See §1.9 (Folder Placement Rules) for the full rules.
+
+In **PraisonAIDocs**, "SDK Location" paths are under **repo root** `praisonaiagents/` (not `src/`).
 
 **Reference folders (check these for any doc proposal, edit, or new page):** repo-root `praisonaiagents/` and `praisonai/`. Synced daily via `update_repos.sh` / `.github/workflows/update-repos.yml`. Reject or correct proposals that conflict with code there; do not document behaviour absent from those trees (use TS/Rust paths below when documenting those SDKs).
 
@@ -74,18 +77,20 @@ In **PraisonAIDocs**, “SDK Location” paths are under **repo root** `praisona
 
 PraisonAI has three SDK implementations. Use these paths as source of truth:
 
+> **Path note:** Only the Python SDK is synced into this repo at `praisonaiagents/` (source of truth for Python docs). The TypeScript and Rust upstream paths below are in the separate `praisonai-package` submodule and are **not** present in this repo root — they are used only by the auto-generation scripts.
+
 | SDK | Source Code Path | Documentation Path | Parity Tracker |
 |-----|------------------|-------------------|----------------|
-| **Python** | `praisonai-package/src/praisonai-agents/` | `docs/concepts/`, `docs/features/` | `docs/features/DOCS_PARITY.md` |
-| **TypeScript/JS** | `praisonai-package/src/praisonai-ts/src/` | `docs/js/` | `docs/js/DOCS_PARITY.md` |
-| **Rust** | `praisonai-package/src/praisonai-rust/src/` | `docs/rust/` | `docs/rust/DOCS_PARITY.md` |
+| **Python** | Repo root `praisonaiagents/` (synced copy; upstream: `praisonai-package/src/praisonai-agents/`) | `docs/features/`, `docs/concepts/` (human-only) | `docs/features/DOCS_PARITY.md` |
+| **TypeScript/JS** | `praisonai-package/src/praisonai-ts/src/` (submodule only) | `docs/js/` | `docs/js/DOCS_PARITY.md` |
+| **Rust** | `praisonai-package/src/praisonai-rust/src/` (submodule only) | `docs/rust/` | `docs/rust/DOCS_PARITY.md` |
 
 **Documentation Parity Trackers** show which features have documentation and which need docs:
 - ✅ Documented categories (real content)
 - ⚠️ Stub documentation (< 50 lines, needs content)
 - ❌ Undocumented categories (needs documentation)
 
-### 1.5 TypeScript SDK Structure
+### 1.6 TypeScript SDK Structure
 
 ```
 praisonai-ts/src/
@@ -97,7 +102,7 @@ praisonai-ts/src/
 └── index.ts          # Main exports
 ```
 
-### 1.6 Rust SDK Structure
+### 1.7 Rust SDK Structure
 
 ```
 praisonai-rust/src/
@@ -109,7 +114,7 @@ praisonai-rust/src/
 └── lib.rs            # Main exports
 ```
 
-### 1.7 Auto-Managed Documentation Sections
+### 1.8 Auto-Managed Documentation Sections
 
 > [!WARNING]
 > **DO NOT manually edit** the following sections in `docs.json`:
@@ -124,17 +129,12 @@ cd praisonai-package
 python3 src/praisonai/scripts/generate_docs_parity.py --copy-docs
 ```
 
-**Full command for agents:**
-```bash
-/usr/bin/python3 /Users/praison/praisonai-package/src/praisonai/scripts/generate_docs_parity.py --copy-docs
-```
-
 This command:
 1. Scans SDK features and docs for all three SDKs
 2. Generates `DOCS_PARITY.md` reports
 3. Copies reports to `docs/features/`, `docs/js/`, `docs/rust/`
 
-### 1.8 Folder Placement Rules
+### 1.9 Folder Placement Rules
 
 > [!CAUTION]
 > **AI agents MUST follow these rules strictly. Violations will cause PRs to be rejected.**
@@ -159,7 +159,7 @@ CRITICAL RULES FOR AI AGENTS:
 7. When reviewing PRs: flag any files in docs/concepts/ as violations
 ```
 
-### 1.9 AI Agent Behavioral Rules
+### 1.10 AI Agent Behavioral Rules
 
 ```
 MANDATORY for all AI agents working on this repository:

--- a/docs.json
+++ b/docs.json
@@ -295,6 +295,7 @@
                       "docs/features/llm-gateways",
                       "docs/features/openai-compatible-server",
                       "docs/features/yaml-template-variables",
+                      "docs/features/templates",
                       "docs/features/gateway-bind-aware-auth",
                       "docs/features/test-documentation"
                     ]
@@ -744,6 +745,7 @@
                   "docs/features/persistence-backend-plugins",
                   "docs/features/integration-registry",
                   "docs/features/endpoint-provider-registry",
+                  "docs/features/web",
                   "docs/features/search-provider-registry",
                   "docs/features/observability-hooks",
                   "docs/features/agent-server",

--- a/docs/features/templates.mdx
+++ b/docs/features/templates.mdx
@@ -1,0 +1,230 @@
+---
+title: "Templates"
+sidebarTitle: "Templates"
+description: "Customize agent behavior with system, prompt, and response templates"
+icon: "file-code"
+---
+
+Templates let you control exactly what an agent says, how it says it, and how it formats its response — all in a few lines.
+
+```mermaid
+graph LR
+    subgraph "Template System"
+        S["📋 System Template"] --> A["🤖 Agent"]
+        P["💬 Prompt Template"] --> A
+        A --> R["📝 Response Template"]
+        R --> O["✅ Output"]
+    end
+
+    classDef template fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class S,P,R template
+    class A agent
+    class O output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Custom System Prompt">
+Override the default system message so the agent stays in character.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Support Bot",
+    system_prompt="You are a friendly customer support agent for Acme Corp. Always be concise and helpful.",
+)
+
+agent.start("How do I reset my password?")
+```
+</Step>
+
+<Step title="With TemplateConfig">
+Use `TemplateConfig` for full control over system, prompt, and response templates.
+
+```python
+from praisonaiagents import Agent, TemplateConfig
+
+agent = Agent(
+    name="Analyst",
+    instructions="Analyze the data provided.",
+    templates=TemplateConfig(
+        system="You are a data analyst. Return only structured insights.",
+        prompt="Analyze this: {input}",
+        response="Summary:\n{response}\n\nKey Points:\n- {points}",
+        use_system_prompt=True,
+    )
+)
+
+agent.start("Sales grew 20% in Q3")
+```
+</Step>
+
+<Step title="YAML Template Variables">
+Define reusable workflows with `{placeholder}` variables in YAML.
+
+```yaml
+# workflow.yaml
+variables:
+  topic: climate change
+
+agents:
+  researcher:
+    name: Researcher
+    instructions: "Research {topic} thoroughly"
+
+steps:
+  - agent: researcher
+    action: "Find the latest data on {topic}"
+```
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.workflows import YAMLWorkflowParser
+
+parser = YAMLWorkflowParser()
+workflow = parser.parse_file("workflow.yaml", extra_vars={"topic": "renewable energy"})
+workflow.run()
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+Templates are applied in a specific order before the LLM sees your request.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Template as Template Engine
+    participant LLM
+
+    User->>Agent: "Analyze sales data"
+    Agent->>Template: Apply system template
+    Template-->>Agent: Formatted system message
+    Agent->>Template: Apply prompt template with {input}
+    Template-->>Agent: Formatted user message
+    Agent->>LLM: system + prompt
+    LLM-->>Agent: Raw response
+    Agent->>Template: Apply response template
+    Template-->>Agent: Formatted output
+    Agent-->>User: Final answer
+```
+
+---
+
+## Configuration Options
+
+<Card title="TemplateConfig API Reference" icon="code" href="/docs/sdk/praisonaiagents/config/feature-configs-module">
+  Full API reference for `TemplateConfig` — system, prompt, response, use_system_prompt
+</Card>
+
+### TemplateConfig Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `system` | `str \| None` | `None` | Override the system prompt |
+| `prompt` | `str \| None` | `None` | Template for the user message; use `{input}` as a placeholder |
+| `response` | `str \| None` | `None` | Format template applied to the LLM response |
+| `use_system_prompt` | `bool` | `True` | Whether to send a system message at all |
+
+---
+
+## Common Patterns
+
+### Structured Output Format
+
+Force the agent to return a consistent format every time.
+
+```python
+from praisonaiagents import Agent, TemplateConfig
+
+agent = Agent(
+    name="Reporter",
+    instructions="Summarize news articles.",
+    templates=TemplateConfig(
+        system="You are a news summarizer. Always output valid JSON.",
+        response='{"headline": "...", "summary": "...", "sentiment": "positive|negative|neutral"}',
+        use_system_prompt=True,
+    )
+)
+
+result = agent.start("OpenAI released a new model today with improved reasoning.")
+print(result)
+```
+
+### Persona Agent
+
+Lock the agent into a role with a strong system template.
+
+```python
+from praisonaiagents import Agent, TemplateConfig
+
+agent = Agent(
+    name="Pirate Guide",
+    instructions="Help users navigate the Caribbean.",
+    templates=TemplateConfig(
+        system="You are a 17th century Caribbean pirate. Speak in pirate dialect. Never break character.",
+        use_system_prompt=True,
+    )
+)
+
+agent.start("How do I get to Tortuga?")
+```
+
+### YAML Variable Substitution
+
+Run the same workflow against different inputs without editing the YAML.
+
+```python
+from praisonaiagents.workflows import YAMLWorkflowParser
+
+parser = YAMLWorkflowParser()
+
+# Same workflow, different topics
+for topic in ["AI safety", "quantum computing", "space exploration"]:
+    workflow = parser.parse_file("research_workflow.yaml", extra_vars={"topic": topic})
+    workflow.run()
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Keep system templates focused">
+A system template that tries to do everything usually does nothing well. One clear role per template — "You are a customer support agent for Acme Corp" — produces better results than a long list of unrelated instructions.
+</Accordion>
+
+<Accordion title="Use {input} placeholder in prompt templates">
+When your prompt template includes `{input}`, PraisonAI substitutes the user's actual request at runtime. This keeps your template generic and reusable across many different queries.
+</Accordion>
+
+<Accordion title="Test response templates with diverse outputs">
+Response templates are applied as a format instruction to the LLM. Test with edge-case inputs (short answers, long answers, refusals) to make sure the template doesn't corrupt valid responses.
+</Accordion>
+
+<Accordion title="Prefer YAML templates for team workflows">
+When multiple people run the same workflow, store templates in a YAML file rather than hardcoding them in Python. YAML files are easier to version, review, and swap without touching code.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="YAML Template Variables" icon="code" href="/docs/features/yaml-template-variables">
+  Safely use `{placeholder}` in YAML alongside JSON literals
+</Card>
+<Card title="Industry Templates" icon="building-2" href="/docs/features/industry-templates/overview">
+  Pre-built agent workforces for Manufacturing, Energy, Healthcare, and more
+</Card>
+</CardGroup>

--- a/docs/features/web.mdx
+++ b/docs/features/web.mdx
@@ -1,0 +1,265 @@
+---
+title: "Web"
+sidebarTitle: "Web"
+description: "Give agents live internet access — search the web or fetch any URL in one line"
+icon: "globe"
+---
+
+Web tools let any agent search the internet or read any webpage, with automatic provider fallback so it works even without an API key.
+
+```mermaid
+graph LR
+    subgraph "Web Feature"
+        A["🤖 Agent"] --> S["🔍 Search"]
+        A --> F["🌐 Fetch"]
+        S --> P["📡 Providers"]
+        P --> T["Tavily"]
+        P --> B["Brave"]
+        P --> D["DuckDuckGo"]
+        F --> C["📄 Content"]
+        C --> A
+    end
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef action fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef provider fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A agent
+    class S,F action
+    class P,T,B,D provider
+    class C output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Enable Web Search">
+Add `web=True` and the agent automatically searches the internet when it needs current information.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Researcher",
+    instructions="Answer questions using current information from the web.",
+    web=True,
+)
+
+agent.start("What are the latest developments in AI this week?")
+```
+</Step>
+
+<Step title="Configure Providers">
+Choose a specific search provider or set multiple as fallbacks.
+
+```python
+from praisonaiagents import Agent, WebConfig
+
+agent = Agent(
+    name="Researcher",
+    instructions="Research topics thoroughly.",
+    web=WebConfig(
+        search=True,
+        fetch=True,
+        search_provider="tavily",
+        max_results=10,
+    )
+)
+
+agent.start("Summarize the latest news on quantum computing.")
+```
+</Step>
+
+<Step title="Web Search Tool Directly">
+Use `search_web` as a standalone tool inside any agent.
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools import search_web, web_crawl
+
+agent = Agent(
+    name="Web Agent",
+    instructions="Search and read web pages to answer questions.",
+    tools=[search_web, web_crawl],
+)
+
+agent.start("Find and summarize the homepage of OpenAI.")
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+The agent decides when to search or fetch based on your query. Results flow back as context for the final answer.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Search as Search Tool
+    participant Fetch as Fetch Tool
+    participant Provider as Search Provider
+
+    User->>Agent: "Latest AI news?"
+    Agent->>Search: search_web("latest AI news")
+    Search->>Provider: Query (Tavily → Brave → DuckDuckGo)
+    Provider-->>Search: Title + URL + Snippet × N
+    Search-->>Agent: Results list
+    Agent->>Fetch: web_crawl(top_url)
+    Fetch-->>Agent: Full page content
+    Agent-->>User: Summarized answer
+```
+
+---
+
+## Configuration Options
+
+<Card title="WebConfig API Reference" icon="code" href="/docs/sdk/praisonaiagents/config/feature-configs-module">
+  Full API reference for `WebConfig` — search, fetch, providers, max_results
+</Card>
+
+### WebConfig Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `search` | `bool` | `True` | Enable web search |
+| `fetch` | `bool` | `True` | Enable web page fetching |
+| `search_provider` | `str` | `"duckduckgo"` | Provider to use: `tavily`, `brave`, `exa`, `youdotcom`, `duckduckgo`, `searxng` |
+| `max_results` | `int` | `5` | Maximum search results returned |
+| `search_config` | `dict \| None` | `None` | Provider-specific search settings |
+| `fetch_config` | `dict \| None` | `None` | Provider-specific fetch settings |
+
+### Search Provider Priority (auto-fallback)
+
+```mermaid
+graph TB
+    Start["🔍 search_web()"] --> T{"Tavily available?"}
+    T -->|Yes| TY["✅ Use Tavily"]
+    T -->|No| B{"Brave available?"}
+    B -->|Yes| BY["✅ Use Brave"]
+    B -->|No| E{"Exa available?"}
+    E -->|Yes| EY["✅ Use Exa"]
+    E -->|No| Y{"You.com available?"}
+    Y -->|Yes| YY["✅ Use You.com"]
+    Y -->|No| D{"DuckDuckGo?"}
+    D -->|Yes| DY["✅ Use DuckDuckGo (free)"]
+    D -->|No| S["✅ Use SearxNG"]
+
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef start fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class Start start
+    class T,B,E,Y,D decision
+    class TY,BY,EY,YY,DY,S success
+```
+
+---
+
+## Common Patterns
+
+### Research Agent with Sources
+
+Search the web and return cited sources alongside the answer.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Research Assistant",
+    instructions="Answer questions with sources. Always cite URLs.",
+    web=True,
+)
+
+agent.start("What is the current state of nuclear fusion research?")
+```
+
+### Crawl and Summarize a URL
+
+Fetch a specific webpage and summarize it.
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools import web_crawl
+
+agent = Agent(
+    name="Summarizer",
+    instructions="Fetch the given URL and write a 3-sentence summary.",
+    tools=[web_crawl],
+)
+
+agent.start("Summarize https://openai.com/research/overview")
+```
+
+### Multi-Agent Research Pipeline
+
+One agent searches, another writes the report.
+
+```python
+from praisonaiagents import Agent, Task, PraisonAIAgents
+
+searcher = Agent(
+    name="Searcher",
+    instructions="Search the web for information on the given topic.",
+    web=True,
+)
+
+writer = Agent(
+    name="Writer",
+    instructions="Write a structured report based on research findings.",
+)
+
+search_task = Task(
+    description="Find the top 5 sources on AI regulation in 2025",
+    agent=searcher,
+    expected_output="List of sources with summaries",
+)
+
+write_task = Task(
+    description="Write a 500-word report on AI regulation",
+    agent=writer,
+    context=[search_task],
+    expected_output="Formatted report",
+)
+
+agents = PraisonAIAgents(agents=[searcher, writer], tasks=[search_task, write_task])
+agents.start()
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Use DuckDuckGo for zero-configuration setups">
+DuckDuckGo requires no API key and no package beyond `ddgs`. It's the best choice for local development, prototypes, and open-source projects where you can't bundle API keys.
+</Accordion>
+
+<Accordion title="Switch to Tavily for production accuracy">
+Tavily returns higher-quality snippets and supports full-page extraction. Set `TAVILY_API_KEY` in your environment and the agent will prefer it automatically over free providers.
+</Accordion>
+
+<Accordion title="Limit max_results to control token costs">
+Each search result adds tokens to the agent's context. Keep `max_results=5` (the default) for most queries. Only increase it when the task genuinely requires broad coverage, such as academic literature surveys.
+</Accordion>
+
+<Accordion title="Combine search and fetch for deep research">
+`search=True` finds the best URLs; `fetch=True` reads the full page content. Use both together when a snippet is not enough — for example, reading full API documentation or news articles.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Tools" icon="wrench" href="/docs/concepts/tools">
+  How tools work and how to add custom tools to agents
+</Card>
+<Card title="Deep Research" icon="magnifying-glass" href="/docs/agents/deep-research">
+  Multi-step research agents that synthesize information from many sources
+</Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

Resolves the actionable items from issue #970 (docs audit per AGENTS.md).

### New documentation pages

- **`docs/features/templates.mdx`** — covers the `TemplateConfig` SDK feature (system prompt, user prompt, response format templates, YAML variable substitution). Includes hero Mermaid diagram, Quick Start with Steps, How It Works sequence diagram, configuration table, 3 Common Patterns, AccordionGroup best practices, CardGroup related links.

- **`docs/features/web.mdx`** — covers the `WebConfig` SDK feature (`search_web` / `web_crawl`, multi-provider fallback: Tavily → Brave → Exa → You.com → DuckDuckGo → SearxNG). Includes hero Mermaid diagram, Quick Start, provider-priority decision diagram, configuration table, 3 Common Patterns, AccordionGroup best practices, CardGroup related links.

Both pages are registered in `docs.json` under the **Features** group (never Concepts — per §1.9).

Note: `docs/features/vector-store.mdx` already existed and was already registered in `docs.json` — no action needed there.

### AGENTS.md fixes

- **§4.1 (duplicate §1.5):** Renumbered — TypeScript structure → §1.6, Rust structure → §1.7, Auto-Managed → §1.8, Folder Placement → §1.9, AI Behavioral Rules → §1.10.
- **§4.2 (contradictory SDK paths):** Clarified that Python SDK source of truth is repo-root `praisonaiagents/` (synced copy); TS/Rust upstream paths are submodule-only and not present in this repo root.
- **§4.3 (hardcoded developer path):** Removed `/usr/bin/python3 /Users/praison/...` command; kept only the repo-relative `cd praisonai-package && python3 src/...` form.
- **§4.4 (§1.4↔§1.8 reconciliation):** Added a caution callout in §1.4 so agents reading top-down immediately see that `docs/concepts/` paths are existing human-only pages; new pages always go to `docs/features/`.

### Out of scope (per issue §6)
- JS/Rust auto-generated pages (forbidden by §1.8)
- `docs/concepts/` restructuring (human-only)
- Stub page fixes (parity generator improvement needed)

Fixes #970

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded agent guidance and navigation for docs coverage.
  * Added a new page on templates, including customization patterns and best practices.
  * Added a new page on web capabilities, including search, fetching, and provider fallback behavior.
  * Updated docs navigation to surface the new feature pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->