### PR TITLE
docs: add TypeScript MCP transport-selection API and refresh Python HTTP-Stream options

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -6696,6 +6696,7 @@
                   "docs/js/computer-use-cli",
                   "docs/js/mcp-tools",
                   "docs/js/mcp-tools-cli",
+                  "docs/js/mcp-transport-selection",
                   "docs/js/mcp-security",
                   "docs/js/mcp-security-cli",
                   "docs/js/server-adapters",

--- a/docs/js/mcp-tools.mdx
+++ b/docs/js/mcp-tools.mdx
@@ -35,6 +35,10 @@ const agent = new Agent({
 const response = await agent.chat('List all files in the directory');
 ```
 
+## Single-class Transport Selection
+
+Prefer the unified `new MCP(url, transportType)` constructor for the most concise remote server setup — see [MCP Transport Selection](/docs/js/mcp-transport-selection). The `createMCP({ transport: ... })` form below remains supported and is best when you need OAuth providers or stdio.
+
 ## Transport Types
 
 ### Stdio (Local Servers)

--- a/docs/js/mcp-transport-selection.mdx
+++ b/docs/js/mcp-transport-selection.mdx
@@ -1,0 +1,207 @@
+---
+title: "MCP Transport Selection"
+sidebarTitle: "MCP Transport Selection"
+description: "Pick or auto-detect SSE vs HTTP-Streaming for remote MCP servers in TypeScript"
+icon: "plug"
+---
+
+Use `new MCP(url, transportType)` to connect to any MCP server — the transport is auto-detected from the URL, or you can force a specific one.
+
+```mermaid
+graph LR
+    URL[🌐 Server URL] --> Detect{🧭 transport?}
+    Detect -->|auto + ends /sse| SSE[📡 SSE]
+    Detect -->|auto + other| HTTP[⚡ HTTP-Streaming]
+    Detect -->|'sse'| SSE
+    Detect -->|'http-streaming'| HTTP
+    SSE --> Tools[🛠 MCP Tools]
+    HTTP --> Tools
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef transport fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class URL input
+    class Detect decision
+    class SSE,HTTP transport
+    class Tools result
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Install">
+```bash
+npm install praisonai-ts
+```
+</Step>
+
+<Step title="Construct">
+```typescript
+import { MCP } from 'praisonai-ts';
+
+const mcp = new MCP('https://mcp.example.com/api'); // auto → http-streaming
+```
+</Step>
+
+<Step title="Initialize">
+```typescript
+await mcp.initialize();
+console.log(mcp.transportType); // "http-streaming"
+```
+</Step>
+
+<Step title="Wire into Agent">
+```typescript
+import { Agent, MCP } from 'praisonai-ts';
+
+const mcp = new MCP('https://mcp.example.com/api');
+await mcp.initialize();
+
+const toolFunctions = Object.fromEntries(
+  [...mcp].map(tool => [tool.name, async (args: any) => tool.execute(args)])
+);
+
+const agent = new Agent({
+  name: 'MCPTransportAgent',
+  instructions: 'You are a helpful assistant with access to MCP tools.',
+  tools: mcp.toOpenAITools(),
+  toolFunctions,
+});
+
+const response = await agent.runSync('What tools are available?');
+console.log(response);
+
+await mcp.close();
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+Auto-detection checks whether the URL ends in `/sse`. Any other path routes to HTTP-Streaming.
+
+```mermaid
+graph TB
+    Q1{Server URL<br/>ends in /sse?}
+    Q1 -->|Yes| A[Use 'auto' or 'sse']
+    Q1 -->|No| Q2{New deployment?}
+    Q2 -->|Yes| B[Use 'auto' → http-streaming]
+    Q2 -->|Legacy server| C[Use 'sse' explicitly]
+
+    classDef question fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef answer fill:#10B981,stroke:#7C90A0,color:#fff
+    class Q1,Q2 question
+    class A,B,C answer
+```
+
+---
+
+## Transport Examples
+
+**Auto-detect on `/sse` URL — resolves to SSE:**
+```typescript
+import { Agent, MCP } from 'praisonai-ts';
+
+const mcp = new MCP('http://127.0.0.1:8080/sse'); // → resolves to 'sse'
+await mcp.initialize();
+console.log(mcp.transportType); // "sse"
+```
+
+**Explicit SSE on a non-`/sse` URL:**
+```typescript
+const mcp = new MCP('http://127.0.0.1:8080/api', 'sse');
+await mcp.initialize();
+```
+
+**Explicit HTTP-Streaming:**
+```typescript
+const mcp = new MCP('http://127.0.0.1:8080/stream', 'http-streaming');
+await mcp.initialize();
+```
+
+**Auto-detect on non-`/sse` URL — resolves to HTTP-Streaming:**
+```typescript
+const mcp = new MCP('http://127.0.0.1:8080/api'); // → resolves to 'http-streaming'
+await mcp.initialize();
+```
+
+---
+
+## Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | `string` | required | MCP server endpoint URL |
+| `transport` | `'auto' \| 'sse' \| 'http-streaming'` | `'auto'` | Force a specific transport, or let auto-detect pick |
+| `debug` | `boolean` | `false` | Log transport selection and connection events |
+
+---
+
+## Instance API
+
+```typescript
+mcp.initialize(): Promise<void>      // Connect and fetch tools
+mcp.close(): Promise<void>           // Disconnect gracefully
+mcp.toOpenAITools(): OpenAITool[]    // Get tools in OpenAI format
+mcp.transportType: string            // The resolved transport ('sse' or 'http-streaming')
+mcp.isConnected: boolean             // Connection status
+[Symbol.iterator]()                  // Iterate over MCPTool instances
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Prefer 'auto' first">
+Start with `new MCP(url)` (default `'auto'`). Only specify `'sse'` or `'http-streaming'` explicitly when you need to override the URL-based detection — for example, when connecting to a legacy SSE server at a non-`/sse` path.
+</Accordion>
+
+<Accordion title="Always close on exit">
+Call `await mcp.close()` when the agent is done. This terminates the underlying transport session and avoids dangling connections.
+
+```typescript
+try {
+  await mcp.initialize();
+  // ... use agent
+} finally {
+  await mcp.close();
+}
+```
+</Accordion>
+
+<Accordion title="Use debug flag for troubleshooting">
+Pass `debug=true` to log transport selection and connection events during development. Remove it in production to keep logs clean.
+
+```typescript
+const mcp = new MCP('http://127.0.0.1:8080/api', 'auto', true);
+```
+</Accordion>
+
+<Accordion title="Invalid transport throws immediately">
+Passing any value other than `'auto'`, `'sse'`, or `'http-streaming'` throws at construction time — not at `initialize()`. Validate user-supplied transport strings before passing them in.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="MCP Transports (Python)" icon="network-wired" href="/docs/mcp/transports">
+    Full transport overview for the Python SDK including stdio, WebSocket, and Streamable HTTP options
+  </Card>
+  <Card title="MCP Tools (TypeScript)" icon="wrench" href="/docs/js/mcp-tools">
+    Broader TypeScript MCP tool integration using `createMCP` with stdio, OAuth, and more
+  </Card>
+  <Card title="MCP API Reference" icon="code" href="/docs/sdk/reference/typescript/classes/MCP">
+    Auto-generated TypeScript API reference for the MCP class
+  </Card>
+  <Card title="HTTPStreamingTransport Reference" icon="code" href="/docs/sdk/reference/typescript/classes/HTTPStreamingTransport">
+    Auto-generated reference for the HTTP-Streaming transport class
+  </Card>
+</CardGroup>

--- a/docs/mcp/transports.mdx
+++ b/docs/mcp/transports.mdx
@@ -280,11 +280,17 @@ The Streamable HTTP transport uses HTTP POST for sending messages and supports S
 from praisonaiagents import Agent, MCP
 
 # Basic HTTP endpoint
+# If URL has no path (or only '/'), defaults to /mcp endpoint
+agent = Agent(
+    tools=MCP("https://api.example.com")  # → https://api.example.com/mcp
+)
+
+# Explicit path
 agent = Agent(
     tools=MCP("https://api.example.com/mcp")
 )
 
-# With all options
+# With all options (passed as top-level kwargs, forwarded to transport)
 agent = Agent(
     tools=MCP(
         "https://api.example.com/mcp",
@@ -292,10 +298,24 @@ agent = Agent(
         debug=True,
         headers={"Authorization": "Bearer token"},
         session=True,           # Enable session management
-        resumability=True       # Enable SSE resumability
+        resumability=True,      # Enable SSE resumability
+        responseMode="stream",  # 'batch' (default) or 'stream'
+        cors={},                # Reserved for future CORS configuration
     )
 )
 ```
+
+### HTTP-Stream Options
+
+All five options are accepted as top-level kwargs and forwarded into the transport's `options` dict:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `responseMode` | `'batch' \| 'stream'` | `'batch'` | `'stream'` starts the background SSE listener for server-initiated messages |
+| `headers` | `dict[str, str]` | `{}` | Extra HTTP headers merged into every request (e.g. `Authorization`) |
+| `cors` | `dict` | — | Forwarded to transport; reserved for future CORS configuration |
+| `session` | `bool \| str` | — | When the server returns `Mcp-Session-Id`, it is tracked automatically on subsequent requests |
+| `resumability` | `bool` | — | Tracks the SSE `id:` field and sends `Last-Event-ID` on reconnect |
 
 ### Session Management
 
@@ -322,12 +342,17 @@ The client automatically includes `Mcp-Protocol-Version` header:
 # Default version: 2025-03-26 (for backward compatibility)
 mcp = MCP("https://api.example.com/mcp")
 
-# Specify version explicitly
+# Pass protocol_version='2025-11-25' to opt into the current spec
+# The SDK default is 2025-03-26 for backward compatibility
 mcp = MCP(
     "https://api.example.com/mcp",
     protocol_version="2025-11-25"
 )
 ```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `protocol_version` | `str` | `'2025-03-26'` | Sent as `Mcp-Protocol-Version` header. Pass `'2025-11-25'` to opt into the current spec |
 
 ---
 


### PR DESCRIPTION
## Summary

- **New page** `docs/js/mcp-transport-selection.mdx` — documents the unified `new MCP(url, transportType)` single-class API with `TransportType` union (`'auto' | 'sse' | 'http-streaming'`), auto-detection logic, Mermaid diagrams, and Mintlify `<Steps>`, `<AccordionGroup>`, `<CardGroup>` components
- **Cross-link** added to `docs/js/mcp-tools.mdx` under a new "Single-class Transport Selection" section
- **Refresh** of `docs/mcp/transports.mdx` — all 5 HTTP-Stream top-level kwargs documented with a parameter table, `protocol_version` note updated (SDK default is `2025-03-26`), and `/mcp` endpoint default noted for bare domain URLs
- **Navigation** updated in `docs.json` — new page registered in the JS Integrations group after `mcp-tools-cli`

Fixes #975

Generated with [Claude Code](https://claude.ai/code)