### PR TITLE
docs(features): use top-level praisonaiagents imports in agent-runtime-protocol page

### DIFF
--- a/docs/features/agent-runtime-protocol.mdx
+++ b/docs/features/agent-runtime-protocol.mdx
@@ -23,13 +23,17 @@ graph LR
     classDef result fill:#10B981,stroke:#7C90A0,color:#fff
 ```
 
+<Note>
+`AgentRuntimeProtocol`, `resolve_runtime`, `register_runtime`, and `list_runtimes` are importable directly from `praisonaiagents` as of PR #2335. The deep `praisonaiagents.runtime.*` paths remain available for backward compatibility.
+</Note>
+
 ## Quick Start
 
 <Steps>
 <Step title="Run a turn with the built-in runtime">
 ```python
 import asyncio
-from praisonaiagents.runtime import resolve_runtime
+from praisonaiagents import resolve_runtime
 
 async def main():
     runtime = resolve_runtime("praisonai")
@@ -43,7 +47,7 @@ asyncio.run(main())
 <Step title="Stream the response">
 ```python
 import asyncio
-from praisonaiagents.runtime import resolve_runtime
+from praisonaiagents import resolve_runtime
 
 async def main():
     runtime = resolve_runtime("praisonai")
@@ -62,7 +66,8 @@ The built-in `praisonai` runtime currently yields a single delta containing the 
 <Step title="Register and use a custom runtime">
 ```python
 import asyncio
-from praisonaiagents.runtime import register_runtime, resolve_runtime, RuntimeResult, RuntimeDelta
+from praisonaiagents import register_runtime, resolve_runtime
+from praisonaiagents.runtime import RuntimeResult, RuntimeDelta
 
 class EchoRuntime:
     def supports(self, model_ref=None):
@@ -214,7 +219,8 @@ The built-in runtime returns `RuntimeResult(error=...)` instead of raising an ex
 ### Implement a custom runtime
 
 ```python
-from praisonaiagents.runtime import register_runtime, RuntimeResult, RuntimeDelta
+from praisonaiagents import register_runtime
+from praisonaiagents.runtime import RuntimeResult, RuntimeDelta
 
 class MyRuntime:
     def supports(self, model_ref=None):
@@ -269,7 +275,7 @@ add_runtime_alias("default", "praisonai")
 
 ```python
 from praisonaiagents.runtime.registry import unregister_runtime
-from praisonaiagents.runtime import register_runtime
+from praisonaiagents import register_runtime
 
 unregister_runtime("praisonai")
 register_runtime("praisonai", lambda: MyCustomRuntime())
@@ -278,7 +284,7 @@ register_runtime("praisonai", lambda: MyCustomRuntime())
 ### List available runtimes
 
 ```python
-from praisonaiagents.runtime import list_runtimes
+from praisonaiagents import list_runtimes
 
 for runtime_id in list_runtimes():
     print(runtime_id)
@@ -318,5 +324,7 @@ The registry is process-wide and thread-safe. Call `RuntimeRegistry().clear()` o
 
 <CardGroup cols={2}>
 <Card icon="cloud" href="/docs/features/managed-runtime-protocol">Run the whole agent loop on remote provider infrastructure</Card>
+<Card icon="bolt" href="/docs/features/runtime-selection">Select runtimes by model or provider at the YAML level</Card>
+<Card icon="route" href="/docs/features/runtime-resolution">Resolve and cache runtimes at turn time</Card>
 <Card icon="plug" href="/docs/concepts/mcp">Plug in tools from any Model Context Protocol server</Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

Updates `docs/features/agent-runtime-protocol.mdx` to reflect the new top-level exports introduced by PR MervinPraison/PraisonAI#2335.

**Changes:**
- Switch all Quick Start examples to use `from praisonaiagents import resolve_runtime / register_runtime / list_runtimes` (friendly top-level imports per AGENTS.md §6.1)
- Switch Common Patterns examples to use top-level imports where applicable
- Keep deep paths for symbols not re-exported at top level: `RuntimeResult`, `RuntimeDelta`, `add_runtime_alias`, `unregister_runtime`, `is_runtime_available`
- Add `<Note>` callout after the hero diagram noting the new top-level exports and backward-compatible deep paths
- Expand `## Related` `<CardGroup>` to include `runtime-selection` and `runtime-resolution` cards (4 cards total)

Fixes #980

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the agent runtime protocol guide to reflect the latest import paths.
  * Added a note clarifying that key runtime helpers can now be imported directly from the main package, while older paths still work.
  * Revised code examples to match the current import style.
  * Improved related links to point to the runtime selection and runtime resolution docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->