### PR TITLE
docs: update security env vars and approval cache docs

### DIFF
--- a/docs/features/approval.mdx
+++ b/docs/features/approval.mdx
@@ -200,6 +200,63 @@ await agent.astart("Delete old files")
 
 Available non-console backends: `webhook`, `http`, `slack`, `telegram`, `discord`, `agent`.
 
+## Argument-aware approval cache
+
+Approval grants are scoped to the exact tool arguments — calling the same tool with different arguments triggers a fresh approval.
+
+```mermaid
+graph LR
+    Call[🔧 Tool Call] --> Key{🔑 Cache Key}
+    Key -->|same args| Hit[✅ Cached — skip prompt]
+    Key -->|different args| Miss[🛡️ New prompt]
+    Key -->|critical tool| Always[⚠️ Always prompt]
+
+    classDef call fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef key fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef hit fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef miss fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class Call call
+    class Key key
+    class Hit hit
+    class Miss,Always miss
+```
+
+The cache key formula is:
+
+```
+"{tool_name}:{sha256(json.dumps(arguments, sort_keys=True))[:16]}"
+```
+
+So `write_file({"path": "/tmp/a.txt"})` and `write_file({"path": "/tmp/b.txt"})` produce **different** keys and each requires its own approval.
+
+**Critical-risk tools** (`execute_command`, `kill_process`, `execute_code`) always re-prompt regardless of the cache — `is_already_approved` returns `False` unconditionally for them.
+
+**Worked example**:
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="FileBot",
+    instructions="Write files as requested",
+    approval=True,
+)
+
+# First call — prompts for approval
+agent.start("Write 'hello' to /tmp/a.txt")
+
+# Second call with SAME path — no prompt (cached)
+agent.start("Write 'hello again' to /tmp/a.txt")
+
+# Third call with DIFFERENT path — prompts again
+agent.start("Write 'world' to /tmp/b.txt")
+```
+
+<Note>
+This is a behavior change from previous versions where approving a tool name once would auto-approve **all** subsequent calls to that tool in the same context, regardless of arguments. Now only calls with **identical arguments** skip the prompt.
+</Note>
+
 ## Troubleshooting
 
 | Error | Cause | Fix |

--- a/docs/features/security-environment-variables.mdx
+++ b/docs/features/security-environment-variables.mdx
@@ -108,12 +108,17 @@ unset PRAISONAI_ALLOW_LOCAL_TOOLS
 - Generic CLI `_load_tools(tools_path)`
 - HTTP API: `praisonai.api.call.import_tools_from_file` (raises `ValueError` if disabled)
 - Path-traversal guard: files outside the current working directory are refused even when `PRAISONAI_ALLOW_LOCAL_TOOLS=true`
+- `praisonaiagents.workflows.workflows.AgentFlow` (SDK-level: skips `tools.py` next to the workflow class when unset)
 
 <Note>
 Even when `PRAISONAI_ALLOW_LOCAL_TOOLS=true`, the loader refuses any path outside the current working directory. This is a deliberate defence-in-depth layer for HTTP-API callers (`praisonai.api.call.import_tools_from_file`) where the path can come from network input. Move the `tools.py` you want to load into your CWD if you hit `Refusing to exec ... outside working directory.` in the logs.
 </Note>
 
-`PRAISONAI_ALLOW_LOCAL_TOOLS` accepts only `true` (case-insensitive). Values like `1`, `yes`, or `on` are **not** truthy for this variable (unlike `PRAISONAI_ALLOW_TEMPLATE_TOOLS`).
+`PRAISONAI_ALLOW_LOCAL_TOOLS` accepts only `true` (case-insensitive) in the **wrapper** (`praisonai`). Values like `1`, `yes`, or `on` are **not** truthy for the wrapper (unlike `PRAISONAI_ALLOW_TEMPLATE_TOOLS`).
+
+<Note>
+**Truthy-value inconsistency across surfaces:** The wrapper (`praisonai`) accepts only `true`; the SDK's `AgentFlow` (`praisonaiagents.workflows.workflows`) accepts `true`, `1`, or `yes`; the SDK's recipe path in `workflows.py` accepts `true`, `1`, `yes`, or `on`. If you rely on `PRAISONAI_ALLOW_LOCAL_TOOLS=1`, the wrapper will reject it even though the SDK's AgentFlow will accept it. This is the SDK's actual behavior — set `true` to be safe across all surfaces.
+</Note>
 
 **Usage Example**:
 ```python
@@ -137,6 +142,7 @@ agent.start("Calculate using local tools")
 | Env var unset, HTTP API (`api/call.py`) | raised exception | `ValueError("Local tools loading disabled. Set PRAISONAI_ALLOW_LOCAL_TOOLS=true to enable.")` |
 | Path outside CWD, env var **set** | logger.warning | `Refusing to exec <path>: outside working directory.` |
 | Path outside CWD via HTTP API, env var **set** | raised exception | `LocalToolsDisabled("Refusing to exec <path>: outside working directory.")` |
+| Env var unset, SDK `AgentFlow` with `tools.py` present | logger.debug | `Skipping tools.py load for <class>: set PRAISONAI_ALLOW_LOCAL_TOOLS=true` |
 
 ### PRAISONAI_ALLOW_TEMPLATE_TOOLS
 
@@ -174,6 +180,143 @@ registry = create_tool_registry_with_overrides(
     include_defaults=True
 )
 ```
+
+### PRAISONAI_ALLOW_PLUGIN_DISCOVERY
+
+Controls automatic discovery and loading of plugins from `.praisonai/plugins/` (project-level) and `~/.praisonai/plugins/` (user-level) directories.
+
+**Security Risk**: Remote Code Execution (RCE) via malicious third-party plugins discovered on `sys.path`.
+
+```bash
+# Enable plugin auto-discovery
+export PRAISONAI_ALLOW_PLUGIN_DISCOVERY=true
+
+# Disable (default - secure)
+unset PRAISONAI_ALLOW_PLUGIN_DISCOVERY
+```
+
+**Default**: unset → discovery skipped silently (debug log only)  
+**Accepted truthy values**: `true`, `1`, `yes` (case-insensitive, whitespace-stripped). `on` is **not** accepted.
+
+**Affected Component**: `praisonaiagents.plugins.manager.PluginManager.discover_and_load_plugins`
+
+**Default behavior when unset**: `discover_and_load_plugins()` is a no-op and returns `0`. A `logger.debug` message fires: `Plugin auto-discovery disabled; set PRAISONAI_ALLOW_PLUGIN_DISCOVERY=true`.
+
+**Usage Example**:
+```python
+import os
+os.environ["PRAISONAI_ALLOW_PLUGIN_DISCOVERY"] = "true"
+
+from praisonaiagents import Agent
+from praisonaiagents.plugins.manager import PluginManager
+
+manager = PluginManager()
+loaded = manager.discover_and_load_plugins()
+print(f"Loaded {loaded} plugins")
+
+agent = Agent(
+    name="Plugin User",
+    instructions="Use discovered plugins to help"
+)
+agent.start("Run task with plugins")
+```
+
+**Workaround when off**: Register plugins explicitly without enabling discovery:
+```python
+from praisonaiagents.plugins.manager import PluginManager
+
+manager = PluginManager()
+manager.register_plugin("my_plugin", my_plugin_module)
+```
+
+### PRAISONAI_PROJECT_ROOT
+
+Sets the allowed root directory for agent output file writes. Writes outside this root are silently blocked.
+
+**Security Risk**: Path-traversal write outside the project tree (e.g. `output_file="../../etc/passwd"`).
+
+```bash
+# Set a specific project root
+export PRAISONAI_PROJECT_ROOT=/home/user/myproject
+
+# Default: current working directory at save time
+unset PRAISONAI_PROJECT_ROOT
+```
+
+**Default**: unset → `os.getcwd()` at save time  
+**Affected Component**: `praisonaiagents.agent.memory_mixin.MemoryMixin._save_output_to_file`
+
+**Silent-failure semantics**: When the output path resolves outside the project root, the save returns `False`, logs `Output file %r is outside project root %r; skipping save` at `logging.warning`, and prints `⚠️ Output path outside project root: <path>` to stdout. No exception is raised.
+
+**Usage Example**:
+```python
+import os
+os.environ["PRAISONAI_PROJECT_ROOT"] = "/home/user/myproject"
+
+from praisonaiagents import Agent
+
+# This saves successfully — path is within project root
+agent = Agent(
+    name="Writer",
+    instructions="Write a report",
+    output_file="report.md"
+)
+agent.start("Summarise the project")
+
+# This is blocked — path escapes the project root
+agent2 = Agent(
+    name="Writer",
+    instructions="Write a report",
+    output_file="../report.md"
+)
+agent2.start("Summarise the project")
+# Prints: ⚠️ Output path outside project root: ../report.md
+```
+
+### ALLOW_LOCAL_CRAWL
+
+Bypasses SSRF protection for loopback, private, link-local, multicast, and unspecified IP addresses in web crawl tools.
+
+**Security Risk**: Server-Side Request Forgery (SSRF) — agents fetching `http://169.254.169.254/...` (cloud metadata), `http://localhost:6379` (Redis), etc.
+
+```bash
+# Allow crawling local/private addresses
+export ALLOW_LOCAL_CRAWL=true
+
+# Disable (default - secure)
+unset ALLOW_LOCAL_CRAWL
+```
+
+**Default**: unset → loopback/private/link-local/multicast/unspecified IPs blocked; returns `{"error": "URL blocked by SSRF policy"}` per blocked URL  
+**Accepted truthy values**: `true` only — **exact, case-sensitive match**. This is stricter than other env vars on this page.
+
+**Affected Components**:
+- `praisonaiagents.tools.web_crawl_tools` (both `_crawl_with_crawl4ai` and `_crawl_with_httpx` via `_is_safe_crawl_url`)
+- `praisonaiagents.tools.url_safety.is_safe_http_url`
+
+**Usage Example**:
+```python
+import os
+
+# Without ALLOW_LOCAL_CRAWL — blocked
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Crawler",
+    instructions="Fetch the given URL"
+)
+result = agent.start("Crawl http://192.168.1.1/api/status")
+# Returns: {"error": "URL blocked by SSRF policy"}
+
+# With ALLOW_LOCAL_CRAWL=true — allowed
+os.environ["ALLOW_LOCAL_CRAWL"] = "true"
+result = agent.start("Crawl http://192.168.1.1/api/status")
+# Fetches and returns content
+```
+
+<Warning>
+`ALLOW_LOCAL_CRAWL` uses **exact** `"true"` matching (case-sensitive). `"True"`, `"TRUE"`, `"1"`, and `"yes"` are all rejected. This differs from the `PRAISONAI_*` variables on this page.
+</Warning>
 
 ### PRAISONAI_ALLOW_JOB_WORKFLOWS
 
@@ -440,6 +583,7 @@ These environment variables address the following security vulnerabilities:
 | **GHSA-xcmw-grxf-wjhj** | High | Implicit RCE via template/CWD tools.py autoload | `PRAISONAI_ALLOW_TEMPLATE_TOOLS` |
 | **GHSA-vc46-vw85-3wvm** | Critical | RCE via job workflow YAML | `PRAISONAI_ALLOW_JOB_WORKFLOWS` |  
 | **GHSA-8x8f-54wf-vv92** | Critical | WebSocket session hijacking | `PRAISONAI_BROWSER_ALLOW_REMOTE` |
+| pending | High | SSRF via web crawl to loopback/private addresses | `ALLOW_LOCAL_CRAWL` |
 
 **CVE IDs**: Pending assignment by GitHub Security Advisory system
 


### PR DESCRIPTION
## Summary

Updates two existing documentation pages with new security behavior introduced in the daily SDK sync (commit `8999a1d6`).

### Changes to `docs/features/security-environment-variables.mdx`

- **`PRAISONAI_ALLOW_LOCAL_TOOLS`**: Added `AgentFlow` to Affected Components list; added debug log message to Error & Warning table; added `<Note>` callout documenting truthy-value inconsistency across wrapper/AgentFlow/recipe surfaces
- **`PRAISONAI_ALLOW_PLUGIN_DISCOVERY`** (new section): RCE risk, `true`/`1`/`yes` truthy values, `on` not accepted, affected component, explicit `register_plugin()` workaround
- **`PRAISONAI_PROJECT_ROOT`** (new section): Path-traversal write protection, default `os.getcwd()`, silent-failure semantics with `⚠️ Output path outside project root` message
- **`ALLOW_LOCAL_CRAWL`** (new section): SSRF risk, exact case-sensitive `true` match, affected components, Security Advisories table entry

### Changes to `docs/features/approval.mdx`

- **`## Argument-aware approval cache`** (new section): Mermaid diagram, cache key formula, worked `write_file` example showing when prompts re-fire, `<Note>` documenting the behavior change from per-tool-name to per-tool-arguments caching

All changes verified against SDK source code — no invented behavior.

Fixes #981

Generated with [Claude Code](https://claude.ai/code)