### PR TITLE
docs: document praisonai --init provider preflight + cross-link to praisonai setup

### DIFF
--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -279,7 +279,7 @@ praisonai
 | `--framework` | choice | Framework: crewai/autogen/praisonai |
 | `--ui` | choice | UI: chainlit/gradio |
 | `--auto` | remainder | Auto-generate agents |
-| `--init` | remainder | Initialize agents |
+| `--init` | remainder | Initialize `agents.yaml` from a task description. Prints provider-setup guidance and exits if no LLM provider is configured (see [`praisonai setup`](/docs/cli/setup)). |
 | `--deploy` | flag | Deploy application |
 | `--schedule` | str | Schedule pattern |
 | `--schedule-config` | str | Schedule configuration file |

--- a/docs/cli/setup.mdx
+++ b/docs/cli/setup.mdx
@@ -7,6 +7,10 @@ icon: "key"
 
 Interactive wizard that stores your LLM provider API key so every subsequent `praisonai` command works without extra configuration.
 
+<Note>
+Running `praisonai --init` without a configured provider prints a pointer to this page — you do not have to find `setup` separately.
+</Note>
+
 ```mermaid
 graph TB
     A[🚀 praisonai setup] --> B[Choose provider]
@@ -170,6 +174,9 @@ API keys are masked in the output. Only non-sensitive settings (provider, model)
 <CardGroup cols={2}>
   <Card title="First-run Onboarding" icon="key-round" href="/docs/features/first-run-onboarding">
     Auto-detects missing credentials at first invocation
+  </Card>
+  <Card title="Quick Start (--init)" icon="bolt" href="/docs/quickstart">
+    Generate agents.yaml with `praisonai --init` — links here when no provider is configured
   </Card>
   <Card title="Run Command" icon="play" href="/docs/cli/run">
     Run agents from files or prompts

--- a/docs/features/cli.mdx
+++ b/docs/features/cli.mdx
@@ -77,6 +77,9 @@ PraisonAI CLI provides a simple way to interact with AI agents directly from you
     praisonai --init "Create a movie script about AI"
     ```
     This will create an `agents.yaml` file with predefined configuration for your task.
+    <Note>
+    If no LLM provider is configured, `--init` prints provider-setup guidance (supporting OpenAI, Anthropic, Google/Gemini, Groq, Cohere, Ollama, OpenRouter and 100+ models via LiteLLM) and exits. Run [`praisonai setup`](/docs/cli/setup) first to configure a provider.
+    </Note>
   </Tab>
 
   <Tab title="Auto Mode">

--- a/docs/features/first-run-onboarding.mdx
+++ b/docs/features/first-run-onboarding.mdx
@@ -7,6 +7,8 @@ icon: "key-round"
 
 When you run PraisonAI for the first time without API keys, it detects the unconfigured environment and offers to launch the setup wizard instead of failing on the first LLM call.
 
+`praisonai --init` is now safe to run before `setup` — if no provider is configured it prints provider guidance and exits cleanly rather than throwing a stack trace. Either order works for onboarding.
+
 ```mermaid
 graph LR
     A[🚀 praisonai / praisonai run] --> B{Credentials<br/>configured?}

--- a/docs/features/onboard.mdx
+++ b/docs/features/onboard.mdx
@@ -258,6 +258,8 @@ Both are called automatically by the installer, but can be run independently.
 
 <Note>
 **"First-run onboarding" and "bot onboarding" are two distinct flows.** First-run onboarding (`praisonai setup`) sets up LLM credentials and is triggered automatically when you first invoke `praisonai` or `praisonai run` without API keys. Bot onboarding (`praisonai onboard`, this page) is an optional step for configuring Telegram/Discord/Slack/WhatsApp bots. See [First-run Onboarding](/docs/features/first-run-onboarding) for the credential setup flow.
+
+`praisonai --init` is safe to run before or after `setup` — if no provider is configured it surfaces setup guidance rather than a stack trace, so onboarding can proceed in either order.
 </Note>
 
 ---

--- a/docs/install/installer.mdx
+++ b/docs/install/installer.mdx
@@ -378,6 +378,10 @@ After installation and verification, the installer runs an interactive onboardin
 If you skip the setup wizard (`--no-prompt`), the next `praisonai` invocation will detect missing credentials and offer to launch the wizard — or exit with a clear error in CI.
 </Note>
 
+<Tip>
+If you have not configured an LLM provider yet, run `praisonai setup` first, or follow the on-screen guidance from `--init`. Running `praisonai --init "task"` without a provider key now prints step-by-step setup instructions instead of crashing.
+</Tip>
+
 ---
 
 ## Related

--- a/docs/nocode/initialise.mdx
+++ b/docs/nocode/initialise.mdx
@@ -6,9 +6,34 @@ icon: "power-off"
 
 ## Set API Key
 
+<Steps>
+<Step title="Configure a provider">
+Run the interactive setup wizard to pick a provider and save your API key:
+
 ```bash
-export OPENAI_API_KEY="your-key"
+praisonai setup
 ```
+
+PraisonAI supports OpenAI, Anthropic, Google/Gemini, Groq, Cohere, Ollama, OpenRouter and 100+ models via LiteLLM. Alternatively, export a key directly:
+
+```bash
+export OPENAI_API_KEY="your-key"       # OpenAI
+export ANTHROPIC_API_KEY="your-key"   # Anthropic Claude
+export GEMINI_API_KEY="your-key"      # Google Gemini
+```
+</Step>
+
+<Step title="Generate agents.yaml">
+
+```bash
+python -m praisonai --init "your topic here"
+```
+
+<Note>
+If no provider is configured, `--init` prints setup guidance and exits instead of crashing. Run `praisonai setup` (step above) to configure a provider first.
+</Note>
+</Step>
+</Steps>
 
 ## Generate agents.yaml
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -151,6 +151,7 @@ You can automatically create `agents.yaml` using:
 ```bash
 praisonai --init "your task description"
 ```
+First time? Run [`praisonai setup`](/docs/cli/setup) to pick a provider and save your API key — `--init` will print provider guidance if no key is configured.
 </Note>
 
       </Step>
@@ -433,6 +434,7 @@ You can automatically create `agents.yaml` file using
 ```bash Terminal
 praisonai --init create movie script about cat in mars
 ```
+First time? Run [`praisonai setup`](/docs/cli/setup) to pick a provider and save your API key — `--init` will print provider guidance if no key is configured.
 </Note>
 
       </Step>


### PR DESCRIPTION
## Summary

Documents the new behavior introduced in PraisonAI PR #2338: `praisonai --init` now prints clear provider-setup guidance (instead of crashing) when no LLM provider key is configured.

## Changes

- **`docs/quickstart.mdx`**: Added `<Note>` near both `--init` references cross-linking to `/docs/cli/setup`
- **`docs/cli/cli-reference.mdx`**: Updated `--init` flag description to mention provider-preflight behavior
- **`docs/cli/setup.mdx`**: Added `<Note>` at top noting `--init` links here; added `--init` card to Related section
- **`docs/install/installer.mdx`**: Added `<Tip>` in post-install section about `--init` safe behavior
- **`docs/features/cli.mdx`**: Added `<Note>` inside `--init` tab with provider list and setup link
- **`docs/nocode/initialise.mdx`**: Added `<Steps>` with step 0 (configure provider via `praisonai setup`) before `--init` step
- **`docs/features/onboard.mdx`**: Added sentence to existing note about `--init` being safe before `setup`
- **`docs/features/first-run-onboarding.mdx`**: Added sentence noting `--init` is safe before `setup`

## Acceptance criteria

- ✅ Cross-links between `--init` references and `praisonai setup` are bidirectional
- ✅ Provider list matches PR #2338 source: "OpenAI, Anthropic, Google/Gemini, Groq, Cohere, Ollama, OpenRouter and 100+ models via LiteLLM"
- ✅ Example env vars match SDK message: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`
- ✅ No page implies OpenAI is required
- ✅ No new files in `docs/concepts/`
- ✅ `docs.json` remains valid JSON

Fixes #985

Generated with [Claude Code](https://claude.ai/code)