### PR TITLE
docs: Auto Runtime Selection + Plugin Harness Registry page + --init provider preflight callout

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -406,6 +406,7 @@
                       "docs/features/external-cli-integrations",
                       "docs/features/cli-backend-protocol",
                       "docs/features/runtime-selection",
+                      "docs/features/runtimes",
                       "docs/features/cli-configuration",
                       "docs/features/single-source-config",
                       "docs/features/prepared-turn-context",

--- a/docs/features/cli.mdx
+++ b/docs/features/cli.mdx
@@ -77,6 +77,12 @@ PraisonAI CLI provides a simple way to interact with AI agents directly from you
     praisonai --init "Create a movie script about AI"
     ```
     This will create an `agents.yaml` file with predefined configuration for your task.
+
+    <Tip>
+    **No API key yet?** Run `praisonai setup` first — an interactive wizard that stores your provider and key in `~/.praisonai/config.yaml`. No shell `export` needed. `praisonai --init` detects a missing key and points you at this command instead of failing.
+
+    Supported providers: OpenAI, Anthropic, Google/Gemini, Groq, Cohere, Ollama, OpenRouter, + 100+ via LiteLLM.
+    </Tip>
   </Tab>
 
   <Tab title="Auto Mode">

--- a/docs/features/runtimes.mdx
+++ b/docs/features/runtimes.mdx
@@ -1,0 +1,312 @@
+---
+title: "Runtimes"
+sidebarTitle: "Runtimes"
+description: "Pick the engine that runs your agent — built-in, plugin, or auto-selected"
+icon: "plug"
+---
+
+Runtimes are the execution engines between your `Agent` and the actual model or tool host. The built-in `praisonai` runtime is the default — zero config needed.
+
+```mermaid
+graph LR
+    subgraph "Runtime Flow"
+        A[🤖 Agent] --> B[⚙️ resolve_runtime]
+        B --> C{Runtime type}
+        C -->|default| D[🏠 Built-in praisonai]
+        C -->|plugin| E[🔌 Plugin harness]
+        C -->|managed| F[☁️ Cloud runtime]
+        D --> G[✅ Model / Tool host]
+        E --> G
+        F --> G
+    end
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef resolve fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef decision fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef runtime fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A agent
+    class B resolve
+    class C decision
+    class D,E,F runtime
+    class G result
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Default runtime — zero config">
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Coder",
+    instructions="Write Python.",
+)
+agent.start("Write a hello-world script")
+```
+
+The built-in `praisonai` runtime runs automatically. Nothing to configure.
+</Step>
+
+<Step title="List installed runtimes">
+```python
+from praisonaiagents import list_runtimes
+
+print(list_runtimes())
+# ['praisonai']          # plus any installed plugin runtimes
+```
+</Step>
+
+<Step title="Pin a specific runtime">
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Coder",
+    instructions="Write Python.",
+    runtime="praisonai",   # or "claude-code" if that plugin is installed
+)
+agent.start("Write a hello-world script")
+```
+</Step>
+
+<Step title="Register a custom runtime">
+```python
+from praisonaiagents import register_runtime, AgentRuntimeProtocol
+
+class MyRuntime:
+    @property
+    def runtime_name(self): return "my-runtime"
+    @property
+    def runtime_version(self): return "0.1"
+    def supports(self, model_ref=None): return True
+
+register_runtime("my-runtime", lambda: MyRuntime())
+
+agent = Agent(
+    name="Coder",
+    instructions="Write Python.",
+    runtime="my-runtime",
+)
+```
+</Step>
+
+<Step title="Install a plugin runtime via entry-point">
+```toml
+# In your plugin's pyproject.toml
+[project.entry-points."praisonai.runtimes"]
+my-runtime = "my_pkg.runtime:MyRuntime"
+```
+
+After `pip install my-pkg`, the runtime is auto-discovered — no code changes needed.
+</Step>
+</Steps>
+
+---
+
+## Which runtime should I use?
+
+```mermaid
+graph TB
+    Start([Start]) --> Q1{Do you need a specific\nlocal CLI tool?}
+    Q1 -->|No| Q2{Do you want PraisonAI\nto auto-select?}
+    Q1 -->|Yes| Plugin[Set runtime='plugin-id'\ne.g. 'claude-code']
+    Q2 -->|Yes| Auto[Leave runtime unset\nauto-selection picks best]
+    Q2 -->|No| Default[Use built-in default\nruntime='praisonai']
+    Auto --> AutoFall[Falls back to 'praisonai'\nif no other is installed]
+    Default --> Done([Done])
+    Plugin --> Done
+    AutoFall --> Done
+
+    classDef question fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef action fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef terminal fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef start fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class Start,Done start
+    class Q1,Q2 question
+    class Plugin,Auto,Default,AutoFall action
+```
+
+| Scenario | What to do |
+|----------|-----------|
+| Just getting started | Use default — set nothing |
+| Want a specific local CLI (Claude Code, Codex) | `runtime="<plugin-id>"` |
+| PraisonAI picks the best available | Leave `runtime` unset |
+| Authoring a plugin runtime | Implement `AgentRuntimeProtocol` + register via entry-point |
+
+---
+
+## How It Works
+
+### Auto-selection
+
+When `runtime` is unset, `resolve_runtime()` scans all registered runtimes, calls `supports(model_ref)` on each, and picks the highest-priority match. If none match, it falls back to the built-in `praisonai` runtime.
+
+```mermaid
+graph TB
+    Req[Agent.start] --> Resolve[resolve_runtime\nmodel_ref]
+    Resolve --> Scan[Scan registered runtimes]
+    Scan --> Check{supports\nmodel_ref?}
+    Check -->|Yes| Priority[Sort by selection_priority]
+    Check -->|No| Skip[Skip]
+    Priority --> Best[Highest priority wins]
+    Skip --> Scan
+    Best --> FallQ{Any match?}
+    FallQ -->|Yes| UseIt[Use selected runtime]
+    FallQ -->|No| Builtin[Fall back to 'praisonai']
+
+    classDef start fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Req start
+    class Resolve,Scan,Priority,Best process
+    class Check,FallQ decision
+    class UseIt,Builtin result
+    class Skip process
+```
+
+### Plugin discovery
+
+At import time, PraisonAI scans the `praisonai.runtimes` entry-point group and registers every installed plugin runtime automatically via `_discover_entry_point_runtimes()`.
+
+```mermaid
+sequenceDiagram
+    participant Pkg as pip install my-plugin
+    participant EP as Entry-point group<br/>praisonai.runtimes
+    participant Registry as RuntimeRegistry
+    participant Agent
+
+    Pkg->>EP: register my-runtime = my_pkg.runtime:MyRuntime
+    Note over EP,Registry: On next import of praisonaiagents
+    EP->>Registry: _discover_entry_point_runtimes()
+    Registry->>Registry: ep.load() → factory
+    Registry-->>Agent: runtime available as "my-runtime"
+    Agent->>Registry: resolve_runtime("my-runtime")
+    Registry-->>Agent: MyRuntime()
+```
+
+### Register → Resolve → Run lifecycle
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant Registry as RuntimeRegistry
+    participant Resolver as resolve_runtime
+    participant RT as Runtime instance
+
+    Dev->>Registry: register_runtime("my-runtime", factory)
+    Dev->>Registry: Agent(runtime="my-runtime").start(prompt)
+    Registry->>Resolver: resolve("my-runtime")
+    Resolver->>Registry: lookup factory
+    Registry->>RT: factory() → MyRuntime()
+    RT->>RT: supports(model_ref) → True
+    RT-->>Dev: RuntimeResult(content=...)
+```
+
+---
+
+## Plugin Harness Contract
+
+A runtime plugin must implement the `AgentRuntimeProtocol`:
+
+```python
+from praisonaiagents import AgentRuntimeProtocol
+
+class MyRuntime:
+    @property
+    def runtime_name(self) -> str:
+        return "my-runtime"
+
+    @property
+    def runtime_version(self) -> str:
+        return "0.1.0"
+
+    def supports(self, model_ref=None) -> bool:
+        return True
+
+    async def run_turn(self, prompt, *, system_prompt=None, model_ref=None, **kwargs):
+        # Your execution logic here
+        from praisonaiagents.runtime.protocols import RuntimeResult
+        return RuntimeResult(content="response", metadata={})
+```
+
+<Tip>
+The `AgentRuntimeProtocol` uses Python structural subtyping — your class does **not** need to explicitly inherit from it. Implement the required properties and methods and it satisfies the protocol automatically.
+</Tip>
+
+### `pyproject.toml` snippet for plugin authors
+
+```toml
+[project.entry-points."praisonai.runtimes"]
+my-runtime = "my_pkg.runtime:MyRuntime"
+```
+
+After publishing and installing your package, `list_runtimes()` will include `"my-runtime"` automatically.
+
+---
+
+## Runtime Families
+
+| Family | Description | Example IDs |
+|--------|-------------|-------------|
+| **Native** | Built-in `praisonai` runtime (default) | `"praisonai"` |
+| **Plugin harness** | External CLI / container registered via `praisonai.runtimes` entry-point | `"claude-code"`, `"codex-cli"` |
+| **Managed** | Cloud-hosted runtimes (E2B, Modal, etc.) | provider-specific |
+
+<Note>
+Default behaviour is unchanged. Agents that don't set `runtime` continue using the built-in PraisonAI runtime — nothing to migrate.
+</Note>
+
+---
+
+## Configuration Options
+
+<Card title="AgentRuntimeProtocol API Reference" icon="code" href="/docs/sdk/reference">
+  Full protocol signature — runtime_name, runtime_version, supports(), run_turn(), stream_turn()
+</Card>
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Leave runtime unset for most agents">
+The built-in `praisonai` runtime handles all standard LLM providers. Only set `runtime` when you specifically need a different execution harness (e.g. Claude Code for code-only tasks).
+</Accordion>
+
+<Accordion title="Use entry-points for shareable plugins">
+Prefer registering runtimes via `pyproject.toml` entry-points rather than calling `register_runtime()` inline. Entry-point plugins work across projects and are discoverable without code changes.
+</Accordion>
+
+<Accordion title="Unknown runtime IDs fail loud">
+If you set `runtime="typo-runtime"` and it's not registered, the agent raises a `ValueError` immediately — it does not silently fall back to the built-in runtime. This is intentional.
+</Accordion>
+
+<Accordion title="Check available runtimes before pinning">
+Call `list_runtimes()` to confirm a plugin is installed before pinning it in production config. This catches missing dependencies early.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Runtime Selection" icon="play" href="/docs/features/runtime-selection">
+  Per-model and per-provider runtime config, YAML configuration, and migration from cli_backend
+</Card>
+<Card title="Runtime Capabilities" icon="shield-check" href="/docs/features/runtime-capabilities">
+  Capability matrix — declare what features your runtime supports
+</Card>
+<Card title="CLI Backend Protocol" icon="terminal" href="/docs/features/cli-backend-protocol">
+  Legacy cli_backend reference (deprecated — see Runtime Selection)
+</Card>
+<Card title="Runtime Preflight" icon="shield" href="/docs/features/runtime-preflight">
+  Validate runtime configuration before AgentTeam.start()
+</Card>
+</CardGroup>


### PR DESCRIPTION
Fixes #983

Part A - New docs/features/runtimes.mdx covering PraisonAI PR #2335:
- Hero Mermaid + decision-tree + auto-selection flow + plugin discovery + lifecycle diagrams
- Quick Start: 5 progressive steps (zero-config, list, pin, register custom, entry-point plugin)
- AgentRuntimeProtocol contract + pyproject.toml snippet for plugin authors
- Backward-compat note: default unchanged
- Added to docs.json Features > Integration & Infrastructure

Part B - Minor update to docs/features/cli.mdx for PraisonAI PR #2338:
- Tip callout under praisonai --init with praisonai setup guidance
- Lists all supported providers (OpenAI, Anthropic, Google/Gemini, Groq, Cohere, Ollama, OpenRouter, 100+ via LiteLLM)

Generated with [Claude Code](https://claude.ai/code)