### PR TITLE
docs(js/mcp): document new MCP class + HTTP-Streaming transport

### DIFF
--- a/docs/js/mcp-tools.mdx
+++ b/docs/js/mcp-tools.mdx
@@ -1,227 +1,350 @@
 ---
 title: "MCP Tools"
-description: "Model Context Protocol integration for AI agents"
+sidebarTitle: "MCP Tools"
+description: "Connect AI agents to any MCP server with automatic transport selection"
 icon: "plug"
 ---
 
-# MCP Tools
+Connect agents to Model Context Protocol (MCP) servers to give them access to external tools, data, and services.
 
-Integrate Model Context Protocol (MCP) servers to extend agent capabilities with external tools, resources, and prompts.
+```mermaid
+graph LR
+    subgraph "MCP Integration"
+        A[🤖 Agent] --> B[🔌 MCP]
+        B --> C{Auto-detect}
+        C -->|URL ends /sse| D[📡 SSE]
+        C -->|other URLs| E[🌊 HTTP-Streaming]
+        D --> F[✅ MCP Server]
+        E --> F
+    end
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef transport fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef detect fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class A agent
+    class B,D,E transport
+    class C detect
+    class F result
+```
 
 ## Quick Start
 
+<Steps>
+<Step title="Install and connect to an MCP server">
+
 ```typescript
-import { Agent, createMCP } from 'praisonai-ts';
+import { Agent, MCP } from 'praisonai-ts';
 
-// Connect to MCP server
-const mcp = await createMCP({
-  transport: {
-    type: 'stdio',
-    command: 'npx',
-    args: ['-y', '@modelcontextprotocol/server-filesystem', '/path/to/dir'],
-  },
-});
-
-// Get tools from MCP server
-const tools = await mcp.tools();
-
-// Create agent with MCP tools
-const agent = new Agent({
-  name: 'FileAgent',
-  instructions: 'You help manage files.',
-  tools: Object.values(tools),
-});
-
-const response = await agent.chat('List all files in the directory');
+const mcp = new MCP('http://127.0.0.1:8080/sse');
+await mcp.initialize();
 ```
 
-## Transport Types
+</Step>
 
-### Stdio (Local Servers)
-
-```typescript
-const mcp = await createMCP({
-  transport: {
-    type: 'stdio',
-    command: 'npx',
-    args: ['-y', '@modelcontextprotocol/server-filesystem', '/path'],
-    env: { NODE_ENV: 'production' },
-  },
-});
-```
-
-### SSE (Server-Sent Events)
+<Step title="Wire MCP tools into an Agent">
 
 ```typescript
-const mcp = await createMCP({
-  transport: {
-    type: 'sse',
-    url: 'https://mcp-server.example.com/sse',
-    headers: { Authorization: 'Bearer token' },
-  },
-});
-```
-
-### HTTP
-
-```typescript
-const mcp = await createMCP({
-  transport: {
-    type: 'http',
-    url: 'https://mcp-server.example.com/api',
-    headers: { 'X-API-Key': 'key' },
-  },
-});
-```
-
-### WebSocket
-
-```typescript
-const mcp = await createMCP({
-  transport: {
-    type: 'websocket',
-    url: 'wss://mcp-server.example.com/ws',
-  },
-});
-```
-
-## OAuth Authentication
-
-```typescript
-import { createMCP, type OAuthClientProvider } from 'praisonai-ts';
-
-const oauthProvider: OAuthClientProvider = {
-  getAccessToken: async () => {
-    return await getStoredToken();
-  },
-  refreshToken: async () => {
-    return await refreshOAuthToken();
-  },
-};
-
-const mcp = await createMCP({
-  transport: {
-    type: 'http',
-    url: 'https://mcp-server.example.com/api',
-    authProvider: oauthProvider,
-  },
-});
-```
-
-## Resources
-
-Access resources from MCP servers:
-
-```typescript
-// List available resources
-const resources = await mcp.listResources();
-console.log('Resources:', resources);
-
-// Read a resource
-const content = await mcp.readResource('file:///path/to/file.txt');
-console.log('Content:', content.text);
-```
-
-## Prompts
-
-Use prompts from MCP servers:
-
-```typescript
-// List available prompts
-const prompts = await mcp.listPrompts();
-console.log('Prompts:', prompts);
-
-// Get a prompt
-const prompt = await mcp.getPrompt('summarize', { length: 'short' });
-console.log('Prompt messages:', prompt.messages);
-```
-
-## Popular MCP Servers
-
-| Server | Package | Description |
-|--------|---------|-------------|
-| Filesystem | `@modelcontextprotocol/server-filesystem` | File operations |
-| GitHub | `@modelcontextprotocol/server-github` | GitHub API |
-| Slack | `@modelcontextprotocol/server-slack` | Slack integration |
-| PostgreSQL | `@modelcontextprotocol/server-postgres` | Database queries |
-| Brave Search | `@modelcontextprotocol/server-brave-search` | Web search |
-
-## Example: Filesystem Server
-
-```typescript
-import { Agent, createMCP } from 'praisonai-ts';
-
-const mcp = await createMCP({
-  transport: {
-    type: 'stdio',
-    command: 'npx',
-    args: ['-y', '@modelcontextprotocol/server-filesystem', './documents'],
-  },
-});
-
-const tools = await mcp.tools();
+const toolFunctions = Object.fromEntries(
+  [...mcp].map(tool => [tool.name, async (args: any) => tool.execute(args)])
+);
 
 const agent = new Agent({
-  name: 'FileManager',
-  instructions: 'You help manage files and directories.',
-  tools: Object.values(tools),
+  instructions: 'You are a helpful assistant with access to MCP tools.',
+  name: 'MCPAgent',
+  tools: mcp.toOpenAITools(),
+  toolFunctions,
 });
 
-await agent.chat('Create a new file called notes.txt with "Hello World"');
+const response = await agent.runSync('What tools are available?');
+console.log(response);
+
+await mcp.close();
 ```
 
-## Example: GitHub Server
+</Step>
+</Steps>
+
+---
+
+## Transport Selection
+
+The `MCP` class picks the right transport automatically — no config objects needed.
+
+```mermaid
+graph TB
+    Start([URL provided]) --> Auto{transport = ?}
+    Auto -->|'auto' default| Detect{URL ends with /sse?}
+    Auto -->|'sse'| SSE[SSE transport]
+    Auto -->|'http-streaming'| HTTP[HTTP-Streaming transport]
+    Detect -->|Yes| SSE
+    Detect -->|No| HTTP
+
+    classDef detect fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef transport fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef start fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class Start start
+    class Auto,Detect detect
+    class SSE,HTTP transport
+```
+
+| URL pattern | `transport` param | Transport used |
+|-------------|-------------------|----------------|
+| `http://host/sse` | `'auto'` (default) | SSE |
+| `http://host/api` | `'auto'` (default) | HTTP-Streaming |
+| any URL | `'sse'` | SSE (forced) |
+| any URL | `'http-streaming'` | HTTP-Streaming (forced) |
+
+<Warning>
+Auto-detection is **suffix-based**: only URLs that end exactly with `/sse` select SSE. A URL like `https://api.example.com/sse/v2` will **not** auto-select SSE — pass `'sse'` explicitly.
+</Warning>
+
+---
+
+## Examples
+
+<Tabs>
+<Tab title="Auto (default)">
 
 ```typescript
-const mcp = await createMCP({
-  transport: {
-    type: 'stdio',
-    command: 'npx',
-    args: ['-y', '@modelcontextprotocol/server-github'],
-    env: { GITHUB_TOKEN: process.env.GITHUB_TOKEN },
-  },
-});
+import { Agent, MCP } from 'praisonai-ts';
 
-const tools = await mcp.tools();
+async function main() {
+  // URL ends with /sse → auto-selects SSE
+  const mcp = new MCP('http://127.0.0.1:8080/sse');
+  await mcp.initialize();
+  console.log(`Transport: ${mcp.transportType}`); // 'sse'
 
-const agent = new Agent({
-  name: 'GitHubAgent',
-  instructions: 'You help with GitHub operations.',
-  tools: Object.values(tools),
-});
+  const toolFunctions = Object.fromEntries(
+    [...mcp].map(tool => [tool.name, async (args: any) => tool.execute(args)])
+  );
 
-await agent.chat('List my recent repositories');
+  const agent = new Agent({
+    instructions: 'You are a helpful assistant.',
+    name: 'AutoMCPAgent',
+    tools: mcp.toOpenAITools(),
+    toolFunctions,
+  });
+
+  const response = await agent.runSync('What tools are available?');
+  console.log(response);
+
+  await mcp.close();
+}
+
+main().catch(console.error);
 ```
 
-## Cleanup
-
-Always close MCP connections when done:
+</Tab>
+<Tab title="Explicit SSE">
 
 ```typescript
-import { closeMCPClient, closeAllMCPClients } from 'praisonai-ts';
+import { Agent, MCP } from 'praisonai-ts';
 
-// Close specific client
-await closeMCPClient('my-client-id');
+async function main() {
+  // Force SSE regardless of URL pattern
+  const mcp = new MCP('http://127.0.0.1:8080/api', 'sse');
+  await mcp.initialize();
+  console.log(`Transport: ${mcp.transportType}`); // 'sse'
 
-// Close all clients
-await closeAllMCPClients();
+  const toolFunctions = Object.fromEntries(
+    [...mcp].map(tool => [tool.name, async (args: any) => tool.execute(args)])
+  );
+
+  const agent = new Agent({
+    instructions: 'You are a helpful assistant.',
+    name: 'SSEMCPAgent',
+    tools: mcp.toOpenAITools(),
+    toolFunctions,
+  });
+
+  const response = await agent.runSync('List available tools');
+  console.log(response);
+
+  await mcp.close();
+}
+
+main().catch(console.error);
 ```
 
-## Environment Variables
+</Tab>
+<Tab title="HTTP-Streaming">
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `OPENAI_API_KEY` | Yes | For the agent |
-| Server-specific | Varies | MCP server requirements |
+```typescript
+import { Agent, MCP } from 'praisonai-ts';
+
+async function main() {
+  // Force HTTP-Streaming
+  const mcp = new MCP('http://127.0.0.1:8080/stream', 'http-streaming');
+  await mcp.initialize();
+  console.log(`Transport: ${mcp.transportType}`); // 'http-streaming'
+
+  const toolFunctions = Object.fromEntries(
+    [...mcp].map(tool => [tool.name, async (args: any) => tool.execute(args)])
+  );
+
+  const agent = new Agent({
+    instructions: 'You are a helpful assistant.',
+    name: 'HTTPMCPAgent',
+    tools: mcp.toOpenAITools(),
+    toolFunctions,
+  });
+
+  const response = await agent.runSync('What can you do?');
+  console.log(response);
+
+  await mcp.close();
+}
+
+main().catch(console.error);
+```
+
+</Tab>
+<Tab title="Debug mode">
+
+```typescript
+import { Agent, MCP } from 'praisonai-ts';
+
+async function main() {
+  // Enable debug logging to see transport selection details
+  const mcp = new MCP('http://127.0.0.1:8080/sse', 'auto', true);
+  await mcp.initialize();
+  // Logs: "MCP client initialized for URL: ... with transport: sse"
+  // Logs: "Initialized MCP with N tools using sse transport"
+
+  const agent = new Agent({
+    instructions: 'You are a helpful assistant.',
+    name: 'DebugMCPAgent',
+    tools: mcp.toOpenAITools(),
+    toolFunctions: Object.fromEntries(
+      [...mcp].map(tool => [tool.name, async (args: any) => tool.execute(args)])
+    ),
+  });
+
+  const response = await agent.runSync('Hello!');
+  console.log(response);
+
+  await mcp.close();
+}
+
+main().catch(console.error);
+```
+
+</Tab>
+</Tabs>
+
+---
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `url` | `string` | required | MCP server URL |
+| `transport` | `TransportType` | `'auto'` | One of `'auto' \| 'sse' \| 'http-streaming'` |
+| `debug` | `boolean` | `false` | Log transport selection and tool count |
+
+```typescript
+import { MCP, TransportType } from 'praisonai-ts';
+
+const mcp = new MCP(
+  'http://127.0.0.1:8080/stream',  // url
+  'http-streaming',                  // transport
+  true                               // debug
+);
+```
+
+---
+
+## Instance API
+
+| Method / Property | Returns | Description |
+|-------------------|---------|-------------|
+| `initialize()` | `Promise<void>` | Connect and load tools from the server |
+| `close()` | `Promise<void>` | Disconnect and release resources |
+| `toOpenAITools()` | `OpenAITool[]` | Convert tools to OpenAI function-call format |
+| `[...mcp]` | `MCPTool[]` | Iterate over available tools |
+| `mcp.tools` | `MCPTool[]` | Array of loaded tools (after `initialize()`) |
+| `mcp.isConnected` | `boolean` | `true` after `initialize()`, `false` after `close()` |
+| `mcp.transportType` | `string` | `'sse'`, `'http-streaming'`, or `'not initialized'` |
+
+---
+
+## New Exports
+
+```typescript
+import { 
+  MCP,                    // Unified MCP client (use this)
+  TransportType,          // 'auto' | 'sse' | 'http-streaming'
+  HTTPStreamingTransport, // Low-level transport (advanced use)
+  MCPHttpStreaming,       // Standalone HTTP-Streaming client
+  MCPTool,               // Tool type
+  MCPToolInfo            // Tool info type
+} from 'praisonai-ts';
+```
+
+---
 
 ## Best Practices
 
-1. **Close connections** - Always close MCP clients when done
-2. **Handle errors** - MCP servers may fail or timeout
-3. **Use appropriate transport** - Stdio for local, HTTP/SSE for remote
-4. **Secure credentials** - Use OAuth for authenticated servers
+<AccordionGroup>
+<Accordion title="Always call close() when done">
+MCP connections stay open until explicitly closed. Always call `await mcp.close()` to release resources, especially in long-running applications or when switching servers.
+
+```typescript
+const mcp = new MCP('http://localhost:8080/sse');
+try {
+  await mcp.initialize();
+  // ... use the agent
+} finally {
+  await mcp.close();
+}
+```
+</Accordion>
+
+<Accordion title="Use debug=true when connecting a new server">
+Enable debug mode when first wiring up a new MCP server. It logs the selected transport and number of tools loaded, making misconfiguration easy to spot.
+
+```typescript
+const mcp = new MCP('http://localhost:8080/api', 'auto', true);
+await mcp.initialize();
+// Console: "Initialized MCP with 5 tools using http-streaming transport"
+```
+</Accordion>
+
+<Accordion title="Pass transport explicitly when URL patterns are ambiguous">
+Auto-detection relies on the URL ending in `/sse`. If your server URL doesn't follow this convention, pass the transport explicitly to avoid surprises.
+
+```typescript
+// This will use HTTP-Streaming even though it's an SSE server
+const wrong = new MCP('https://api.example.com/sse/v2');  // auto = http-streaming
+
+// Correct: pass transport explicitly
+const right = new MCP('https://api.example.com/sse/v2', 'sse');
+```
+</Accordion>
+
+<Accordion title="Prefer MCP over MCPHttpStreaming for new code">
+Use the unified `MCP` class for all new integrations. `MCPHttpStreaming` is a standalone client without auto-detection. Only use it if you specifically need direct HTTP-Streaming without the unified interface.
+</Accordion>
+</AccordionGroup>
+
+---
 
 ## Related
 
-- [Tools](/docs/js/tools) - Tool system overview
-- [Agent](/docs/js/agent) - Agent configuration
+<CardGroup cols={2}>
+<Card title="MCP Security" icon="shield" href="/docs/js/mcp-security">
+  Secure MCP connections with authentication and rate limiting
+</Card>
+<Card title="Python MCP Transports" icon="python" href="/docs/mcp/transports">
+  Python equivalent — stdio, Streamable HTTP, WebSocket, SSE
+</Card>
+<Card title="Tools" icon="wrench" href="/docs/js/tools">
+  Tool system overview for TypeScript agents
+</Card>
+<Card title="Agent" icon="user" href="/docs/js/agent">
+  Agent configuration and capabilities
+</Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Updates `docs/js/mcp-tools.mdx` to document the new `MCP` class and HTTP-Streaming transport introduced in PraisonAI PR #2336
- Replaces outdated `createMCP({ transport: { type, url } })` factory examples with the new `new MCP(url, transport, debug)` constructor
- Documents `TransportType = 'auto' | 'sse' | 'http-streaming'` and the auto-detection rule (URL ending `/sse` → SSE, else → HTTP-Streaming)

## Changes

- **Hero mermaid diagram**: Agent → MCP → auto-detect → {SSE, HTTP-Streaming} → Server
- **Transport-selection decision diagram**: when to use each transport
- **Quick Start**: 2-step flow with `new MCP(url)` + Agent wiring
- **Transport Selection** section with detection table and pitfall warning about suffix-based detection
- **Tabbed examples**: Auto, Explicit SSE, HTTP-Streaming, Debug mode
- **Instance API table**: all methods/properties (`initialize`, `close`, `toOpenAITools`, `transportType`, `isConnected`, iteration)
- **Configuration Options table**: all 3 constructor params with types and defaults
- **New Exports** section: `MCP`, `TransportType`, `HTTPStreamingTransport`, `MCPHttpStreaming`
- **Best Practices** AccordionGroup: 4 best practices
- **Related** CardGroup: links to mcp-security, Python transports doc, tools, agent

Fixes #993

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reworked the MCP tools guide with a new, clearer setup flow.
  * Added examples for automatic transport selection, forced transport modes, and debug usage.
  * Updated the API reference to reflect the latest client creation, connection lifecycle, and tool access patterns.
  * Expanded guidance on configuration options, available exports, and best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->