### PR TITLE
docs: gateway streaming flood-control + reasoning-tag filtering

### DIFF
--- a/docs/features/bot-streaming-replies.mdx
+++ b/docs/features/bot-streaming-replies.mdx
@@ -202,6 +202,68 @@ Live streaming (`draft` mode) works on **Telegram, Slack, and Discord** — each
 | `min_delta` | `int` | `120` | Minimum new characters in the buffer before an edit fires |
 | `placeholder_text` | `str` | `"🤔 Thinking..."` | Initial message text sent before any content arrives |
 | `progress_prefix` | `str` | `"🤔 "` | Prefix used in `progress` mode tool-status updates |
+| `disable_progressive_edits_after` | `int` | `3` | Consecutive recoverable edit failures before progressive editing is turned off for the rest of the stream — the completed answer is then delivered as a single final send |
+| `flood_backoff_factor` | `float` | `2.0` | Multiplier applied to the edit interval on each recoverable (flood / 429 / transient) failure |
+| `max_interval` | `float` | `30.0` | Cap in seconds for the adaptively widened edit interval — backoff stops growing past this |
+| `strip_reasoning_tags` | `bool` | `True` | Strip `<think>…</think>` and `<reasoning>…</reasoning>` spans from streamed and final output. Default ON — set to `false` to opt out |
+
+---
+
+## Flood-control
+
+Your Telegram bot is streaming a long answer during peak hours. Telegram starts returning 429 after the third edit. The streamer doubles its edit interval (1.5s → 3s → 6s → capped at `max_interval`). After `disable_progressive_edits_after` consecutive failures it stops editing entirely and waits — when `finalize()` fires it delivers the completed answer as a fresh message. The user never sees a stuck placeholder, never sees a partial reply, and the rest of your bot's chats are unaffected because the backoff is per-stream.
+
+<Note>
+Backoff is per-stream — `_current_min_interval` is mutated on the stream instance, not the shared `StreamingConfig`. A flood in one chat will never slow streaming in another.
+</Note>
+
+```mermaid
+graph TB
+    Edit[✏️ Try edit] --> OK{🔍 Succeeded?}
+    OK -->|Yes| Reset[✅ Reset fail streak]
+    OK -->|No, recoverable| Back[📈 fail_streak += 1<br/>interval *= backoff_factor<br/>capped at max_interval]
+    Back --> Cap{🔍 fail_streak ≥<br/>disable_progressive_edits_after?}
+    Cap -->|No| Edit
+    Cap -->|Yes| OffPath[🔌 Progressive edits OFF<br/>wait for finalize]
+    OffPath --> Final[📨 finalize: edit-then-send fallback<br/>full answer delivered]
+    Reset --> Edit
+
+    classDef try fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef happy fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef warn fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class Edit try
+    class OK,Cap check
+    class Reset,Final happy
+    class Back,OffPath warn
+```
+
+| Event | What the streamer does |
+|-------|----------------------|
+| Recoverable edit failure (flood / 429 / transient) | `fail_streak += 1`; `current_min_interval *= flood_backoff_factor` (capped at `max_interval`). Per-stream — does not mutate the shared `StreamingConfig` |
+| `fail_streak >= disable_progressive_edits_after` | Progressive editing turns OFF for the rest of this stream. Subsequent token events skip `_perform_update`. The placeholder is left in place until `finalize()` |
+| Non-recoverable edit failure | Logged at WARNING. Fail streak does NOT increment; progressive stays enabled |
+| Successful edit | `fail_streak` resets to 0 (recovery) |
+| `finalize(final_content)` | Strip reasoning tags (if enabled), try edit-in-place, fall back to `send_message` if edit fails |
+
+---
+
+## Reasoning-tag filtering
+
+**Default ON.** `<think>` and `<reasoning>` spans (case-insensitive, multi-line) are stripped from both streamed and final output. A trailing unclosed opening tag is also dropped so internal reasoning never leaks mid-stream while a block is still being produced. Set `strip_reasoning_tags: false` to opt out (for example, on a reasoning-transparency bot).
+
+```python
+from praisonai.bots._streaming import strip_reasoning_tags
+
+strip_reasoning_tags("Hi <think>secret</think> there")        # -> "Hi  there"
+strip_reasoning_tags("a <REASONING>x\ny</REASONING> b")       # -> "a  b"
+strip_reasoning_tags("Answer <think>still going")             # -> "Answer "
+```
+
+<Tip>
+Used to see `<think>` or `<reasoning>` spans land in your Telegram/Slack/Discord chat? Fixed in [PR #2356](https://github.com/MervinPraison/PraisonAI/pull/2356). Reasoning-tag filtering is now on by default. Upgrade `praisonai`.
+</Tip>
 
 ---
 
@@ -221,6 +283,11 @@ channels:
       min_delta: 120
       placeholder_text: "🤔 Thinking..."
       progress_prefix: "🤔 "
+      # New in #2356
+      disable_progressive_edits_after: 3
+      flood_backoff_factor: 2.0
+      max_interval: 30.0
+      strip_reasoning_tags: true
 ```
 
 ### Python API
@@ -257,6 +324,7 @@ streamer = DraftStreamer(
     channel_id="123456",
     config=StreamingConfig(mode=StreamingMode.DRAFT, min_interval=1.5),
     rate_limiter=None,                # optional, defaults from platform
+    platform="telegram",              # enables platform-specific recoverable-error classification
 )
 
 message_id = await streamer.start()                      # sends placeholder
@@ -305,8 +373,40 @@ bot.configure_streaming(StreamingConfig(
 The feature has zero impact on existing bots. Only channels with explicit `streaming:` configuration will use the new behavior. All other channels continue with the original single-message approach.
 </Accordion>
 
-<Accordion title="The final edit always contains the complete text">
-Even if every intermediate edit fails due to network issues or rate limits, the user will always see the full answer at the end when `finalize()` is called. This ensures reliability even in poor network conditions.
+<Accordion title="Final delivery is guaranteed even when edits are flooded">
+When `finalize()` runs, the streamer first tries to edit the placeholder with the full answer. If that edit fails (or progressive editing was already disabled by a flood-control strike), the streamer falls back to a fresh `send_message` so you always receive the completed answer. No stale "🤔 Thinking…" placeholder is left behind.
+
+```mermaid
+sequenceDiagram
+    participant Streamer
+    participant Adapter
+    participant User
+
+    Note over Streamer: finalize(final_content)
+    Streamer->>Streamer: strip_reasoning_tags(final_content)
+    Streamer->>Adapter: edit_message(placeholder_id, final_content)
+    alt edit succeeds
+        Adapter-->>User: ✅ placeholder replaced with full answer
+    else edit fails
+        Adapter-->>Streamer: error
+        Streamer->>Adapter: send_message(final_content)
+        Adapter-->>User: ✅ fresh message with full answer
+    end
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="Used to see `<think>` or `<reasoning>` spans in your chat?">
+Fixed in [PR #2356](https://github.com/MervinPraison/PraisonAI/pull/2356). Reasoning-tag filtering is now on by default. Upgrade `praisonai` to get the fix automatically.
+</Accordion>
+
+<Accordion title="Bot reply got stuck mid-edit on a busy chat?">
+Fixed in [PR #2356](https://github.com/MervinPraison/PraisonAI/pull/2356). The streamer now backs off on 429/flood, and after 3 consecutive failures falls back to a single final send so you always get the completed answer. Tune `disable_progressive_edits_after` / `flood_backoff_factor` / `max_interval` per channel if your platform's rate limits differ.
 </Accordion>
 </AccordionGroup>
 

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -298,7 +298,7 @@ Every entry under `channels:` is validated by `ChannelConfigSchema`:
 | `routing` / `routes` | `dict[str, str]` | `{}` | Context-to-agent routing — keys are `dm` / `group` / `channel` / `default`, values are agent IDs. |
 | `webhook_url` | `str` | `None` | Webhook URL for webhook/hybrid mode. |
 | `webhook_port` | `int` | `8080` | Local webhook listener port. |
-| `streaming` | `object` | `None` | Per-channel streaming reply config (`mode`, `min_interval`, `min_delta`, `placeholder_text`, `progress_prefix`). |
+| `streaming` | `object` | `None` | Per-channel streaming reply config (`mode`, `min_interval`, `min_delta`, `placeholder_text`, `progress_prefix`, `disable_progressive_edits_after`, `flood_backoff_factor`, `max_interval`, `strip_reasoning_tags`). See [Bot Streaming Replies](/docs/features/bot-streaming-replies) for the full reference. |
 | `home_channel` | `str` | `None` | Default channel ID for this platform. |
 | `aliases` | `dict[str, str]` | `{}` | Friendly name → channel ID map. |
 | `outbound_resilience` | `object` | `None` | Retry/DLQ settings (`enabled`, `initial_ms`, `max_ms`, `factor`, `max_attempts`, `jitter`, `dlq_path`). |


### PR DESCRIPTION
## Summary

Documents the behaviour changes and new API surface introduced in [MervinPraison/PraisonAI#2356](https://github.com/MervinPraison/PraisonAI/pull/2356) (merged 2026-06-27).

### Changes in `docs/features/bot-streaming-replies.mdx`

- **StreamingConfig options table** — 4 new rows: `disable_progressive_edits_after`, `flood_backoff_factor`, `max_interval`, `strip_reasoning_tags`
- **"Final delivery" accordion** — rewritten to describe the explicit edit-then-send fallback path; includes a `sequenceDiagram` showing both success and fallback cases
- **New "Flood-control" section** — user-flow framing (Telegram peak hours / 429 scenario), behaviour table, and Mermaid state diagram using the standard AGENTS.md colour scheme; includes per-stream isolation callout
- **New "Reasoning-tag filtering" section** — default-ON note, three code examples (complete block / case-insensitive / trailing unclosed), upgrade tip
- **YAML config example** — all 9 `streaming.*` keys now present with comments
- **Manual Streamer Usage snippet** — adds `platform="telegram"` arg
- **New "Troubleshooting" section** — FAQ accordions for reasoning leakage and stuck mid-edit replies

### Changes in `docs/features/gateway.mdx`

- **Channel Configuration Reference table** — `streaming` row now lists all 9 keys with a link to the full reference in `bot-streaming-replies.mdx`

### Acceptance criteria

- [x] StreamingConfig options table includes 4 new fields with correct defaults
- [x] "Flood-control" section exists with per-stream-backoff diagram
- [x] "Reasoning-tag filtering" section with `True` default and 3 behaviour examples
- [x] YAML config example shows all 9 `streaming.*` keys
- [x] "Final delivery" accordion rewritten with edit-then-send fallback
- [x] Manual Streamer Usage snippet passes `platform="telegram"`
- [x] `gateway.mdx` streaming row lists 4 new keys (with link)
- [x] No edits in `docs/concepts/`
- [x] Mermaid diagrams use standard AGENTS.md colour scheme

Fixes #998

Generated with [Claude Code](https://claude.ai/code)