### PR TITLE
docs: update send-message-tool for observed targets + media downgrade behaviour

### DIFF
--- a/docs/features/send-message-tool.mdx
+++ b/docs/features/send-message-tool.mdx
@@ -66,10 +66,14 @@ Use `action="list"` first when you want the agent to pick the right channel rath
 ```python
 # Model call:
 #   send_message("origin", "Weekly report ready MEDIA:/tmp/report.pdf")
-# Returns: "Delivered to origin"
+# Returns: "Sent to telegram:<chat_id> (media not attached)."
 ```
 
 Append `MEDIA:<path>` to the message text to attach a local file. Multiple attachments are supported.
+
+<Note>
+**Media attachments aren't delivered yet.** The text portion is sent, the `MEDIA:` paths are parsed and counted, and the result detail confirms how many files were skipped. File delivery will land in a future transport update — track [PraisonAI#2374](https://github.com/MervinPraison/PraisonAI/pull/2374) for follow-ups.
+</Note>
 
 </Step>
 </Steps>
@@ -182,7 +186,9 @@ Each entry in the array:
 |-------|------|-------------|
 | `target` | `str` | Token to pass as the `target` argument to `send_message` |
 | `platform` | `str` | Platform name (e.g. `"telegram"`, `"slack"`) |
-| `kind` | `str` | One of `"origin"`, `"home"`, or `"alias"` |
+| `kind` | `str` | One of `"origin"`, `"home"`, `"alias"`, or `"observed"` |
+
+`"observed"` means a channel the gateway has seen activity on but isn't a configured home or alias.
 | `label` | `str` | Friendly name for display |
 
 ---
@@ -221,7 +227,7 @@ Agent instructions can check for this string and fall back gracefully.
 
 ## User Interaction Flow
 
-A user starts a long research task on Telegram, then closes their phone. The agent finishes compiling the report, calls `send_message("origin", "Your report is ready MEDIA:/tmp/report.pdf")`, and the user receives a Telegram push notification with the PDF attached — without ever having to ask "are you done yet?".
+A user starts a long research task on Telegram, then closes their phone. The agent finishes compiling the report, calls `send_message("origin", "Your report is ready MEDIA:/tmp/report.pdf")`, and the user receives a Telegram push notification with the text — without ever having to ask "are you done yet?".
 
 ```mermaid
 sequenceDiagram
@@ -232,9 +238,9 @@ sequenceDiagram
     User->>Bot: "Generate the weekly sales report"
     Note over User: Closes Telegram, goes offline
     Bot->>Bot: Works on report...
-    Bot->>Gateway: send_message("origin", "Done! MEDIA:/tmp/report.pdf")
-    Gateway->>User: 📬 Telegram push with PDF
-    Note over User: Gets notification, opens file
+    Bot->>Gateway: send_message("origin", "Done! Report attached MEDIA:/tmp/report.pdf")
+    Gateway->>User: 📬 Telegram message "Done! Report attached"
+    Note over User: Gets the text notification (file delivery coming soon)
 ```
 
 ---
@@ -246,7 +252,7 @@ sequenceDiagram
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
 | `target` | `str` | `"origin"` | Symbolic destination (see Targets table) |
-| `message` | `str` | `""` | Text to send; append `" MEDIA:<path>"` to attach files |
+| `message` | `str` | `""` | Text to send; append `" MEDIA:<path>"` to attach files. Attachments are parsed today but not yet delivered through bot transports — the result detail reports how many were skipped. |
 | `action` | `str` | `"send"` | `"send"` to deliver, `"list"` to enumerate reachable targets |
 
 `action="send"` vs `action="list"` at a glance:


### PR DESCRIPTION
Fixes #1006. Updates send-message-tool.mdx: adds observed to kind enum, fixes media attachment return value and adds Note callout, updates User Interaction Flow diagram, updates message row caveat. Generated with Claude Code.