### PR TITLE
docs: reflect bare-positional one-shot prompt CLI behavior (fixes #1003)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -290,6 +290,7 @@
                       "docs/features/autoagents",
                       "docs/features/onboard",
                       "docs/features/first-run-onboarding",
+                      "docs/features/cli-direct-prompt",
                       "docs/features/installation-extras",
                       "docs/features/llm-endpoint-config",
                       "docs/features/llm-gateways",

--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -36,7 +36,7 @@ Detected env vars (any one satisfies the check): `OPENAI_API_KEY`, `ANTHROPIC_AP
 
 ```
 praisonai
-├── [direct prompt]              # Any text → runs agent
+├── [direct prompt]              # Any text → runs agent (see examples below)
 ├── [file.yaml]                  # YAML workflow execution
 ├── praisonai chat           # TUI mode
 ├── praisonai chat                  # Single prompt chat mode
@@ -271,6 +271,19 @@ praisonai
     ├── search                   # Search
     └── realtime-api             # Realtime API
 ```
+
+### Direct Prompt Examples
+
+The `[direct prompt]` entry in the tree above means any bare positional that isn't an existing file path or a `.yaml`/`.yml` name is routed as a one-shot prompt:
+
+```bash
+praisonai "summarise this folder"   # bare positional → one-shot prompt
+praisonai agents.yaml               # ends in .yaml → run as agent file
+praisonai ./my_agents               # existing file → run as agent file
+praisonai memory show               # known subcommand → routed normally
+```
+
+---
 
 ## Global Flags (70+ flags)
 

--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -6,6 +6,10 @@ icon: "play"
 
 The `run` command executes agents from YAML configuration files or direct prompts.
 
+<Note>
+For a quick one-off prompt you can omit the `run` subcommand entirely: `praisonai "What is the capital of France?"` is equivalent to `praisonai run "What is the capital of France?"` when the positional argument isn't an existing file or a `.yaml`/`.yml` path. Use `praisonai run` when you need flags like `--output stream-json`, `--model`, `--continue`, `--session`, `--no-rules`, `--allow`, etc.
+</Note>
+
 ## Usage
 
 ```bash

--- a/docs/features/cli-direct-prompt.mdx
+++ b/docs/features/cli-direct-prompt.mdx
@@ -1,0 +1,141 @@
+---
+title: "Direct Prompt (One-Shot CLI)"
+sidebarTitle: "Direct Prompt"
+description: "Run a one-shot AI task from the terminal with a single command — no YAML, no subcommand, just your prompt."
+icon: "terminal"
+---
+
+Run an agent with a single bare command — the fastest way to get something done.
+
+```bash
+praisonai "summarise this folder"
+```
+
+```mermaid
+graph LR
+    subgraph "CLI Dispatch"
+        A["📋 praisonai &quot;…&quot;"] --> B{Disambiguate}
+        B -->|"existing file"| C["📄 Agent file"]
+        B -->|"*.yaml / *.yml"| C
+        B -->|"known subcommand"| D["⚙️ Subcommand"]
+        B -->|"anything else"| E["🤖 One-shot prompt"]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef agentfile fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef prompt fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef sub fill:#189AB4,stroke:#7C90A0,color:#fff
+
+    class A input
+    class B decision
+    class C agentfile
+    class D sub
+    class E prompt
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Install PraisonAI">
+```bash
+pip install praisonai
+```
+</Step>
+
+<Step title="Set your API key">
+```bash
+export OPENAI_API_KEY=your_openai_key
+```
+</Step>
+
+<Step title="Run your first prompt">
+```bash
+praisonai "Hello"
+```
+
+That's it — the agent runs and returns a response immediately.
+</Step>
+</Steps>
+
+---
+
+## How Disambiguation Works
+
+The CLI inspects the bare positional argument and routes it using these rules (evaluated in order):
+
+| Positional value | Routed as |
+|---|---|
+| An existing file path on disk | Agent file |
+| Ends in `.yaml` or `.yml` (any case) | Agent file |
+| A known subcommand (`run`, `chat`, `memory`, …) | Subcommand |
+| Anything else (e.g. `"summarise this folder"`) | One-shot direct prompt |
+
+<Note>
+When to use `praisonai run` instead: the bare form is a shortcut for simple one-off prompts. Use `praisonai run` when you need flags such as `--output stream-json`, `--model`, `--continue`, `--session`, `--no-rules`, `--allow`, etc. See [praisonai run](/docs/cli/run) for the full flag reference.
+</Note>
+
+---
+
+## Examples
+
+```bash
+praisonai "What is the capital of France?"
+praisonai "Summarize the README.md file"
+praisonai "Write a Python function to reverse a string"
+praisonai "List the top 5 AI trends in 2025"
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Always quote multi-word prompts">
+Wrap your prompt in double quotes to prevent the shell from splitting it into multiple arguments:
+
+```bash
+praisonai "summarise this folder"   # correct
+praisonai  summarise this folder    # wrong — shell sees separate args
+```
+</Accordion>
+
+<Accordion title="Avoid name collisions with local files">
+If a file named `summarise` exists in your current directory, the CLI treats the positional as a file path. Quote the prompt and ensure it doesn't match a real file name, or use `praisonai run "summarise"` which forces prompt mode.
+</Accordion>
+
+<Accordion title="Combining stdin with a positional prompt">
+You can pipe content into the CLI and provide a prompt at the same time:
+
+```bash
+cat report.txt | praisonai "Summarise the following text"
+```
+
+The piped stdin is appended to the agent's context alongside the prompt.
+</Accordion>
+
+<Accordion title="Using with different models">
+The bare positional form works with any model flag:
+
+```bash
+praisonai run "Explain quantum computing" --model gpt-4o
+```
+
+The `--model` flag requires `praisonai run` — the bare shortcut form does not accept flags.
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="praisonai run" icon="play" href="/docs/cli/run">
+    Full flag reference for the run subcommand, including output modes, session continuity, and permission controls.
+  </Card>
+  <Card title="Quick Start" icon="bolt" href="/docs/quickstart">
+    End-to-end guide for installing PraisonAI and running your first agent.
+  </Card>
+</CardGroup>

--- a/docs/nocode/introduction.mdx
+++ b/docs/nocode/introduction.mdx
@@ -5,7 +5,7 @@ icon: "hand-wave"
 ---
 
 PraisonAI is a framework for building multi-agent AI systems. The **No Code** approach uses:
-- **CLI** (`python -m praisonai`) to run agents
+- **CLI** (`praisonai`) to run agents
 - **YAML** (`agents.yaml`) to define agent configurations
 
 No Python coding required for basic workflows.
@@ -20,20 +20,20 @@ pip install praisonai
 export OPENAI_API_KEY="your-key"
 
 # Generate agents.yaml from a topic
-python -m praisonai --init "research AI trends"
+praisonai --init "research AI trends"
 
 # Run the agents
-python -m praisonai
+praisonai
 ```
 
 ## What You Can Do
 
 | Mode | Command | Description |
 |:-----|:--------|:------------|
-| **Direct prompt** | `python -m praisonai "question"` | Ask a question directly |
-| **Auto mode** | `python -m praisonai --auto "topic"` | Auto-generate and run agents |
-| **YAML mode** | `python -m praisonai` | Run from `agents.yaml` |
-| **Init** | `python -m praisonai --init "topic"` | Generate `agents.yaml` |
+| **Direct prompt** | `praisonai "question"` | Ask a question directly |
+| **Auto mode** | `praisonai --auto "topic"` | Auto-generate and run agents |
+| **YAML mode** | `praisonai` | Run from `agents.yaml` |
+| **Init** | `praisonai --init "topic"` | Generate `agents.yaml` |
 
 ## Next Steps
 

--- a/docs/nocode/run.mdx
+++ b/docs/nocode/run.mdx
@@ -7,18 +7,22 @@ icon: "play"
 ## Run from agents.yaml
 
 ```bash
-python -m praisonai
+praisonai
 ```
 
 Runs the agents defined in `agents.yaml` in the current directory.
 
+Also works with `python -m praisonai` for users in venvs without an entry-point shim.
+
 ## Run with Direct Prompt
 
 ```bash
-python -m praisonai "What is machine learning?"
+praisonai "What is machine learning?"
 ```
 
-No `agents.yaml` needed - answers directly.
+No `agents.yaml` needed — answers directly.
+
+Alternatively: `python -m praisonai "What is machine learning?"`
 
 ## Run with Auto Mode
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -23,31 +23,31 @@ icon: "bolt"
           <Tab title="OpenAI">
             ```bash
             export OPENAI_API_KEY=your_openai_key
-            praisonai run "hello"
+            praisonai "hello"
             ```
           </Tab>
           <Tab title="Anthropic">
             ```bash
             export ANTHROPIC_API_KEY=your_anthropic_key
-            praisonai run "hello"
+            praisonai "hello"
             ```
           </Tab>
           <Tab title="Gemini">
             ```bash
             export GEMINI_API_KEY=your_gemini_key
-            praisonai run "hello"
+            praisonai "hello"
             ```
           </Tab>
           <Tab title="Groq">
             ```bash
             export GROQ_API_KEY=your_groq_key
-            praisonai run "hello"
+            praisonai "hello"
             ```
           </Tab>
           <Tab title="Ollama">
             ```bash
             export OLLAMA_HOST=http://localhost:11434
-            praisonai run "hello"
+            praisonai "hello"
             ```
           </Tab>
         </Tabs>


### PR DESCRIPTION
## Summary

Reflects the new bare-positional one-shot prompt CLI behavior from `MervinPraison/PraisonAI#2359` in the documentation.

- **`docs/quickstart.mdx`**: Replace `praisonai run "hello"` with `praisonai "hello"` across all 5 provider tabs (OpenAI, Anthropic, Gemini, Groq, Ollama).
- **`docs/nocode/run.mdx`**: Lead with `praisonai` / `praisonai "..."` as primary form; keep `python -m praisonai` as secondary fallback.
- **`docs/nocode/introduction.mdx`**: Update CLI references, Quick Example, and "What You Can Do" table to use `praisonai` as the primary command form.
- **`docs/cli/run.mdx`**: Add a `<Note>` callout near the top explaining that the `run` subcommand can be omitted for plain prompts.
- **`docs/cli/cli-reference.mdx`**: Add "Direct Prompt Examples" subsection after the command tree showing the disambiguation rules in action.
- **`docs/features/cli-direct-prompt.mdx`**: New feature page with disambiguation flow Mermaid diagram, Quick Start steps, disambiguation truth table, Best Practices accordion group, and Related card group.
- **`docs.json`**: Add `cli-direct-prompt` under Features > Agent Capabilities > Core Agent Features group.

Fixes #1003

Generated with [Claude Code](https://claude.ai/code)