### PR TITLE
docs: update inbound durable delivery to default-ON and per-platform scoped

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -344,6 +344,7 @@
                       "docs/features/bot-gateway",
                       "docs/features/bot-intentional-silence",
                       "docs/features/bot-presentations",
+                      "docs/features/delivery-config",
                       "docs/features/inbound-dlq",
                       "docs/features/inbound-journal",
                       "docs/features/long-running-bots",

--- a/docs/features/delivery-config.mdx
+++ b/docs/features/delivery-config.mdx
@@ -1,0 +1,189 @@
+---
+title: "Delivery Config"
+sidebarTitle: "Delivery Config"
+description: "Configure durable inbound delivery for your bot channels — on by default, per-platform isolated"
+icon: "shield-check"
+---
+
+Every bot channel automatically gets crash-safe inbound delivery: a deduplicating journal and a dead-letter queue, stored in `~/.praisonai/state/<platform>/`.
+
+```mermaid
+graph LR
+    subgraph "Default Durable Delivery"
+        Bot[🤖 Bot Start] --> Build[build_session_manager]
+        Build --> Journal[📒 InboundJournal\ningress.sqlite]
+        Build --> DLQ[📥 InboundDLQ\ninbound_dlq.sqlite]
+        Journal --> Store[💾 ~/.praisonai/state/\nplatform/]
+        DLQ --> Store
+    end
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef storage fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class Bot agent
+    class Build process
+    class Journal,DLQ process
+    class Store storage
+```
+
+## What's on by default
+
+When you start any bot via `praisonai bot start`, `onboard`, or `bot.yaml`, PraisonAI automatically wires:
+
+- **Inbound Journal** (`ingress.sqlite`) — deduplicates webhook redeliveries and replays in-flight messages on crash recovery
+- **Inbound DLQ** (`inbound_dlq.sqlite`) — persists failed-LLM messages for later replay
+
+Both live in one canonical per-platform directory. No configuration needed.
+
+## Canonical path
+
+```
+~/.praisonai/state/<platform>/ingress.sqlite
+~/.praisonai/state/<platform>/inbound_dlq.sqlite
+```
+
+`<platform>` is the sanitized platform name (characters outside `[A-Za-z0-9_.-]` replaced with `_`).
+
+| Platform | Journal path | DLQ path |
+|----------|-------------|----------|
+| `telegram` | `~/.praisonai/state/telegram/ingress.sqlite` | `~/.praisonai/state/telegram/inbound_dlq.sqlite` |
+| `discord` | `~/.praisonai/state/discord/ingress.sqlite` | `~/.praisonai/state/discord/inbound_dlq.sqlite` |
+| `slack` | `~/.praisonai/state/slack/ingress.sqlite` | `~/.praisonai/state/slack/inbound_dlq.sqlite` |
+| `whatsapp` | `~/.praisonai/state/whatsapp/ingress.sqlite` | `~/.praisonai/state/whatsapp/inbound_dlq.sqlite` |
+
+Set `PRAISONAI_HOME` to change the base directory:
+
+```bash
+export PRAISONAI_HOME=/var/lib/praisonai
+# → /var/lib/praisonai/state/telegram/ingress.sqlite
+```
+
+## `delivery:` schema
+
+The `delivery` block is part of each channel configuration in `bot.yaml` / `gateway.yaml`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `durable` | `bool` | `true` | Set to `false` to fully opt out and return to in-memory delivery. |
+| `store` | `str` | `None` | Path override. If it has a file suffix, sibling DBs are placed in its parent directory. `None` resolves to the canonical per-platform path. |
+
+## How to configure
+
+<Steps>
+<Step title="Default (nothing to do)">
+Just start your bot — durable delivery is already on.
+
+```bash
+praisonai bot start --config bot.yaml
+```
+</Step>
+
+<Step title="Opt out for a channel">
+```yaml
+# bot.yaml
+channels:
+  telegram:
+    token: "${TELEGRAM_BOT_TOKEN}"
+    delivery:
+      durable: false   # returns to in-memory delivery
+```
+</Step>
+
+<Step title="Override the store directory">
+```yaml
+channels:
+  telegram:
+    token: "${TELEGRAM_BOT_TOKEN}"
+    delivery:
+      store: /var/lib/praisonai/telegram-state
+      # → ingress.sqlite and inbound_dlq.sqlite in /var/lib/praisonai/telegram-state/
+```
+</Step>
+</Steps>
+
+## Per-platform isolation
+
+Each platform gets its own directory so DLQ replays never cross platforms:
+
+```mermaid
+graph TB
+    Root["~/.praisonai/state/"]:::storage --> TG["telegram/"]:::process
+    Root --> DC["discord/"]:::process
+    Root --> SL["slack/"]:::process
+    TG --> TGJ["ingress.sqlite"]:::success
+    TG --> TGDLQ["inbound_dlq.sqlite"]:::success
+    DC --> DCJ["ingress.sqlite"]:::success
+    DC --> DCDLQ["inbound_dlq.sqlite"]:::success
+    SL --> SLJ["ingress.sqlite"]:::success
+    SL --> SLDLQ["inbound_dlq.sqlite"]:::success
+
+    classDef storage fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+```
+
+A Discord DLQ replay never consumes a Telegram failed event. Dedup keys never collide cross-platform.
+
+## Failure mode
+
+If durability is requested but the SQLite components fail to initialise (permissions, disk full, etc.), `_build_durable_components` logs a warning and the manager safely falls back to in-memory delivery. Your bot continues working — no crash.
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Keep the default ON unless you have a reason to opt out">
+Durable delivery costs a tiny SQLite write per message. The benefit — zero silent message loss on crash or LLM failure — is almost always worth it.
+</Accordion>
+
+<Accordion title="Use PRAISONAI_HOME for containerized deployments">
+Mount a persistent volume and point `PRAISONAI_HOME` at it so the SQLite files survive container restarts.
+
+```bash
+docker run -e PRAISONAI_HOME=/data -v /host/data:/data my-bot
+```
+</Accordion>
+
+<Accordion title="Override store for multi-bot setups on one host">
+If you run two Telegram bots on the same host for different use cases, give each bot its own store directory to keep their journals isolated.
+
+```yaml
+# bot-support.yaml
+channels:
+  telegram:
+    token: "${SUPPORT_BOT_TOKEN}"
+    delivery:
+      store: /var/lib/praisonai/support-telegram
+
+# bot-sales.yaml
+channels:
+  telegram:
+    token: "${SALES_BOT_TOKEN}"
+    delivery:
+      store: /var/lib/praisonai/sales-telegram
+```
+</Accordion>
+
+<Accordion title="Monitor DLQ size as a reliability indicator">
+A growing DLQ (`praisonai bot dlq list`) signals chronic LLM failures. Wire `dlq.size()` into your alerting stack.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Inbound Journal" icon="book" href="/docs/features/inbound-journal">
+  Deduplication and crash-safe replay for inbound messages
+</Card>
+<Card title="Inbound DLQ" icon="inbox" href="/docs/features/inbound-dlq">
+  Dead-letter queue for failed LLM calls — inspect and replay
+</Card>
+<Card title="Durable Outbound Delivery" icon="shield-check" href="/docs/features/durable-delivery">
+  Outbound counterpart — persist outgoing messages with retry
+</Card>
+<Card title="Gateway Channel Config" icon="tower-broadcast" href="/docs/features/gateway">
+  Full channel configuration reference including the `delivery` field
+</Card>
+</CardGroup>

--- a/docs/features/durable-delivery.mdx
+++ b/docs/features/durable-delivery.mdx
@@ -7,6 +7,10 @@ icon: "shield-check"
 
 Durable Delivery persists every outbound bot message to a SQLite outbox so retries, restarts, and platform outages never drop a reply.
 
+<Note>
+This page covers **outbound** durability (`DurableDelivery` / `OutboundQueue`). For **inbound** durability — which is now on by default for all gateway/bot runs — see [Inbound Journal](/docs/features/inbound-journal) and [Inbound DLQ](/docs/features/inbound-dlq).
+</Note>
+
 ```mermaid
 graph LR
     subgraph "Durable Outbound Delivery"

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -302,6 +302,7 @@ Every entry under `channels:` is validated by `ChannelConfigSchema`:
 | `home_channel` | `str` | `None` | Default channel ID for this platform. |
 | `aliases` | `dict[str, str]` | `{}` | Friendly name → channel ID map. |
 | `outbound_resilience` | `object` | `None` | Retry/DLQ settings (`enabled`, `initial_ms`, `max_ms`, `factor`, `max_attempts`, `jitter`, `dlq_path`). |
+| `delivery` | `object` | `None` | Durable inbound delivery config (`durable`: bool, default `true`; `store`: optional path override). When unset, defaults to `{durable: true}` and uses `~/.praisonai/state/<platform>/`. See [Delivery Config](/docs/features/delivery-config). |
 | `session` | `object` | `None` | Session config (`max_history`, `reset` policy, `compaction` policy). |
 | `max_history` | `int` | `None` | Legacy alias for `session.max_history`. |
 | `phone_number_id` | `str` | `None` | WhatsApp Cloud API phone number ID. |
@@ -313,6 +314,17 @@ Every entry under `channels:` is validated by `ChannelConfigSchema`:
 | `smtp_server` | `str` | `None` | Email SMTP server. |
 | `inbox_id` | `str` | `None` | AgentMail inbox ID. |
 | `domain` | `str` | `None` | AgentMail domain. |
+
+### Durable Inbound Delivery
+
+```yaml
+channels:
+  telegram:
+    token: "${TELEGRAM_BOT_TOKEN}"
+    delivery:
+      durable: true             # default; set to false to opt out
+      # store: ~/my-bot-state  # optional override; otherwise ~/.praisonai/state/telegram/
+```
 
 ### Session Compaction
 

--- a/docs/features/inbound-dlq.mdx
+++ b/docs/features/inbound-dlq.mdx
@@ -5,8 +5,20 @@ icon: "inbox"
 ---
 
 <Note>
-**TL;DR** — When `agent.chat()` fails (LLM 5xx, timeout, rate-limit) the user's message is normally lost. Set `dlq=InboundDLQ(...)` and PraisonAI persists the failed message so you can replay it later.
+**On by default for gateway/bot runs** — When your bot starts via `praisonai bot start`, `onboard`, or `bot.yaml`, an `InboundDLQ` is wired automatically. No code needed. Set `delivery.durable: false` in your channel config to opt out.
 </Note>
+
+When `agent.chat()` fails (LLM 5xx, timeout, rate-limit), the user's message is normally lost. The Inbound DLQ persists the failed message so you can replay it later.
+
+```mermaid
+flowchart LR
+    A[User message]:::agent --> B[BotSessionManager.chat]:::agent
+    B -->|LLM ok| C[Reply]:::agent
+    B -->|LLM fails| D[InboundDLQ]:::tool
+    D -->|operator replay| B
+    classDef agent fill:#8B0000,color:#fff,stroke:#fff,stroke-width:1px;
+    classDef tool fill:#189AB4,color:#fff,stroke:#fff,stroke-width:1px;
+```
 
 ## Why you want this
 
@@ -21,35 +33,48 @@ icon: "inbox"
     TTL + `max_size` keep the queue from growing unbounded; oldest entries evict first.
   </Card>
   <Card title="Zero new dependency" icon="feather">
-    Uses only stdlib `sqlite3`. Default OFF — your existing bots are untouched.
+    Uses only stdlib `sqlite3`. On by default for gateway/bot runs — existing bots are upgraded automatically.
   </Card>
 </CardGroup>
 
-## How it flows
+## Default behavior (no config needed)
 
-```mermaid
-flowchart LR
-    A[User message]:::agent --> B[BotSessionManager.chat]:::agent
-    B -->|LLM ok| C[Reply]:::agent
-    B -->|LLM fails| D[InboundDLQ]:::tool
-    D -->|operator replay| B
-    classDef agent fill:#8B0000,color:#fff,stroke:#fff,stroke-width:1px;
-    classDef tool fill:#189AB4,color:#fff,stroke:#fff,stroke-width:1px;
+Every bot started through `build_session_manager` (all shipped adapters) automatically gets a DLQ at:
+
+```
+~/.praisonai/state/<platform>/inbound_dlq.sqlite
 ```
 
-## Quick start (3 lines)
+For example, a Telegram bot stores failed messages at `~/.praisonai/state/telegram/inbound_dlq.sqlite`. A Discord bot uses `~/.praisonai/state/discord/inbound_dlq.sqlite`. Each platform is fully isolated.
 
-```python
-from praisonai.bots import BotSessionManager, InboundDLQ
+Set `PRAISONAI_HOME` to override the base directory:
 
-dlq = InboundDLQ(path="~/.praisonai/dlq.sqlite")
-mgr = BotSessionManager(platform="telegram", dlq=dlq)
-# ↑ that's it — failed agent.chat() now lands in the DLQ
+```
+$PRAISONAI_HOME/state/<platform>/inbound_dlq.sqlite
 ```
 
-<Tip>
-Default behaviour is **unchanged** when no `dlq=` is passed. This is fully opt-in.
-</Tip>
+## Opt out or override path
+
+Add a `delivery:` block to any channel in your `bot.yaml` or `gateway.yaml`:
+
+```yaml
+channels:
+  telegram:
+    token: "${TELEGRAM_BOT_TOKEN}"
+    delivery:
+      durable: false   # opt out of durable inbound delivery for this channel
+```
+
+Override the store directory:
+
+```yaml
+channels:
+  telegram:
+    token: "${TELEGRAM_BOT_TOKEN}"
+    delivery:
+      store: /var/lib/praisonai/telegram-state
+      # → inbound_dlq.sqlite lives in /var/lib/praisonai/telegram-state/
+```
 
 ## CLI
 
@@ -66,6 +91,18 @@ praisonai bot dlq replay --config bot.yaml
 # Purge everything (asks for confirmation)
 praisonai bot dlq purge
 praisonai bot dlq purge --yes  # skip confirmation
+```
+
+## Advanced: manual instantiation
+
+Most users get the DLQ automatically. For custom setups outside `build_session_manager`, create it directly:
+
+```python
+from praisonai.bots import BotSessionManager, InboundDLQ
+
+dlq = InboundDLQ(path="~/.praisonai/state/telegram/inbound_dlq.sqlite")
+mgr = BotSessionManager(platform="telegram", dlq=dlq)
+# ↑ that's it — failed agent.chat() now lands in the DLQ
 ```
 
 ## API reference
@@ -157,9 +194,9 @@ PASS: DLQ → replay → real LLM produced expected '4'.
 **Thread safety** — every write is guarded by an internal `threading.Lock`. SQLite WAL is enabled. Safe to share one `InboundDLQ` instance across threads.
 </Info>
 
-<Check>
-**Backward compatible** — `BotSessionManager(...)` without `dlq=` behaves exactly as before. No behaviour change for existing bots.
-</Check>
+<Info>
+**Fallback** — if durability is requested but SQLite fails to initialise (permissions, disk full, etc.), the manager logs a warning and falls back to in-memory delivery automatically.
+</Info>
 
 ## Combining with other features
 
@@ -186,6 +223,9 @@ PASS: DLQ → replay → real LLM produced expected '4'.
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Delivery Config" icon="shield-check" href="/docs/features/delivery-config">
+  Full reference for the `delivery:` channel config block — defaults, opt-out, and path override
+</Card>
 <Card title="Inbound Journal" icon="book" href="/docs/features/inbound-journal">
   Deduplicate webhook redeliveries and recover in-flight messages after a crash
 </Card>

--- a/docs/features/inbound-journal.mdx
+++ b/docs/features/inbound-journal.mdx
@@ -7,6 +7,10 @@ icon: "book"
 
 Inbound Journal tracks messages before agents process them, providing deduplication of webhook redeliveries and crash-safe replay of in-flight messages.
 
+<Note>
+**On by default for gateway/bot runs** — Every bot started via `praisonai bot start`, `onboard`, or `bot.yaml` gets the journal automatically. No code needed. The journal lives at `~/.praisonai/state/<platform>/ingress.sqlite`. Set `delivery.durable: false` to opt out.
+</Note>
+
 ```mermaid
 graph LR
     subgraph "Inbound Journal"
@@ -28,7 +32,48 @@ graph LR
     class Skip skip
 ```
 
-## Quick Start
+## Default behavior (no config needed)
+
+Every bot started through `build_session_manager` (all shipped adapters) automatically gets an Inbound Journal at:
+
+```
+~/.praisonai/state/<platform>/ingress.sqlite
+```
+
+For example, a Telegram bot journals messages at `~/.praisonai/state/telegram/ingress.sqlite`. A Discord bot uses `~/.praisonai/state/discord/ingress.sqlite`. Each platform is fully isolated — no cross-platform dedup collisions.
+
+Set `PRAISONAI_HOME` to override the base directory:
+
+```
+$PRAISONAI_HOME/state/<platform>/ingress.sqlite
+```
+
+## Opt out or override path
+
+Add a `delivery:` block to any channel in your `bot.yaml` or `gateway.yaml`:
+
+```yaml
+channels:
+  telegram:
+    token: "${TELEGRAM_BOT_TOKEN}"
+    delivery:
+      durable: false   # opt out of durable inbound delivery for this channel
+```
+
+Override the store directory:
+
+```yaml
+channels:
+  telegram:
+    token: "${TELEGRAM_BOT_TOKEN}"
+    delivery:
+      store: /var/lib/praisonai/telegram-state
+      # → ingress.sqlite lives in /var/lib/praisonai/telegram-state/
+```
+
+## Quick Start (advanced: manual setup)
+
+Most users get the journal automatically. For custom setups outside `build_session_manager`:
 
 <Steps>
 <Step title="Create journal that survives restarts">
@@ -36,17 +81,14 @@ graph LR
 from praisonaiagents import Agent
 from praisonai.bots import InboundJournal, BotSessionManager
 
-# 1. Create a journal that survives restarts
-journal = InboundJournal(path="~/.praisonai/state/ingress.sqlite")
+journal = InboundJournal(path="~/.praisonai/state/telegram/ingress.sqlite")
 ```
 </Step>
 
 <Step title="Enable on your bot">
 ```python
-# 2. Plug it into the session manager
 session = BotSessionManager(platform="telegram", ingress_journal=journal)
 
-# 3. Use your agent normally — duplicates and crashes are now handled for you
 agent = Agent(name="Support Bot", instructions="Help users with their questions")
 ```
 </Step>
@@ -143,7 +185,7 @@ graph TB
 from praisonaiagents import Agent
 from praisonai.bots import InboundJournal, BotSessionManager
 
-journal = InboundJournal(path="~/.praisonai/telegram-journal.sqlite")
+journal = InboundJournal(path="~/.praisonai/state/telegram/ingress.sqlite")
 session = BotSessionManager(platform="telegram", ingress_journal=journal)
 
 agent = Agent(
@@ -167,7 +209,7 @@ response = await session.chat(
 from praisonaiagents import Agent
 from praisonai.bots import InboundJournal, BotSessionManager
 
-journal = InboundJournal(path="~/.praisonai/discord-journal.sqlite")
+journal = InboundJournal(path="~/.praisonai/state/discord/ingress.sqlite")
 session = BotSessionManager(platform="discord", ingress_journal=journal)
 
 agent = Agent(
@@ -191,7 +233,7 @@ response = await session.chat(
 from praisonaiagents import Agent
 from praisonai.bots import InboundJournal, BotSessionManager
 
-journal = InboundJournal(path="~/.praisonai/slack-journal.sqlite")
+journal = InboundJournal(path="~/.praisonai/state/slack/ingress.sqlite")
 session = BotSessionManager(platform="slack", ingress_journal=journal)
 
 agent = Agent(
@@ -215,7 +257,7 @@ response = await session.chat(
 from praisonaiagents import Agent
 from praisonai.bots import InboundJournal, BotSessionManager
 
-journal = InboundJournal(path="~/.praisonai/whatsapp-journal.sqlite")
+journal = InboundJournal(path="~/.praisonai/state/whatsapp/ingress.sqlite")
 session = BotSessionManager(platform="whatsapp", ingress_journal=journal)
 
 agent = Agent(
@@ -239,7 +281,7 @@ response = await session.chat(
 from praisonaiagents import Agent
 from praisonai.bots import InboundJournal, BotSessionManager
 
-journal = InboundJournal(path="~/.praisonai/email-journal.sqlite")
+journal = InboundJournal(path="~/.praisonai/state/email/ingress.sqlite")
 session = BotSessionManager(platform="email", ingress_journal=journal)
 
 agent = Agent(
@@ -263,7 +305,7 @@ response = await session.chat(
 from praisonaiagents import Agent
 from praisonai.bots import InboundJournal, BotSessionManager
 
-journal = InboundJournal(path="~/.praisonai/agentmail-journal.sqlite")
+journal = InboundJournal(path="~/.praisonai/state/agentmail/ingress.sqlite")
 session = BotSessionManager(platform="agentmail", ingress_journal=journal)
 
 agent = Agent(
@@ -292,7 +334,7 @@ response = await session.chat(
 ```python
 # Minimal setup for webhook deduplication
 journal = InboundJournal(
-    path="~/.praisonai/dedup.sqlite",
+    path="~/.praisonai/state/telegram/ingress.sqlite",
     claim_timeout=60  # Fast timeout for quick processing
 )
 
@@ -308,7 +350,7 @@ session = BotSessionManager(platform="telegram", ingress_journal=journal)
 ```python
 # Setup with crash recovery
 journal = InboundJournal(
-    path="~/.praisonai/durable.sqlite",
+    path="~/.praisonai/state/telegram/ingress.sqlite",
     claim_timeout=600  # 10 minutes for complex agent tasks
 )
 
@@ -329,8 +371,8 @@ After PR #1989, redelivery of a still-pending message also retries automatically
 from praisonai.bots import InboundJournal, InboundDLQ, BotSessionManager
 
 # Both journal and DLQ for complete durability
-journal = InboundJournal(path="~/.praisonai/journal.sqlite")
-dlq = InboundDLQ(path="~/.praisonai/dlq.sqlite")
+journal = InboundJournal(path="~/.praisonai/state/slack/ingress.sqlite")
+dlq = InboundDLQ(path="~/.praisonai/state/slack/inbound_dlq.sqlite")
 
 session = BotSessionManager(
     platform="slack",
@@ -351,7 +393,7 @@ The journal's SQLite file must survive restarts for crash recovery to work. Use 
 
 ```python
 # ✅ Good: persists across restarts
-journal = InboundJournal(path="/var/lib/myapp/journal.sqlite")
+journal = InboundJournal(path="/var/lib/myapp/ingress.sqlite")
 
 # ❌ Bad: temporary path, lost on restart
 journal = InboundJournal(path="/tmp/journal.sqlite")
@@ -364,7 +406,7 @@ Set `claim_timeout` to be longer than your p99 `agent.chat()` latency to avoid f
 ```python
 # If your agent takes up to 30 seconds, use a longer timeout
 journal = InboundJournal(
-    path="~/.praisonai/journal.sqlite",
+    path="~/.praisonai/state/telegram/ingress.sqlite",
     claim_timeout=900  # 15 minutes safety margin
 )
 ```
@@ -405,7 +447,7 @@ Platforms redeliver webhooks at fixed intervals (Telegram retries within seconds
 # Slack retries after 3s; 30s leaves room for normal processing
 # while ensuring a crashed claim is stale on the next redelivery
 journal = InboundJournal(
-    path="~/.praisonai/slack-journal.sqlite",
+    path="~/.praisonai/state/slack/ingress.sqlite",
     claim_timeout=30,
 )
 ```
@@ -417,6 +459,9 @@ journal = InboundJournal(
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Delivery Config" icon="shield-check" href="/docs/features/delivery-config">
+  Full reference for the `delivery:` channel config block — defaults, opt-out, and path override
+</Card>
 <Card title="Inbound DLQ" icon="inbox" href="/docs/features/inbound-dlq">
   Failure-side durability when agent execution fails
 </Card>


### PR DESCRIPTION
## Summary

Updates documentation to reflect that inbound durable delivery (Inbound Journal + Inbound DLQ) is now **on by default** for all gateway/bot runs, and that the canonical store is scoped per-platform.

### Changes

- **`docs/features/inbound-dlq.mdx`**: Removed all "fully opt-in", "Default OFF", and "backward compatible — unchanged" claims. Added default-ON Note callout, opt-out YAML with `delivery.durable: false`, store-override example, and canonical per-platform path (`~/.praisonai/state/<platform>/inbound_dlq.sqlite`). Manual instantiation moved to "Advanced" section.

- **`docs/features/inbound-journal.mdx`**: Added default-ON `<Note>` callout at top. Updated all path examples from old un-scoped `~/.praisonai/state/ingress.sqlite` to `~/.praisonai/state/<platform>/ingress.sqlite`. Added opt-out/override YAML section. Manual construction examples moved to "Advanced" section.

- **`docs/features/gateway.mdx`**: Added `delivery` field row to the Channel Configuration Reference table with description linking to the new delivery-config page. Added a "Durable Inbound Delivery" YAML example block after the table.

- **`docs/features/durable-delivery.mdx`**: Added scope `<Note>` near the top clarifying this page covers **outbound** durability and linking to Inbound Journal and Inbound DLQ for the inbound side.

- **`docs/features/delivery-config.mdx`** *(new)*: Dedicated page documenting the `DeliveryConfigSchema` (`durable: bool = True`, `store: Optional[str] = None`), canonical per-platform path resolution, per-platform isolation diagram, opt-out/override YAML, `PRAISONAI_HOME` env var, and failure-mode fallback.

- **`docs.json`**: Registered `docs/features/delivery-config` under the Features group alongside `inbound-dlq` and `inbound-journal`.

### Acceptance Criteria Met

- ✅ `inbound-dlq.mdx` no longer claims DLQ is "fully opt-in" or "default OFF"
- ✅ `inbound-journal.mdx` shows default-ON path first; paths updated to `~/.praisonai/state/<platform>/ingress.sqlite`
- ✅ `gateway.mdx` Channel Configuration Reference includes `delivery` field
- ✅ `durable-delivery.mdx` has scope `<Note>` distinguishing outbound from inbound
- ✅ New `delivery-config.mdx` page registered in `docs.json` under Features (not Concepts)
- ✅ All config tables match `DeliveryConfigSchema` exactly (`durable: bool = True`, `store: Optional[str] = None`)
- ✅ All path examples use `~/.praisonai/state/<platform>/`, not un-scoped paths
- ✅ Mermaid diagrams use standard color scheme with white text
- ✅ No files in `docs/concepts/` created or modified
- ✅ `docs.json` parses as valid JSON

Fixes #1001

Generated with [Claude Code](https://claude.ai/code)