### PR TITLE
docs: wrapper extensibility docs for PraisonAI PR #2363

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -869,6 +869,7 @@
                   "docs/features/code",
                   "docs/features/camera-integration",
                   "docs/features/hosted-agent",
+                  "docs/features/managed-backend-plugins",
                   "docs/features/local-agent",
                   "docs/features/sandboxed-agent",
                   "docs/features/managed-runtime-protocol",

--- a/docs/features/framework-adapter-plugins.mdx
+++ b/docs/features/framework-adapter-plugins.mdx
@@ -604,6 +604,64 @@ The `is_available()` method is called on every CLI startup and framework probe. 
 
 ---
 
+## Default Framework Selection
+
+`FrameworkAdapterRegistry.pick_default()` selects the default framework when none is specified.
+
+```mermaid
+graph TB
+    A[pick_default called] --> B{Walk DEFAULT_PRIORITY}
+    B -->|crewai available| C[✅ Return crewai]
+    B -->|praisonai available| D[✅ Return praisonai]
+    B -->|autogen available| E[✅ Return autogen]
+    B -->|ag2 available| F[✅ Return ag2]
+    B -->|none available| G{Any other registered adapter?}
+    G -->|yes| H[✅ Return first available plugin]
+    G -->|no| I[❌ RuntimeError]
+
+    classDef priority fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef fail fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class A,B decision
+    class C,D,E,F,H success
+    class G decision
+    class I fail
+```
+
+`DEFAULT_PRIORITY` is a class attribute on `FrameworkAdapterRegistry`:
+
+```python
+DEFAULT_PRIORITY: tuple[str, ...] = ("crewai", "praisonai", "autogen", "ag2")
+```
+
+`pick_default()` walks this tuple and returns the first available adapter. If none of the four built-ins are installed, it falls back to any other registered adapter — including entry-point plugins. If no adapter is available at all, it raises `RuntimeError`.
+
+```python
+from praisonai.framework_adapters.registry import get_default_registry
+
+registry = get_default_registry()
+default = registry.pick_default()   # returns "crewai", "praisonai", etc.
+print(f"Using framework: {default}")
+```
+
+`_entrypoint.run()` and `arun()` now delegate to `pick_default()`. This means an entry-point adapter can become the default framework once the four built-ins are uninstalled:
+
+```python
+from praisonai.framework_adapters.registry import get_default_registry
+
+# Scenario: only your plugin adapter is installed
+registry = get_default_registry()
+default = registry.pick_default()  # returns your plugin adapter name
+```
+
+<Note>
+The `praisonaiagents → praisonai` rename is reflected in `DEFAULT_PRIORITY` — the tuple uses `"praisonai"`, not `"praisonaiagents"`. Any YAML or code that relied on the old probe tuple `("crewai", "praisonaiagents", "autogen", "ag2")` now uses `pick_default()` instead.
+</Note>
+
+---
+
 ## Inject Your Own Registry (Multi-tenant / Tests)
 
 <Note>

--- a/docs/features/hosted-agent.mdx
+++ b/docs/features/hosted-agent.mdx
@@ -223,6 +223,106 @@ agent.start("Continue where we left off")
 
 ---
 
+## Pluggable Provider Backends
+
+`HostedAgent` uses `ManagedBackendRegistry` to look up provider backends — third-party packages can register new providers via the `praisonai.managed_backends` entry-point group.
+
+```mermaid
+graph LR
+    subgraph "Provider Resolution"
+        A[HostedAgent provider=...] --> B[ManagedBackendRegistry]
+        B --> C{Provider registered?}
+        C -->|anthropic| D[AnthropicManagedAgent]
+        C -->|e2b plugin| E[E2BManagedAgent]
+        C -->|modal plugin| F[ModalManagedAgent]
+        C -->|not found| G[❌ ValueError with available list]
+    end
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef registry fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef fail fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class A input
+    class B registry
+    class C decision
+    class D,E,F success
+    class G fail
+```
+
+### Entry-point registration
+
+A pip-installable package can publish a new `HostedAgent` provider by declaring an entry point:
+
+```toml
+# pyproject.toml
+[project.entry-points."praisonai.managed_backends"]
+e2b = "e2b_praisonai.backend:E2BManagedAgent"
+```
+
+After `pip install e2b-praisonai`, `HostedAgent(provider="e2b")` resolves it automatically — no core change needed.
+
+### Factory semantics
+
+For non-Anthropic backends, `HostedAgent.__new__` acts as a **factory** — it returns the resolved backend instance directly. Python skips `__init__` when `__new__` returns a non-`cls` instance, so callers get the real backend's methods rather than Anthropic-inherited ones:
+
+```python
+from praisonai import HostedAgent, HostedAgentConfig
+from praisonaiagents import Agent
+
+# A third-party "e2b" plugin is installed via pip.
+# HostedAgent resolves it through the registry — no core change.
+hosted = HostedAgent(
+    provider="e2b",
+    config=HostedAgentConfig(model="claude-haiku-4-5"),
+)
+
+agent = Agent(name="Researcher", instructions="Research and summarise.", llm=hosted)
+agent.start("Find three sources on agentic RAG.")
+```
+
+### Programmatic registration
+
+Register a backend without an entry point for testing or embedding:
+
+```python
+from praisonai import HostedAgent, HostedAgentConfig
+from praisonaiagents import Agent
+
+class E2BManagedAgent:
+    def __init__(self, provider, config=None, **kwargs):
+        self.provider = provider
+        self.config = config
+
+    def is_available(self):
+        try:
+            import e2b
+            return True
+        except ImportError:
+            return False
+
+from praisonai.integrations.backend_registry import get_backend_registry
+get_backend_registry().register("e2b", E2BManagedAgent)
+
+hosted = HostedAgent(provider="e2b", config=HostedAgentConfig(model="claude-haiku-4-5"))
+agent = Agent(name="Coder", instructions="Write code.", llm=hosted)
+agent.start("Write a hello world script.")
+```
+
+### Error message
+
+When `HostedAgent(provider="unknown")` is called with an unregistered provider, the error lists available backends:
+
+```
+ValueError: Managed runtime for provider 'unknown' is not available.
+Available: ['anthropic', 'e2b', ...]
+```
+
+Cross-reference: [Managed Backend Plugins](/docs/features/managed-backend-plugins) — full guide to authoring and publishing provider backends.
+
+---
+
 ## Migrating from ManagedAgent
 
 Replace the deprecated `ManagedAgent` factory with the new canonical class:
@@ -294,15 +394,15 @@ hosted = HostedAgent(
   Run agent loops locally with any LLM
 </Card>
 
+<Card title="Managed Backend Plugins" icon="puzzle-piece" href="/docs/features/managed-backend-plugins">
+  Add new HostedAgent providers via entry points
+</Card>
+
 <Card title="ManagedAgent Persistence" icon="database" href="/docs/features/managed-agent-persistence">
   Database integration with hosted agents
 </Card>
 
 <Card title="Session Info" icon="info" href="/docs/features/managed-agents-session-info">
   Session metadata and usage tracking
-</Card>
-
-<Card title="Managed CLI" icon="terminal" href="/docs/features/managed-cli">
-  Command-line tools for hosted resources
 </Card>
 </CardGroup>

--- a/docs/features/managed-backend-plugins.mdx
+++ b/docs/features/managed-backend-plugins.mdx
@@ -1,0 +1,347 @@
+---
+title: "Managed Backend Plugins"
+sidebarTitle: "Managed Backend Plugins"
+description: "Add HostedAgent provider backends via Python entry points"
+icon: "puzzle-piece"
+---
+
+Managed backend plugins let third-party packages register new `HostedAgent(provider=...)` runtimes — like `e2b`, `modal`, or `flyio` — without editing PraisonAI core.
+
+```mermaid
+graph LR
+    subgraph "Managed Backend Plugin System"
+        A[📦 Third-party Package] --> B[🔌 praisonai.managed_backends]
+        B --> C[📝 ManagedBackendRegistry]
+        C --> D[🤖 HostedAgent]
+    end
+
+    classDef package fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef entrypoint fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef registry fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agent fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A package
+    class B entrypoint
+    class C registry
+    class D agent
+```
+
+## Quick Start
+
+```python
+from praisonaiagents import Agent
+from praisonai import HostedAgent, HostedAgentConfig
+
+# A third-party "e2b" plugin is installed via pip.
+# HostedAgent resolves it through the registry — no core change.
+hosted = HostedAgent(
+    provider="e2b",
+    config=HostedAgentConfig(model="claude-haiku-4-5"),
+)
+
+agent = Agent(name="Researcher", instructions="Research and summarise.", llm=hosted)
+agent.start("Find three sources on agentic RAG.")
+```
+
+<Steps>
+<Step title="Simple — Programmatic Registration">
+
+Register a backend class directly at runtime (ideal for testing or single-project use):
+
+```python
+from praisonaiagents import Agent
+from praisonai import HostedAgent, HostedAgentConfig
+from praisonai.integrations.backend_registry import get_backend_registry
+
+class E2BManagedAgent:
+    def __init__(self, provider, config=None, **kwargs):
+        self.provider = provider
+        self.config = config
+
+    def is_available(self):
+        try:
+            import e2b
+            return True
+        except ImportError:
+            return False
+
+    def run(self, prompt, **kwargs):
+        import e2b
+        return e2b.run(prompt)
+
+registry = get_backend_registry()
+registry.register("e2b", E2BManagedAgent)
+
+hosted = HostedAgent(provider="e2b", config=HostedAgentConfig(model="claude-haiku-4-5"))
+agent = Agent(name="Coder", instructions="Write Python code.", llm=hosted)
+agent.start("Write a function to reverse a string.")
+```
+
+</Step>
+
+<Step title="With Entry Point — pip-installable Plugin">
+
+Create a Python package with a `praisonai.managed_backends` entry point so your backend is automatically available after `pip install`:
+
+```toml
+# pyproject.toml
+[project]
+name = "e2b-praisonai"
+version = "1.0.0"
+dependencies = ["e2b", "praisonai"]
+
+[project.entry-points."praisonai.managed_backends"]
+e2b = "e2b_praisonai.backend:E2BManagedAgent"
+```
+
+```python
+# e2b_praisonai/backend.py
+import os
+
+class E2BManagedAgent:
+    def __init__(self, provider="e2b", config=None, **kwargs):
+        self.provider = provider
+        self.config = config
+
+    def is_available(self):
+        try:
+            import e2b
+            return True
+        except ImportError:
+            return False
+
+    def run(self, prompt, **kwargs):
+        import e2b
+        sandbox = e2b.Sandbox()
+        return sandbox.run_code(prompt)
+```
+
+After installation:
+
+```bash
+pip install e2b-praisonai
+```
+
+```python
+from praisonaiagents import Agent
+from praisonai import HostedAgent, HostedAgentConfig
+
+# e2b is now available automatically
+hosted = HostedAgent(provider="e2b", config=HostedAgentConfig(model="claude-haiku-4-5"))
+agent = Agent(name="Researcher", instructions="Research topics.", llm=hosted)
+agent.start("Summarise the key papers on agentic RAG.")
+```
+
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant HostedAgent
+    participant ManagedBackendRegistry
+    participant BackendFactory
+    participant BackendInstance
+
+    User->>HostedAgent: HostedAgent(provider="e2b", ...)
+    HostedAgent->>ManagedBackendRegistry: lookup("e2b")
+    ManagedBackendRegistry->>BackendFactory: load entry point / registered class
+    BackendFactory-->>ManagedBackendRegistry: E2BManagedAgent class
+    ManagedBackendRegistry-->>HostedAgent: E2BManagedAgent class
+    HostedAgent->>BackendFactory: E2BManagedAgent(provider="e2b", config=...)
+    BackendFactory-->>BackendInstance: e2b_instance
+    HostedAgent-->>User: e2b_instance (via __new__ factory)
+```
+
+`HostedAgent.__new__` acts as a **factory** for non-Anthropic backends. When the resolved backend class is different from `HostedAgent`, Python's `__new__` returns the backend instance directly — `__init__` is skipped. Callers receive the real backend's methods without any `AnthropicManagedAgent`-inherited state:
+
+```python
+hosted = HostedAgent(provider="e2b", config=HostedAgentConfig(model="claude-haiku-4-5"))
+type(hosted)  # <class 'e2b_praisonai.backend.E2BManagedAgent'>
+```
+
+The builtin `anthropic` backend is pre-registered in `ManagedBackendRegistry` — it resolves to `AnthropicManagedAgent`.
+
+---
+
+## Configuration Options
+
+<Card title="ManagedBackendRegistry API Reference" icon="code" href="/docs/sdk/reference/praisonai/classes/ManagedBackendRegistry">
+  Complete API reference for ManagedBackendRegistry
+</Card>
+
+| Entry-point group | `praisonai.managed_backends` |
+|---|---|
+| Built-in backends | `anthropic` → `AnthropicManagedAgent` |
+| Discovery | Auto-discovered on first registry access |
+
+---
+
+## Common Patterns
+
+### Custom Hosted Runtime
+
+```python
+from praisonaiagents import Agent
+from praisonai import HostedAgent, HostedAgentConfig
+from praisonai.integrations.backend_registry import get_backend_registry
+import os
+
+class ModalManagedAgent:
+    def __init__(self, provider="modal", config=None, **kwargs):
+        self.provider = provider
+        self.config = config
+
+    def is_available(self):
+        try:
+            import modal
+            return True
+        except ImportError:
+            return False
+
+    def run(self, prompt, **kwargs):
+        import modal
+        f = modal.Function.lookup("my-app", "run_agent")
+        return f.remote(prompt)
+
+get_backend_registry().register("modal", ModalManagedAgent)
+
+hosted = HostedAgent(
+    provider="modal",
+    config=HostedAgentConfig(model="claude-haiku-4-5"),
+)
+agent = Agent(name="Cloud Runner", instructions="Run tasks on Modal.", llm=hosted)
+agent.start("Process this dataset in parallel.")
+```
+
+### Selecting Between Multiple Registered Backends
+
+```python
+from praisonai import HostedAgent, HostedAgentConfig
+from praisonai.integrations.backend_registry import get_backend_registry
+from praisonaiagents import Agent
+import os
+
+registry = get_backend_registry()
+available = registry.list_all_names()
+print(f"Available backends: {available}")
+
+provider = os.getenv("AGENT_BACKEND", "anthropic")
+if provider not in available:
+    raise ValueError(f"Backend '{provider}' not installed. Available: {sorted(available)}")
+
+hosted = HostedAgent(provider=provider, config=HostedAgentConfig(model="claude-haiku-4-5"))
+agent = Agent(name="Flexible Agent", instructions="Complete tasks.", llm=hosted)
+agent.start("What is 2 + 2?")
+```
+
+### Graceful Unavailable-Backend Handling
+
+```python
+from praisonai import HostedAgent, HostedAgentConfig
+from praisonai.integrations.backend_registry import get_backend_registry
+from praisonaiagents import Agent
+
+def create_agent(preferred_backend: str) -> Agent:
+    registry = get_backend_registry()
+    try:
+        hosted = HostedAgent(
+            provider=preferred_backend,
+            config=HostedAgentConfig(model="claude-haiku-4-5"),
+        )
+    except ValueError:
+        available = sorted(registry.list_all_names())
+        print(f"Backend '{preferred_backend}' unavailable. Using 'anthropic'. Available: {available}")
+        hosted = HostedAgent(
+            provider="anthropic",
+            config=HostedAgentConfig(model="claude-haiku-4-5"),
+        )
+    return Agent(name="Resilient Agent", instructions="Complete tasks.", llm=hosted)
+
+agent = create_agent("e2b")
+agent.start("Write a hello world script.")
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Entry-point naming conventions">
+Use the provider name as the entry-point key — lowercase, no hyphens. The key becomes the value passed to `provider=`:
+
+```toml
+[project.entry-points."praisonai.managed_backends"]
+e2b    = "e2b_praisonai.backend:E2BManagedAgent"     # HostedAgent(provider="e2b")
+modal  = "modal_praisonai.backend:ModalManagedAgent"  # HostedAgent(provider="modal")
+flyio  = "flyio_praisonai.backend:FlyioManagedAgent"  # HostedAgent(provider="flyio")
+```
+</Accordion>
+
+<Accordion title="is_available() discipline">
+Always implement `is_available()` with a fast, cached check. The registry calls it during startup probing:
+
+```python
+from praisonai._framework_availability import is_available as check_availability
+
+class E2BManagedAgent:
+    def is_available(self) -> bool:
+        return check_availability("e2b")  # cached importlib.util.find_spec
+```
+
+Never do heavy imports inside `is_available()` — it is called on every registry probe.
+</Accordion>
+
+<Accordion title="Error-message hints">
+Include helpful hints in your error messages so users know what to install:
+
+```python
+def run(self, prompt, **kwargs):
+    if not self.is_available():
+        raise RuntimeError(
+            "e2b backend requires 'e2b' package. Install with: pip install e2b"
+        )
+    import e2b
+    ...
+```
+</Accordion>
+
+<Accordion title="Cleanup hooks">
+Implement resource cleanup if your backend opens connections or sandbox environments:
+
+```python
+class E2BManagedAgent:
+    def __init__(self, provider="e2b", config=None, **kwargs):
+        self._sandbox = None
+
+    def run(self, prompt, **kwargs):
+        import e2b
+        self._sandbox = e2b.Sandbox()
+        return self._sandbox.run_code(prompt)
+
+    def cleanup(self):
+        if self._sandbox:
+            self._sandbox.close()
+            self._sandbox = None
+```
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Framework Adapter Plugins" icon="puzzle-piece" href="/docs/features/framework-adapter-plugins">
+  Add new execution frameworks via entry points
+</Card>
+<Card title="Hosted Agent" icon="cloud" href="/docs/features/hosted-agent">
+  Run agent loops on managed cloud runtimes
+</Card>
+</CardGroup>

--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -569,9 +569,11 @@ tool2 = resolver.resolve("tavily_search")  # Re-resolves from sources
 resolver.invalidate()
 ```
 
-### ToolSource protocol (experimental)
+### ToolSource protocol
 
-`ToolSource` is an optional extensibility hook — pass custom sources via `ToolResolver(sources=[...])`. The resolver does not yet iterate `_sources` in `resolve()`; treat this as experimental until wired.
+`ToolSource` is a supported extensibility hook — pass custom sources via `ToolResolver(sources=[...])` to fully control resolution order.
+
+`resolve()` walks `self._sources` when custom sources are provided. Each source's `lookup(name)` is called in order; the first non-`None` result wins. A source that raises an exception does **not** poison the cache — `allow_none_cache=False` ensures the next call after a dependency installs can still resolve the tool.
 
 ```python
 from praisonai.tool_resolver import ToolResolver, ToolSource
@@ -579,9 +581,42 @@ from praisonai.tool_resolver import ToolResolver, ToolSource
 class MyToolSource:
     name = "my_tools"
     def lookup(self, name: str):
-        ...
+        if name == "my_custom_tool":
+            return my_custom_tool
+        return None
 
 resolver = ToolResolver(sources=[MyToolSource()])
+tool = resolver.resolve("my_custom_tool")
+```
+
+**Composing custom and default sources:**
+
+The `default_sources(registry=None)` method returns the historical 5-step resolution chain as a list of `ToolSource` objects (`local-tools.py` → `wrapper-registry` → `praisonaiagents` → `praisonai-tools` → `core-registry`). Prepend your custom source to search it first while keeping all built-in sources:
+
+```python
+from praisonai.tool_resolver import ToolResolver
+from praisonai.tool_registry import ToolRegistry
+
+registry = ToolRegistry()
+resolver = ToolResolver(
+    registry=registry,
+    sources=[MyToolSource(), *ToolResolver(registry=registry).default_sources(registry)],
+)
+```
+
+**Auto-wiring with `registry=`:**
+
+Passing `registry=` to `ToolResolver(...)` automatically calls `registry.set_resolver(self)`. This means `register_function()` on the registry will automatically invalidate the resolver's cache — no manual `set_resolver()` call needed:
+
+```python
+from praisonai.tool_resolver import ToolResolver
+from praisonai.tool_registry import ToolRegistry
+
+registry = ToolRegistry()
+resolver = ToolResolver(registry=registry)  # auto-wires: registry.set_resolver(resolver)
+
+registry.register_function("new_tool", my_tool)  # automatically invalidates resolver cache
+tool = resolver.resolve("new_tool")              # re-resolves from sources
 ```
 
 **Class tools and the cache:** When `tools.py` exports `BaseTool` subclasses (rather than plain functions), pass `instantiate=True` to get a ready-to-use instance back. The cache returns the same instantiation path whether or not `has_tool()` or `validate_yaml_tools()` warmed the cache first — so YAML validation flows that check tools exist before resolving them no longer return uninstantiated classes (fixed in [PR #1858](https://github.com/MervinPraison/PraisonAI/pull/1858)).


### PR DESCRIPTION
## Summary

- Removes "experimental" language from `ToolSource` protocol in `tool-resolver.mdx`; documents `default_sources()`, auto-wiring via `registry=`, and raising-source cache guarantee
- Adds "Default Framework Selection" section to `framework-adapter-plugins.mdx` covering `DEFAULT_PRIORITY`, `pick_default()` semantics, and entry-point fallback path
- Adds "Pluggable Provider Backends" section to `hosted-agent.mdx` covering `ManagedBackendRegistry`, `praisonai.managed_backends` entry-point group, `__new__` factory semantics, and updated error message
- Creates new `docs/features/managed-backend-plugins.mdx` page following AGENTS.md §2 template with hero Mermaid, Quick Start, How It Works sequence diagram, Common Patterns, Best Practices, and Related cards
- Updates `docs.json` to add new page under Python Features group

## References

- Fixes #1007
- Documents PraisonAI PR [#2363](https://github.com/MervinPraison/PraisonAI/pull/2363)

Generated with [Claude Code](https://claude.ai/code)