### PR TITLE
docs: provider-aware default model resolution + last-used recency (fixes #1018)

### DIFF
--- a/docs/cli/chat.mdx
+++ b/docs/cli/chat.mdx
@@ -22,7 +22,7 @@ praisonai chat [OPTIONS] [PROMPT]
 
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
-| `--model` | `-m` | LLM model to use | `gpt-4o-mini` |
+| `--model` | `-m` | LLM model to use | provider-aware default |
 | `--verbose` | `-v` | Verbose output | `false` |
 | `--memory` | | Enable memory persistence | `false` |
 | `--tools` | `-t` | Tools file path | |
@@ -38,6 +38,10 @@ praisonai chat [OPTIONS] [PROMPT]
 | `--theme` | | UI theme: `default`, `dark`, `light`, `minimal` | `default` |
 | `--compact` | | Compact output mode | `false` |
 | `--no-rules` | | Disable auto-injection of project instruction files | `false` |
+
+<Note>
+`praisonai chat` with no `--model` picks a default that matches your active provider credential — it no longer always falls back to `gpt-4o-mini`. See [Setup → What happens if you skip `--model`](/docs/cli/setup#what-happens-if-you-skip---model) for the precedence ladder.
+</Note>
 
 ## Examples
 

--- a/docs/cli/config.mdx
+++ b/docs/cli/config.mdx
@@ -197,7 +197,7 @@ From `cwd`, the resolver walks up to the git root searching:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `agent.model` | `str` | — | Default model |
+| `agent.model` | `str` | — | Default model; if unset, resolved via the [provider-aware ladder](/docs/cli/setup#what-happens-if-you-skip---model) rather than a hardcoded OpenAI default |
 | `agent.provider` | `str` | — | Provider name |
 | `agent.base_url` | `str` | — | Custom API base URL |
 | `agent.tools` | `list[str]` | `[]` | Default tool names |

--- a/docs/cli/setup.mdx
+++ b/docs/cli/setup.mdx
@@ -136,6 +136,80 @@ All sensitive files are written with `chmod 600` and are never included in any t
 
 ---
 
+## What happens if you skip `--model`
+
+When you don't pass `--model` to `setup` (or when you run a command like `praisonai chat` with no `--model`), PraisonAI picks a sensible default that **matches the provider you actually have a key for** — it no longer always picks an OpenAI model.
+
+```python
+from praisonaiagents import Agent
+
+# Only ANTHROPIC_API_KEY is set in the environment — Agent picks
+# anthropic/claude-3-5-sonnet-latest automatically.
+agent = Agent(name="Research Agent", instructions="Summarise news")
+agent.start("What happened in AI today?")
+```
+
+```mermaid
+graph TB
+    A[🚀 No --model given] --> B{Explicit<br/>config?}
+    B -->|Yes| Y[✅ Use explicit<br/>Persist as recent]
+    B -->|No| C{Recent model<br/>on disk?}
+    C -->|Yes| Y2[✅ Reuse recent]
+    C -->|No| D{MODEL_NAME or<br/>OPENAI_MODEL_NAME?}
+    D -->|Yes| Y3[✅ Use env<br/>Persist as recent]
+    D -->|No| E{Provider credential<br/>present?}
+    E -->|Yes| Y4[✅ Provider default<br/>Not persisted]
+    E -->|No| F[gpt-4o-mini]
+
+    classDef start fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef decision fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef good fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef fallback fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class A start
+    class B,C,D,E decision
+    class Y,Y2,Y3,Y4 good
+    class F fallback
+```
+
+### Resolution precedence
+
+| Step | Source | Notes |
+|------|--------|-------|
+| 1 | Explicit `--model` / `llm=` arg / YAML / config | Wins, persisted as the recent model |
+| 2 | Most-recently-used model (`~/.praison/state/model.json`) | Only *user-chosen* values are remembered |
+| 3 | `MODEL_NAME` env var (then `OPENAI_MODEL_NAME` for backward compatibility) | Persisted on use |
+| 4 | First present provider credential (table below) | **Not** persisted — kept fresh per run |
+| 5 | `gpt-4o-mini` as ultimate fallback | **Not** persisted |
+
+### Credential → default-model map
+
+The first credential found wins, in this order:
+
+| Credential env var | Default model picked |
+|--------------------|----------------------|
+| `OPENAI_API_KEY` | `gpt-4o-mini` |
+| `ANTHROPIC_API_KEY` | `anthropic/claude-3-5-sonnet-latest` |
+| `GEMINI_API_KEY` | `gemini/gemini-1.5-flash` |
+| `GOOGLE_API_KEY` | `google/gemini-1.5-flash` |
+| `GROQ_API_KEY` | `groq/llama-3.3-70b-versatile` |
+| `COHERE_API_KEY` | `cohere/command-r` |
+| `OLLAMA_HOST` | `ollama/llama3.2` |
+
+The first time a provider-aware default is inferred, the CLI prints a one-line notice:
+
+```
+No model set; using anthropic/claude-3-5-sonnet-latest because ANTHROPIC_API_KEY is present.
+```
+
+Only *user-chosen* values (explicit `--model`, env overrides) are persisted as the recent model. Provider-inferred defaults and the `gpt-4o-mini` fallback are **deliberately not** persisted — this keeps model selection fresh if your available providers change between runs.
+
+<Note>
+The recency file lives at `~/.praison/state/model.json` (note: `.praison`, not `.praisonai`). It is created on demand; if it's missing or unreadable, resolution falls straight through to provider inference and works normally.
+</Note>
+
+---
+
 ## When Does Setup Run Automatically?
 
 If you skip setup at install time (or run `--no-prompt`), the first `praisonai` or `praisonai run` command detects the missing credentials and offers to launch this wizard for you. See [First-run Onboarding](/docs/features/first-run-onboarding) for the full flow.
@@ -160,6 +234,10 @@ praisonai setup config --show
 ```
 
 API keys are masked in the output. Only non-sensitive settings (provider, model) appear in plaintext.
+</Accordion>
+
+<Accordion title="With one credential set, --model is optional">
+With just one credential env var set (e.g. `ANTHROPIC_API_KEY`), running `praisonai chat` without `--model` now picks the matching default automatically. You only need `--model` to override or to mix providers in one session.
 </Accordion>
 </AccordionGroup>
 

--- a/docs/features/first-run-onboarding.mdx
+++ b/docs/features/first-run-onboarding.mdx
@@ -158,6 +158,12 @@ Three ways to avoid the setup prompt:
 
 ---
 
+## Default model on first run
+
+If you run a command like `praisonai chat` without `--model` on first use, PraisonAI picks a default that matches the provider credential it finds in your environment — Anthropic key → Claude, Gemini key → Gemini Flash, etc. See [Default Model Resolution](/docs/cli/setup#what-happens-if-you-skip---model) for the full ladder.
+
+---
+
 ## Best Practices
 
 <AccordionGroup>

--- a/docs/install/installer.mdx
+++ b/docs/install/installer.mdx
@@ -65,6 +65,10 @@ flowchart TD
   </Step>
   <Step title="Interactive onboarding">
     Runs `praisonai setup` for LLM API key configuration, then offers `praisonai onboard` for Telegram / Discord / Slack / WhatsApp bot setup.
+
+    <Tip>
+    Any one of the supported provider keys is enough — OpenAI is no longer required. PraisonAI auto-selects a model that matches whichever credential you set (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`, `OLLAMA_HOST`, etc.).
+    </Tip>
   </Step>
 </Steps>
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -272,9 +272,13 @@ team.start()
 <Note>
 **Prerequisites**
 - Python 3.10 or higher
-- OpenAI API key (get it [here](https://platform.openai.com/api-keys))
-- For other LLM providers, see [Models](/models)
+- An API key for any supported provider (OpenAI, Anthropic, Google, Groq, Cohere) or a running Ollama instance — OpenAI is not required
+- For the full list of providers, see [Models](/models)
 </Note>
+
+<Tip>
+Don't have an OpenAI key? PraisonAI picks a default model that matches whichever provider credential you do have set — set `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`, or run a local `OLLAMA_HOST` and the same `praisonai` command works without `--model`. [Full precedence](/docs/cli/setup#what-happens-if-you-skip---model).
+</Tip>
 
 # Advanced
 


### PR DESCRIPTION
## Summary

Documents PR [#2361](https://github.com/MervinPraison/PraisonAI/pull/2361) — provider-aware default model resolution + last-used recency.

### Changes

- **`docs/cli/setup.mdx`**: New "What happens if you skip `--model`" section with:
  - Agent-centric code example (no `llm=`)
  - Mermaid `graph TB` precedence diagram (standard §3.1 palette)
  - 5-step resolution precedence table
  - Credential → default-model table (all 7 providers)
  - Transparency notice wording verbatim from source
  - Persistence rules (provider-inferred defaults NOT persisted)
  - `~/.praison/state/model.json` Note
  - New "With one credential set, --model is optional" accordion

- **`docs/cli/chat.mdx`**: Note near `--model` flag; updated default from `gpt-4o-mini` to "provider-aware default"

- **`docs/features/first-run-onboarding.mdx`**: "Default model on first run" section cross-linking setup ladder

- **`docs/quickstart.mdx`**: Updated Prerequisites Note (OpenAI no longer required); Tip for non-OpenAI users

- **`docs/cli/config.mdx`**: `agent.model` description notes provider-aware ladder when unset

- **`docs/install/installer.mdx`**: Tip in Interactive Onboarding step

No new pages created. No `docs/concepts/`, `docs/js/`, `docs/rust/`, or `docs/sdk/reference/` pages touched. `docs.json` unchanged and valid.

Fixes #1018

Generated with [Claude Code](https://claude.ai/code)