### PR TITLE
docs(cli/rules): drop Agent-Requested Rules section after PraisonAI#2384 removed rules_tools

### DIFF
--- a/docs/cli/rules.mdx
+++ b/docs/cli/rules.mdx
@@ -232,55 +232,6 @@ agent = Agent(name="Assistant", instructions="You are helpful.")
 # Rules are injected into system prompt automatically
 ```
 
-## Agent-Requested Rules
-
-Agents can create, read, and manage rules dynamically using built-in tools:
-
-```python
-from praisonaiagents import Agent
-from praisonaiagents.tools.rules_tools import (
-    create_rule_tool,
-    list_rules_tool,
-    get_rule_tool,
-    delete_rule_tool,
-    get_active_rules_tool
-)
-
-# Create an agent that can manage rules
-agent = Agent(
-    name="RulesManager",
-    role="Rules Administrator",
-    tools=[create_rule_tool, list_rules_tool, get_rule_tool, delete_rule_tool]
-)
-
-# Agent can now create rules dynamically
-response = agent.chat("Create a rule for Python coding standards")
-```
-
-### Available Tools
-
-| Tool | Description |
-|------|-------------|
-| `create_rule_tool` | Create a new rule with name, content, and options |
-| `list_rules_tool` | List all available rules |
-| `get_rule_tool` | Get content of a specific rule |
-| `delete_rule_tool` | Delete a rule |
-| `get_active_rules_tool` | Get rules active for current context |
-
-### Tool Parameters
-
-```python
-create_rule_tool(
-    name="python-style",           # Rule name (filename)
-    content="- Use type hints",    # Rule content
-    description="Python standards", # Short description
-    globs="**/*.py",               # Comma-separated glob patterns
-    activation="glob",             # always, glob, manual, ai_decision
-    priority=10,                   # Higher = applied first
-    scope="workspace"              # workspace or global
-)
-```
-
 ## Best Practices
 
 <Tip>


### PR DESCRIPTION
## Summary

Removes the **Agent-Requested Rules** section from `docs/cli/rules.mdx` as the underlying module `praisonaiagents/tools/rules_tools.py` was deleted in upstream PR [MervinPraison/PraisonAI#2384](https://github.com/MervinPraison/PraisonAI/pull/2384).

The deleted section contained imports of five symbols that no longer exist:
- `create_rule_tool`
- `list_rules_tool`
- `get_rule_tool`
- `delete_rule_tool`
- `get_active_rules_tool`

All other sections (CLI commands, auto-discovery, opt-out, size caps, activation modes, programmatic usage, best practices) are preserved as-is.

Verified zero remaining references to `rules_tools` or any of the removed symbols in the file.

Fixes #1033

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the section about agent-requested rules and related examples from the CLI rules guide.
  * The guide now flows directly from Programmatic Usage to Best Practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->