### PR TITLE
docs: bring docs/features/ into AGENTS.md compliance

### DIFF
--- a/docs/features/knowledge.mdx
+++ b/docs/features/knowledge.mdx
@@ -1,12 +1,11 @@
 ---
 title: "Knowledge Base"
-description: "Advanced knowledge management system for AI agents"
-icon: "book-open"
+sidebarTitle: "Knowledge"
+description: "Add document and URL knowledge to agents for grounded, accurate answers"
+icon: "book"
 ---
 
-# Knowledge Base System
-
-The knowledge system provides sophisticated document processing and semantic search capabilities, enabling agents to access and utilise information from various sources.
+The knowledge system lets agents retrieve relevant information from PDFs, documents, and URLs before answering, grounding responses in your own sources.
 
 ```mermaid
 graph TB
@@ -51,8 +50,8 @@ graph TB
     
     classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef storage fill:#2E8B57,stroke:#7C90A0,color:#fff
-    classDef retrieval fill:#FF6B6B,stroke:#7C90A0,color:#fff
+    classDef storage fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef retrieval fill:#10B981,stroke:#7C90A0,color:#fff
     
     class PDF,DOC,TXT,IMG,URL input
     class CHUNK,EMB,META process
@@ -410,28 +409,20 @@ results = kb.search_graph(
 
 ## Best Practices
 
-<CardGroup cols={2}>
-  <Card icon="cut" title="Chunking Strategy">
-    - Smaller chunks (100-200 tokens): Better precision
-    - Larger chunks (500-1000 tokens): Better context
-    - Match chunk size to query complexity
-  </Card>
-  <Card icon="folder-tree" title="Organisation">
-    - Separate collections by domain
-    - Use metadata for filtering
-    - Regular cleanup of outdated content
-  </Card>
-  <Card icon="gauge-high" title="Performance">
-    - Enable caching for repeated queries
-    - Use appropriate embedding models
-    - Batch document processing
-  </Card>
-  <Card icon="shield-check" title="Quality">
-    - Verify document processing
-    - Monitor search relevance
-    - Regular reindexing if needed
-  </Card>
-</CardGroup>
+<AccordionGroup>
+  <Accordion title="Match chunk size to your query complexity">
+    Use smaller chunks (100-200 tokens) for precise fact retrieval. Use larger chunks (500-1000 tokens) when answers need more context. Semantic chunking works best for research papers and long-form documents.
+  </Accordion>
+  <Accordion title="Separate collections by domain">
+    Use a different `collection_name` per knowledge domain (e.g., `product_docs`, `legal_contracts`). This prevents cross-contamination and allows targeted filtering by domain.
+  </Accordion>
+  <Accordion title="Use metadata for filtering">
+    Add `metadata` when indexing documents to enable `filters=` in searches. Filter by `category`, `year`, or `author` to narrow results without changing query text.
+  </Accordion>
+  <Accordion title="Enable reranking for higher precision">
+    Set `rerank=True` in `kb.search()` when you need top-quality results. Reranking retrieves more candidates then scores them for relevance — best for Q&A and research assistants.
+  </Accordion>
+</AccordionGroup>
 
 ## Example: Research Assistant
 
@@ -490,14 +481,11 @@ for paper in papers:
 ```
 </CodeGroup>
 
-## Next Steps
+## Related
 
 <CardGroup cols={2}>
-  <Card icon="brain" href="/docs/concepts/memory">
-    Learn about memory integration
-  </Card>
-  <Card icon="magnifying-glass" href="/features/rag">
-    Build RAG applications
+  <Card title="RAG" icon="database" href="/docs/features/rag">
+    Build retrieval-augmented generation pipelines
   </Card>
   <Card title="Vector Store" icon="database" href="/docs/features/vector-store">
     Store and query embeddings with a pluggable, namespace-aware backend

--- a/docs/features/parallelisation.mdx
+++ b/docs/features/parallelisation.mdx
@@ -6,21 +6,26 @@ icon: "arrows-split-up-and-left"
 ---
 
 ```mermaid
-flowchart LR
-    In[In] --> LLM2[LLM Call 2]
-    In --> LLM1[LLM Call 1]
-    In --> LLM3[LLM Call 3]
-    LLM1 --> Aggregator[Aggregator]
-    LLM2 --> Aggregator
-    LLM3 --> Aggregator
-    Aggregator --> Out[Out]
-    
-    style In fill:#8B0000,color:#fff
-    style LLM1 fill:#2E8B57,color:#fff
-    style LLM2 fill:#2E8B57,color:#fff
-    style LLM3 fill:#2E8B57,color:#fff
-    style Aggregator fill:#fff,color:#000
-    style Out fill:#8B0000,color:#fff
+graph LR
+    subgraph "Parallel Execution"
+        In["📥 Input"] --> LLM1["🤖 Agent 1"]
+        In --> LLM2["🤖 Agent 2"]
+        In --> LLM3["🤖 Agent 3"]
+        LLM1 --> Aggregator["📊 Aggregator"]
+        LLM2 --> Aggregator
+        LLM3 --> Aggregator
+        Aggregator --> Out["✅ Output"]
+    end
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agg fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class In input
+    class LLM1,LLM2,LLM3 agent
+    class Aggregator agg
+    class Out output
 ```
 
 A workflow that distributes tasks across multiple LLM calls simultaneously, aggregating results to handle complex or large-scale operations efficiently.

--- a/docs/features/promptchaining.mdx
+++ b/docs/features/promptchaining.mdx
@@ -6,17 +6,27 @@ icon: "link"
 ---
 
 ```mermaid
-flowchart LR
-    In[In] --> LLM1[LLM Call 1] --> Gate{Gate}
-    Gate -->|Pass| LLM2[LLM Call 2] -->|Output 2| LLM3[LLM Call 3] --> Out[Out]
-    Gate -->|Fail| Exit[Exit]
-    
-    style In fill:#8B0000,color:#fff
-    style LLM1 fill:#2E8B57,color:#fff
-    style LLM2 fill:#2E8B57,color:#fff
-    style LLM3 fill:#2E8B57,color:#fff
-    style Out fill:#8B0000,color:#fff
-    style Exit fill:#8B0000,color:#fff
+graph LR
+    subgraph "Prompt Chain"
+        In["💬 Input"] --> LLM1["🤖 Step 1"]
+        LLM1 --> Gate{"✓ Gate"}
+        Gate -->|"✅ Pass"| LLM2["🤖 Step 2"]
+        LLM2 --> LLM3["🤖 Step 3"]
+        LLM3 --> Out["✅ Output"]
+        Gate -->|"❌ Fail"| Exit["🚫 Exit"]
+    end
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef gate fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef exit fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class In input
+    class LLM1,LLM2,LLM3 agent
+    class Gate gate
+    class Out output
+    class Exit exit
 ```
 
 A workflow where the output of one LLM call becomes the input for the next. This sequential design allows for structured reasoning and step-by-step task completion.

--- a/docs/features/rag.mdx
+++ b/docs/features/rag.mdx
@@ -1,26 +1,31 @@
 ---
 title: "RAG Quick Start"
-sidebarTitle: "Quick Start"
-description: "Learn how to configure retrieval behavior for AI agents with knowledge bases."
+sidebarTitle: "RAG"
+description: "Build retrieval-augmented generation agents that answer questions from your documents and knowledge bases"
 icon: "database"
 ---
 
-```mermaid
-flowchart LR
-    In[Input] --> RAGAgent[("RAG Agent")]
-    VDB[(Vector DB)] --> RAGAgent
-    RAGAgent --> Task[Knowledge Task]
-    Task --> |Query| VDB
-    Task --> Out[Output]
-    
-    style In fill:#8B0000,color:#fff
-    style RAGAgent fill:#2E8B57,color:#fff,shape:circle
-    style VDB fill:#4169E1,color:#fff,shape:cylinder
-    style Task fill:#2E8B57,color:#fff
-    style Out fill:#8B0000,color:#fff
-```
+RAG agents retrieve relevant information from your documents before answering, grounding responses in your own knowledge base.
 
-A knowledge-centric workflow where RAG (Retrieval Augmented Generation) agents interact with vector databases to store and retrieve information efficiently, enabling sophisticated question-answering and information retrieval capabilities.
+```mermaid
+graph LR
+    subgraph "RAG Flow"
+        Input["📄 Documents"] --> VDB[("🗄️ Vector DB")]
+        Query["💬 Question"] --> Agent["🤖 RAG Agent"]
+        VDB --> Agent
+        Agent --> Output["✅ Grounded Answer"]
+    end
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef store fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Input,Query input
+    class VDB store
+    class Agent process
+    class Output output
+```
 
 ## Quick Start
 
@@ -62,18 +67,18 @@ agent.start("What is KAG in one line?") # Retrieval
 </Note>
 
 ```mermaid
-flowchart LR
-    subgraph In[Input]
+graph LR
+    subgraph In["📂 Input Documents"]
         PDF[PDF]
         TXT[TXT]
         MD[MD]
     end
 
-    subgraph Router[Vector Store]
+    subgraph Router["🗄️ Vector Store"]
         DB[(Vector DB)]
     end
     
-    subgraph Out[Agents]
+    subgraph Out["🤖 Agents"]
         A1[Agent 1]
         A2[Agent 2]
         A3[Agent 3]
@@ -84,9 +89,13 @@ flowchart LR
     Router --> A2
     Router --> A3
 
-    style In fill:#8B0000,color:#fff
-    style Router fill:#2E8B57,color:#fff
-    style Out fill:#8B0000,color:#fff
+    classDef inputGroup fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef storeGroup fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agentGroup fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class PDF,TXT,MD inputGroup
+    class DB storeGroup
+    class A1,A2,A3 agentGroup
 ```
 
 The simplest way to create a knowledge-based agent is without any configuration:
@@ -342,20 +351,32 @@ agent.start("What is KAG in one line?") # Retrieval
   </Card>
 </CardGroup>
 
-## Next Steps
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Index documents before querying">
+    Pass your documents via `knowledge=["file.pdf"]` when creating the agent. The first run indexes them into the vector store; subsequent queries retrieve from it without re-indexing.
+  </Accordion>
+  <Accordion title="Use specific, targeted questions">
+    RAG retrieves the most semantically similar chunks. Narrow questions like "What is the refund policy for digital downloads?" retrieve better than broad ones like "Tell me about refunds."
+  </Accordion>
+  <Accordion title="Configure your vector store for production">
+    Use a persistent backend (Chroma with a path, Qdrant, Pinecone) instead of in-memory for production. Set `collection_name` to namespace knowledge bases by domain or user.
+  </Accordion>
+  <Accordion title="Combine RAG with agent tools for live data">
+    RAG agents can also have tools. Pair `knowledge=` with `tools=[internet_search]` when you need both static document knowledge and real-time web data in the same agent.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Related
 
 <CardGroup cols={2}>
-  <Card title="AutoAgents" icon="robot" href="./autoagents">
-    Learn about automatically created and managed AI agents
-  </Card>
-  <Card title="Mini Agents" icon="microchip" href="./mini">
-    Explore lightweight, focused AI agents
-  </Card>
   <Card title="Vector Store" icon="database" href="/docs/features/vector-store">
     Store and query embeddings with a pluggable, namespace-aware backend
   </Card>
+  <Card title="Knowledge" icon="book" href="/docs/features/knowledge">
+    Configure knowledge sources and retrieval strategies
+  </Card>
 </CardGroup>
-
-<Note>
-  For optimal results, ensure your vector database is properly configured and indexed for your specific use case.
-</Note>

--- a/docs/features/reasoning.mdx
+++ b/docs/features/reasoning.mdx
@@ -1,353 +1,193 @@
 ---
 title: "Reasoning Agents"
-description: "Learn how to create AI agents with advanced reasoning capabilities for complex problem-solving."
+sidebarTitle: "Reasoning"
+description: "Create AI agents with advanced reasoning capabilities for complex problem-solving"
 icon: "brain"
 ---
 
-```mermaid
-flowchart LR
-    In[In] --> Agent[AI Agent]
-    Agent --> Think[Think]
-    Think --> Decide[Decide]
-    Decide --> Act[Act]
-    Act --> Out[Out]
-    
-    style In fill:#8B0000,color:#fff
-    style Agent fill:#2E8B57,color:#fff
-    style Think fill:#2E8B57,color:#fff
-    style Decide fill:#2E8B57,color:#fff
-    style Act fill:#2E8B57,color:#fff
-    style Out fill:#8B0000,color:#fff
-```
+Reasoning agents think step-by-step before acting, breaking complex problems into structured solutions.
 
-Learn how to create AI agents with advanced reasoning capabilities for complex problem-solving.
+```mermaid
+graph LR
+    subgraph "Reasoning Flow"
+        Input["💬 Problem"] --> Think["🧠 Reason"]
+        Think --> Decide["⚖️ Decide"]
+        Decide --> Act["⚡ Act"]
+        Act --> Output["✅ Solution"]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Input input
+    class Think,Decide,Act process
+    class Output output
+```
 
 ## Quick Start
 
-<Tabs>
-  <Tab title="Code">
-    <Steps>
-        <Step title="Install Package">
-            First, install the PraisonAI Agents package:
-            ```bash
-            pip install praisonaiagents
-            ```
-        </Step>
+<Steps>
+<Step title="Simple Usage">
+```python
+from praisonaiagents import Agent
 
-        <Step title="Set API Key">
-            Set your OpenAI API key as an environment variable in your terminal:
-            ```bash
-            export OPENAI_API_KEY=your_api_key_here
-            ```
-        </Step>
+agent = Agent(
+    name="Reasoner",
+    instructions="You are an expert problem solver. Think step by step."
+)
 
-        <Step title="Create a file">
-            Create a new file `app.py` with the basic setup:
-            ```python
-            from praisonaiagents import Agent, Task, AgentTeam, Tools
-
-            # Create reasoning agent
-            reasoner = Agent(
-                role="Problem Solver",
-                goal="Solve complex problems using logical reasoning",
-                backstory="Expert in logical analysis and problem-solving",
-                tools=[Tools.internet_search],
-                
-            )
-
-            # Create task
-            task = Task(
-                description="Analyze and solve a complex business problem",
-                expected_output="Detailed solution with reasoning steps",
-                agent=reasoner
-            )
-
-            # Create and start the agents
-            agents = AgentTeam(
-                agents=[reasoner],
-                tasks=[task],
-                process="sequential",
-                verbose=2
-            )
-
-            # Start execution
-            result = agents.start()
-            print(result)
-            ```
-        </Step>
-
-        <Step title="Start Agents">
-            Type this in your terminal to run your agents:
-            ```bash
-            python app.py
-            ```
-        </Step>
-    </Steps>
-  </Tab>
-  <Tab title="No Code">
-    <Steps>
-        <Step title="Install Package">
-            Install the PraisonAI package:
-            ```bash
-            pip install praisonai
-            ```
-        </Step>
-        <Step title="Set API Key">
-            Set your OpenAI API key as an environment variable in your terminal:
-            ```bash
-            export OPENAI_API_KEY=your_api_key_here
-            ```
-        </Step>
-        <Step title="Create a file">
-            Create a new file `agents.yaml` with the basic setup:
-```yaml
-framework: praisonai
-process: sequential
-topic: solve complex business problem
-agents:  # Canonical: use 'agents' instead of 'roles'
-  reasoner:
-    instructions:  # Canonical: use 'instructions' instead of 'backstory' Expert in logical analysis and problem-solving.
-    goal: Solve complex problems using logical reasoning
-    role: Problem Solver
-    tools:
-      - internet_search
-    tasks:
-      analysis_task:
-        description: Analyze and solve a complex business problem.
-        expected_output: Detailed solution with reasoning steps.
+agent.start("Analyze the pros and cons of electric vehicles")
 ```
-        </Step>
-        <Step title="Start Agents">
-            Type this in your terminal to run your agents:
-```bash
-praisonai agents.yaml
+</Step>
+
+<Step title="With Reasoning Model">
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="DeepReasoner",
+    instructions="You solve complex problems with structured analysis.",
+    llm="o1-mini"
+)
+
+agent.start("What strategy should a startup use to enter a competitive market?")
 ```
-        </Step>
-    </Steps>
-  </Tab>
-</Tabs>
+</Step>
+</Steps>
 
-<Note>
-  **Requirements**
-  - Python 3.10 or higher
-  - OpenAI API key. Generate OpenAI API key [here](https://platform.openai.com/api-keys). Use Other models using [this guide](/models).   
-  - Basic understanding of Python
-</Note>
+---
 
-<div className="relative w-full aspect-video">
-  <iframe
-    className="absolute top-0 left-0 w-full h-full"
-    src="https://www.youtube.com/embed/KNDVWGN3TpM"
-    title="YouTube video player"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-  ></iframe>
-</div>
+## How It Works
 
-## Understanding Reasoning
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant LLM
+    participant Output
 
-<Card title="What is Reasoning?" icon="question">
-  Reasoning agents are designed to:
-  - Break down complex problems into manageable steps
-  - Apply logical analysis to find solutions
-  - Explain their thought process and decisions
-  - Handle uncertainty and incomplete information
-</Card>
-
-## Features
-
-<CardGroup cols={2}>
-  <Card title="Problem Decomposition" icon="puzzle-piece">
-    Break complex problems into smaller, manageable parts.
-  </Card>
-  <Card title="Logical Analysis" icon="brain">
-    Apply structured thinking to solve problems.
-  </Card>
-  <Card title="Error Recovery" icon="shield-check">
-    Handle edge cases and recover from errors.
-  </Card>
-  <Card title="Explanation" icon="comment">
-    Provide detailed reasoning for decisions.
-  </Card>
-</CardGroup>
-
-## Multi-Agent Reasoning
-
-<Tabs>
-  <Tab title="Code">
-    <Steps>
-        <Step title="Install Package">
-            First, install the PraisonAI Agents package:
-            ```bash
-            pip install praisonaiagents
-            ```
-        </Step>
-
-        <Step title="Set API Key">
-            Set your OpenAI API key as an environment variable in your terminal:
-            ```bash
-            export OPENAI_API_KEY=your_api_key_here
-            ```
-        </Step>
-
-        <Step title="Create a file">
-            Create a new file `app.py` with the basic setup:
-            ```python
-            from praisonaiagents import Agent, Task, AgentTeam, Tools
-
-            # Create first agent for analysis
-            analyst = Agent(
-                role="Business Analyst",
-                goal="Analyze business problems and identify key issues",
-                backstory="Expert in business analysis and problem identification",
-                tools=[Tools.internet_search],
-                
-            )
-
-            # Create second agent for solution development
-            solver = Agent(
-                role="Solution Architect",
-                goal="Develop comprehensive solutions to business problems",
-                backstory="Expert in solution design and implementation",
-                
-            )
-
-            # Create first task
-            analysis_task = Task(
-                description="Analyze the current market challenges",
-                expected_output="Detailed analysis of key issues",
-                agent=analyst
-            )
-
-            # Create second task
-            solution_task = Task(
-                description="Develop solutions for identified challenges",
-                expected_output="Comprehensive solution strategy",
-                agent=solver
-            )
-
-            # Create and start the agents
-            agents = AgentTeam(
-                agents=[analyst, solver],
-                tasks=[analysis_task, solution_task],
-                process="sequential"
-            )
-
-            # Start execution
-            result = agents.start()
-            ```
-        </Step>
-
-        <Step title="Start Agents">
-            Type this in your terminal to run your agents:
-            ```bash
-            python app.py
-            ```
-        </Step>
-    </Steps>
-  </Tab>
-  <Tab title="No Code">
-    <Steps>
-        <Step title="Install Package">
-            Install the PraisonAI package:
-            ```bash
-            pip install praisonai
-            ```
-        </Step>
-        <Step title="Set API Key">
-            Set your OpenAI API key as an environment variable in your terminal:
-            ```bash
-            export OPENAI_API_KEY=your_api_key_here
-            ```
-        </Step>
-        <Step title="Create a file">
-            Create a new file `agents.yaml` with the basic setup:
-```yaml
-framework: praisonai
-process: sequential
-topic: solve market challenges
-agents:  # Canonical: use 'agents' instead of 'roles'
-  analyst:
-    instructions:  # Canonical: use 'instructions' instead of 'backstory' Expert in business analysis and problem identification.
-    goal: Analyze business problems and identify key issues
-    role: Business Analyst
-    tools:
-      - internet_search
-    tasks:
-      analysis_task:
-        description: Analyze the current market challenges.
-        expected_output: Detailed analysis of key issues.
-
-  solver:
-    instructions:  # Canonical: use 'instructions' instead of 'backstory' Expert in solution design and implementation.
-    goal: Develop comprehensive solutions to business problems
-    role: Solution Architect
-    tasks:
-      solution_task:
-        description: Develop solutions for identified challenges.
-        expected_output: Comprehensive solution strategy.
+    User->>Agent: start("complex problem")
+    Agent->>LLM: Think step by step
+    LLM-->>Agent: Reasoning chain
+    Agent->>LLM: Formulate answer
+    LLM-->>Agent: Structured solution
+    Agent-->>Output: Final answer with reasoning
+    Output-->>User: response
 ```
-        </Step>
-        <Step title="Start Agents">
-            Type this in your terminal to run your agents:
-```bash
-praisonai agents.yaml
-```
-        </Step>
-    </Steps>
-  </Tab>
-</Tabs>
 
-### Configuration Options
+| Stage | Description |
+|-------|-------------|
+| **Reason** | Agent breaks the problem into sub-questions |
+| **Decide** | Agent evaluates options with evidence |
+| **Act** | Agent executes the chosen approach |
+| **Output** | Agent returns solution with explanation |
+
+---
+
+## Common Patterns
+
+### Multi-Agent Reasoning Pipeline
 
 ```python
-# Create an agent with reasoning configuration
-agent = Agent(
-    role="Problem Solver",
-    goal="Solve complex problems",
-    backstory="Expert in problem-solving",
-    tools=[Tools.internet_search],
-      # Enable detailed logging
-    llm="gpt-4o"  # Language model to use
+from praisonaiagents import Agent, Task, PraisonAIAgents
+
+analyst = Agent(
+    name="Analyst",
+    instructions="Analyze problems and identify key issues with evidence."
 )
 
-# Task with reasoning requirements
-task = Task(
-    description="Solve complex problem",
-    expected_output="Detailed solution",
-    agent=agent
+solver = Agent(
+    name="Solver",
+    instructions="Design comprehensive solutions based on analysis."
 )
+
+analysis_task = Task(
+    description="Analyze market challenges in the electric vehicle industry",
+    expected_output="Detailed analysis with key findings",
+    agent=analyst
+)
+
+solution_task = Task(
+    description="Develop strategy based on the analysis",
+    expected_output="Action plan with prioritized recommendations",
+    agent=solver
+)
+
+agents = PraisonAIAgents(
+    agents=[analyst, solver],
+    tasks=[analysis_task, solution_task],
+    process="sequential"
+)
+
+agents.start()
 ```
 
-## Troubleshooting
+### Reasoning with Tools
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools import internet_search
+
+agent = Agent(
+    name="ResearchReasoner",
+    instructions="Research topics deeply and reason about the findings.",
+    tools=[internet_search]
+)
+
+agent.start("What are the biggest AI safety concerns in 2025?")
+```
+
+### Structured Output Reasoning
+
+```python
+from praisonaiagents import Agent
+from pydantic import BaseModel
+
+class Analysis(BaseModel):
+    summary: str
+    pros: list[str]
+    cons: list[str]
+    recommendation: str
+
+agent = Agent(
+    name="StructuredReasoner",
+    instructions="Analyze topics and provide structured assessments.",
+    output_pydantic=Analysis
+)
+
+result = agent.start("Should we migrate our database to PostgreSQL?")
+print(result.recommendation)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Write clear, specific problem statements">
+    Vague inputs produce vague reasoning. State the problem with context: instead of "help with marketing", use "suggest three low-budget marketing strategies for a B2B SaaS startup targeting mid-sized logistics companies."
+  </Accordion>
+  <Accordion title="Use reasoning-optimized models for complex tasks">
+    Models like `o1-mini`, `o3-mini`, or `claude-3-7-sonnet` perform better on multi-step problems. Use standard models for simpler tasks to save cost and latency.
+  </Accordion>
+  <Accordion title="Break problems into sub-tasks with multi-agent pipelines">
+    Complex reasoning benefits from specialization. Assign analysis to one agent and solution design to another — each agent focuses on its strength without context overload.
+  </Accordion>
+  <Accordion title="Use structured output for decision-making">
+    When reasoning must produce actionable decisions, use `output_pydantic` to get typed results. This ensures reasoning outputs are machine-readable and integration-ready.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Related
 
 <CardGroup cols={2}>
-  <Card title="Reasoning Errors" icon="triangle-exclamation">
-    If reasoning seems incorrect:
-    - Check problem description clarity
-    - Enable verbose mode for debugging
-    - Review agent configuration
+  <Card title="Planning" icon="list-check" href="/docs/features/planning-mode">
+    Enable agents to plan before executing multi-step tasks
   </Card>
-
-  <Card title="Process Flow" icon="code">
-    If process flow is unclear:
-    - Verify task dependencies
-    - Check agent roles and goals
-    - Review task descriptions
+  <Card title="Self-Reflection" icon="rotate" href="/docs/features/selfreflection">
+    Let agents critique and improve their own outputs
   </Card>
 </CardGroup>
-
-## Next Steps
-
-<CardGroup cols={2}>
-  <Card title="AutoAgents" icon="robot" href="./autoagents">
-    Learn about automatically created and managed AI agents
-  </Card>
-  <Card title="Mini Agents" icon="microchip" href="./mini">
-    Explore lightweight, focused AI agents
-  </Card>
-</CardGroup>
-
-<Note>
-  For optimal results, ensure your problem descriptions are clear and provide sufficient context for the reasoning agents.
-</Note>

--- a/docs/features/selfreflection.mdx
+++ b/docs/features/selfreflection.mdx
@@ -6,16 +6,23 @@ icon: "brain"
 ---
 
 ```mermaid
-flowchart LR
-    In[In] --> Agent[AI Agent]
-    Agent --> Reflect[Self Reflection]
-    Reflect --> Agent
-    Agent --> Out[Out]
-    
-    style In fill:#8B0000,color:#fff
-    style Agent fill:#2E8B57,color:#fff
-    style Reflect fill:#2E8B57,color:#fff
-    style Out fill:#8B0000,color:#fff
+graph LR
+    subgraph "Self Reflection Loop"
+        In["💬 Input"] --> Agent["🤖 Agent"]
+        Agent --> Reflect["🔄 Reflect"]
+        Reflect -->|"improve"| Agent
+        Agent -->|"satisfied"| Out["✅ Output"]
+    end
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef reflect fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class In input
+    class Agent agent
+    class Reflect reflect
+    class Out output
 ```
 
 Self-reflection enables agents to evaluate and improve their own responses before delivering them.

--- a/docs/features/workflows.mdx
+++ b/docs/features/workflows.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Workflows"
+sidebarTitle: "Workflows"
 description: "Create reusable multi-step workflows with context passing and per-step agents"
 icon: "diagram-project"
 ---
@@ -36,7 +37,7 @@ graph LR
     STEP2 -->|"context"| STEP3
     
     classDef def fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef manager fill:#2E8B57,stroke:#7C90A0,color:#fff
+    classDef manager fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef exec fill:#189AB4,stroke:#7C90A0,color:#fff
     
     class MD def
@@ -1362,10 +1363,10 @@ graph TB
         WORKFLOW --> LOOP[Loop - iteration]
     end
     
-    classDef orchestrator fill:#2E8B57,stroke:#333,color:#fff
-    classDef agent fill:#189AB4,stroke:#333,color:#fff
-    classDef workitem fill:#8B0000,stroke:#333,color:#fff
-    classDef pattern fill:#FF8C00,stroke:#333,color:#fff
+    classDef orchestrator fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef workitem fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef pattern fill:#F59E0B,stroke:#7C90A0,color:#fff
     
     class AGENTS,WORKFLOW orchestrator
     class AGENT1,AGENT2,AGENT3 agent


### PR DESCRIPTION
## Summary

Compliance audit pass on 7 high-traffic `docs/features/` pages against AGENTS.md §9.

### §9 sub-checks addressed

**§9.1 Structure (frontmatter)**
- Added missing `sidebarTitle` to `reasoning.mdx`, `rag.mdx`, `knowledge.mdx`, `workflows.mdx`
- `reasoning.mdx`: rewrote intro as one sentence (not a duplicate of `description`)

**§9.2 SDK accuracy**
- `reasoning.mdx`: replaced deprecated `AgentTeam`/`Tools.internet_search` with `PraisonAIAgents` and `from praisonaiagents.tools import internet_search`
- Removed `your_api_key_here` placeholder

**§9.3 Code quality**
- `reasoning.mdx`: first example is now minimal agent-centric Quick Start (2 steps)

**§9.4 Diagrams — Mermaid colour palette**
- All 7 files: replaced off-palette `#2E8B57` (sea green) and `#4169E1`/`#FF6B6B` with the AGENTS.md §3.1 standard palette only: `#8B0000`, `#189AB4`, `#10B981`, `#F59E0B`, `#6366F1`
- Replaced raw `style X fill:...` with `classDef` + `class` declarations throughout
- Border strokes unified to `#7C90A0`

**§9.5 Writing style**
- `reasoning.mdx`: removed forbidden phrase "Learn how to create AI agents..." from page intro
- Active voice, direct opening sentences

### Best Practices sections
- `reasoning.mdx`: added AccordionGroup (4 entries)
- `rag.mdx`: replaced "Next Steps" CardGroup with AccordionGroup + Related CardGroup
- `knowledge.mdx`: converted Best Practices from CardGroup to AccordionGroup; "Next Steps" → "Related"

### How It Works section
- `reasoning.mdx`: added missing sequenceDiagram + explanation table

Fixes #1032

Generated with [Claude Code](https://claude.ai/code)