### PR TITLE
docs: clarify retry callback fires on async LLM path

### DIFF
--- a/docs/best-practices/agent-retry-strategies.mdx
+++ b/docs/best-practices/agent-retry-strategies.mdx
@@ -12,6 +12,10 @@ Implementing robust retry strategies is crucial for building resilient multi-age
 PraisonAI has built-in LLM retry support via `Agent(retry=...)`. See [Agent Retry](/features/agent-retry) for the API reference before implementing custom retry logic.
 </Tip>
 
+<Note>
+The `on_retry` hook fires identically on `agent.chat()` and `await agent.achat()` — the examples below work for both.
+</Note>
+
 ## Retry Strategy Fundamentals
 
 ### When to Retry

--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -303,6 +303,10 @@ config = FailoverConfig(
 manager = FailoverManager(config)
 ```
 
+<Info>
+**Sync + async parity (from PraisonAI #2386).** The `retry` callback now fires on **both** the sync (`agent.chat`) and async (`await agent.achat`) LLM paths. Older versions silently skipped the callback on async calls — upgrade to get retry observability for gateway bots, async tools, and any `await`-based agent code.
+</Info>
+
 ---
 
 ## Provider Status
@@ -346,7 +350,7 @@ manager.reset_all()
   </Accordion>
   
   <Accordion title="Monitor failover events">
-    Use the `on_failover` callback to track when failovers occur. This helps identify provider issues early.
+    Use the `on_failover` callback to track when failovers occur. This helps identify provider issues early. The callback fires on both sync and async LLM paths — works the same whether your agent runs via `agent.chat()` or `await agent.achat()`.
   </Accordion>
 
   <Accordion title="Integrate with error classification">

--- a/docs/features/hook-events.mdx
+++ b/docs/features/hook-events.mdx
@@ -192,6 +192,14 @@ def on_retry(event_data):
     return HookResult.allow()
 ```
 
+### Async vs Sync
+
+`ON_RETRY` fires on **both** sync and async retry paths. If you register the handler as a regular `def`, it is dispatched in a thread executor on the async path; if you register an `async def`, it is awaited directly. Either form is safe on both paths.
+
+<Note>
+Released in PraisonAI #2386 — earlier versions skipped this event on the async path.
+</Note>
+
 #### OnRetryInput Fields
 
 The `OnRetryInput` event includes both new tool-specific fields and legacy fields for backward compatibility:

--- a/docs/features/hooks.mdx
+++ b/docs/features/hooks.mdx
@@ -122,9 +122,11 @@ sequenceDiagram
 | `before_llm` | Before an LLM API call |
 | `after_llm` | After an LLM API response |
 | `on_error` | When any error occurs |
-| `on_retry` | Before a retry attempt |
+| `on_retry` | Before a retry attempt — fires on both sync and async LLM paths (post-PR #2386) |
 | `session_start` | When a session begins |
 | `session_end` | When a session ends |
+
+`on_retry` is emitted once per retryable error, just before the back-off sleep. It runs whether the LLM call is `agent.chat(...)` (sync) or `await agent.achat(...)` (async). Sync-registered callbacks on the async path are run in a thread executor — they cannot block the event loop.
 
 ---
 

--- a/docs/reference/simplified-api.mdx
+++ b/docs/reference/simplified-api.mdx
@@ -50,6 +50,8 @@ def my_hook(event_data):
 
 **Events:** `before_tool`, `after_tool`, `before_llm`, `after_llm`, `before_agent`, `after_agent`, `session_start`, `session_end`, `on_error`, `on_retry`
 
+Lifecycle events (`on_retry`, `on_error`, `before_llm`, `after_llm`) fire on both sync and async LLM paths.
+
 ### has_hook
 
 Check if hooks exist for an event.


### PR DESCRIPTION
## Summary

Clarifies that the `'retry'` callback / `on_retry` hook now fires on **both** the sync and async LLM paths, fixing a long-standing observability gap for async agent code.

### Changes

- **`docs/features/failover.mdx`**: Added `<Info>` callout under Failover Callbacks noting sync+async parity; added note to "Monitor failover events" accordion
- **`docs/features/hooks.mdx`**: Updated `on_retry` table description to mention both paths; added paragraph explaining thread executor dispatch for sync callbacks on async path
- **`docs/features/hook-events.mdx`**: Added "Async vs Sync" subsection under `ON_RETRY` with `<Note>` referencing PR #2386
- **`docs/best-practices/agent-retry-strategies.mdx`**: Added `<Note>` at top clarifying `on_retry` hook works identically for `agent.chat()` and `await agent.achat()`
- **`docs/reference/simplified-api.mdx`**: Added sentence noting lifecycle events fire on both sync and async LLM paths

Fixes #1037

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified hook and retry behavior across both synchronous and asynchronous execution paths.
  * Updated guidance for failover, retry events, and lifecycle hooks so examples and event descriptions now apply consistently in async usage.
  * Added notes explaining when retry callbacks fire and how they behave during backoff handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->