### PR TITLE
docs: AGENTS.md CLI auto-loading + --no-context flag (PraisonAI #2358)

### DIFF
--- a/docs/cli/chat.mdx
+++ b/docs/cli/chat.mdx
@@ -38,6 +38,7 @@ praisonai chat [OPTIONS] [PROMPT]
 | `--theme` | | UI theme: `default`, `dark`, `light`, `minimal` | `default` |
 | `--compact` | | Compact output mode | `false` |
 | `--no-rules` | | Disable auto-injection of project instruction files | `false` |
+| `--no-context` | | Disable AGENTS.md/CLAUDE.md auto-loading into system prompt | `false` |
 
 ## Examples
 
@@ -96,6 +97,10 @@ praisonai chat --no-rules "Hello, ignore project rules"
 ```
 
 The chat session normally inherits `AGENTS.md`/`CLAUDE.md`/`PRAISON.md` from the working directory. `--no-rules` runs the assistant with only its built-in instructions.
+
+## Project context
+
+By default, `praisonai chat` walks up from the current directory to your git root and prepends any `AGENTS.md` / `CLAUDE.md` / `agents.md` / `.agents/AGENTS.md` it finds to the agent's system prompt, layered on top of `~/.praisonai/AGENTS.md`. Pass `--no-context` (or set `PRAISON_NO_CONTEXT=true`) to disable. See [Context Files](/docs/features/context-files) for details.
 
 ## UI Backends
 

--- a/docs/cli/cli.mdx
+++ b/docs/cli/cli.mdx
@@ -378,6 +378,7 @@ praisonai "List files here" -v
 | `--expand-tools` | Tools for prompt expansion | `praisonai "task" --expand-prompt --expand-tools tools.py` |
 | `--include-rules` | Include rules file | `praisonai "task" --include-rules rules.md` |
 | `--no-rules` | Disable auto-loading of project instruction files | `praisonai "task" --no-rules` |
+| `--no-context` | Disable AGENTS.md/CLAUDE.md auto-loading into system prompt for `chat`, `run`, `code`, and `tui` | `praisonai chat --no-context` |
 | `--max-tokens` | Maximum tokens for response | `praisonai "task" --max-tokens 4000` |
 
 ### Monitoring & Display

--- a/docs/cli/code.mdx
+++ b/docs/cli/code.mdx
@@ -32,6 +32,7 @@ praisonai code [OPTIONS] [PROMPT]
 | `--safe` | | Safe mode: require approval for file writes | `false` |
 | `--session` | `-s` | Session ID to resume | |
 | `--continue` | `-c` | Continue last session | `false` |
+| `--no-context` | | Disable AGENTS.md/CLAUDE.md auto-loading into system prompt | `false` |
 
 ## Examples
 
@@ -52,6 +53,10 @@ praisonai code "Write a Python function to sort a list"
 ```bash
 praisonai code --language python "Explain decorators"
 ```
+
+## Project context
+
+By default, `praisonai code` walks up from the current directory to your git root and prepends any `AGENTS.md` / `CLAUDE.md` / `agents.md` / `.agents/AGENTS.md` it finds to the agent's system prompt, layered on top of `~/.praisonai/AGENTS.md`. Pass `--no-context` (or set `PRAISON_NO_CONTEXT=true`) to disable. See [Context Files](/docs/features/context-files) for details.
 
 ## Windows Automation
 

--- a/docs/cli/rules.mdx
+++ b/docs/cli/rules.mdx
@@ -151,7 +151,7 @@ PraisonAI automatically discovers instruction files from your project root and g
 | `~/.praisonai/AGENTS.md` | Global single-file instructions (loaded by `load_context_files()`) | Lowest |
 
 <Note>
-`~/.praisonai/AGENTS.md` is loaded by `load_context_files()` as the lowest-precedence layer whenever `walk_up=True` (the default). It is separate from the modular `~/.praisonai/rules/*.md` files loaded by `RulesManager`. See [Context Files](/docs/features/context-files) for details on layered merge behaviour.
+`~/.praisonai/AGENTS.md` is loaded by `load_context_files()` as the lowest-precedence layer whenever `walk_up=True` (the default). It is separate from the modular `~/.praisonai/rules/*.md` files loaded by `RulesManager`. See [Context Files → CLI auto-loading](/docs/features/context-files#cli-auto-loading) for how `chat`, `run`, `code`, and `tui` automatically inject this context into the agent system prompt.
 </Note>
 
 ## Rule File Format

--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -38,6 +38,7 @@ praisonai run [OPTIONS] [TARGET]
 | `--fork` | | Fork from the specified session (requires `--session`) | `false` |
 | `--no-save` | | Don't auto-save the session after execution | `false` |
 | `--no-rules` | | Disable auto-injection of project instruction files (AGENTS.md, CLAUDE.md, etc.) | `false` |
+| `--no-context` | | Disable AGENTS.md/CLAUDE.md auto-loading into system prompt | `false` |
 | `--agent` | `-a` | Use a named custom agent from `.praisonai/agents/` | |
 | `--command` | | Execute a named custom command; `TARGET` becomes `$ARGUMENTS` | |
 | `--allow` | | Allow a permission pattern (e.g. `'bash:git *'`); repeatable | |
@@ -217,6 +218,10 @@ praisonai run "What does this codebase do?" --verbose
 ```
 
 ---
+
+## Project context
+
+By default, `praisonai run` walks up from the current directory to your git root and prepends any `AGENTS.md` / `CLAUDE.md` / `agents.md` / `.agents/AGENTS.md` it finds to the agent's system prompt, layered on top of `~/.praisonai/AGENTS.md`. Pass `--no-context` (or set `PRAISON_NO_CONTEXT=true`) to disable. See [Context Files](/docs/features/context-files) for details.
 
 ## First-run Credential Check
 

--- a/docs/cli/tui.mdx
+++ b/docs/cli/tui.mdx
@@ -41,6 +41,10 @@ praisonai tui simulate script.yaml
 praisonai tui snapshot
 ```
 
+## Project context
+
+By default, `praisonai tui` walks up from the current directory to your git root and prepends any `AGENTS.md` / `CLAUDE.md` / `agents.md` / `.agents/AGENTS.md` it finds to the agent's system prompt, layered on top of `~/.praisonai/AGENTS.md`. Pass `--no-context` (or set `PRAISON_NO_CONTEXT=true`) to disable. See [Context Files](/docs/features/context-files) for details.
+
 ## See Also
 
 - [Interactive TUI](/docs/cli/interactive-tui) - TUI details

--- a/docs/features/context-files.mdx
+++ b/docs/features/context-files.mdx
@@ -111,6 +111,107 @@ Context:
 
 ---
 
+## CLI Auto-loading
+
+As of PraisonAI PR #2358, `praisonai chat`, `praisonai run`, `praisonai code`, and `praisonai tui` automatically discover and inject AGENTS.md-style project context into the system prompt — no flag required.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as praisonai CLI
+    participant Loader as load_context_files
+    participant Agent as Agent backstory
+
+    User->>CLI: praisonai chat / run / code / tui
+    CLI->>Loader: walk_up=True, cwd=workspace
+    Loader-->>CLI: merged context (≤8000 chars)
+    CLI->>Agent: prepend "# Project Context\n{context}"
+    Agent-->>User: response with project awareness
+
+    classDef user fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef cli fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef loader fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agent fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class User user
+    class CLI cli
+    class Loader loader
+    class Agent agent
+```
+
+### Opt-out
+
+<Steps>
+<Step title="CLI flag">
+
+Pass `--no-context` to any of the four commands to skip all project-context loading for that invocation:
+
+```bash
+praisonai chat --no-context
+praisonai run --no-context "Quick one-off task"
+praisonai code --no-context
+```
+
+</Step>
+
+<Step title="Environment variable">
+
+Set `PRAISON_NO_CONTEXT=true` in your shell or CI environment to disable auto-loading globally:
+
+```bash
+export PRAISON_NO_CONTEXT=true
+praisonai run "task"   # context skipped
+```
+
+</Step>
+
+<Step title="InteractiveConfig field">
+
+When using the interactive core programmatically:
+
+```python
+from praisonai.cli.interactive.config import InteractiveConfig
+
+config = InteractiveConfig(no_context=True)
+```
+
+</Step>
+
+<Step title="configure_host() param">
+
+In host integrations, pass `no_context=True` directly or via `agent_kwargs` for backward compatibility:
+
+```python
+configure_host(no_context=True)
+# or
+configure_host(agent_kwargs={"no_context": True})
+```
+
+</Step>
+</Steps>
+
+### Opt-out matrix
+
+| Surface | Opt-out |
+|---------|---------|
+| CLI flag | `--no-context` |
+| Env var | `PRAISON_NO_CONTEXT=true` |
+| `InteractiveConfig` field | `no_context=True` |
+| `configure_host()` param | `no_context=True` (or `agent_kwargs={"no_context": True}`) |
+
+### Token budget and truncation
+
+The default budget is **8000 characters**. When discovered context exceeds the budget, it is truncated and `\n... [project context truncated]` is appended. Override via:
+
+- `InteractiveConfig(context_token_budget=16000)` for interactive sessions
+- `configure_host(context_token_budget=16000)` for host integrations
+
+<Note>
+Discovery runs once per session and the result is cached. Editing `AGENTS.md` mid-session requires restarting the CLI to pick up changes.
+</Note>
+
+---
+
 ## Configuration Options
 
 ### Default File Discovery

--- a/docs/features/host-integration.mdx
+++ b/docs/features/host-integration.mdx
@@ -134,7 +134,10 @@ graph TB
 | `sidebar` | `bool` | `True` | Show navigation sidebar |
 | `page_header` | `bool` | `True` | Show page header |
 | `style` | `str` | `"dashboard"` | UI layout: `"dashboard"` or `"chat"` |
-| `context_paths` | `Sequence[str]` | `None` | Explicit paths to context files prepended to agent instructions. When omitted (`None`), `load_context_files()` runs in auto-discovery mode and walks up from cwd to the git root collecting `AGENTS.md` / `CLAUDE.md` / `agents.md` / `.agents/AGENTS.md` at each level, layered on top of `~/.praisonai/AGENTS.md`. When an explicit list is given, discovery is skipped and paths are read from cwd only (backward compatible). |
+| `context_paths` | `Sequence[str]` | `None` | Context file paths. `None` → walk-up auto-discovery from `context_cwd` (or process cwd). `[]` → authoritative "load nothing" sentinel; discovery is skipped. `["AGENTS.md", ...]` → load exactly those paths from cwd; no walk-up. |
+| `no_context` | `bool` | `False` | Skip all project-context loading. Honoured as a first-class param **and** when threaded through `agent_kwargs={"no_context": True}` (backward compat). |
+| `context_cwd` | `Optional[str]` | `None` | Starting directory for walk-up discovery. Falls back to process cwd. Ignored when `context_paths` is explicitly provided. |
+| `context_token_budget` | `int` | `8000` | Maximum characters of discovered context to inject. Excess is truncated and `\n... [project context truncated]` is appended. |
 | `theme` | `Dict[str, Any]` | `None` | Custom theme settings |
 | `agents` | `List[Any]` | `None` | Pre-configured agents |
 | `agent_kwargs` | `Dict[str, Any]` | `None` | Default agent parameters |

--- a/docs/features/rules.mdx
+++ b/docs/features/rules.mdx
@@ -221,7 +221,7 @@ monorepo/                    # Git root
 
 Rules closer to the current working directory have higher priority than rules at the git root.
 
-The wrapper-layer `load_context_files()` (used by `configure_host` / `context_paths`) uses the same git-root walk-up and adds layered merge semantics — collecting `AGENTS.md`, `CLAUDE.md`, `agents.md`, and `.agents/AGENTS.md` at every directory level from `~/.praisonai/AGENTS.md` (lowest) up through the git root to `cwd` (highest). See [Context Files](/docs/features/context-files) for the full layered merge details.
+The wrapper-layer `load_context_files()` (used by `configure_host` / `context_paths`) uses the same git-root walk-up and adds layered merge semantics — collecting `AGENTS.md`, `CLAUDE.md`, `agents.md`, and `.agents/AGENTS.md` at every directory level from `~/.praisonai/AGENTS.md` (lowest) up through the git root to `cwd` (highest). See [Context Files → CLI auto-loading](/docs/features/context-files#cli-auto-loading) for how `chat`, `run`, `code`, and `tui` automatically inject this context into the agent system prompt.
 
 ## Storage Structure
 


### PR DESCRIPTION
## Summary

Documents PraisonAI PR #2358 which wires `load_context_files()` into `chat`/`run`/`code`/`tui` CLI commands and adds `--no-context` opt-out flag.

## Files updated

| File | Changes |
|------|---------|
| `docs/features/context-files.mdx` | New "CLI auto-loading" section: sequence diagram, opt-out matrix (`--no-context`, `PRAISON_NO_CONTEXT`, `InteractiveConfig.no_context`, `configure_host no_context`), token budget docs (8000 chars default, truncation marker), per-session caching `<Note>` callout |
| `docs/features/host-integration.mdx` | Added `no_context`, `context_cwd`, `context_token_budget` parameter rows; clarified `None` vs `[]` distinction for `context_paths` |
| `docs/cli/chat.mdx` | Added `--no-context` option + "Project context" subsection |
| `docs/cli/run.mdx` | Added `--no-context` option + "Project context" subsection |
| `docs/cli/code.mdx` | Added `--no-context` option + "Project context" subsection |
| `docs/cli/tui.mdx` | Added "Project context" subsection |
| `docs/cli/cli.mdx` | Added `--no-context` to Context & Prompts flag table |
| `docs/features/rules.mdx` | Updated cross-link to Context Files → CLI auto-loading section |
| `docs/cli/rules.mdx` | Updated cross-link to Context Files → CLI auto-loading section |

## §9 Quality checklist

- ✅ Sequence diagram uses standard color palette (#8B0000, #189AB4, #6366F1, #10B981)
- ✅ `<Steps>` component used for opt-out walk-through
- ✅ `<Note>` callout for per-session caching behaviour
- ✅ One-sentence section intro
- ✅ No forbidden phrases
- ✅ Active voice
- ✅ No new pages created (all edits on existing pages)
- ✅ No `docs/concepts/` files touched

Fixes #1044

Generated with [Claude Code](https://claude.ai/code)