### PR TITLE
Document praisonai attach CLI (Fixes #964)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1333,7 +1333,8 @@
                   "docs/cli/mcp-server",
                   "docs/cli/workflow",
                   "docs/cli/validate",
-                  "docs/cli/daemon"
+                  "docs/cli/daemon",
+                  "docs/cli/attach"
                 ]
               },
               {

--- a/docs/cli/attach.mdx
+++ b/docs/cli/attach.mdx
@@ -1,0 +1,169 @@
+---
+title: "Attach"
+sidebarTitle: "Attach"
+description: "Stream live events from a session running on the warm runtime"
+icon: "play"
+---
+
+`praisonai attach` subscribes to a live agent session on the warm runtime and streams its events in real time from a second terminal — read-only, with multiple observers supported.
+
+```mermaid
+graph LR
+    A[Terminal A<br/>run --attach id] --> R[Warm Runtime]
+    R -->|SSE events| B[Terminal B<br/>attach id]
+    R -->|SSE events| C[Terminal C<br/>attach id --json]
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A input
+    class R process
+    class B,C output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Start the warm runtime">
+```bash
+praisonai daemon start --background
+```
+</Step>
+
+<Step title="Run an agent with a session id (terminal A)">
+```bash
+praisonai run "Research topic X" --attach my-session
+```
+</Step>
+
+<Step title="Attach from another terminal (terminal B)">
+```bash
+praisonai attach my-session
+```
+</Step>
+</Steps>
+
+---
+
+## Usage
+
+```bash
+praisonai attach <session-id> [--json]
+```
+
+| Argument / Option | Type | Default | Description |
+|---|---|---|---|
+| `session_id` | positional | required | Session id to attach to |
+| `--json` | flag | `false` | Emit raw NDJSON events instead of human-readable output |
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant A as Terminal A
+    participant R as Warm Runtime
+    participant H as Event Hub
+    participant B as Terminal B
+    participant C as Terminal C
+
+    A->>R: run --attach my-session
+    B->>R: attach my-session
+    C->>R: attach my-session --json
+    R->>H: fan-out session events
+    H-->>B: run.start / run.result / run.error
+    H-->>C: NDJSON lines
+```
+
+Attaching never starts execution — it only observes. Detaching (Ctrl-C) does not stop the run on terminal A.
+
+<Tip>
+Events arrive over Server-Sent Events at `GET /sessions/{session_id}/events` with Bearer auth from the runtime lockfile. Session ids are percent-encoded on the wire. A `: keep-alive` comment is sent every ~15s and ignored.
+</Tip>
+
+---
+
+## Event Reference
+
+| Type | Fields | Human render |
+|---|---|---|
+| `run.start` | `session_id`, `prompt` | `▶ run.start: <prompt>` |
+| `run.result` | `session_id`, `ok`, `result` | `✓ run.result` then result text |
+| `run.error` | `session_id`, `error` | `✗ run.error: <error>` |
+
+<Tabs>
+<Tab title="Human output">
+```
+Attached to session 'my-session'. Ctrl-C to detach.
+▶ run.start: Research topic X
+✓ run.result
+Here is the summary...
+```
+</Tab>
+<Tab title="--json (NDJSON)">
+```bash
+praisonai attach my-session --json | jq 'select(.type=="run.result")'
+```
+```json
+{"type": "run.start", "session_id": "my-session", "prompt": "Research topic X"}
+{"type": "run.result", "session_id": "my-session", "ok": true, "result": "..."}
+```
+</Tab>
+</Tabs>
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Clean detach (Ctrl-C) |
+| `1` | No compatible warm runtime, or stream lost mid-attach |
+| `4` | Runtime module not importable |
+
+---
+
+## Common Patterns
+
+**Watch a long-running agent from a second terminal** — start with `--attach`, observe progress without blocking terminal A.
+
+**Pipe JSON into jq** — `praisonai attach my-session --json | jq 'select(.type=="run.result")'`.
+
+**Multiple observers** — several terminals can attach to the same session concurrently; all receive the same events.
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Start the daemon first">
+Run `praisonai daemon start` before `run --attach`. Without a warm runtime, attach exits with code 1.
+</Accordion>
+
+<Accordion title="Use direct prompt runs only">
+`--attach` on `praisonai run` works for direct prompts only — not YAML files, `--agent`, or `--command`.
+</Accordion>
+
+<Accordion title="Detaching is safe">
+Ctrl-C in an attach terminal never cancels the underlying agent run.
+</Accordion>
+
+<Accordion title="Version mismatch after upgrade">
+If CLI and daemon major versions differ, attach refuses to connect. Run `praisonai daemon stop && praisonai daemon start` after upgrading.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Run" icon="play" href="/docs/cli/run">
+  `--attach` flag for tagging warm-runtime sessions
+</Card>
+<Card title="Daemon" icon="bolt" href="/docs/cli/daemon">
+  Warm runtime lifecycle and version handshake
+</Card>
+</CardGroup>

--- a/docs/cli/daemon.mdx
+++ b/docs/cli/daemon.mdx
@@ -101,6 +101,7 @@ sequenceDiagram
 | `--memory` | Memory backend must be initialized per-session |
 | `--approval` | Approval backends need a live terminal or channel |
 | `--tools`, `--toolset` | Per-invocation tool overrides change agent config |
+| `--attach` | Live session tagging for multi-terminal observation |
 | `--output json`, `--stream` | Structured output modes attach directly to the process |
 | `--trace`, `--profile` | Tracing and profiling require direct process access |
 
@@ -149,6 +150,21 @@ praisonai daemon stop
 ```
 
 Sends `SIGTERM` to the daemon process. If the lockfile is stale (PID reuse), cleans up the lockfile instead of killing a random process.
+
+---
+
+## Version compatibility
+
+The warm runtime records its package version in the lockfile. Thin clients (`praisonai run`, `praisonai attach`) require a **matching major version** before reusing the runtime — a stale daemon after upgrade is ignored and the CLI falls back to in-process execution (or attach exits with code 1).
+
+After upgrading PraisonAI:
+
+```bash
+praisonai daemon stop
+praisonai daemon start --background
+```
+
+See [Attach](/docs/cli/attach) for streaming live session events from a second terminal.
 
 ---
 
@@ -218,5 +234,8 @@ nohup praisonai daemon start > ~/.praisonai/daemon.log 2>&1 &
 </Card>
 <Card title="CLI Reference" icon="terminal" href="/docs/cli/cli-reference">
   Full CLI flag reference
+</Card>
+<Card title="Attach" icon="play" href="/docs/cli/attach">
+  Stream live session events from another terminal
 </Card>
 </CardGroup>

--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -52,6 +52,7 @@ praisonai run [OPTIONS] [TARGET]
 | `--approval` | | Approval backend mode: `console`, `plan`, `accept-edits`, `bypass` | |
 | `--restore` | | Restore workspace to a checkpoint (`id`, `last`, or `latest`) and exit | |
 | `--no-checkpoint` | | Disable automatic pre-run checkpoint for this invocation | `false` |
+| `--attach` | | Run on the warm runtime under this session id so other terminals can observe via `praisonai attach` | |
 
 ## Output Modes
 
@@ -222,6 +223,25 @@ Use `--verbose` to see which instruction files were loaded:
 praisonai run "What does this codebase do?" --verbose
 # > Loaded project instructions: AGENTS.md, CLAUDE.md
 ```
+
+---
+
+## Live session attach
+
+Tag a warm-runtime run with a session id so other terminals can stream its events with [`praisonai attach`](/docs/cli/attach).
+
+```bash
+# Terminal A
+praisonai daemon start --background
+praisonai run "Research topic X" --attach my-session
+
+# Terminal B
+praisonai attach my-session
+```
+
+<Note>
+`--attach` is supported for **direct prompt runs only** — not YAML files, `--agent`, or `--command`. Requires a compatible warm runtime (`praisonai daemon start`). Major-version mismatch falls back to in-process execution for `run`, or exit code 1 for `attach`.
+</Note>
 
 ---
 
@@ -538,3 +558,4 @@ See [Checkpoints](/docs/features/checkpoints) and [Checkpoint CLI](/docs/cli/che
 - [Agents](/docs/cli/agents) - Agent management
 - [Workflow](/docs/cli/workflow) - Workflow execution
 - [Interactive TUI](/docs/cli/interactive-tui) - Interactive terminal interface
+- [Attach](/docs/cli/attach) - Stream live events from a warm-runtime session


### PR DESCRIPTION
## Summary
- Add `docs/cli/attach.mdx` for live session streaming from the warm runtime
- Document `--attach` on `docs/cli/run.mdx` and version handshake on `docs/cli/daemon.mdx`
- Register attach page in `docs.json`

Fixes #964

## Test plan
- [x] Page follows AGENTS.md CLI structure
- [x] Nav entry added under Core Commands