### PR TITLE
Document tool timeout workers env var (Fixes #945)

### DIFF
--- a/docs/cli/auto.mdx
+++ b/docs/cli/auto.mdx
@@ -178,6 +178,8 @@ The auto mode creates an `agents.yaml` file with:
 - **Focused tasks** with expected outputs
 - **Process configuration** (sequential, parallel, etc.)
 
+Generated YAML files are written atomically — a crash or interruption during save will not corrupt the existing file.
+
 ## When to Use Each
 
 <AccordionGroup>

--- a/docs/configuration/tool-config.mdx
+++ b/docs/configuration/tool-config.mdx
@@ -172,6 +172,8 @@ The returned shape on wrapper-level timeout is a **JSON string** (because the wr
 }
 ```
 
+For **sync tools** that have already started executing, the payload may also include `"background_work_may_continue": true`. This means the timeout fired but the worker thread may still be running — do not assume a timed-out tool stopped doing work.
+
 If the worker thread exits without publishing a result (defensive fallback), the wrapper returns:
 ```json
 {
@@ -208,6 +210,10 @@ roles:
 When `fetch_url` blocks for more than 15 s, the agent receives the structured JSON dict above instead of an indefinite hang, so the crew keeps moving.
 
 **Precedence note:** When both wrapper-level and SDK-level timeouts apply, the **shorter** of the two wins in practice (whichever fires first). Both currently read from the same `tool_timeout` value, so they fire at the same time; if a user later configures different values at different layers, the first-to-fire semantics still hold.
+
+<Note>
+`PRAISONAI_TOOL_TIMEOUT_WORKERS` caps the named thread pool that runs sync tools under timeout (default `32`). Invalid or non-positive values fall back to `32` with a warning log line.
+</Note>
 
 ### Advanced Timeout Configuration
 
@@ -648,6 +654,7 @@ agent = Agent(
 ```bash
 # Tool timeout settings
 export PRAISONAI_TOOL_TIMEOUT="60"
+export PRAISONAI_TOOL_TIMEOUT_WORKERS="32"  # cap sync tool timeout thread pool (default 32)
 export PRAISONAI_TOOL_CONNECT_TIMEOUT="5"
 export PRAISONAI_TOOL_READ_TIMEOUT="55"
 

--- a/docs/features/async-tool-safety.mdx
+++ b/docs/features/async-tool-safety.mdx
@@ -215,9 +215,12 @@ graph LR
 {
   "error": "tool_timeout",
   "tool": "<function name>",
-  "timeout_seconds": 30
+  "timeout_seconds": 30,
+  "background_work_may_continue": true
 }
 ```
+
+The `background_work_may_continue` field appears on sync tool timeouts when the worker thread could not be cancelled — the call timed out but side effects may still occur.
 
 See [Tool Configuration](/configuration/tool-config#wrapper-level-tool-timeout) for full details and [Concurrency](/features/concurrency#timeout-return-shape) for shape comparison.
 


### PR DESCRIPTION
Fixes #945\n\n- PRAISONAI_TOOL_TIMEOUT_WORKERS in tool-config\n- background_work_may_continue in async-tool-safety\n- atomic YAML write note on cli/auto