### PR TITLE
Update runtime selection for auto runtime (Fixes #983)

### DIFF
--- a/docs/features/runtime-selection.mdx
+++ b/docs/features/runtime-selection.mdx
@@ -86,7 +86,7 @@ sequenceDiagram
 
 1. **Per-model runtime** — `model_runtime_configs[model_name]`
 2. **Per-provider default** — `provider_runtime_configs[provider_name]`
-3. **Auto-selection** — placeholder; currently returns `None` (reserved for a future release)
+3. **Auto-selection** — `resolve_runtime()` picks the highest-priority runtime whose `supports(model_ref)` returns true; see [Agent Runtime Protocol](/docs/features/agent-runtime-protocol)
 4. **Built-in default** — `"praisonai"`
 5. **Legacy `cli_backend`** — emits `DeprecationWarning`
 
@@ -263,6 +263,9 @@ Use the migration table above or `praisonai doctor runtime --fix` before 2.0.0 r
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Agent Runtime Protocol" icon="plug" href="/docs/features/agent-runtime-protocol">
+  Plugin harness registry, `register_runtime`, and `praisonai.runtimes` entry points
+</Card>
 <Card title="CLI Backend Protocol" icon="plug" href="/docs/features/cli-backend-protocol">
   Legacy cli_backend reference (deprecated — see Runtime Selection)
 </Card>


### PR DESCRIPTION
Fixes #983 — agent-runtime-protocol and first-run onboarding already cover PR #2335/#2338; this fixes stale auto-selection placeholder.