### PR TITLE
docs: subagent background mode + subagent_result (fixes #1063)

### DIFF
--- a/docs/features/subagent-tool.mdx
+++ b/docs/features/subagent-tool.mdx
@@ -5,29 +5,28 @@ description: "Spawn subagents dynamically with model and permission control"
 icon: "robot"
 ---
 
-The Subagent Tool enables agents to spawn specialized subagents for specific tasks, with full control over model selection and permission modes.
+The Subagent Tool lets a parent agent spawn specialised subagents for specific tasks — synchronously, or in the **background** so the parent keeps working and collects the result later.
 
 ```mermaid
 graph LR
     subgraph "Subagent Tool Flow"
         A[🤖 Parent Agent] --> B[🔧 create_subagent_tool]
         B --> C{spawn_subagent}
-        C --> D[📝 Task]
-        C --> E[🧠 LLM Model]
-        C --> F[🔒 Permission Mode]
-        D --> G[✅ Result]
-        E --> G
-        F --> G
+        C -->|background=False| S[⚡ Synchronous]
+        C -->|background=True| K[📨 job_id]
+        K --> R[🔁 subagent_result]
+        S --> G[✅ Result]
+        R --> G
     end
-    
+
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
     classDef config fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef result fill:#10B981,stroke:#7C90A0,color:#fff
-    
+
     class A agent
-    class B,C tool
-    class D,E,F config
+    class B,C,R tool
+    class S,K config
     class G result
 ```
 
@@ -121,6 +120,141 @@ result = func(
 | `tools` | `List[str]` | No | Tools to give the subagent |
 | `llm` | `str` | No | LLM model override |
 | `permission_mode` | `str` | No | Permission mode override |
+| `background` | `bool` | No | When `True`, enqueue on the background job runner and return immediately with a `job_id` |
+
+---
+
+## Background Mode
+
+Run a long subtask without blocking the parent agent. Use it for full test runs, broad codebase scans, or large refactors — anything where the parent agent should keep working instead of waiting.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Parent as Parent Agent
+    participant BG as Background Runner
+    participant Sub as Subagent
+
+    User->>Parent: "refactor utils & keep working"
+    Parent->>BG: spawn_subagent(background=True)
+    BG-->>Parent: job_id
+    Parent->>Parent: continue other work
+    Parent->>BG: subagent_result(job_id, wait=True)
+    BG->>Sub: execute
+    Sub-->>BG: result
+    BG-->>Parent: completed + result
+    Parent-->>User: final answer
+```
+
+<Steps>
+
+<Step title="Kick off in the background">
+```python
+from praisonaiagents.tools.subagent_tool import create_subagent_tool
+
+tool = create_subagent_tool()
+spawn = tool["function"]
+
+handle = spawn(
+    task="Run the full test suite",
+    background=True,
+)
+job_id = handle["job_id"]
+```
+</Step>
+
+<Step title="Keep working, then collect the result">
+```python
+collect = tool["result_tool"]["function"]
+
+# Non-blocking poll — returns status="running" or status="completed"
+status = collect(job_id)
+
+# Or block until done
+final = collect(job_id, wait=True)
+if final["status"] == "completed":
+    print(final["result"]["output"])
+```
+</Step>
+
+<Step title="Handle failures cleanly">
+```python
+result = collect(job_id, wait=True)
+
+if not result["success"]:
+    print("Job failed:", result.get("error"))
+elif result["result"]["success"] is False:
+    print("Subagent error:", result["result"]["error"])
+else:
+    print(result["result"]["output"])
+```
+</Step>
+
+</Steps>
+
+### When to use background mode
+
+```mermaid
+graph TB
+    Q{Will the subtask take<br/>more than a few seconds?}
+    Q -->|No| Sync[Use synchronous<br/>spawn_subagent]
+    Q -->|Yes| B{Does the parent agent<br/>have other work to do<br/>right now?}
+    B -->|No| Sync
+    B -->|Yes| BG[Use background=True<br/>+ subagent_result]
+
+    classDef question fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef sync fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef async fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Q,B question
+    class Sync sync
+    class BG async
+```
+
+### Background return shapes
+
+`spawn_subagent(..., background=True)` returns a **handle** (not a final result):
+
+```python
+{
+    "success": True,
+    "job_id": "...",
+    "status": "running",
+    "agent_name": "subagent",
+    "task": "...",
+    "llm": "...",
+    "permission_mode": "...",
+}
+```
+
+`subagent_result(job_id)` polls without blocking:
+
+```python
+# While running
+{"success": True, "job_id": "...", "status": "running"}
+```
+
+`subagent_result(job_id, wait=True)` blocks until done:
+
+```python
+# On completion — the subagent's normal result dict is under "result"
+{
+    "success": True,
+    "job_id": "...",
+    "status": "completed",
+    "result": {"success": True, "output": "...", "agent_name": "...", ...},
+}
+
+# On failure
+{"success": False, "job_id": "...", "status": "failed", "error": "..."}
+
+# Unknown job_id
+{"success": False, "job_id": "...", "error": "Job '...' not found"}
+```
+
+<Note>
+Depth (`max_depth`), `allowed_agents`, and per-call `tools` / `llm` / `permission_mode` apply to background subagents identically to synchronous ones. Background jobs run on a worker thread but inherit the same scoping the parent set up.
+</Note>
 
 ---
 
@@ -241,6 +375,8 @@ result = func(task="Write code", agent_name="coder")
 
 ## Result Structure
 
+Synchronous calls (`background=False`, the default) return the final result directly:
+
 ```python
 result = func(task="Analyze code")
 
@@ -262,6 +398,8 @@ result = func(task="Analyze code")
 }
 ```
 
+Background calls return a handle — see [Background Mode](#background-mode) for `subagent_result` shapes.
+
 ---
 
 ## Best Practices
@@ -282,6 +420,10 @@ Restrict `allowed_agents` to only the agent types needed for your use case.
 
 <Accordion title="Handle errors">
 Always check `result["success"]` before accessing the output.
+</Accordion>
+
+<Accordion title="Use background mode for long tasks">
+For test suites, broad scans, or refactors, use `background=True` so the parent agent can keep working and collect results with `subagent_result`.
 </Accordion>
 
 </AccordionGroup>


### PR DESCRIPTION
## Summary
- Update `docs/features/subagent-tool.mdx` for `spawn_subagent(background=True)` and `subagent_result` companion tool (PraisonAI PR #2399)

## Test plan
- [x] Hero diagram shows sync vs background paths
- [x] Spawn parameters table includes `background`
- [x] Background Mode section with Steps, return shapes, and Note
- [x] No `docs/concepts/` changes


Made with [Cursor](https://cursor.com)