### PR TITLE
docs: correct BUSY/STUCK wording for in-run progress (fixes #1066)

### DIFF
--- a/docs/features/gateway-channel-supervision.mdx
+++ b/docs/features/gateway-channel-supervision.mdx
@@ -183,7 +183,7 @@ gateway:
     interval: 300            # seconds between sweeps (default 300)
     startup_grace: 60        # grace window after start (default 60)
     stale_after: 120         # no inbound activity (idle) → stale-socket (default 120)
-    stuck_after: 900         # busy with no progress → stuck (default 900)
+    stuck_after: 900         # busy with no progress (inbound OR in-run) → stuck (default 900)
     max_restarts_per_hour: 10
     enabled: true            # default true
 ```
@@ -205,7 +205,7 @@ supervisor = ChannelSupervisor(health_config=health_config)
 | `interval` | `float` | `300.0` | Seconds between health sweeps |
 | `startup_grace` | `float` | `60.0` | Seconds after start before checks count |
 | `stale_after` | `float` | `120.0` | Seconds without **inbound** transport activity (while idle) → `stale-socket` |
-| `stuck_after` | `float` | `900.0` | Seconds a **busy** channel can go without inbound progress → `stuck` |
+| `stuck_after` | `float` | `900.0` | Seconds a **busy** channel can go without **any progress signal** (inbound transport activity OR in-run progress — tool calls, streamed tokens, emitter events) → `stuck` |
 | `max_restarts_per_hour` | `int` | `10` | Hard cap on restart attempts per channel per hour |
 | `enabled` | `bool` | `True` | Whether monitoring is enabled |
 
@@ -218,8 +218,8 @@ supervisor = ChannelSupervisor(health_config=health_config)
 | `startup-grace` | No | `uptime_seconds < startup_grace` |
 | `disconnected` | Yes | `health.probe` exists and `probe.ok` is false |
 | `stale-socket` | Yes | Idle and no **inbound** activity for `stale_after` seconds |
-| `busy` | **No** | `active_runs > 0` with inbound progress within `stuck_after` — protects long runs from mid-run kills |
-| `stuck` | Yes | `active_runs > 0` and no inbound progress for `> stuck_after` — likely wedged |
+| `busy` | **No** | `active_runs > 0` with progress within `stuck_after` — protects long runs from mid-run kills |
+| `stuck` | Yes | `active_runs > 0` and no progress (inbound or in-run) for `> stuck_after` — likely wedged |
 | `error` | Yes | `health.error` set or `health.ok` is false |
 
 Decision order in `evaluate_channel_health()`:
@@ -255,7 +255,11 @@ Channel liveness is driven by whether messages are still flowing IN, not just wh
 
 ### Run awareness
 
-The evaluator knows about in-flight agent turns (`HealthResult.active_runs`). A busy channel is never killed mid-run — `BUSY` is non-recoverable on purpose. Only when a busy channel has made no inbound progress for `stuck_after` seconds does it escalate to `STUCK` (recoverable).
+The evaluator knows about in-flight agent turns (`HealthResult.active_runs`) **and tracks per-run progress** (`HealthResult.last_run_progress`, refreshed on tool calls, streamed tokens, and agent emitter events). A busy channel is never killed mid-run — `BUSY` is non-recoverable on purpose. Only when a busy channel has made **no progress at all** (neither inbound transport activity nor in-run progress) for `stuck_after` seconds does it escalate to `STUCK` (recoverable). An actively-streaming long agent turn stays `BUSY` indefinitely; a genuinely-hung turn that emits nothing for `stuck_after` is still correctly flagged `STUCK`.
+
+<Note>
+Before praisonaiagents 1.6.82, only inbound transport activity counted toward progress, so a single long agent turn (deep research, big refactor, slow model) was classified `STUCK` once it crossed `stuck_after` — even while actively streaming. The protocol now honours in-run progress (`HealthResult.last_run_progress`), so progressing long runs stay `BUSY` indefinitely. See [PraisonAI #2400](https://github.com/MervinPraison/PraisonAI/pull/2400).
+</Note>
 
 ### Restart guard-rails
 


### PR DESCRIPTION
## Summary
- Surgical wording fix in `gateway-channel-supervision.mdx` for `stuck_after` semantics after PraisonAI PR #2400
- Documents `HealthResult.last_run_progress` and in-run progress sources

## Test plan
- [x] `stuck_after` table row mentions inbound + in-run progress
- [x] Run awareness paragraph updated
- [x] Note callout pins behaviour to 1.6.82 / PR #2400


Made with [Cursor](https://cursor.com)