### PR TITLE
docs: post-edit formatter + --agent/--thinking on code/run (fixes #1065)

### DIFF
--- a/docs/cli/code.mdx
+++ b/docs/cli/code.mdx
@@ -38,6 +38,8 @@ praisonai code [OPTIONS] [PROMPT]
 | `--session` | `-s` | Session ID to resume | |
 | `--continue` | `-c` | Continue last session | `false` |
 | `--no-context` | | Disable AGENTS.md/CLAUDE.md auto-loading into system prompt | `false` |
+| `--agent` | `-a` | Named custom agent profile from `.praisonai/agents/` (tools + permission scope) | |
+| `--thinking` | | Reasoning effort for this invocation: `off`, `minimal`, `low`, `medium`, `high` | |
 
 <Note>
 Safe mode (`--safe`) is **on by default** as of PR #2369. Dangerous built-in tools ask for approval in interactive sessions and are denied in non-interactive (CI) sessions. Use `--no-safe` to opt out, or `--dangerously-skip-approval` for a complete bypass. See [Approval](/docs/features/approval) for full details.
@@ -74,6 +76,24 @@ praisonai code --no-safe "Refactor main.py"
 ```bash
 praisonai code --dangerously-skip-approval "Clean up old logs"
 ```
+
+### Reasoning effort (per invocation)
+
+```bash
+praisonai code --thinking high "Refactor src/utils.py for readability"
+```
+
+### Custom agent profile
+
+```bash
+# Profile defined in .praisonai/agents/plan.md
+praisonai code --agent plan "Review the auth module and propose a refactor"
+
+# Profile + reasoning effort combined
+praisonai code --agent reviewer --thinking high "Audit src/security/"
+```
+
+See [Custom Agents & Commands](/docs/features/custom-agents-commands) for profile definitions and [Thinking](/docs/cli/thinking) for budget levels.
 
 ## Project context
 

--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -44,6 +44,7 @@ praisonai run [OPTIONS] [TARGET]
 | `--no-rules` | | Disable auto-injection of project instruction files (AGENTS.md, CLAUDE.md, etc.) | `false` |
 | `--no-context` | | Disable AGENTS.md/CLAUDE.md auto-loading into system prompt | `false` |
 | `--agent` | `-a` | Use a named custom agent from `.praisonai/agents/` | |
+| `--thinking` | | Reasoning effort for this invocation: `off`, `minimal`, `low`, `medium`, `high` | |
 | `--command` | | Execute a named custom command; `TARGET` becomes `$ARGUMENTS` | |
 | `--allow` | | Allow a permission pattern (e.g. `'bash:git *'`); repeatable | |
 | `--deny` | | Deny a permission pattern; repeatable | |
@@ -132,6 +133,17 @@ praisonai run --agent researcher "Find info on X"
 # --allow overrides to let git commands run without prompting
 praisonai run --agent reviewer "review the diff" --allow 'bash:git *'
 ```
+
+### Run with reasoning effort
+
+```bash
+praisonai run --thinking medium "Plan a release checklist for v4.7"
+
+# Works with custom agents too
+praisonai run --agent researcher --thinking high "Deep dive on vector DB options"
+```
+
+`--thinking` applies across direct-prompt, actions-mode, and custom-agent paths. See [Thinking](/docs/cli/thinking).
 
 ### Run with a custom command
 

--- a/docs/cli/thinking.mdx
+++ b/docs/cli/thinking.mdx
@@ -39,6 +39,40 @@ praisonai thinking set high
 
 Available levels: `minimal`, `low`, `medium`, `high`, `maximum`
 
+## Use from `code` / `run`
+
+For a single invocation without persisting a global default, pass `--thinking` on `praisonai code` or `praisonai run`:
+
+```bash
+praisonai code --thinking high "Refactor src/utils.py for readability"
+praisonai run --thinking medium "Plan a release checklist"
+```
+
+```mermaid
+graph TB
+    Q[Need extended thinking?]
+    Q -->|one-off call| Flag[--thinking on code/run]
+    Q -->|every session| Set[praisonai thinking set]
+    Flag --> Levels1[off / minimal / low / medium / high]
+    Set --> Levels2[minimal / low / medium / high / maximum]
+    Flag --> Note1[per-invocation, not persisted]
+    Set --> Note2[persisted to .praison/thinking.json]
+
+    classDef q fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef opt fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef out fill:#10B981,stroke:#7C90A0,color:#fff
+    class Q q
+    class Flag,Set opt
+    class Levels1,Levels2,Note1,Note2 out
+```
+
+| Surface | Levels | Persisted? |
+|---|---|---|
+| `--thinking` on `code` / `run` | `off`, `minimal`, `low`, `medium`, `high` | No — per invocation |
+| `praisonai thinking set` | `minimal`, `low`, `medium`, `high`, `maximum` | Yes — `.praison/thinking.json` |
+
+Unknown `--thinking` values fail closed with exit code `1` before any work runs.
+
 ### Show Usage Stats
 
 ```bash

--- a/docs/features/file-editing.mdx
+++ b/docs/features/file-editing.mdx
@@ -559,6 +559,84 @@ src/calc.py:1:18: F821 Undefined name `c`
 
 ---
 
+## Post-edit Formatting
+
+After a successful edit, `EditTools` can run a configured language-appropriate formatter on the touched file and persist the formatted result. Default is **`"off"`** — byte-for-byte identical to prior behaviour. A missing or failing formatter **never** turns a successful edit into a failure.
+
+```mermaid
+graph LR
+    Edit[✏️ edit_file / apply_patch] --> Success{✅ edit OK?}
+    Success -->|yes| Format{🎨 post_edit_format?}
+    Format -->|off| Done[💾 file saved]
+    Format -->|auto/on| Detect[🔍 detect formatter]
+    Detect --> Run[⚙️ run formatter]
+    Run --> Refresh[🔁 refresh hash]
+    Refresh --> Done
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    class Edit input
+    class Success,Format,Detect,Run,Refresh process
+    class Done output
+```
+
+### Agent Quick Start
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools.edit_tools import create_edit_tools
+
+edit_tools = create_edit_tools(post_edit_format="auto")
+
+agent = Agent(
+    name="Code Editor",
+    instructions="Edit files cleanly and let the formatter tidy up afterward.",
+    tools=[edit_tools.edit_file, edit_tools.apply_patch],
+)
+
+agent.start("Refactor src/utils.py to use list comprehensions")
+```
+
+### Three modes
+
+| Mode | Behaviour | Use when |
+|---|---|---|
+| `"off"` (default) | Never runs a formatter | Backward-compatible zero overhead |
+| `"auto"` | Run a formatter if one is detected for the file type, otherwise skip silently | Typical projects with formatters installed |
+| `"on"` | Same as `"auto"` — run when detected | Explicit opt-in |
+
+Invalid values silently fall back to `"off"`.
+
+### Built-in formatters
+
+| Extension(s) | Formatter (preference order) | Notes |
+|---|---|---|
+| `.py`, `.pyi` | `ruff format` → `black` | First on PATH wins |
+| `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.json`, `.css`, `.scss`, `.less`, `.html`, `.md`, `.yaml`, `.yml` | `prettier` | Runs with `--no-config --no-editorconfig` |
+| `.go` | `gofmt` | |
+| `.rs` | `rustfmt` | |
+
+Relative commands (e.g. `./node_modules/.bin/prettier`) resolve relative to the **edited file's directory**, not CWD. Formatter runs under a 10-second timeout; timeouts are swallowed. The on-disk hash baseline is only refreshed when the formatter exits `0`.
+
+### Custom formatter overrides
+
+```python
+from praisonaiagents.tools.edit_tools import create_edit_tools
+
+edit_tools = create_edit_tools(
+    post_edit_format="auto",
+    formatters={
+        ".py": ("black", ["black", "--quiet"]),
+        ".ts": ("local-prettier", ["./node_modules/.bin/prettier", "--write", "{path}"]),
+    },
+)
+```
+
+`formatters` maps lowercase extensions to `(tool_name, argv_template)`. Use `{path}` in argv entries; if omitted, the path is appended.
+
+---
+
 ## Configuration Options
 
 ### File Editing Functions
@@ -586,6 +664,8 @@ src/calc.py:1:18: F821 Undefined name `c`
 | Parameter | Type | Default | Purpose |
 |---|---|---|---|
 | `post_edit_diagnostics` | `str` (`"auto"` \| `"on"` \| `"off"`) | `"auto"` | Run a per-file checker after a successful edit and append concise diagnostics. See [Post-edit Diagnostics](#post-edit-diagnostics). Invalid values fall back to `"auto"`. |
+| `post_edit_format` | `str` (`"off"` \| `"auto"` \| `"on"`) | `"off"` | Run a language-appropriate formatter after a successful edit and persist the result. See [Post-edit Formatting](#post-edit-formatting). Invalid values fall back to `"off"`. |
+| `formatters` | `Optional[dict]` | `None` | Override map: extension → `(tool_name, argv_template)`. See [Post-edit Formatting](#post-edit-formatting). |
 
 ```python
 # Single unique match — guard fires automatically after a prior read

--- a/docs/features/thinking-budgets.mdx
+++ b/docs/features/thinking-budgets.mdx
@@ -88,6 +88,8 @@ praisonai thinking set high    # Set budget level
 praisonai thinking stats       # Show usage statistics
 ```
 
+For one-off runs without changing the persisted default, use `--thinking` on `praisonai code` or `praisonai run` (levels: `off`, `minimal`, `low`, `medium`, `high`). See [Thinking CLI](/docs/cli/thinking#use-from-code--run).
+
 ---
 
 ## Low-level API Reference


### PR DESCRIPTION
## Summary
- `file-editing.mdx`: Post-edit Formatting section + constructor params
- `code.mdx`: `--agent` / `--thinking` options and examples
- `run.mdx`: `--thinking` option and examples
- `thinking.mdx`: Use from code/run section with decision diagram
- `thinking-budgets.mdx`: CLI flag surface callout

## Test plan
- [x] Formatter defaults to off (backward compatible)
- [x] Flag levels documented vs `praisonai thinking set`
- [x] No `docs/concepts/` changes


Made with [Cursor](https://cursor.com)