### PR TITLE
docs: surface --agent/--thinking, post-edit formatter, and in-run progress signal

### DIFF
--- a/docs/cli/code.mdx
+++ b/docs/cli/code.mdx
@@ -38,6 +38,8 @@ praisonai code [OPTIONS] [PROMPT]
 | `--session` | `-s` | Session ID to resume | |
 | `--continue` | `-c` | Continue last session | `false` |
 | `--no-context` | | Disable AGENTS.md/CLAUDE.md auto-loading into system prompt | `false` |
+| `--agent` | `-a` | Use a named custom agent from `.praisonai/agents/` (applies its tools + permission/mode scope) | |
+| `--thinking` | | Reasoning effort: `off`, `minimal`, `low`, `medium`, `high` | |
 
 <Note>
 Safe mode (`--safe`) is **on by default** as of PR #2369. Dangerous built-in tools ask for approval in interactive sessions and are denied in non-interactive (CI) sessions. Use `--no-safe` to opt out, or `--dangerously-skip-approval` for a complete bypass. See [Approval](/docs/features/approval) for full details.
@@ -62,6 +64,33 @@ praisonai code "Write a Python function to sort a list"
 ```bash
 praisonai code --language python "Explain decorators"
 ```
+
+### Run under a custom agent profile
+
+```bash
+# read-only planner profile defined in .praisonai/agents/plan.md
+praisonai code --agent plan "explore the auth flow"
+
+# code-review profile that asks before shell commands
+praisonai code -a review "review the recent diff"
+```
+
+### Set reasoning effort
+
+```bash
+# light reasoning for quick edits
+praisonai code --thinking low "rename UserService to AccountService"
+
+# deeper thinking for complex refactors
+praisonai code --thinking high "redesign the session-store interface"
+
+# disable extended thinking entirely
+praisonai code --thinking off "rename a variable"
+```
+
+<Note>
+`--thinking` is per-invocation. To set a persistent project-wide budget, use [`praisonai thinking set`](/docs/cli/thinking).
+</Note>
 
 ### Disable safe mode (opt out of approval prompts)
 

--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -44,6 +44,7 @@ praisonai run [OPTIONS] [TARGET]
 | `--no-rules` | | Disable auto-injection of project instruction files (AGENTS.md, CLAUDE.md, etc.) | `false` |
 | `--no-context` | | Disable AGENTS.md/CLAUDE.md auto-loading into system prompt | `false` |
 | `--agent` | `-a` | Use a named custom agent from `.praisonai/agents/` | |
+| `--thinking` | | Reasoning effort: `off`, `minimal`, `low`, `medium`, `high` | |
 | `--command` | | Execute a named custom command; `TARGET` becomes `$ARGUMENTS` | |
 | `--allow` | | Allow a permission pattern (e.g. `'bash:git *'`); repeatable | |
 | `--deny` | | Deny a permission pattern; repeatable | |
@@ -132,6 +133,18 @@ praisonai run --agent researcher "Find info on X"
 # --allow overrides to let git commands run without prompting
 praisonai run --agent reviewer "review the diff" --allow 'bash:git *'
 ```
+
+### Set reasoning effort
+
+```bash
+praisonai run --thinking medium "refactor the planner"
+praisonai run --agent researcher --thinking high "find every reference to UserService"
+praisonai run --output actions --thinking low "build the report"
+```
+
+<Note>
+`--thinking` is per-invocation. To set a persistent project-wide budget, use [`praisonai thinking set`](/docs/cli/thinking).
+</Note>
 
 ### Run with a custom command
 

--- a/docs/features/file-editing.mdx
+++ b/docs/features/file-editing.mdx
@@ -559,6 +559,93 @@ src/calc.py:1:18: F821 Undefined name `c`
 
 ---
 
+## Post-edit Formatting
+
+After a successful edit, `edit_file` and `apply_patch` can run a language-appropriate formatter on the file and re-read it — so the saved result is already formatted, with no follow-up turn from the agent.
+
+```mermaid
+graph LR
+    subgraph "Edit → Format → Persist (single tool call)"
+        A[🤖 Agent] --> E[✏️ edit_file]
+        E --> S{✅ Success?}
+        S -->|Yes| F[💅 Run formatter]
+        F --> P{Ran cleanly?}
+        P -->|Yes| W[💾 Re-read, refresh hash]
+        P -->|No / missing| KEEP[Keep unformatted edit]
+        W --> OK[Plain success]
+        KEEP --> OK
+    end
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef step fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef check fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A agent
+    class E,F,W step
+    class S,P check
+    class OK,KEEP ok
+```
+
+### Agent Quick Start
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools.edit_tools import create_edit_tools
+
+edit_tools = create_edit_tools(post_edit_format="auto")  # opt in
+
+agent = Agent(
+    name="Self-formatting Editor",
+    instructions="Edit files precisely. Formatting is handled for you.",
+    tools=edit_tools.get_tools(),
+)
+
+agent.start("In src/calc.py, append a new `total` line to the example.")
+```
+
+### Three modes
+
+| Mode | Formatter runs? | Use when |
+|---|---|---|
+| `"off"` (default) | Never | Backward-compatible baseline; you have your own pre-commit formatter |
+| `"auto"` / `"on"` | When a formatter is detected for the file type | You want every agent edit to land already-formatted |
+
+### Built-in formatters (auto-detected by extension)
+
+| Extension(s) | Formatter (first installed wins) |
+|---|---|
+| `.py`, `.pyi` | `ruff format` → `black` |
+| `.ts` `.tsx` `.js` `.jsx` `.mjs` `.cjs` `.json` `.css` `.scss` `.less` `.html` `.md` `.yaml` `.yml` | `prettier` (run with `--no-config --no-editorconfig` for safety) |
+| `.go` | `gofmt -w` |
+| `.rs` | `rustfmt --quiet` |
+| anything else | (no formatter — silent) |
+
+### Pinning a project formatter
+
+The `formatters` argument lets you override the per-extension command. Use the literal `"{path}"` placeholder if your command needs the file path somewhere other than the end of `argv`. Relative paths (e.g. `./node_modules/.bin/prettier`) are resolved relative to the **edited file's directory**, so a project-local binary works without putting it on `PATH`.
+
+```python
+from praisonaiagents.tools.edit_tools import create_edit_tools
+
+edit_tools = create_edit_tools(
+    post_edit_format="on",
+    formatters={
+        ".py": ("black", ["black", "--quiet", "{path}"]),
+        ".ts": ("prettier", ["./node_modules/.bin/prettier", "--write", "{path}"]),
+    },
+)
+```
+
+### Guarantees
+
+- **Backward compatible** — `post_edit_format="off"` is the default, no formatter process ever spawned.
+- **Never breaks an edit** — missing binary, non-zero exit, or 10-second timeout is logged at `DEBUG` and swallowed; the edit still returns success.
+- **Refresh on success only** — the cached read hash is only updated when the formatter exits 0, so partial/corrupt formatter output is never adopted as the new clean baseline.
+- **Sandbox-safe `prettier`** — built-in `prettier` runs with `--no-config --no-editorconfig` so repository-controlled config code cannot execute.
+
+---
+
 ## Configuration Options
 
 ### File Editing Functions
@@ -586,6 +673,8 @@ src/calc.py:1:18: F821 Undefined name `c`
 | Parameter | Type | Default | Purpose |
 |---|---|---|---|
 | `post_edit_diagnostics` | `str` (`"auto"` \| `"on"` \| `"off"`) | `"auto"` | Run a per-file checker after a successful edit and append concise diagnostics. See [Post-edit Diagnostics](#post-edit-diagnostics). Invalid values fall back to `"auto"`. |
+| `post_edit_format` | `str` (`"off"` \| `"auto"` \| `"on"`) | `"off"` | Run a language-appropriate formatter after a successful edit, then re-read. See [Post-edit Formatting](#post-edit-formatting). Invalid values fall back to `"off"`. |
+| `formatters` | `Optional[dict[str, tuple[str, list[str]]]]` | `None` | Per-extension formatter override `{ext: (tool_name, argv_template)}`. Argv may include the `"{path}"` placeholder; otherwise the path is appended. Relative commands resolve against the edited file's directory. |
 
 ```python
 # Single unique match — guard fires automatically after a prior read

--- a/docs/features/gateway-channel-supervision.mdx
+++ b/docs/features/gateway-channel-supervision.mdx
@@ -234,7 +234,7 @@ graph TB
     C -->|no| D[probe fails?]
     D -->|yes| DC[disconnected]
     D -->|no| R[active_runs > 0?]
-    R -->|yes| RS[idle > stuck_after?]
+    R -->|yes| RS["max(last_activity, last_run_progress) > stuck_after?"]
     RS -->|yes| ST[stuck]
     RS -->|no| BS[busy]
     R -->|no| F[last_activity stale?]
@@ -248,6 +248,15 @@ graph TB
     class A,B,C,D,F,G,R,RS check
     class NR,SG,E,DC,SS,E2,H,ST,BS result
 ```
+
+### In-run progress signal
+
+For a single agent turn that streams output for several minutes, inbound transport activity alone (`last_activity`) doesn't advance — and before PR #2400 the channel was classified `STUCK` and restarted mid-run. `HealthResult.last_run_progress` now records every in-run progress event (tool call, streamed event, agent-emitter heartbeat). The active-run branch checks `max(last_activity, last_run_progress)` against `stuck_after`, so:
+
+- Actively-progressing run → stays `BUSY` indefinitely.
+- No progress for `stuck_after` (default 900s) → still flagged `STUCK` and restarted.
+
+`HealthResult.to_dict()` includes `last_run_progress` for downstream tooling. No configuration knob is exposed — progress reporting is automatic when using the bot session manager.
 
 ### Passive inbound liveness
 
@@ -447,6 +456,7 @@ Key supervision fields:
 - `manual_pause`: Whether channel is manually paused by operator
 - `active_runs`: Number of in-flight agent turns (busy count)
 - `last_activity`: Unix timestamp of last **inbound** transport activity (used for `stale-socket` and `stuck` detection)
+- `last_run_progress`: Unix timestamp of the last in-run progress event (tool call, streamed event, agent-emitter heartbeat); used together with `last_activity` to keep streaming runs out of `STUCK`
 - `health_monitor.enabled`: Whether proactive monitoring is active
 - `health_monitor.restart_count`: Restarts in the current hour
 - `health_monitor.can_restart`: Whether guard-rails allow another restart


### PR DESCRIPTION
## Summary

Documentation updates for three user-facing changes in PraisonAI v4.6.81 → v4.6.82:

### PR #2402 — `--agent` / `--thinking` on `code` and `run`
- **`docs/cli/code.mdx`**: Added `--agent/-a` and `--thinking` rows to Options table; added examples for custom agent profiles and reasoning effort levels; added `<Note>` cross-linking `praisonai thinking set`
- **`docs/cli/run.mdx`**: Added `--thinking` row to Options table; added "Set reasoning effort" examples section; added `<Note>` cross-linking `praisonai thinking set`

### PR #2401 — Post-edit Formatter
- **`docs/features/file-editing.mdx`**: Added new `## Post-edit Formatting` section (mirroring structure of existing `## Post-edit Diagnostics` section) with agent quick start, three modes explanation, built-in formatters table, project formatter pinning example, and guarantees; added `post_edit_format` and `formatters` rows to Constructor Parameters table

### PR #2400 — `last_run_progress` in `HealthResult`
- **`docs/features/gateway-channel-supervision.mdx`**: Updated active-run branch in Mermaid decision diagram to use `max(last_activity, last_run_progress) > stuck_after?`; added "In-run progress signal" subsection explaining the new field; added `last_run_progress` to the `/health` field list

**No new files created** — all changes land in existing pages. `docs/concepts/` untouched.

Fixes #1068

Generated with [Claude Code](https://claude.ai/code)