### PR TITLE
docs: cover post-edit formatter (PR #2401) and --agent / --thinking on code & run (PR #2402)

### DIFF
--- a/docs/cli/code.mdx
+++ b/docs/cli/code.mdx
@@ -38,6 +38,8 @@ praisonai code [OPTIONS] [PROMPT]
 | `--session` | `-s` | Session ID to resume | |
 | `--continue` | `-c` | Continue last session | `false` |
 | `--no-context` | | Disable AGENTS.md/CLAUDE.md auto-loading into system prompt | `false` |
+| `--agent` | `-a` | Use a named custom agent profile (applies its tools and permission/mode scope). Unknown name exits `1`. | |
+| `--thinking` | | Reasoning effort: `off`, `minimal`, `low`, `medium`, `high`. Per-invocation, not persisted. Unknown value exits `1`. | |
 
 <Note>
 Safe mode (`--safe`) is **on by default** as of PR #2369. Dangerous built-in tools ask for approval in interactive sessions and are denied in non-interactive (CI) sessions. Use `--no-safe` to opt out, or `--dangerously-skip-approval` for a complete bypass. See [Approval](/docs/features/approval) for full details.
@@ -75,6 +77,41 @@ praisonai code --no-safe "Refactor main.py"
 praisonai code --dangerously-skip-approval "Clean up old logs"
 ```
 
+### Use a named agent profile
+
+Load a custom agent profile from `.praisonai/agents/` — applies its tools and permission/mode scope:
+
+```bash
+# Read-only profile: rejects write/edit/shell in a code session
+praisonai code --agent plan "Review the auth module and propose a refactor"
+
+# Reviewer profile with elevated reasoning
+praisonai code --agent reviewer --thinking high "Audit src/security/"
+```
+
+An unknown profile name exits `1` with `Error: Agent '<name>' not found`.
+
+See [Custom Agent Commands](/docs/features/custom-agents-commands) for how to define agent profiles.
+
+### Set per-invocation reasoning effort
+
+`--thinking` controls the extended-thinking token budget for this run only — it does not persist:
+
+```bash
+# One-off high-effort reasoning
+praisonai code --thinking high "Refactor src/utils.py for readability"
+
+# Minimal reasoning for a quick task
+praisonai code --thinking minimal "Add a docstring to main()"
+
+# Disable extended thinking explicitly
+praisonai code --thinking off "What does this function do?"
+```
+
+Available levels: `off`, `minimal` (2 k), `low` (4 k), `medium` (8 k), `high` (16 k).
+
+An unknown value exits `1` before any work runs. For a persistent global budget, use [`praisonai thinking set`](/docs/cli/thinking).
+
 ## Project context
 
 By default, `praisonai code` walks up from the current directory to your git root and prepends any `AGENTS.md` / `CLAUDE.md` / `agents.md` / `.agents/AGENTS.md` it finds to the agent's system prompt, layered on top of `~/.praisonai/AGENTS.md`. Pass `--no-context` (or set `PRAISON_NO_CONTEXT=true`) to disable. See [Context Files](/docs/features/context-files) for details.
@@ -98,3 +135,5 @@ See the [Windows Automation section](/cli/realworld-examples#windows-automation)
 - [Chat](/docs/cli/chat) - General chat mode
 - [LSP Code Intelligence](/docs/cli/lsp-code-intelligence) - Language server integration
 - [Approval](/docs/features/approval) - Tool approval and safety defaults
+- [Thinking Budgets](/docs/cli/thinking) - Reasoning effort levels and persistent budgets
+- [Custom Agent Commands](/docs/features/custom-agents-commands) - Define reusable agent profiles

--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -44,6 +44,7 @@ praisonai run [OPTIONS] [TARGET]
 | `--no-rules` | | Disable auto-injection of project instruction files (AGENTS.md, CLAUDE.md, etc.) | `false` |
 | `--no-context` | | Disable AGENTS.md/CLAUDE.md auto-loading into system prompt | `false` |
 | `--agent` | `-a` | Use a named custom agent from `.praisonai/agents/` | |
+| `--thinking` | | Reasoning effort: `off`, `minimal`, `low`, `medium`, `high`. Per-invocation, not persisted. Unknown value exits `1`. Applies across direct-prompt, actions-mode, and custom-agent paths. | |
 | `--command` | | Execute a named custom command; `TARGET` becomes `$ARGUMENTS` | |
 | `--allow` | | Allow a permission pattern (e.g. `'bash:git *'`); repeatable | |
 | `--deny` | | Deny a permission pattern; repeatable | |
@@ -105,6 +106,23 @@ praisonai run --output verbose "What is the capital of France?"
 ---
 
 ## Examples
+
+### Set per-invocation reasoning effort
+
+`--thinking` controls the extended-thinking token budget for this run only — it does not persist and applies across direct-prompt, actions-mode, and custom-agent paths:
+
+```bash
+# Medium reasoning effort for planning tasks
+praisonai run --thinking medium "Plan a release checklist for v4.7"
+
+# High reasoning effort for complex analysis
+praisonai run --thinking high "Audit the authentication flow for security issues"
+
+# Disable extended thinking explicitly
+praisonai run --thinking off "What does this script do?"
+```
+
+Available levels: `off`, `minimal` (2 k), `low` (4 k), `medium` (8 k), `high` (16 k). An unknown value exits `1` before any work runs. For a persistent global budget, use [`praisonai thinking set`](/docs/cli/thinking).
 
 ### Run a built-in preset (no YAML required)
 
@@ -559,3 +577,4 @@ See [Checkpoints](/docs/features/checkpoints) and [Checkpoint CLI](/docs/cli/che
 - [Workflow](/docs/cli/workflow) - Workflow execution
 - [Interactive TUI](/docs/cli/interactive-tui) - Interactive terminal interface
 - [Attach](/docs/cli/attach) - Stream live events from a warm-runtime session
+- [Thinking Budgets](/docs/cli/thinking) - Reasoning effort levels and persistent budgets

--- a/docs/cli/thinking.mdx
+++ b/docs/cli/thinking.mdx
@@ -62,6 +62,61 @@ summary = tracker.get_summary()
 print(f"Utilization: {summary['average_utilization']:.1%}")
 ```
 
+## Use from `code` / `run`
+
+Both `praisonai code` and `praisonai run` accept a `--thinking` flag that sets the reasoning effort for that single invocation without touching `.praison/thinking.json`.
+
+```mermaid
+graph TB
+    Q[Need extended thinking?] -->|one-off call| Flag[--thinking on code/run]
+    Q -->|every session| Set[praisonai thinking set]
+    Flag --> Levels1[off / minimal / low / medium / high]
+    Set --> Levels2[minimal / low / medium / high / maximum]
+    Flag --> Note1[per-invocation, not persisted]
+    Set --> Note2[persisted to .praison/thinking.json]
+
+    classDef q fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef opt fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef out fill:#10B981,stroke:#7C90A0,color:#fff
+    class Q q
+    class Flag,Set opt
+    class Levels1,Levels2,Note1,Note2 out
+```
+
+```bash
+# Per-invocation — does not persist
+praisonai code --thinking high "Refactor src/utils.py for readability"
+praisonai run --thinking medium "Plan a release checklist for v4.7"
+```
+
+### Canonical levels for `--thinking`
+
+| Level | Token budget | Notes |
+|---|---|---|
+| `off` | none | Disables extended thinking |
+| `minimal` | 2,000 | |
+| `low` | 4,000 | |
+| `medium` | 8,000 | |
+| `high` | 16,000 | |
+
+Values are case-insensitive. An unknown value exits `1` before any work runs:
+```
+Error: Invalid thinking level: <x>. Valid levels: off, minimal, low, medium, high
+```
+
+### Difference vs `praisonai thinking set`
+
+| | `--thinking` flag | `praisonai thinking set` |
+|---|---|---|
+| Scope | Single invocation | Global (all sessions) |
+| Persisted | No | Yes (`.praison/thinking.json`) |
+| Levels | `off`, `minimal`, `low`, `medium`, `high` | `minimal`, `low`, `medium`, `high`, `maximum` |
+| Extra level | — | `maximum` (32,000 tokens) |
+
+Use `--thinking` for one-off calls; use `praisonai thinking set` when you want a higher budget to apply every time.
+
 ## See Also
 
 - [Thinking Budgets Feature](/docs/features/thinking-budgets)
+- [Code](/docs/cli/code) - `--thinking` on the code command
+- [Run](/docs/cli/run) - `--thinking` on the run command

--- a/docs/features/file-editing.mdx
+++ b/docs/features/file-editing.mdx
@@ -559,6 +559,127 @@ src/calc.py:1:18: F821 Undefined name `c`
 
 ---
 
+## Post-edit Formatting
+
+After a successful edit, `edit_file` and `apply_patch` can run a language-appropriate formatter on the modified file and persist the formatted result — keeping diffs clean without a separate formatting step.
+
+```mermaid
+graph LR
+    Edit[✏️ edit_file / apply_patch] --> Success{✅ edit OK?}
+    Success -->|yes| Format{🎨 post_edit_format?}
+    Format -->|off| Done[💾 file saved]
+    Format -->|auto/on| Detect[🔍 detect formatter]
+    Detect --> Run[⚙️ run formatter]
+    Run --> Refresh[🔁 refresh hash]
+    Refresh --> Done
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    class Edit input
+    class Success,Format,Detect,Run,Refresh process
+    class Done output
+```
+
+### Agent Quick Start
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools.edit_tools import create_edit_tools
+
+edit_tools = create_edit_tools(post_edit_format="auto")
+
+agent = Agent(
+    name="Code Editor",
+    instructions="Edit files cleanly and let the formatter tidy up afterward.",
+    tools=[edit_tools.edit_file, edit_tools.apply_patch],
+)
+
+agent.start("Refactor src/utils.py to use list comprehensions")
+```
+
+### Three modes
+
+```mermaid
+graph TB
+    Q[Which mode?]
+    Q --> M1{Default — no formatter overhead?}
+    M1 -->|Yes| OFF[off — default]
+    M1 -->|No| M2{Run formatter if available?}
+    M2 -->|Yes| AUTO[auto]
+    M2 -->|Always try| ON[on]
+
+    classDef q fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef pick fill:#10B981,stroke:#7C90A0,color:#fff
+    class Q,M1,M2 q
+    class OFF,AUTO,ON pick
+```
+
+| Mode | When the formatter runs | Use when |
+|---|---|---|
+| `"off"` (default) | Never — zero overhead, byte-for-byte identical to pre-existing behaviour | You don't need auto-formatting, or you run your own formatter in CI |
+| `"auto"` | If a formatter is detected for the file type; silently skipped otherwise | You want formatting when available but no errors when the tool is missing |
+| `"on"` | Same as `"auto"` — run a formatter if detected, skip silently otherwise | Alias for `"auto"`; both behave identically |
+
+A missing or failing formatter **never** turns a successful edit into a failure.
+
+### Configure the mode
+
+```python
+from praisonaiagents.tools.edit_tools import create_edit_tools
+
+# Enable auto-formatting for all edits
+edit_tools = create_edit_tools(post_edit_format="auto")
+
+# Pin a project-specific formatter per extension
+edit_tools = create_edit_tools(
+    post_edit_format="auto",
+    formatters={
+        ".py": ("black", ["black", "--quiet"]),
+        ".ts": ("local-prettier", ["./node_modules/.bin/prettier", "--write", "{path}"]),
+    },
+)
+```
+
+### Built-in formatter map
+
+| Extension(s) | Formatter (in preference order) | Notes |
+|---|---|---|
+| `.py`, `.pyi` | `ruff format` → `black` | Uses `ruff format --quiet --no-cache` if `ruff` on PATH; falls back to `black --quiet` |
+| `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.json`, `.css`, `.scss`, `.less`, `.html`, `.md`, `.yaml`, `.yml` | `prettier` | Run with `--no-config --no-editorconfig` — workspace JS/TS config is never loaded |
+| `.go` | `gofmt` | `gofmt -w` |
+| `.rs` | `rustfmt` | `rustfmt --quiet` |
+
+### Custom formatter overrides (`formatters`)
+
+Pass `formatters` as a dict mapping lowercase extension → `(tool_name, argv_template)`:
+
+```python
+edit_tools = create_edit_tools(
+    post_edit_format="auto",
+    formatters={
+        ".py": ("black", ["black", "--quiet"]),
+        # {path} placeholder is substituted; if absent, path is appended
+        ".ts": ("local-prettier", ["./node_modules/.bin/prettier", "--write", "{path}"]),
+    },
+)
+```
+
+- `argv_template` entries may include the literal `"{path}"` placeholder, which is replaced with the file path.
+- If no entry contains `"{path}"`, the path is appended to the end of the argv.
+- Unspecified extensions fall back to the built-in defaults.
+- Relative commands (e.g. `./node_modules/.bin/prettier`) resolve relative to the **edited file's directory**, not CWD.
+
+### Guarantees
+
+- **Default is unchanged** — `"off"` keeps byte-for-byte identical output to all prior versions.
+- **Never breaks an edit** — a missing, slow, or crashing formatter is silently skipped (logged at `DEBUG`).
+- **Bounded** — same 10-second timeout as diagnostics; timeouts are swallowed.
+- **Safe hash update** — the on-disk hash baseline is only refreshed when the formatter exits `0`. A partial write from a non-zero exit is never adopted as the new baseline.
+- **Security** — `prettier` runs with `--no-config --no-editorconfig` so workspace-controlled JS/TS configs cannot execute code.
+
+---
+
 ## Configuration Options
 
 ### File Editing Functions
@@ -586,6 +707,8 @@ src/calc.py:1:18: F821 Undefined name `c`
 | Parameter | Type | Default | Purpose |
 |---|---|---|---|
 | `post_edit_diagnostics` | `str` (`"auto"` \| `"on"` \| `"off"`) | `"auto"` | Run a per-file checker after a successful edit and append concise diagnostics. See [Post-edit Diagnostics](#post-edit-diagnostics). Invalid values fall back to `"auto"`. |
+| `post_edit_format` | `str` (`"off"` \| `"auto"` \| `"on"`) | `"off"` | Run a language-appropriate formatter after a successful edit and persist the result. See [Post-edit Formatting](#post-edit-formatting). Invalid values fall back to `"off"`. |
+| `formatters` | `Optional[dict]` | `None` | Override map: lowercase extension (e.g. `".py"`) → `(tool_name, argv_template)`. Unspecified extensions fall back to built-in defaults. |
 
 ```python
 # Single unique match — guard fires automatically after a prior read
@@ -752,6 +875,10 @@ File operations respect workspace boundaries. Paths outside the workspace are re
 
 <Accordion title="Post-edit diagnostics mode">
 Leave `post_edit_diagnostics` at its default (`"auto"`). When the checker reports problems, the tool result includes a `Diagnostics (<tool>):` block — instruct the agent to fix the reported issues in its next edit. Switch to `"on"` if you want positive `no problems found` confirmations in traces, or `"off"` if you're in a sandbox with no checkers available.
+</Accordion>
+
+<Accordion title="Post-edit formatting mode">
+Default is `"off"` — no overhead, identical output to pre-existing behaviour. Set `post_edit_format="auto"` when you want the agent's edits automatically tidied by your project's formatter. A missing or failing formatter never blocks a successful edit. Pin a project-specific formatter via `formatters` to override the built-in defaults (e.g. use `black` instead of `ruff format` for Python files).
 </Accordion>
 </AccordionGroup>
 

--- a/docs/features/thinking-budgets.mdx
+++ b/docs/features/thinking-budgets.mdx
@@ -84,9 +84,22 @@ complex = budget.get_tokens_for_complexity(0.9)  # ~14,600 tokens
 
 ```bash
 praisonai thinking status      # Show current budget
-praisonai thinking set high    # Set budget level
+praisonai thinking set high    # Set budget level (persisted globally)
 praisonai thinking stats       # Show usage statistics
 ```
+
+### Per-invocation flag (`--thinking`)
+
+`praisonai code` and `praisonai run` accept `--thinking` for a one-off reasoning effort that does **not** persist to `.praison/thinking.json`:
+
+```bash
+praisonai code --thinking high "Refactor src/utils.py"
+praisonai run --thinking medium "Plan a release checklist"
+```
+
+<Note>
+The `--thinking` flag supports `off`, `minimal`, `low`, `medium`, and `high`. The `maximum` level (32,000 tokens) is only available via `praisonai thinking set maximum`. See [Thinking CLI](/docs/cli/thinking) for the full comparison.
+</Note>
 
 ---
 


### PR DESCRIPTION
## Summary

- **docs/features/file-editing.mdx** — New "Post-edit Formatting" section placed immediately after the existing Post-edit Diagnostics section. Includes Mermaid flow diagram, three-mode table (`off`/`auto`/`on`), built-in formatter map for Python/JS/Go/Rust, custom `formatters` override example, and security/guarantee callouts. Constructor parameter table updated with `post_edit_format` and `formatters` rows. New "Post-edit formatting mode" best-practice accordion added.

- **docs/cli/code.mdx** — Added `--agent` / `-a` and `--thinking` rows to the Options table. Added two new examples sections: "Use a named agent profile" and "Set per-invocation reasoning effort". Updated See Also to cross-link thinking and custom-agents-commands pages.

- **docs/cli/run.mdx** — Added `--thinking` row to Options table (noting it applies across direct-prompt, actions-mode, and custom-agent paths). Added "Set per-invocation reasoning effort" examples section at the top of Examples. Updated See Also.

- **docs/cli/thinking.mdx** — New "Use from code / run" section with decision diagram (flag vs `thinking set`), canonical `--thinking` level table, fail-closed error message, and comparison table showing that `maximum` is only available via `thinking set`.

- **docs/features/thinking-budgets.mdx** — Added per-invocation `--thinking` callout with Note distinguishing the flag surface from `thinking set maximum`.

## Test plan

- [ ] Verify MDX renders correctly in Mintlify preview
- [ ] Confirm all Mermaid diagrams display with correct colours
- [ ] Spot-check code examples are copy-paste runnable

Fixes #1065

Generated with [Claude Code](https://claude.ai/code)