### PR TITLE
docs(features): AGENTS.md compliance batch 12 — 5 pages

### DIFF
--- a/docs/features/gateway-handshake-protocol.mdx
+++ b/docs/features/gateway-handshake-protocol.mdx
@@ -7,6 +7,17 @@ icon: "handshake"
 
 The gateway handshake lets clients and servers agree on a protocol version, discover supported features, and recover from disconnects — all in one round trip.
 
+```python
+import asyncio
+from praisonai.gateway import GatewayClient
+
+async def main():
+    client = GatewayClient(url="ws://localhost:8765", agent_id="assistant")
+    await client.connect()  # sends hello; receives hello_ok with negotiated protocol
+
+asyncio.run(main())
+```
+
 ```mermaid
 graph LR
     C[Client] -->|hello| G[Gateway]

--- a/docs/features/gateway-hooks.mdx
+++ b/docs/features/gateway-hooks.mdx
@@ -7,6 +7,16 @@ icon: "webhook"
 
 Inbound hooks expose a `POST /hooks/<path>` endpoint on the gateway — point any external service (GitHub Actions, Linear, Gmail push, Sentry alerts) at it and the gateway runs an agent and delivers the reply to a configured channel.
 
+```python
+from praisonaiagents import Agent
+from praisonai.gateway import Gateway
+
+agent = Agent(name="triage", instructions="Triage inbound alerts and summarise the action needed.")
+gw = Gateway(agents=[agent])
+gw.register_hook({"path": "alerts", "agent": "triage", "auth": "my-shared-secret"})
+gw.start()
+```
+
 ```mermaid
 graph LR
     S[External Service] --> P[POST /hooks/gmail]

--- a/docs/features/gateway-hot-reload.mdx
+++ b/docs/features/gateway-hot-reload.mdx
@@ -7,6 +7,18 @@ icon: "rotate"
 
 The gateway diffs `gateway.yaml` against the running config and restarts only affected agents or channels. The WebSocket server keeps running.
 
+```yaml
+# gateway.yaml
+agents:
+  assistant:
+    instructions: "You are a helpful assistant."
+```
+
+```bash
+praisonai gateway run gateway.yaml
+# Edit agents.assistant.instructions and save — only agents reload (~5s)
+```
+
 ```mermaid
 graph LR
     Edit[✏️ Edit gateway.yaml] --> Diff[🔍 Diff paths]

--- a/docs/features/gateway-inbound-hooks.mdx
+++ b/docs/features/gateway-inbound-hooks.mdx
@@ -7,6 +7,18 @@ icon: "webhook"
 
 Trigger an agent run from any external HTTP event — Gmail, GitHub, Stripe, CI, forms, IoT — by POSTing JSON to `/hooks/<path>`.
 
+```yaml
+hooks:
+  - path: gmail
+    agent: assistant
+    auth: "${GATEWAY_HOOK_TOKEN}"
+    message: "New email from {{ payload.from }}: {{ payload.subject }}"
+```
+
+```bash
+praisonai gateway start --config gateway.yaml
+```
+
 ```mermaid
 graph LR
     ES[🌐 External Service] --> GW

--- a/docs/features/gateway-metrics.mdx
+++ b/docs/features/gateway-metrics.mdx
@@ -7,6 +7,17 @@ icon: "chart-line"
 
 Scrape `GET /metrics` on the PraisonAI gateway to feed Prometheus — counters and gauges for every hop of the message flow, zero new dependencies.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="Be helpful")
+# When the gateway is running, scrape GET /metrics for Prometheus
+```
+
+```bash
+curl -sH "Authorization: Bearer $PRAISONAI_GATEWAY_AUTH_TOKEN" http://localhost:8765/metrics
+```
+
 ```mermaid
 graph LR
     Inbound[📨 Inbound] --> Gateway[🛰️ Gateway]
@@ -229,16 +240,16 @@ print(metrics.render_prometheus())
 ## Related
 
 <CardGroup cols={2}>
-  <Card icon="shield" href="/features/gateway-bind-aware-auth" title="Bind-Aware Auth">
+  <Card icon="shield" href="/docs/features/gateway-bind-aware-auth" title="Bind-Aware Auth">
     The same `_check_auth` / loopback model used by `/metrics` — understand how token auth and loopback bypass work together.
   </Card>
-  <Card icon="link" href="/features/correlation-ids" title="Correlation IDs">
+  <Card icon="link" href="/docs/features/correlation-ids" title="Correlation IDs">
     Join ingress, session, and agent-run logs on one stable id per message.
   </Card>
-  <Card icon="server" href="/features/bot-gateway" title="Gateway Server">
+  <Card icon="server" href="/docs/features/bot-gateway" title="Gateway Server">
     Multi-bot WebSocket gateway — the host that exposes `/metrics`.
   </Card>
-  <Card icon="layout-grid" href="/features/botos" title="BotOS">
+  <Card icon="layout-grid" href="/docs/features/botos" title="BotOS">
     The full bot operating system layer above the gateway.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Agent-centric openers before hero diagrams on 5 gateway feature pages
- Fix Related Card hrefs on `gateway-metrics.mdx` (`/docs/features/...`)

Refs #1000

## Pages
- gateway-handshake-protocol.mdx
- gateway-hot-reload.mdx
- gateway-hooks.mdx
- gateway-inbound-hooks.mdx
- gateway-metrics.mdx

## Test plan
- [x] Hero Mermaid, Steps, AccordionGroup, CardGroup present on all pages
- [x] No `docs/concepts/` changes

Made with [Cursor](https://cursor.com)