### PR TITLE
docs: surface --agent and --thinking on code / run

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -133,6 +133,7 @@
               "docs/guides/documentation-style-guide",
               "docs/guides/single-agent",
               "docs/guides/multi-agent",
+              "docs/guides/least-privilege-coding",
               {
                 "group": "Templates",
                 "icon": "layer-group",

--- a/docs/cli/code.mdx
+++ b/docs/cli/code.mdx
@@ -6,9 +6,62 @@ icon: "code"
 
 The `code` command starts a code assistant session optimized for programming tasks.
 
+```mermaid
+graph LR
+    Start[💬 Task] --> Q{🤔 Risk?}
+    Q -->|"Read/review only"| Plan["--agent plan<br/>(read-only)"]
+    Q -->|"Need to edit"| Build["--agent build<br/>(write/edit/shell)"]
+    Q -->|"No profile needed"| Default["no --agent<br/>(default tools)"]
+    Plan --> Effort{⚡ Effort?}
+    Build --> Effort
+    Default --> Effort
+    Effort -->|"Cheap & fast"| Off["--thinking off / minimal"]
+    Effort -->|"Balanced"| Med["--thinking low / medium"]
+    Effort -->|"Hardest tasks"| High["--thinking high"]
+
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef profile fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef effort fill:#10B981,stroke:#7C90A0,color:#fff
+    class Start start
+    class Q,Effort decision
+    class Plan,Build,Default profile
+    class Off,Med,High effort
+```
+
 <Note>
 `praisonai code` is **safe by default**: file writes and shell commands prompt for approval on first call. Pass `--no-safe` or `--dangerously-skip-approval` to restore the legacy ungated behaviour. See [Tool Approval](/docs/cli/tool-approval).
 </Note>
+
+## Quick Start
+
+<Steps>
+
+<Step title="Read-only coding session (plan mode)">
+
+```bash
+praisonai code --agent plan "review auth.py for security issues"
+```
+
+</Step>
+
+<Step title="High-effort reasoning with default tools">
+
+```bash
+praisonai code --thinking high "refactor the retry loop in client.py"
+```
+
+</Step>
+
+<Step title="Combine: build profile + medium reasoning">
+
+```bash
+praisonai code --agent build --thinking medium "implement the TODOs in cache.py"
+```
+
+</Step>
+
+</Steps>
 
 ## Usage
 
@@ -31,6 +84,8 @@ praisonai code [OPTIONS] [PROMPT]
 | `--tools` | `-t` | Tools file path | |
 | `--workspace` | `-w` | Workspace directory | |
 | `--file` | `-f` | Attach file(s) to context | |
+| `--agent` | `-a` | Use a named custom agent profile from `.praisonai/agents/<name>.md` (applies its `tools` and `permission`/`mode` scope) | `None` |
+| `--thinking` | | Reasoning effort: `off`, `minimal`, `low`, `medium`, `high`. Unknown values fail with exit code 1. | `None` |
 | `--no-acp` | | Disable ACP tools (file operations) | `false` |
 | `--no-lsp` | | Disable LSP tools (code intelligence) | `false` |
 | `--safe` / `--no-safe` | | Safe mode: prompt before file writes and shell commands (default: **on**). Use `--no-safe` to disable. | `true` |
@@ -42,6 +97,55 @@ praisonai code [OPTIONS] [PROMPT]
 <Note>
 Safe mode (`--safe`) is **on by default** as of PR #2369. Dangerous built-in tools ask for approval in interactive sessions and are denied in non-interactive (CI) sessions. Use `--no-safe` to opt out, or `--dangerously-skip-approval` for a complete bypass. See [Approval](/docs/features/approval) for full details.
 </Note>
+
+## `--agent` flag
+
+`--agent <name>` loads a custom agent profile from `.praisonai/agents/<name>.md` and applies its `tools` and `permission`/`mode` scope to the coding session.
+
+- The profile's `tools` field **replaces** the default tool set.
+- The profile's `permission` block controls what file and shell actions are allowed.
+- Unknown profile name → `Error: Agent '<name>' not found` (exit code 1).
+- If you also pass `--model`, the explicit model overrides the profile's `llm` field.
+
+Three built-in profiles work without any file:
+
+| Profile | Tools | Permission |
+|---------|-------|------------|
+| `plan` | read, grep, glob | read-only (no writes or shell) |
+| `review` | read, grep | ask before shell commands |
+| `build` | read, write, edit, shell | ask before shell commands |
+
+```bash
+# Read-only — no file modifications possible
+praisonai code --agent plan "review auth.py"
+
+# Write-enabled — prompts before edits
+praisonai code --agent build "fix the TODO items"
+```
+
+See [Custom Agents & Commands](/docs/features/custom-agents-commands) to define your own profiles.
+
+## `--thinking` flag
+
+`--thinking <level>` sets the extended reasoning token budget for this session.
+
+| Level | Token budget | Notes |
+|-------|-------------|-------|
+| `off` | `None` | Extended thinking disabled (default) |
+| `minimal` | `2,000` | |
+| `low` | `4,000` | |
+| `medium` | `8,000` | |
+| `high` | `16,000` | |
+
+- Case-insensitive. Unknown values fail closed with `ValueError` (exit code 1).
+- Omitting `--thinking` leaves the default unchanged — no behaviour change from prior releases.
+- These budgets match the persistent levels set by `praisonai thinking set`.
+
+```bash
+praisonai code --thinking high "design a caching layer for this API"
+```
+
+See [Thinking Budgets](/docs/features/thinking-budgets) for details on what the budgets mean.
 
 ## Examples
 
@@ -55,12 +159,6 @@ praisonai code
 
 ```bash
 praisonai code "Write a Python function to sort a list"
-```
-
-### Specify language context
-
-```bash
-praisonai code --language python "Explain decorators"
 ```
 
 ### Disable safe mode (opt out of approval prompts)
@@ -98,3 +196,6 @@ See the [Windows Automation section](/cli/realworld-examples#windows-automation)
 - [Chat](/docs/cli/chat) - General chat mode
 - [LSP Code Intelligence](/docs/cli/lsp-code-intelligence) - Language server integration
 - [Approval](/docs/features/approval) - Tool approval and safety defaults
+- [Custom Agents & Commands](/docs/features/custom-agents-commands) - Define custom agent profiles
+- [Thinking Budgets](/docs/features/thinking-budgets) - Extended reasoning token budgets
+- [Least-Privilege Coding](/docs/guides/least-privilege-coding) - Agent-centric guide for safe coding sessions

--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -44,6 +44,7 @@ praisonai run [OPTIONS] [TARGET]
 | `--no-rules` | | Disable auto-injection of project instruction files (AGENTS.md, CLAUDE.md, etc.) | `false` |
 | `--no-context` | | Disable AGENTS.md/CLAUDE.md auto-loading into system prompt | `false` |
 | `--agent` | `-a` | Use a named custom agent from `.praisonai/agents/` | |
+| `--thinking` | | Reasoning effort: `off`, `minimal`, `low`, `medium`, `high`. Unknown values fail with exit code 1. | `None` |
 | `--command` | | Execute a named custom command; `TARGET` becomes `$ARGUMENTS` | |
 | `--allow` | | Allow a permission pattern (e.g. `'bash:git *'`); repeatable | |
 | `--deny` | | Deny a permission pattern; repeatable | |
@@ -117,6 +118,16 @@ praisonai run --agent review "review the recent diff"
 
 # Full toolset
 praisonai run --agent build "add a /health endpoint"
+```
+
+### Run with extended reasoning
+
+```bash
+# Same five levels as `praisonai code`
+praisonai run --thinking high "summarise the architecture of this repo"
+
+# --agent and --thinking compose
+praisonai run --agent researcher --thinking medium "find the slowest tests"
 ```
 
 ### Run with a custom agent
@@ -559,3 +570,5 @@ See [Checkpoints](/docs/features/checkpoints) and [Checkpoint CLI](/docs/cli/che
 - [Workflow](/docs/cli/workflow) - Workflow execution
 - [Interactive TUI](/docs/cli/interactive-tui) - Interactive terminal interface
 - [Attach](/docs/cli/attach) - Stream live events from a warm-runtime session
+- [Custom Agents & Commands](/docs/features/custom-agents-commands) - Define custom agent profiles for `--agent`
+- [Thinking Budgets](/docs/features/thinking-budgets) - Extended reasoning token budgets for `--thinking`

--- a/docs/cli/thinking.mdx
+++ b/docs/cli/thinking.mdx
@@ -45,6 +45,41 @@ Available levels: `minimal`, `low`, `medium`, `high`, `maximum`
 praisonai thinking stats
 ```
 
+---
+
+## Per-invocation flag (`code` / `run`)
+
+Pass `--thinking <level>` directly on `praisonai code` or `praisonai run` to override the budget for a single session without changing the persistent default.
+
+```bash
+# Persistent default (applies to all future sessions)
+praisonai thinking set medium
+
+# Per-invocation override on `code`
+praisonai code --thinking high "design a caching layer"
+
+# Per-invocation override on `run`
+praisonai run --thinking off "quick lookup"
+```
+
+The same five levels apply:
+
+| `--thinking` value | Token budget |
+|--------------------|-------------|
+| `off` | `None` (extended thinking disabled) |
+| `minimal` | `2,000` |
+| `low` | `4,000` |
+| `medium` | `8,000` |
+| `high` | `16,000` |
+
+- Unknown values fail closed with exit code 1.
+- Omitting `--thinking` uses whatever the persistent default is (set by `praisonai thinking set`).
+- `--thinking` composes with `--agent`: the agent profile's tools/permissions are applied first, then the thinking budget is set on the constructed agent.
+
+See [`praisonai code --thinking`](/docs/cli/code#--thinking-flag) and [`praisonai run`](/docs/cli/run#options) for full option details.
+
+---
+
 ## Python API
 
 ```python
@@ -64,4 +99,6 @@ print(f"Utilization: {summary['average_utilization']:.1%}")
 
 ## See Also
 
-- [Thinking Budgets Feature](/docs/features/thinking-budgets)
+- [Thinking Budgets Feature](/docs/features/thinking-budgets) - Full budget reference and Python API
+- [Code CLI](/docs/cli/code) - `--thinking` flag on `praisonai code`
+- [Run CLI](/docs/cli/run) - `--thinking` flag on `praisonai run`

--- a/docs/features/custom-agents-commands.mdx
+++ b/docs/features/custom-agents-commands.mdx
@@ -14,6 +14,7 @@ graph LR
     D --> A[Custom agents]
     D --> C[Custom commands]
     A --> R[praisonai run --agent]
+    A --> RC2[praisonai code --agent]
     C --> RC[praisonai run --command]
 
     classDef dir fill:#6366F1,stroke:#7C90A0,color:#fff
@@ -22,7 +23,7 @@ graph LR
 
     class U,P dir
     class D discover
-    class A,C,R,RC run
+    class A,C,R,RC,RC2 run
 ```
 
 ## Quick Start
@@ -56,7 +57,12 @@ You are an expert researcher. Provide concise, cited answers.
 <Step title="Run the agent">
 
 ```bash
+# Use in praisonai run
 praisonai run --agent researcher "What's new in WebAssembly 3.0?"
+
+# --agent works identically on praisonai code
+praisonai code --agent plan "review auth.py for security issues"
+praisonai code --agent build "implement the TODO items in cache.py"
 ```
 
 </Step>
@@ -246,6 +252,9 @@ Run [`praisonai init`](/docs/cli/init) to scaffold `.praisonai/agents/` and `.pr
   <Card title="Run CLI" icon="play" href="/docs/cli/run">
     --agent and --command flags
   </Card>
+  <Card title="Code CLI" icon="code" href="/docs/cli/code">
+    --agent and --thinking flags on praisonai code
+  </Card>
   <Card title="Agent CLI" icon="robot" href="/docs/cli/agent">
     List and inspect custom agents
   </Card>
@@ -260,5 +269,8 @@ Run [`praisonai init`](/docs/cli/init) to scaffold `.praisonai/agents/` and `.pr
   </Card>
   <Card title="Agent Presets & Modes" icon="shield-check" href="/docs/features/agent-presets-and-modes">
     Built-in presets and per-agent permission scoping
+  </Card>
+  <Card title="Least-Privilege Coding" icon="shield" href="/docs/guides/least-privilege-coding">
+    Safe coding sessions with --agent plan and --agent build
   </Card>
 </CardGroup>

--- a/docs/features/thinking-budgets.mdx
+++ b/docs/features/thinking-budgets.mdx
@@ -82,11 +82,37 @@ complex = budget.get_tokens_for_complexity(0.9)  # ~14,600 tokens
 
 ## CLI Usage
 
+### Persistent default
+
 ```bash
 praisonai thinking status      # Show current budget
-praisonai thinking set high    # Set budget level
+praisonai thinking set high    # Set budget level (persists across sessions)
 praisonai thinking stats       # Show usage statistics
 ```
+
+### Per-invocation flag
+
+Pass `--thinking <level>` on `praisonai code` or `praisonai run` to override the budget for a single session:
+
+```bash
+praisonai code --thinking high "design a caching layer"
+praisonai run  --thinking medium "summarise the architecture"
+praisonai run  --thinking off "quick lookup"
+```
+
+| `--thinking` value | Token budget | Notes |
+|--------------------|-------------|-------|
+| `off` | `None` | Extended thinking disabled (default when flag omitted) |
+| `minimal` | `2,000` | |
+| `low` | `4,000` | |
+| `medium` | `8,000` | |
+| `high` | `16,000` | |
+
+- These are the **same** budgets used by `praisonai thinking set` — the per-invocation flag and the persistent subcommand share one map.
+- Case-insensitive. Unknown values fail closed with exit code 1.
+- `--thinking` composes with `--agent`: profile tools/permissions apply first, then the thinking budget is set.
+
+See [Thinking CLI](/docs/cli/thinking) for the subcommand reference and [Code CLI](/docs/cli/code), [Run CLI](/docs/cli/run) for the per-invocation flag.
 
 ---
 

--- a/docs/guides/least-privilege-coding.mdx
+++ b/docs/guides/least-privilege-coding.mdx
@@ -1,0 +1,184 @@
+---
+title: "Least-Privilege Coding"
+sidebarTitle: "Least-Privilege Coding"
+description: "Run safe coding sessions by combining --agent plan and --agent build"
+icon: "shield"
+---
+
+Open a read-only session to review code safely, then re-run with write permissions only when you are ready to apply changes.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as praisonai code
+    participant Profile as .praisonai/agents/plan.md
+    participant Agent
+
+    User->>CLI: praisonai code --agent plan --thinking high "review auth.py"
+    CLI->>Profile: load_agent_from_name("plan")
+    Profile-->>CLI: tools=[read,grep,glob], permission=read-only
+    CLI->>Agent: build with profile.tools + approval(read-only)
+    CLI->>Agent: agent.thinking_budget = 16000
+    User->>Agent: "review auth.py"
+    Agent-->>User: review (edit attempts rejected by mode-rules)
+
+    Note over User,Agent: Re-run with --agent build to apply edits
+    User->>CLI: praisonai code --agent build "fix the bugs you found"
+    CLI->>Agent: build with build.tools (incl. edit/shell), approval=ask
+    Agent-->>User: edits applied
+```
+
+## Quick Start
+
+<Steps>
+
+<Step title="Review with read-only access">
+
+Use the built-in `plan` profile to read and analyse — no file writes or shell commands are possible.
+
+```bash
+praisonai code --agent plan "review auth.py for security issues"
+```
+
+</Step>
+
+<Step title="Add extended reasoning for complex analysis">
+
+Combine `--agent plan` with `--thinking high` for deep review of critical modules.
+
+```bash
+praisonai code --agent plan --thinking high "review the authentication flow in auth.py"
+```
+
+</Step>
+
+<Step title="Apply edits with the build profile">
+
+Once you are satisfied with the review, re-run with `--agent build` to give the agent write and shell access.
+
+```bash
+praisonai code --agent build "fix the security issues you found in auth.py"
+```
+
+</Step>
+
+<Step title="Combine agent and reasoning on build">
+
+Use `--thinking medium` with `--agent build` for moderately complex implementation tasks.
+
+```bash
+praisonai code --agent build --thinking medium "implement the TODOs in cache.py"
+```
+
+</Step>
+
+</Steps>
+
+## Built-in profiles
+
+Three profiles work without any configuration file:
+
+| Profile | Tools | Permission | When to use |
+|---------|-------|------------|-------------|
+| `plan` | read, grep, glob | read-only | Safe review, no risk of modifications |
+| `review` | read, grep | ask before shell | Code review that may run tests |
+| `build` | read, write, edit, shell | ask before edits | Implementation and refactoring |
+
+## Choosing the right profile
+
+```mermaid
+graph TB
+    Start["What do you need?"]
+    Start -->|"Just read and understand"| Plan["--agent plan"]
+    Start -->|"Review and maybe run tests"| Review["--agent review"]
+    Start -->|"Write, edit, or run commands"| Build["--agent build"]
+
+    Plan --> ReadOnly["read-only tools<br/>no approval prompts needed"]
+    Review --> AskShell["ask before shell<br/>read tools always allowed"]
+    Build --> AskWrite["ask before writes/shell<br/>full tool access"]
+
+    classDef question fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef profile fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Start question
+    class Plan,Review,Build profile
+    class ReadOnly,AskShell,AskWrite result
+```
+
+## Custom profiles
+
+Define a custom profile by creating a Markdown file in `.praisonai/agents/`:
+
+```markdown
+<!-- .praisonai/agents/secure-reviewer.md -->
+---
+model: gpt-4o
+role: Security Reviewer
+tools:
+  - read_file
+  - grep
+  - list_directory
+mode: read-only
+---
+
+You are a security-focused code reviewer. Identify vulnerabilities, misconfigurations,
+and data exposure risks. Never modify files.
+```
+
+Use the custom profile on `praisonai code`:
+
+```bash
+praisonai code --agent secure-reviewer --thinking high "audit the auth module"
+```
+
+See [Custom Agents & Commands](/docs/features/custom-agents-commands) for the full profile format.
+
+## Thinking levels at a glance
+
+| `--thinking` | Budget | Typical use |
+|---|---|---|
+| `off` | None | Fast lookups, no reasoning needed |
+| `minimal` | 2,000 | Simple questions |
+| `low` | 4,000 | Moderate complexity |
+| `medium` | 8,000 | Refactoring, implementation |
+| `high` | 16,000 | Security audits, architecture review |
+
+## Best practices
+
+<AccordionGroup>
+
+<Accordion title="Start with plan, switch to build">
+Always open sessions with `--agent plan` first to understand the codebase. Only switch to `--agent build` when you have a clear implementation plan. This prevents accidental modifications.
+</Accordion>
+
+<Accordion title="Use --thinking high for security reviews">
+Security and architecture reviews benefit from extended reasoning. Use `--thinking high` with `--agent plan` to get thorough analysis without risking file modifications.
+</Accordion>
+
+<Accordion title="Define custom profiles for team workflows">
+Commit `.praisonai/agents/` profiles to your repository so the whole team uses consistent tool scopes and permission levels. Name profiles after the workflow stage (e.g., `audit`, `implement`, `test`).
+</Accordion>
+
+<Accordion title="--model overrides profile LLM">
+If a profile specifies a model but you want to use a different one, pass `--model` explicitly — it always wins over the profile's `llm` field.
+</Accordion>
+
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Code CLI" icon="code" href="/docs/cli/code">
+    Full --agent and --thinking flag reference
+  </Card>
+  <Card title="Custom Agents & Commands" icon="file-code" href="/docs/features/custom-agents-commands">
+    Define custom agent profiles
+  </Card>
+  <Card title="Agent Presets & Modes" icon="shield-check" href="/docs/features/agent-presets-and-modes">
+    Built-in preset profiles and permission scoping
+  </Card>
+  <Card title="Thinking Budgets" icon="brain" href="/docs/features/thinking-budgets">
+    Extended reasoning token budgets
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Fixes #1069

## Summary

Updated 5 existing pages and created 1 new guide to surface the --agent and --thinking flags on praisonai code and praisonai run.

Changes:
- docs/cli/code.mdx: Added --agent/-a and --thinking to options table, hero decision Mermaid diagram, Quick Start steps, dedicated flag reference sections with cross-links
- docs/cli/run.mdx: Added --thinking to options table, added extended reasoning examples section, added cross-links in See Also
- docs/cli/thinking.mdx: Added Per-invocation flag (code / run) section with level to budget table
- docs/features/thinking-budgets.mdx: Split CLI Usage into Persistent default and Per-invocation flag subsections with canonical level to budget mapping table
- docs/features/custom-agents-commands.mdx: Updated hero diagram to show praisonai code --agent, added code examples in Quick Start, added Code CLI and Least-Privilege Coding to Related cards
- docs/guides/least-privilege-coding.mdx: New how-to guide showing plan to build workflow with sequence diagram, decision diagram, and best practices
- docs.json: Registered docs/guides/least-privilege-coding under the Guides group

Generated with [Claude Code](https://claude.ai/code)