### PR TITLE
docs: update Flow + Langflow docs for [flow] extra (Fixes #1076)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1333,6 +1333,7 @@
                   "docs/cli/auto",
                   "docs/cli/serve",
                   "docs/cli/dashboard",
+                  "docs/cli/flow",
                   "docs/cli/mcp-server",
                   "docs/cli/workflow",
                   "docs/cli/validate",

--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -95,6 +95,13 @@ praisonai
 │   ├── template <name>          # Create from template
 │   └── auto <topic>             # Auto-generate workflow
 │
+├── flow                         # Visual workflow builder (Langflow)
+│   ├── (no args)                # Start the builder UI
+│   ├── import <file>            # Import YAML → Langflow
+│   ├── export <flow_id>         # Export Langflow → YAML/JSON
+│   ├── list                     # List flows on a server
+│   └── version                  # Show Langflow version
+│
 ├── hooks                        # Hooks management
 │   ├── list                     # List hooks
 │   ├── stats                    # Hook statistics
@@ -461,6 +468,11 @@ praisonai tools list
 praisonai workflow list
 praisonai workflow auto "Research AI trends"
 
+# Visual workflow builder
+praisonai flow
+praisonai flow import workflow.yaml --open
+praisonai flow export <flow_id> -o my_flow.yaml
+
 # Deployment
 praisonai deploy init
 praisonai deploy run
@@ -571,5 +583,6 @@ praisonai session resume <session_id> --transcript
 - [Session Resume](/docs/cli/session-resume) - Deterministic CLI session resume
 - [Doctor CLI](/docs/cli/doctor) - Health checks and diagnostics
 - [Workflows](/docs/features/workflows) - Workflow management
+- [Flow CLI](/docs/cli/flow) - Visual workflow builder (Langflow)
 - [Memory](/docs/concepts/memory) - Memory and sessions
 - [Tools](/docs/tools) - Tool reference

--- a/docs/cli/flow.mdx
+++ b/docs/cli/flow.mdx
@@ -1,0 +1,213 @@
+---
+title: "Flow"
+sidebarTitle: "Flow"
+description: "Launch the Langflow visual workflow builder with PraisonAI Agent + AgentTeam components pre-loaded"
+icon: "diagram-project"
+---
+
+The `praisonai flow` command launches Langflow with PraisonAI components pre-loaded, and provides YAML ↔ Langflow JSON conversion utilities.
+
+```mermaid
+graph LR
+    CLI[🖥️ praisonai flow] --> LF[🌐 Langflow<br/>:7860]
+    LF --> UI[👁️ Browser UI]
+    LF --> Agent[🤖 Agent]
+    LF --> Team[🤝 Agent Team]
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef service fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class CLI input
+    class LF process
+    class UI service
+    class Agent,Team agent
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Install">
+
+```bash
+pip install "praisonai[flow]"
+```
+
+</Step>
+
+<Step title="Launch">
+
+```bash
+praisonai flow
+```
+
+</Step>
+
+<Step title="Build visually">
+
+Open `http://localhost:7860` and drag **Agent** / **Agent Team** components from the PraisonAI sidebar.
+
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as praisonai flow
+    participant Langflow
+    participant Components as PraisonAI Components
+
+    User->>CLI: praisonai flow
+    CLI->>Langflow: langflow run + LANGFLOW_COMPONENTS_PATH
+    Langflow-->>User: Visual UI on :7860
+    User->>Components: Configure Agent / Agent Team
+    Components-->>User: Workflow result
+```
+
+| Phase | Description |
+|-------|-------------|
+| **Install** | `pip install "praisonai[flow]"` pulls Langflow and requests |
+| **Launch** | CLI sets `LANGFLOW_COMPONENTS_PATH` to PraisonAI components |
+| **Build** | Drag Agent and Agent Team nodes in the browser |
+| **Export** | `praisonai flow export <flow_id>` converts back to YAML |
+
+---
+
+## Subcommands
+
+### `praisonai flow`
+
+Start the visual builder.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--port`, `-p` | `int` | `7860` | Port to listen on |
+| `--host`, `-H` | `str` | `127.0.0.1` | Host to bind to (use `0.0.0.0` to expose) |
+| `--env-file` | `str` | `None` | Path to a `.env` file Langflow should load |
+| `--no-open` | flag | `False` | Don't open the browser on start |
+| `--log-level`, `-l` | `str` | `error` | `debug`, `info`, `warning`, `error`, `critical` |
+| `--backend-only` | flag | `False` | Run backend API only (no frontend UI) |
+| `--components-path` | `str` | `None` | Extra custom components directory (appended to PraisonAI's) |
+
+```bash
+praisonai flow --host 0.0.0.0 --port 8080
+```
+
+### `praisonai flow import`
+
+Convert PraisonAI YAML → Langflow JSON and upload.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `yaml_path` | `str` | — | Path to YAML workflow file (positional) |
+| `--url` | `str` | `http://localhost:7860` | Langflow server URL |
+| `--dry-run` | flag | `False` | Preview JSON without uploading |
+| `--open` | flag | `False` | Open the imported flow in the browser |
+| `--output`, `-o` | `str` | `None` | Save JSON to file instead of uploading |
+
+```bash
+praisonai flow import my_workflow.yaml --open
+```
+
+### `praisonai flow export`
+
+Download a Langflow flow and convert back to YAML or JSON.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `flow_id` | `str` | — | Flow ID to export (positional) |
+| `--output`, `-o` | `str` | `<flow_name>.<ext>` | Output file path |
+| `--url` | `str` | `http://localhost:7860` | Langflow server URL |
+| `--format` | `str` | `yaml` | Output format: `yaml` or `json` |
+
+```bash
+praisonai flow export abc-123-def -o my_workflow.yaml
+```
+
+### `praisonai flow list`
+
+List flows on a running Langflow server.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--url` | `str` | `http://localhost:7860` | Langflow server URL |
+| `--search`, `-s` | `str` | `None` | Search flows by name or description |
+
+```bash
+praisonai flow list --search research
+```
+
+### `praisonai flow version`
+
+Show installed Langflow version.
+
+```bash
+praisonai flow version
+```
+
+---
+
+## Common Patterns
+
+```bash
+# YAML → visual editor round-trip
+praisonai flow                                   # 1. start the builder
+praisonai flow import my_workflow.yaml --open    # 2. push YAML in
+# (edit in browser, copy the flow ID from the URL)
+praisonai flow export <flow_id> -o my_workflow.yaml   # 3. pull edits back to YAML
+
+# Preview the converted JSON without uploading
+praisonai flow import my_workflow.yaml --dry-run
+
+# Run on a custom port / expose to LAN
+praisonai flow --host 0.0.0.0 --port 8080
+
+# Headless / API-only deploy
+praisonai flow --backend-only --no-open
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Keep YAML as source of truth">
+Always export back to YAML for version control after visual edits.
+</Accordion>
+
+<Accordion title="Use --dry-run before uploading">
+Preview JSON conversion with `praisonai flow import workflow.yaml --dry-run` before pushing to a running server.
+</Accordion>
+
+<Accordion title="Add custom components with --components-path">
+Extend the sidebar with your own Langflow components via `--components-path /path/to/components`.
+</Accordion>
+
+<Accordion title="Run --backend-only for headless deployments">
+Skip the UI in CI or Docker with `praisonai flow --backend-only --no-open`.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Visual Workflow Builder" icon="sitemap" href="/docs/ui/flow">
+  UI guide for Agent and Agent Team nodes
+</Card>
+<Card title="Langflow Integration" icon="diagram-project" href="/docs/integrations/langflow">
+  Component reference and model formats
+</Card>
+<Card title="Dashboard" icon="layout-dashboard" href="/docs/cli/dashboard">
+  Unified dashboard — launches Flow + Claw + UI together
+</Card>
+<Card title="Installation Extras" icon="puzzle-piece" href="/docs/features/installation-extras">
+  `[flow]` extra reference
+</Card>
+</CardGroup>

--- a/docs/features/installation-extras.mdx
+++ b/docs/features/installation-extras.mdx
@@ -17,6 +17,7 @@ graph LR
             API[🌐 api] 
             TOOLS[🔧 tools]
             STORAGE[💾 storage]
+            FLOW[🎨 flow]
             ALL[⭐ all]
         end
         
@@ -25,6 +26,7 @@ graph LR
             F2[Gateway, WebSocket, REST]
             F3[Web Search, File Processing]
             F4[Vector DBs, Cloud Storage]
+            F6[Visual Workflow Builder + Langflow]
             F5[Everything Included]
         end
     end
@@ -33,6 +35,7 @@ graph LR
     CORE --> API --> F2
     CORE --> TOOLS --> F3
     CORE --> STORAGE --> F4
+    CORE --> FLOW --> F6
     CORE --> ALL --> F5
     
     classDef core fill:#8B0000,stroke:#7C90A0,color:#fff
@@ -40,8 +43,8 @@ graph LR
     classDef feature fill:#10B981,stroke:#7C90A0,color:#fff
     
     class CORE core
-    class BOT,API,TOOLS,STORAGE,ALL extra
-    class F1,F2,F3,F4,F5 feature
+    class BOT,API,TOOLS,STORAGE,FLOW,ALL extra
+    class F1,F2,F3,F4,F5,F6 feature
 ```
 
 ## Quick Start
@@ -60,6 +63,9 @@ pip install "praisonai[bot]"
 
 # Gateway server with WebSocket/REST
 pip install "praisonai[api]"
+
+# Visual workflow builder (Langflow)
+pip install "praisonai[flow]"
 
 # Gateway + bots (most common)
 pip install "praisonai[bot,api]"
@@ -215,6 +221,31 @@ pip install "praisonai[storage]"
 - Session state persistence
 - Caching and performance
 - Multi-agent coordination
+
+### Visual Flow Builder (`[flow]`)
+
+Launch Langflow with PraisonAI Agent and AgentTeam components pre-loaded:
+
+```bash
+pip install "praisonai[flow]"
+```
+
+**Includes:**
+- `langflow>=1.0.0` — visual workflow builder
+- `requests>=2.31.0` — Langflow REST client
+
+**Use cases:**
+- Launch the Langflow UI with PraisonAI components in the sidebar
+- Import/export YAML ↔ Langflow JSON
+- Visual multi-agent workflow design
+
+**Example:**
+```bash
+praisonai flow
+# Opens http://localhost:7860 with Agent + Agent Team components
+```
+
+See [Flow CLI](/docs/cli/flow) and [Visual Workflow Builder](/docs/ui/flow).
 
 ### Complete Installation (`[all]`)
 
@@ -376,6 +407,20 @@ conda install -c conda-forge praisonai
 
 </Accordion>
 
+<Accordion title="Langflow is not installed">
+
+**Error:**
+```
+Langflow is not installed. Install with: pip install praisonai[flow]
+```
+
+**Solution:**
+```bash
+pip install "praisonai[flow]"
+```
+
+</Accordion>
+
 </AccordionGroup>
 
 ### Dependency Conflicts
@@ -420,6 +465,7 @@ Complete dependency listing by extra:
 | `[api]` | uvicorn, fastapi, starlette | ~30MB | Web server and WebSocket |
 | `[tools]` | tavily-python, beautifulsoup4, PyPDF2 | ~25MB | Document and web processing |
 | `[storage]` | chromadb, qdrant-client, pymongo | ~100MB | Databases and vector stores |
+| `[flow]` | langflow, requests | ~500MB | Visual workflow builder (Langflow) |
 | `[all]` | All of the above + additional | ~200MB | Complete functionality |
 
 ### Platform-Specific Notes

--- a/docs/integrations/langflow.mdx
+++ b/docs/integrations/langflow.mdx
@@ -8,16 +8,20 @@ icon: diagram-project
 
 [Langflow](https://langflow.org) is a visual authoring platform for AI agents and workflows. PraisonAI provides native Langflow components for building agent workflows visually.
 
-<Note>
-**Status**: [PR #11294](https://github.com/langflow-ai/langflow/pull/11294) submitted to Langflow repository. Once merged, PraisonAI components will be available natively in Langflow.
-</Note>
-
 ## Installation
 
 ```bash
-# Install Langflow with PraisonAI support
-pip install langflow praisonaiagents
+pip install "praisonai[flow]"
 ```
+
+## Launch
+
+```bash
+# Launches Langflow on http://localhost:7860 with PraisonAI components in the sidebar
+praisonai flow
+```
+
+See [Flow CLI](/docs/cli/flow) and [Visual Workflow Builder](/docs/ui/flow) for subcommands and component options.
 
 ## Components
 

--- a/docs/ui/flow.mdx
+++ b/docs/ui/flow.mdx
@@ -25,6 +25,10 @@ graph LR
     class E output
 ```
 
+<Warning>
+The `[flow]` extra is opt-in and heavy (~500MB) because Langflow pulls many dependencies. Install only when you need the visual builder: `pip install "praisonai[flow]"`.
+</Warning>
+
 ## Quick Start
 
 <Steps>
@@ -52,6 +56,79 @@ Drag and drop **Agent** and **Agent Team** nodes to orchestrate workflows.
 
 ---
 
+## CLI Subcommands
+
+| Command | Purpose |
+|---------|---------|
+| `praisonai flow` | Launch Langflow with PraisonAI components |
+| `praisonai flow import <yaml>` | Convert PraisonAI YAML → Langflow JSON and upload |
+| `praisonai flow export <flow_id>` | Download a Langflow flow and convert back to YAML |
+| `praisonai flow list` | List flows on a running Langflow server |
+| `praisonai flow version` | Show installed Langflow version |
+
+See [Flow CLI](/docs/cli/flow) for the full flag reference.
+
+### Which subcommand should I use?
+
+```mermaid
+graph TD
+    Start{What do you need?}
+    Start -->|Open the visual editor| Launch[praisonai flow]
+    Start -->|Push YAML into Langflow| Import[praisonai flow import]
+    Start -->|Pull edits back to YAML| Export[praisonai flow export]
+    Start -->|Find a flow ID| List[praisonai flow list]
+    Start -->|Check Langflow version| Version[praisonai flow version]
+
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef action fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef cli fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class Start decision
+    class Launch,Import,Export,List,Version action
+```
+
+---
+
+## Start Command Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--port`, `-p` | `int` | `7860` | Port to listen on |
+| `--host`, `-H` | `str` | `127.0.0.1` | Host to bind to (use `0.0.0.0` to expose) |
+| `--env-file` | `str` | `None` | Path to a `.env` file Langflow should load |
+| `--no-open` | flag | `False` | Don't open the browser on start |
+| `--log-level`, `-l` | `str` | `error` | `debug`, `info`, `warning`, `error`, `critical` |
+| `--backend-only` | flag | `False` | Run backend API only (no frontend UI) |
+| `--components-path` | `str` | `None` | Extra custom components directory (appended to PraisonAI's) |
+
+### Import flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `yaml_path` | `str` | — | Path to YAML workflow file (positional) |
+| `--url` | `str` | `http://localhost:7860` | Langflow server URL |
+| `--dry-run` | flag | `False` | Preview JSON without uploading |
+| `--open` | flag | `False` | Open the imported flow in the browser |
+| `--output`, `-o` | `str` | `None` | Save JSON to file instead of uploading |
+
+### Export flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `flow_id` | `str` | — | Flow ID to export (positional) |
+| `--output`, `-o` | `str` | `<flow_name>.<ext>` | Output file path |
+| `--url` | `str` | `http://localhost:7860` | Langflow server URL |
+| `--format` | `str` | `yaml` | Output format: `yaml` or `json` |
+
+### List flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--url` | `str` | `http://localhost:7860` | Langflow server URL |
+| `--search`, `-s` | `str` | `None` | Search flows by name or description |
+
+---
+
 ## How It Works
 
 ```mermaid
@@ -74,6 +151,10 @@ sequenceDiagram
 | **Agent Team Node** | Multi-agent orchestrator connecting multiple nodes | Sidebar > PraisonAI |
 | **CLI Command** | Backend server runtime wrapper | `praisonai` CLI |
 
+<Tip>
+If `PRAISONAI_OBSERVE=langfuse` is set, the Agent component auto-wires a `LangfuseSink` with `praisonai_source=langflow` trace metadata.
+</Tip>
+
 ---
 
 ## Agent Configuration Options
@@ -82,17 +163,32 @@ Options available on the **Agent** node visual component.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `Agent Name` | `str` | `"Agent"` | Name for identification and logging. |
-| `Previous Agent` | `Handle` | `None` | Connect from previous agent to define execution order. |
-| `Role` | `str` | `None` | Role defining the agent's expertise. |
-| `Goal` | `str` | `None` | Primary objective the agent aims to achieve. |
-| `Instructions` | `str` | `"You are a helpful assistant."` | System prompt for the agent. |
-| `Model` | `str` | `"openai/gpt-4o-mini"` | LLM model to use (provider/model format). |
-| `Input` | `Handle` | `None` | User input to process. |
-| `Tools` | `Handle` | `None` | Tools available to the agent. |
-| `Memory` | `bool` | `False` | Enable context retention. |
-| `Guardrails` | `bool` | `False` | Enable output validation guardrails. |
-| `Knowledge Files` | `File` | `None` | Files to use as knowledge sources (PDF, TXT, etc.). |
+| `Agent Name` | `str` | `"Agent"` | Name for identification and logging |
+| `Previous Agent` | `Handle` | `None` | Connect from previous agent to define execution order |
+| `Role` | `str` | `None` | Role defining the agent's expertise |
+| `Goal` | `str` | `None` | Primary objective the agent aims to achieve |
+| `Backstory` | `str` (multiline) | `None` | Background context shaping personality |
+| `Instructions` | `str` | `"You are a helpful assistant."` | System prompt for the agent |
+| `Input` | `Handle` | `None` | User input to process |
+| `Model` | `str` | `"openai/gpt-4o-mini"` | LLM model (`provider/model` format) |
+| `Language Model` | `Handle` (LanguageModel) | `None` | External LLM from Langflow model components (overrides dropdown) |
+| `Base URL` | `str` | `None` | Custom LLM endpoint (e.g. `http://localhost:11434` for Ollama) |
+| `API Key` | `Secret` | `None` | API key for LLM provider (overrides env var) |
+| `Tools` | `Handle` | `None` | Tools available to the agent |
+| `Allow Delegation` | `bool` | `False` | Allow task delegation to other agents |
+| `Allow Code Execution` | `bool` | `False` | Enable code execution during tasks |
+| `Code Execution Mode` | `str` | `safe` | `safe` (sandboxed) or `unsafe` (full system access) |
+| `Handoffs` | `Handle[Agent]` | `[]` | Other agents this agent can hand off conversations to |
+| `Memory` | `bool` | `False` | Enable context retention |
+| `Memory Provider` | `str` | `""` | `""`, `rag`, or `mem0` |
+| `Memory Config` | `dict` | `None` | Full MemoryConfig dictionary |
+| `Knowledge Files` | `File` | `None` | Files to use as knowledge sources (PDF, TXT, etc.) |
+| `Knowledge URLs` | `str` (multiline) | `None` | URLs to use as knowledge sources (one per line) |
+| `Guardrails` | `bool` | `False` | Enable output validation guardrails |
+| `Verbose` | `bool` | `False` | Show detailed execution logs |
+| `Markdown Output` | `bool` | `True` | Format output as markdown |
+| `Self Reflect` | `bool` | `False` | Enable self-reflection |
+| `Max Iterations` | `int` | `20` | Maximum agent loop iterations |
 
 ---
 
@@ -102,24 +198,48 @@ Options available on the **Agent Team** node visual component for multi-agent wo
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `Name` | `str` | `"AgentTeam"` | Name for this multi-agent team. |
-| `Agents` | `Handle` | `[]` | List of connected PraisonAI agents to orchestrate. |
-| `Input` | `Handle` | `None` | Initial input to start the multi-agent workflow. |
-| `Process` | `str` | `"sequential"` | Collaboration mode (sequential, hierarchical, workflow). |
-| `Manager LLM` | `str` | `"openai/gpt-4o"` | LLM used for auto-created managers. |
-| `Shared Memory` | `bool` | `False` | Enable shared memory across all agents. |
-| `Planning` | `bool` | `False` | Enable planning mode for task decomposition. |
-| `Reflection` | `bool` | `False` | Enable self-reflection for improved results. |
+| `Name` | `str` | `"AgentTeam"` | Name for this multi-agent team |
+| `Agents` | `Handle` | `[]` | List of connected PraisonAI agents to orchestrate |
+| `Input` | `Handle` | `None` | Initial input to start the multi-agent workflow |
+| `Process` | `str` | `"sequential"` | Collaboration mode (sequential, hierarchical, workflow) |
+| `Manager Agent` | `Handle[Agent]` | `None` | Explicit manager agent for hierarchical process |
+| `Manager LLM` | `str` | `"openai/gpt-4o"` | LLM used for auto-created managers |
+| `Variables` | `dict` | `None` | Global variables for substitution in task descriptions |
+| `Shared Memory` | `bool` | `False` | Enable shared memory across all agents |
+| `Guardrails` | `bool` | `False` | Enable team-level validation guardrails |
+| `Verbose` | `bool` | `False` | Show detailed execution logs |
+| `Full Output` | `bool` | `False` | Return full output including all task results |
+| `Planning` | `bool` | `False` | Enable planning mode for task decomposition |
+| `Reflection` | `bool` | `False` | Enable self-reflection for improved results |
+| `Caching` | `bool` | `False` | Enable caching of agent responses |
 
 ---
 
 ## Common Patterns
 
+### YAML round-trip
+
+```bash
+praisonai flow                                   # 1. start the builder
+praisonai flow import my_workflow.yaml --open    # 2. push YAML in
+# (edit in browser, copy the flow ID from the URL)
+praisonai flow export <flow_id> -o my_workflow.yaml   # 3. pull edits back to YAML
+```
+
 ### Sequential Connections
-Connect individual `Agent` nodes linearly (Agent 1 → Agent 2) by linking the `Agent` output handle on the first node to the `Previous Agent` input handle on the second node. 
+
+Connect individual `Agent` nodes linearly (Agent 1 → Agent 2) by linking the `Agent` output handle on the first node to the `Previous Agent` input handle on the second node.
 
 ### Multi-Agent Orchestration
+
 Connect multiple `Agent` nodes directly to the `Agents` input handle of an `Agent Team` node. The team node evaluates the topology and runs the sub-agents properly.
+
+### Headless / LAN deploy
+
+```bash
+praisonai flow --host 0.0.0.0 --port 8080
+praisonai flow --backend-only --no-open
+```
 
 ---
 
@@ -127,13 +247,16 @@ Connect multiple `Agent` nodes directly to the `Agents` input handle of an `Agen
 
 <AccordionGroup>
 <Accordion title="Configure Knowledge Properly">
-When using the agent node's knowledge capabilities, be sure to upload compatible document types (PDF, TXT, CSV) or provide valid URLs in the `Knowledge` inputs.
+When using the agent node's knowledge capabilities, upload compatible document types (PDF, TXT, CSV) or provide valid URLs in the `Knowledge` inputs.
 </Accordion>
 <Accordion title="Use Sequential Handles">
 Use the `Previous Agent` connection to establish hard execution boundaries. The orchestrator automatically parses node inputs backwards to map deterministic execution flow.
 </Accordion>
 <Accordion title="Enable Advanced Node Features">
 Click the "Advanced" toggle on nodes inside Langflow to expose robust SDK parameters like custom Base URLs, `Code Execution Mode`, `Verbose` logging, and specific `Memory Providers`.
+</Accordion>
+<Accordion title="Keep YAML as source of truth">
+Export flows back to YAML after visual edits so workflows stay in version control.
 </Accordion>
 </AccordionGroup>
 
@@ -142,10 +265,16 @@ Click the "Advanced" toggle on nodes inside Langflow to expose robust SDK parame
 ## Related
 
 <CardGroup cols={2}>
-<Card title="Agent Workflow" icon="route" href="/docs/features/workflows">
-  Understand the core concepts of workflows.
+<Card title="Flow CLI" icon="diagram-project" href="/docs/cli/flow">
+  CLI reference for all subcommands and flags
 </Card>
-<Card title="Agent Teams" icon="users" href="/docs/concepts/agentteam">
-  Learn how to build collaborative AI teams.
+<Card title="Langflow Integration" icon="plug" href="/docs/integrations/langflow">
+  Component reference and model formats
+</Card>
+<Card title="Agent Workflow" icon="route" href="/docs/features/workflows">
+  Core workflow concepts
+</Card>
+<Card title="Installation Extras" icon="puzzle-piece" href="/docs/features/installation-extras">
+  `[flow]` extra reference
 </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Document `pip install "praisonai[flow]"` across installation-extras and langflow integration pages
- Add new `docs/cli/flow.mdx` CLI reference with all subcommands and flags
- Expand `docs/ui/flow.mdx` with subcommand decision diagram, full Agent/AgentTeam input tables, and YAML round-trip patterns
- Register page in `docs.json`; add `flow` to `cli-reference.mdx` command tree

Fixes #1076

## Test plan
- [x] `python3 -m json.tool docs.json` passes
- [x] All acceptance criteria from #1076 covered
- [x] No `docs/concepts/` files touched

Made with [Cursor](https://cursor.com)