### PR TITLE
docs(features): AGENTS.md compliance batch 14 — 5 gateway pages

### DIFF
--- a/docs/features/gateway-session-persistence.mdx
+++ b/docs/features/gateway-session-persistence.mdx
@@ -11,6 +11,13 @@ Persistent sessions keep conversation state alive across gateway restarts and le
 This page covers **agent session** persistence (messages, events, cursors). **Gateway** sessions additionally preserve `pending_inbox` and `is_executing` across disconnects and graceful shutdown — see [Gateway Session Continuity](/docs/features/gateway-session-continuity).
 </Note>
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="Be helpful")
+# Set session.persist: true in gateway.yaml so this agent's session survives restarts
+```
+
 ```mermaid
 graph LR
     A[Active session] --> B[Disconnect]

--- a/docs/features/gateway-telegram-multichannel.mdx
+++ b/docs/features/gateway-telegram-multichannel.mdx
@@ -7,6 +7,14 @@ icon: "paper-plane"
 
 Deploy a Hermes-style AI workforce using PraisonAI Gateway with multiple specialized Telegram bots, each serving different business functions while sharing common knowledge.
 
+```python
+from praisonaiagents import Agent
+
+cfo = Agent(name="cfo", instructions="Handle finance questions.")
+ops = Agent(name="ops", instructions="Handle operations.")
+# Register both on one gateway — see channels: in gateway.yaml below
+```
+
 ```mermaid
 graph TB
     subgraph "Telegram Users"

--- a/docs/features/gateway-tool-policy.mdx
+++ b/docs/features/gateway-tool-policy.mdx
@@ -7,6 +7,13 @@ icon: "shield-check"
 
 Untrusted inbound routes never even see dangerous tools — the model is offered a scoped subset for that turn, then the agent's original toolset is restored.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", tools=["read_file", "search_web"])
+# Gateway bindings with trust: untrusted scope which tools the model sees per route
+```
+
 ```mermaid
 graph LR
     subgraph "Per-route Tool Policy"

--- a/docs/features/gateway-windows-deployment.mdx
+++ b/docs/features/gateway-windows-deployment.mdx
@@ -7,6 +7,11 @@ icon: "windows"
 
 Deploy the PraisonAI Gateway on Windows with multiple Telegram bots, proper encoding, and production-ready configuration.
 
+```bash
+# After UTF-8 env setup (see below), start the gateway from your config
+praisonai gateway start --config gateway.yaml
+```
+
 ```mermaid
 graph TB
     subgraph "Windows Environment Setup"

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -7,6 +7,13 @@ icon: "tower-broadcast"
 
 Gateway provides a WebSocket-based control plane for coordinating multiple agents, managing sessions, and enabling real-time communication between agents and clients.
 
+```python
+from praisonaiagents import Agent, GatewayConfig
+
+agent = Agent(name="assistant", instructions="Be helpful")
+config = GatewayConfig(host="127.0.0.1", port=8765)
+```
+
 ```mermaid
 graph LR
     subgraph "Gateway Control Plane"
@@ -28,7 +35,7 @@ graph LR
 ```
 
 <Tip>
-Reconnecting after a disconnect? See [Resume Integrity](#resume-integrity) — the `joined` ack now signals when you must take a snapshot instead of trusting partial replay. For automatic reconnect, version negotiation, and gap detection on the client side, see [Gateway Client](/features/gateway-client).
+Reconnecting after a disconnect? See [Resume Integrity](#resume-integrity) — the `joined` ack now signals when you must take a snapshot instead of trusting partial replay. For automatic reconnect, version negotiation, and gap detection on the client side, see [Gateway Client](/docs/features/gateway-client).
 </Tip>
 
 ## Quick Start
@@ -883,16 +890,16 @@ Inbound gateway messages from strangers are the framework's largest prompt-injec
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="Multi-Agent Workflows" icon="users" href="/features/multi-agent">
+  <Card title="Multi-Agent Workflows" icon="users" href="/docs/features/multi-agent">
     Coordinate multiple agents
   </Card>
-  <Card title="Sessions" icon="clock" href="/concepts/sessions">
+  <Card title="Sessions" icon="clock" href="/docs/concepts/sessions">
     Manage conversation state
   </Card>
   <Card title="Session Continuity" icon="shield-check" href="/docs/features/gateway-session-continuity">
     Graceful drain, reconnect, and two-layer shutdown
   </Card>
-  <Card title="Resume Integrity" icon="rotate-ccw" href="/features/gateway#resume-integrity">
+  <Card title="Resume Integrity" icon="rotate-ccw" href="/docs/features/gateway#resume-integrity">
     Handle reconnect, resync, and snapshot
   </Card>
   <Card title="Push Notifications" icon="bell" href="/docs/features/push-notifications">


### PR DESCRIPTION
## Summary
- Add agent-centric openers before hero diagrams on 5 gateway pages
- Fix Related Card hrefs on `gateway.mdx` (`/docs/features/` prefix)

## Pages
- gateway-session-persistence.mdx
- gateway-telegram-multichannel.mdx
- gateway-tool-policy.mdx
- gateway-windows-deployment.mdx
- gateway.mdx

Refs #1000

## Test plan
- [x] Mintlify nav paths use `/docs/` prefix in Related cards
- [x] Agent-centric snippets appear before hero Mermaid on each page