### PR TITLE
docs: outbound-media-delivery cross-links

### DIFF
--- a/docs/features/channels-gateway.mdx
+++ b/docs/features/channels-gateway.mdx
@@ -310,6 +310,14 @@ All channels enforce the same access-control pipeline regardless of whether you 
 - Business API features
 - Webhook verification
 
+<Card title="Outbound Media Delivery" icon="photo-film" href="/docs/features/outbound-media-delivery">
+  Send agent-generated images and files through channel adapters with path validation
+</Card>
+
+<Card title="Bot Inbound Media" icon="paperclip" href="/docs/features/bot-inbound-media">
+  Receive and validate photos and documents from users
+</Card>
+
 ---
 
 ## Development vs Production
@@ -530,5 +538,11 @@ async def health_check():
 </Card>
 <Card title="Integration Patterns" icon="diagram-project" href="/docs/features/integration-patterns">
   Pattern comparison
+</Card>
+<Card title="Outbound Media Delivery" icon="photo-film" href="/docs/features/outbound-media-delivery">
+  Deliver agent-generated media via gateway channel adapters
+</Card>
+<Card title="Messaging Bots" icon="robot" href="/docs/features/messaging-bots">
+  Full bot setup for Telegram, Discord, Slack, and WhatsApp
 </Card>
 </CardGroup>

--- a/docs/features/messaging-bots.mdx
+++ b/docs/features/messaging-bots.mdx
@@ -311,6 +311,10 @@ Send the bot a photo with or without a caption — the agent sees the image dire
   Full reference: security pipeline, SSRF guard, size limits, and common patterns
 </Card>
 
+<Card title="Outbound Media Delivery" icon="photo-film" href="/docs/features/outbound-media-delivery">
+  Send agent-generated images, charts, and files via native platform uploads
+</Card>
+
 ---
 
 ## How It Works
@@ -2099,5 +2103,8 @@ bot.run()
   </Card>
   <Card title="Bot Session Compaction" icon="compress" href="/docs/features/bot-session-compaction">
     Summarise old turns instead of dropping them
+  </Card>
+  <Card title="Outbound Media Delivery" icon="photo-film" href="/docs/features/outbound-media-delivery">
+    Deliver agent-generated images and files to users on Telegram, Slack, and Discord
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Add reciprocal cross-links to `outbound-media-delivery.mdx` from `messaging-bots.mdx` and `channels-gateway.mdx`
- Inbound media section + Related cards on both pages

## Test plan
- [x] Links resolve to `/docs/features/outbound-media-delivery`
- [x] No other files changed


Made with [Cursor](https://cursor.com)