### PR TITLE
docs: AGENTS.md §9 compliance batch 23 (#1000)

### DIFF
--- a/docs/features/permission-modes.mdx
+++ b/docs/features/permission-modes.mdx
@@ -1,266 +1,131 @@
 ---
 title: "Permission Modes"
 sidebarTitle: "Permission Modes"
-description: "Control agent permission behavior with predefined modes"
+description: "Control how subagents handle tool approval with predefined modes"
 icon: "shield-check"
 ---
 
+Permission modes set how subagents handle tool approval — read-only exploration, auto-accept edits, or full bypass.
+
 <Info>
-**Two things are called "mode" in PraisonAI.** This page documents the runtime **`PermissionMode` enum** used by the approval backend (`DEFAULT` / `PLAN` / `ACCEPT_EDITS` / `BYPASS` / `DONT_ASK`). For the declarative `mode:` field inside an agent definition file (`build` / `read-only` / `plan` / `review`), see [Agent Presets & Modes](/docs/features/agent-presets-and-modes).
+This page covers the runtime **`PermissionMode` enum** (`DEFAULT`, `PLAN`, `ACCEPT_EDITS`, `DONT_ASK`, `BYPASS`). For the declarative `mode:` field in agent definition files (`build` / `read-only` / `plan` / `review`), see [Agent Presets & Modes](/docs/features/agent-presets-and-modes).
 </Info>
 
-Permission modes provide predefined permission behaviors for agents, controlling how they handle permission requests during execution.
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools.subagent_tool import create_subagent_tool
 
-<Note>
-**Default behaviour (PR #2369):** Without any `approval=` argument, the runtime automatically attaches the `ConsoleBackend` in interactive sessions (TTY) and the `default` deny preset in non-interactive sessions (CI/pipes). See [Approval](/docs/features/approval) for the full default model.
-</Note>
+spawn = create_subagent_tool(default_permission_mode="plan")
+
+agent = Agent(
+    name="Lead",
+    instructions="Delegate read-only exploration to subagents",
+    tools=[spawn],
+)
+agent.start("Explore the auth module without making changes")
+```
 
 ```mermaid
 graph LR
-    subgraph "Permission Mode Flow"
-        A[🤖 Agent Action] --> B{Permission Check}
-        B --> C[🔒 Mode Applied]
-        C --> D{Decision}
-        D -->|Allow| E[✅ Execute]
-        D -->|Deny| F[❌ Block]
-        D -->|Ask| G[❓ Prompt User]
-    end
-    
+    Agent[🤖 Lead Agent] --> Spawn[🔧 spawn_subagent]
+    Spawn --> Mode{Permission Mode}
+    Mode -->|plan| Read[📖 Read-only]
+    Mode -->|accept_edits| Edit[✏️ Auto-edit]
+    Mode -->|default| Ask[❓ Prompt user]
+
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef block fill:#EF4444,stroke:#7C90A0,color:#fff
-    classDef ask fill:#189AB4,stroke:#7C90A0,color:#fff
-    
-    class A agent
-    class B,C,D check
-    class E result
-    class F block
-    class G ask
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef mode fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class Agent agent
+    class Spawn tool
+    class Mode,Read,Edit,Ask mode
 ```
 
 ## Quick Start
 
 <Steps>
+<Step title="Simple Usage">
 
-<Step title="Import Permission Mode">
 ```python
-from praisonaiagents.permissions import PermissionMode
-```
-</Step>
-
-<Step title="Use with Subagents">
-```python
+from praisonaiagents import Agent
 from praisonaiagents.tools.subagent_tool import create_subagent_tool
 
-# Create subagent tool with permission mode
-tool = create_subagent_tool(
-    default_permission_mode="plan"  # Read-only mode
-)
+spawn = create_subagent_tool(default_permission_mode="plan")
 
-# Spawn subagent
-func = tool["function"]
-result = func(task="Explore the codebase")
+agent = Agent(name="Lead", tools=[spawn])
+agent.start("Map the project structure read-only")
 ```
+
 </Step>
 
+<Step title="With Configuration">
+
+Override the mode per subagent call:
+
+```python
+func = spawn["function"]
+
+func(task="Explore auth", permission_mode="plan")
+func(task="Fix lint in utils", permission_mode="accept_edits")
+```
+
+From the CLI:
+
+```bash
+praisonai --approval plan run "Explore the repo"
+praisonai --approval accept-edits run "Fix lint errors"
+```
+
+</Step>
 </Steps>
 
 ---
 
 ## Available Modes
 
-```mermaid
-graph TB
-    subgraph "Permission Modes"
-        DEFAULT[🔒 DEFAULT<br/>Standard checking]
-        ACCEPT[✏️ ACCEPT_EDITS<br/>Auto-accept edits]
-        DONT[🚫 DONT_ASK<br/>Auto-deny prompts]
-        BYPASS[⚡ BYPASS<br/>Skip all checks]
-        PLAN[📋 PLAN<br/>Read-only mode]
-    end
-    
-    classDef safe fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef moderate fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef dangerous fill:#EF4444,stroke:#7C90A0,color:#fff
-    
-    class DEFAULT,PLAN safe
-    class ACCEPT,DONT moderate
-    class BYPASS dangerous
-```
-
 | Mode | Value | Safety | Description |
 |------|-------|--------|-------------|
-| `DEFAULT` | `default` | ✅ Safe | Standard permission checking - prompts for each operation |
-| `ACCEPT_EDITS` | `accept_edits` | ⚠️ Moderate | Auto-accepts file edit operations without prompting |
-| `DONT_ASK` | `dont_ask` | ⚠️ Moderate | Auto-denies all permission prompts |
-| `BYPASS` | `bypass_permissions` | 🔴 Dangerous | Skips all permission checks entirely |
-| `PLAN` | `plan` | ✅ Safe | Read-only exploration mode - no modifications allowed |
+| `DEFAULT` | `default` | Safe | Standard checking — prompt for each operation |
+| `PLAN` | `plan` | Safe | Read-only — no write or shell operations |
+| `ACCEPT_EDITS` | `accept_edits` | Moderate | Auto-accept file edits; still prompts for other ops |
+| `DONT_ASK` | `dont_ask` | Moderate | Auto-deny all permission prompts |
+| `BYPASS` | `bypass_permissions` | Dangerous | Skip all checks — requires explicit opt-in |
 
----
+```mermaid
+graph TB
+    Start[Choose a mode] --> Explore{Exploration only?}
+    Explore -->|Yes| Plan[plan]
+    Explore -->|No| Refactor{Auto-accept edits?}
+    Refactor -->|Yes| Accept[accept_edits]
+    Refactor -->|No| Interactive{Interactive session?}
+    Interactive -->|Yes| Default[default]
+    Interactive -->|No| Dont[dont_ask]
 
-## Mode Details
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef safe fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef moderate fill:#189AB4,stroke:#7C90A0,color:#fff
 
-<AccordionGroup>
-
-<Accordion title="DEFAULT - Standard Permission Checking">
-
-The default mode prompts for permission on each operation that requires approval.
-
-```python
-from praisonaiagents.permissions import PermissionMode
-
-mode = PermissionMode.DEFAULT
-print(mode.value)  # "default"
+    class Explore,Refactor,Interactive decision
+    class Plan,Default safe
+    class Accept,Dont moderate
 ```
-
-**Behavior:**
-- Prompts user for each permission request
-- Follows configured permission rules
-- Safest mode for production use
-</Accordion>
-
-<Accordion title="ACCEPT_EDITS - Auto-Accept File Edits">
-
-Automatically accepts file edit operations without user confirmation.
-
-```python
-from praisonaiagents.permissions import PermissionMode
-
-mode = PermissionMode.ACCEPT_EDITS
-print(mode.value)  # "accept_edits"
-```
-
-**Behavior:**
-- Auto-approves file write operations
-- Still prompts for other operations
-- Useful for automated refactoring tasks
 
 <Warning>
-Use with caution - agents can modify files without confirmation.
+`BYPASS` skips all permission checks. For Claude Code backend, set both `ClaudeCodeBackend(unsafe=True)` and `PRAISONAI_CLAUDE_BYPASS_PERMISSIONS=1`.
 </Warning>
 
-</Accordion>
-
-<Accordion title="DONT_ASK - Auto-Deny Prompts">
-
-Automatically denies all permission prompts without user interaction.
-
-```python
-from praisonaiagents.permissions import PermissionMode
-
-mode = PermissionMode.DONT_ASK
-print(mode.value)  # "dont_ask"
-```
-
-**Behavior:**
-- Auto-denies all permission requests
-- Agent continues with read-only operations
-- Useful for safe exploration tasks
-</Accordion>
-
-<Accordion title="BYPASS - Skip All Checks">
-
-Bypasses all permission checks entirely. **Requires explicit opt-in (PR #2122)** — the Claude Code CLI backend no longer launches in `bypassPermissions` mode by default.
-
-```python
-from praisonaiagents.permissions import PermissionMode
-
-mode = PermissionMode.BYPASS
-print(mode.value)  # "bypass_permissions"
-```
-
-To opt into bypass for Claude Code backend:
-
-1. Construct with `ClaudeCodeBackend(unsafe=True)`
-2. Set `PRAISONAI_CLAUDE_BYPASS_PERMISSIONS=1`
-
-With only one set, the backend logs *"Overriding unsafe bypassPermissions to default mode"* and runs safely.
-
-<Danger>
-**Security Risk**: Only use in fully trusted environments with both opt-in steps above.
-</Danger>
-
-</Accordion>
-
-<Accordion title="PLAN - Read-Only Exploration">
-
-Restricts agent to read-only operations for safe exploration.
-
-```python
-from praisonaiagents.permissions import PermissionMode
-
-mode = PermissionMode.PLAN
-print(mode.value)  # "plan"
-```
-
-**Behavior:**
-- Only read operations allowed
-- Write/modify operations blocked
-- Perfect for codebase exploration
-
-<Tip>
-Recommended for subagents that only need to analyze code without making changes.
-</Tip>
-
-</Accordion>
-
-</AccordionGroup>
-
 ---
 
-## Usage with Subagents
+## Configuration Options
 
-### Default Mode for All Subagents
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `default_permission_mode` | `str` | `None` | Default mode for all subagents from `create_subagent_tool` |
+| `permission_mode` | `str` | `None` | Per-call override on `spawn_subagent` |
+| `--approval` | CLI flag | TTY-dependent | Maps to modes: `console`, `plan`, `accept-edits`, `bypass` |
 
-```python
-from praisonaiagents.tools.subagent_tool import create_subagent_tool
-
-# All subagents use plan mode by default
-tool = create_subagent_tool(
-    default_permission_mode="plan"
-)
-```
-
-### Per-Call Override
-
-```python
-func = tool["function"]
-
-# This call uses plan mode (read-only)
-result1 = func(
-    task="Explore the auth module",
-    permission_mode="plan"
-)
-
-# This call uses accept_edits mode
-result2 = func(
-    task="Refactor the utils module",
-    permission_mode="accept_edits"
-)
-```
-
-### Combined with Model Selection
-
-```python
-tool = create_subagent_tool(
-    default_llm="gpt-4o-mini",
-    default_permission_mode="plan"
-)
-
-func = tool["function"]
-result = func(
-    task="Analyze code patterns",
-    llm="gpt-4o",  # Override model
-    permission_mode="default"  # Override permission mode
-)
-```
-
----
-
-## From the CLI
-
-Map each mode to a `--approval` flag when running agents from the terminal:
+CLI mapping:
 
 | `PermissionMode` | Enum value | CLI flag |
 |------------------|------------|----------|
@@ -270,40 +135,23 @@ Map each mode to a `--approval` flag when running agents from the terminal:
 | `BYPASS` | `bypass_permissions` | `--approval bypass` |
 | `DONT_ASK` | `dont_ask` | Non-interactive only (`--yes` / `PRAISONAI_NON_INTERACTIVE=1`) |
 
-<Note>
-The CLI flag is `bypass` but `PermissionMode.BYPASS.value` is `bypass_permissions`.
-</Note>
-
-```bash
-praisonai --approval plan run "Explore the repo"
-praisonai --approval accept-edits run "Fix lint errors"
-```
-
 ---
 
 ## Best Practices
 
 <AccordionGroup>
-
-<Accordion title="Use PLAN mode for exploration">
-When subagents only need to read and analyze code, use `plan` mode to prevent accidental modifications.
+<Accordion title="Use plan for exploration subagents">
+Set `default_permission_mode="plan"` when subagents only read and analyse code — prevents accidental file changes.
 </Accordion>
-
-<Accordion title="Avoid BYPASS in production">
-The `bypass_permissions` mode should only be used in controlled development environments, never in production.
+<Accordion title="Match mode to task scope">
+Exploration → `plan`. Refactoring → `accept_edits`. Interactive work → `default`.
 </Accordion>
-
-<Accordion title="Match mode to task">
-Choose the permission mode that matches the task requirements:
-- **Exploration tasks** → `plan`
-- **Refactoring tasks** → `accept_edits`
-- **Interactive tasks** → `default`
+<Accordion title="Never use bypass in production">
+Reserve `bypass_permissions` for fully trusted local development environments only.
 </Accordion>
-
-<Accordion title="Log permission decisions">
-When using non-default modes, log the permission mode being used for audit purposes.
+<Accordion title="Log the active mode">
+Record which permission mode is active for audit trails when running non-default modes.
 </Accordion>
-
 </AccordionGroup>
 
 ---
@@ -311,16 +159,10 @@ When using non-default modes, log the permission mode being used for audit purpo
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="Permissions CLI" icon="terminal" href="/docs/cli/permissions">
-    `praisonai permissions` command
-  </Card>
-  <Card title="Interactive Tool Approval" icon="shield-check" href="/docs/features/interactive-approval">
-    Terminal approval experience
-  </Card>
-  <Card title="Permissions Module" icon="shield-halved" href="/docs/features/permissions">
-    Pattern-based permission rules
-  </Card>
-  <Card title="Subagent Delegation" icon="users" href="/docs/features/subagent-delegation">
-    Spawn and manage subagents
-  </Card>
+<Card title="Permissions Module" icon="shield-halved" href="/docs/features/permissions">
+  Pattern-based allow, deny, and ask rules
+</Card>
+<Card title="Interactive Approval" icon="shield-check" href="/docs/features/interactive-approval">
+  Terminal approval experience for tool calls
+</Card>
 </CardGroup>

--- a/docs/features/permissions.mdx
+++ b/docs/features/permissions.mdx
@@ -1,59 +1,107 @@
 ---
 title: "Permissions Module"
+sidebarTitle: "Permissions"
 description: "Pattern-based permission rules, persistent approvals, and doom loop detection"
 icon: "shield-halved"
 ---
 
-# Permissions Module
+Pattern-based rules let you allow, deny, or ask about tool calls — with persistent approvals and doom loop detection.
 
 <Info>
-Looking for the CLI? See [`praisonai permissions`](/docs/cli/permissions) and the [Interactive Tool Approval](/docs/features/interactive-approval) guide.
+For the CLI, see [`praisonai permissions`](/docs/cli/permissions) and [Interactive Tool Approval](/docs/features/interactive-approval).
 </Info>
 
-The Permissions module provides pattern-based permission rules, persistent approval storage, and doom loop detection for safe agent execution.
+```python
+from praisonaiagents import Agent
 
-<Note>
-**Default behaviour (PR #2369):** Without any `approval=` argument, the runtime attaches the `ConsoleBackend` interactively (TTY) or the `default` deny preset non-interactively. See [Approval](/docs/features/approval) for the full default model.
-</Note>
+agent = Agent(
+    name="Safe Coder",
+    instructions="Run shell commands safely",
+    approval={
+        "permissions": {
+            "read:*": "allow",
+            "bash:rm *": "deny",
+            "*": "ask",
+        },
+    },
+)
+agent.start("List files in the project root")
+```
 
-## Features
+```mermaid
+graph LR
+    Agent[🤖 Agent] --> Check{Permission Check}
+    Check -->|allow| Run[✅ Execute]
+    Check -->|deny| Block[❌ Block]
+    Check -->|ask| Prompt[❓ User prompt]
 
-- **Pattern-Based Rules** - Allow, deny, or ask based on glob/regex patterns
-- **Persistent Approvals** - Remember user decisions across sessions
-- **Doom Loop Detection** - Prevent agents from getting stuck in loops
-- **Per-Agent Rules** - Different rules for different agents
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef block fill:#EF4444,stroke:#7C90A0,color:#fff
+
+    class Agent agent
+    class Check check
+    class Run ok
+    class Block block
+    class Prompt check
+```
 
 ## Quick Start
+
+<Steps>
+<Step title="Simple Usage">
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="CI Worker",
+    instructions="Run safely without prompts",
+    approval={
+        "permissions": {
+            "read:*": "allow",
+            "bash:rm *": "deny",
+        },
+    },
+)
+agent.start("Check the deployment status")
+```
+
+</Step>
+
+<Step title="With Configuration">
+
+Use `PermissionManager` directly for programmatic rule management:
 
 ```python
 from praisonaiagents.permissions import (
     PermissionManager,
     PermissionRule,
     PermissionAction,
-    PersistentApproval,
-    DoomLoopDetector,
 )
 
-# Create permission manager
 manager = PermissionManager()
-
-# Add rules
 manager.add_rule(PermissionRule(
     pattern="bash:rm *",
     action=PermissionAction.DENY,
-    description="Block rm commands"
+    description="Block destructive commands",
 ))
-
 manager.add_rule(PermissionRule(
     pattern="read:*",
     action=PermissionAction.ALLOW,
-    description="Allow all read operations"
 ))
 
-# Check permission
 result = manager.check("bash:rm -rf /tmp")
-print(f"Action: {result.action}")  # deny
+print(result.is_denied)  # True
 ```
+
+For YAML and CLI surfaces, see [Declarative Permissions](/docs/features/declarative-permissions).
+
+</Step>
+</Steps>
+
+---
 
 ## Permission Actions
 
@@ -63,253 +111,93 @@ print(f"Action: {result.action}")  # deny
 | `DENY` | Automatically deny the operation |
 | `ASK` | Require user approval |
 
+---
+
 ## Permission Modes
 
-Permission modes control how agents handle permission requests globally.
-
-```mermaid
-graph TB
-    subgraph "Permission Modes"
-        A[🔒 DEFAULT] --> B[Standard checking]
-        C[✏️ ACCEPT_EDITS] --> D[Auto-accept file edits]
-        E[🚫 DONT_ASK] --> F[Auto-deny prompts]
-        G[⚡ BYPASS] --> H[Skip all checks]
-        I[📋 PLAN] --> J[Read-only exploration]
-    end
-    
-    classDef mode fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef action fill:#189AB4,stroke:#7C90A0,color:#fff
-    
-    class A,C,E,G,I mode
-    class B,D,F,H,J action
-```
+Global modes for subagent delegation — see [Permission Modes](/docs/features/permission-modes) for full details.
 
 | Mode | Value | Description |
 |------|-------|-------------|
-| `DEFAULT` | `default` | Standard permission checking - ask for each operation |
-| `ACCEPT_EDITS` | `accept_edits` | Auto-accept file edit operations |
-| `DONT_ASK` | `dont_ask` | Auto-deny all permission prompts |
-| `BYPASS` | `bypass_permissions` | Skip all permission checks (use with caution) |
-| `PLAN` | `plan` | Read-only exploration mode |
+| `DEFAULT` | `default` | Standard permission checking |
+| `PLAN` | `plan` | Read-only exploration |
+| `ACCEPT_EDITS` | `accept_edits` | Auto-accept file edits |
+| `DONT_ASK` | `dont_ask` | Auto-deny all prompts |
+| `BYPASS` | `bypass_permissions` | Skip all checks |
 
-### Using Permission Modes
+---
 
-```python
-from praisonaiagents.permissions import PermissionMode
-
-# Check the mode value
-print(PermissionMode.DEFAULT.value)        # "default"
-print(PermissionMode.ACCEPT_EDITS.value)   # "accept_edits"
-print(PermissionMode.PLAN.value)           # "plan"
-
-# Use with subagents
-from praisonaiagents.tools.subagent_tool import create_subagent_tool
-
-tool = create_subagent_tool(
-    default_permission_mode="plan"  # Read-only mode for subagents
-)
-```
-
-<Warning>
-**Security Notice**: The `BYPASS` mode skips all permission checks. Only use this in trusted environments where you have full control over agent behavior.
-</Warning>
-
-## Loading Rules from Configuration
-
-For YAML, CLI, and Python configuration surfaces, see [Declarative Permissions](/docs/features/declarative-permissions).
-
-```python
-from praisonaiagents.permissions.rules import PermissionRule
-from praisonaiagents.permissions.manager import PermissionManager
-
-rule = PermissionRule.from_config("bash:rm *", "deny", description="Block destructive")
-manager = PermissionManager()
-manager.load_rules_from_config(
-    {"read:*": "allow", "bash:rm *": "deny"},
-    priority_base=75,
-    persist=False,
-)
-```
-
-## API Reference
-
-### PermissionManager
-
-```python
-class PermissionManager:
-    def add_rule(self, rule: PermissionRule) -> str:
-        """Add a permission rule. Returns rule ID."""
-    
-    def remove_rule(self, rule_id: str) -> bool:
-        """Remove a rule by ID."""
-    
-    def check(
-        self,
-        target: str,
-        agent_name: Optional[str] = None
-    ) -> PermissionResult:
-        """
-        Check permission for a target.
-
-        For bash: / shell: targets, decomposes the command into constituent
-        operations (&&, ||, ;, |, subshells, $(...), backticks, truncating
-        redirects) and evaluates each independently, then aggregates as
-        deny → ask → allow. The original compound target is also matched so
-        legacy flat rules continue to fire. Falls back to the flat matcher
-        for simple commands and on parse failure.
-        """
-    
-    def approve(
-        self,
-        target: str,
-        approved: bool,
-        scope: str = "once"  # once, session, always
-    ) -> PersistentApproval:
-        """Record an approval decision."""
-
-    def save_rules(self) -> None:
-        """Persist current rules to disk (public API)."""
-    
-    def check_doom_loop(
-        self,
-        tool_name: str,
-        arguments: Dict[str, Any]
-    ) -> DoomLoopResult:
-        """Check for doom loop patterns."""
-```
+## Configuration Options
 
 ### PermissionRule
 
-```python
-@dataclass
-class PermissionRule:
-    pattern: str                    # Glob or regex pattern
-    action: PermissionAction        # allow, deny, ask
-    description: str = ""           # Human-readable description
-    is_regex: bool = False          # Use regex instead of glob
-    priority: int = 0               # Higher = checked first
-    agent_name: Optional[str] = None  # Apply to specific agent
-```
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `pattern` | `str` | — | Glob or regex pattern to match |
+| `action` | `PermissionAction` | `ASK` | `allow`, `deny`, or `ask` |
+| `description` | `str` | `""` | Human-readable description |
+| `is_regex` | `bool` | `False` | Use regex instead of glob |
+| `priority` | `int` | `0` | Higher priority rules checked first |
+| `agent_name` | `str` | `None` | Apply to a specific agent only |
+| `enabled` | `bool` | `True` | Whether the rule is active |
+
+### PermissionManager
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `storage_dir` | `str` | `~/.praisonai/permissions` | Directory for persistent approvals |
+| `agent_name` | `str` | `None` | Filter rules to one agent |
+| `approval_callback` | `Callable` | `None` | Custom callback for user approval |
 
 ### PersistentApproval
 
-```python
-@dataclass
-class PersistentApproval:
-    target: str
-    approved: bool
-    scope: str = "once"  # once, session, always
-    created_at: float = ...
-    expires_at: Optional[float] = None
-```
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `pattern` | `str` | — | Pattern this approval covers |
+| `approved` | `bool` | — | Whether the action was approved |
+| `scope` | `str` | `"once"` | `once`, `session`, or `always` |
 
-Exported from `praisonaiagents.permissions` for session-scoped approval records.
+---
 
-### DoomLoopDetector
+## How It Works
 
-```python
-class DoomLoopDetector:
-    def record(self, tool_name: str, arguments: Dict) -> None:
-        """Record a tool call."""
-    
-    def check(self, tool_name: str, arguments: Dict) -> DoomLoopResult:
-        """Check if calling this tool indicates a loop."""
-    
-    def reset(self) -> None:
-        """Reset all records."""
-```
-
-## Examples
-
-### Command-Aware Deny
+Compound shell commands (`&&`, `||`, `|`, subshells) are decomposed and evaluated independently — deny beats ask beats allow. See [Command-Aware Permissions](/docs/features/command-aware-permissions).
 
 ```python
 manager = PermissionManager()
+manager.add_rule(PermissionRule(pattern="bash:rm *", action=PermissionAction.DENY))
 
-manager.add_rule(PermissionRule(
-    pattern="bash:rm *",
-    action=PermissionAction.DENY,
-    description="Block rm commands everywhere"
-))
-
-result = manager.check("bash:cd /tmp && rm -rf x")
-print(result.is_denied)  # True — rm detected in compound command
-
-result = manager.check("bash:ls | rm -rf x")
-print(result.is_denied)  # True — rm detected in pipe
-
-result = manager.check("bash:echo $(rm -rf x)")
-print(result.is_denied)  # True — rm detected in substitution
+manager.check("bash:cd /tmp && rm -rf x").is_denied  # True — rm in compound command
 ```
 
-### Regex Patterns
+---
 
-```python
-manager = PermissionManager()
+## Best Practices
 
-# Use regex for complex patterns
-manager.add_rule(PermissionRule(
-    pattern=r"bash:(sudo|su)\s+.*",
-    action=PermissionAction.DENY,
-    is_regex=True,
-    description="Block privilege escalation"
-))
-```
+<AccordionGroup>
+<Accordion title="Deny destructive commands first">
+Add high-priority deny rules for `bash:rm *`, `bash:sudo *`, and similar patterns before broader allow rules.
+</Accordion>
+<Accordion title="Use session scope for repeated tools">
+Approve with `scope="session"` so `npm install` or `git status` do not re-prompt every call in one run.
+</Accordion>
+<Accordion title="Set per-agent rules for teams">
+Use `agent_name` on rules when a coder agent may write but a reviewer agent must stay read-only.
+</Accordion>
+<Accordion title="Watch for doom loops">
+`DoomLoopDetector` flags repeated identical tool calls — reset or change strategy when `is_loop` is true.
+</Accordion>
+</AccordionGroup>
 
-### Persistent Approvals
+---
 
-```python
-manager = PermissionManager(storage_dir="./permissions")
+## Related
 
-# User approves once
-result = manager.check("bash:npm install")
-if result.needs_approval:
-    # User says yes, remember for session
-    manager.approve("bash:npm *", approved=True, scope="session")
-
-# Future npm commands auto-approved this session
-result = manager.check("bash:npm test")
-print(result.is_allowed)  # True
-```
-
-### Doom Loop Detection
-
-```python
-detector = DoomLoopDetector(loop_threshold=3)
-
-# Agent keeps calling same tool
-for i in range(5):
-    result = detector.record_and_check("bash", {"cmd": "ls"})
-    if result.is_loop:
-        print(f"Loop detected after {result.loop_count} calls!")
-        print(f"Recommendation: {result.recommendation}")
-        break
-```
-
-<Card title="Command-Aware Permissions" icon="shield-halved" href="/docs/features/command-aware-permissions">
-  How compound shell commands are decomposed and aggregated
+<CardGroup cols={2}>
+<Card title="Declarative Permissions" icon="file-code" href="/docs/features/declarative-permissions">
+  YAML, CLI, and Python permission policies
 </Card>
-
-### Agent-Specific Rules
-
-```python
-manager = PermissionManager()
-
-# Coder agent can write files
-manager.add_rule(PermissionRule(
-    pattern="write:*",
-    action=PermissionAction.ALLOW,
-    agent_name="coder"
-))
-
-# Reviewer agent can only read
-manager.add_rule(PermissionRule(
-    pattern="write:*",
-    action=PermissionAction.DENY,
-    agent_name="reviewer"
-))
-
-# Check with agent context
-result = manager.check("write:main.py", agent_name="reviewer")
-print(result.is_denied)  # True
-```
+<Card title="Command-Aware Permissions" icon="shield-halved" href="/docs/features/command-aware-permissions">
+  How compound shell commands are evaluated
+</Card>
+</CardGroup>

--- a/docs/features/persistence-backend-plugins.mdx
+++ b/docs/features/persistence-backend-plugins.mdx
@@ -5,34 +5,61 @@ description: "Add custom conversation, knowledge, and state stores via Python en
 icon: "puzzle-piece"
 ---
 
-Persistence backend plugins extend PraisonAI with custom storage solutions for conversations, knowledge, and state management through a centralized registry system.
+Register custom storage backends for conversations, knowledge, and state through a central registry.
+
+```python
+from praisonaiagents import Agent, db
+
+agent = Agent(
+    name="Assistant",
+    instructions="Persist conversations to MySQL",
+    db=db(database_url="mysql://user:pass@localhost:3306/praisonai"),
+    session_id="session-1",
+)
+agent.start("Hello — save this conversation")
+```
 
 ```mermaid
 graph LR
-    subgraph "Plugin System"
-        A[📦 Third-party Package] --> B[🔌 Entry Point]
-        B --> C[📝 StoreRegistry]
-        C --> D{Kind?}
-        D -->|conversation| E[💬 Conversation]
-        D -->|knowledge|    F[📚 Knowledge]
-        D -->|state|        G[🔄 State]
-    end
-    
-    classDef package fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef entrypoint fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef registry fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef stores fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A package
-    class B entrypoint
-    class C registry
-    class D,E,F,G stores
+    Agent[🤖 Agent] --> Registry[📝 StoreRegistry]
+    Registry --> Conv[💬 Conversation]
+    Registry --> Know[📚 Knowledge]
+    Registry --> State[🔄 State]
+    Plugin[📦 Entry Point] --> Registry
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef registry fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef store fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef plugin fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class Agent agent
+    class Registry registry
+    class Conv,Know,State store
+    class Plugin plugin
 ```
 
 ## Quick Start
 
 <Steps>
-<Step title="Register a Custom Backend">
+<Step title="Simple Usage">
+
+Use a built-in backend via the registry:
+
+```python
+from praisonai.persistence import create_conversation_store
+
+store = create_conversation_store(
+    "mysql",
+    url="mysql://user:pass@localhost:3306/praisonai",
+)
+```
+
+</Step>
+
+<Step title="With Configuration">
+
+Register a custom backend at runtime:
+
 ```python
 from praisonai.persistence.registry import CONVERSATION_STORES
 
@@ -41,22 +68,16 @@ def my_store_factory(url=None, **kwargs):
     return MyConversationStore(url=url, **kwargs)
 
 CONVERSATION_STORES.register("mybackend", my_store_factory, aliases=("mb",))
-
 store = CONVERSATION_STORES.create("mb", url="proto://host")
 ```
-</Step>
 
-<Step title="Create an Entry-Point Plugin">
+Package it as an entry point in `pyproject.toml`:
+
 ```toml
 [project.entry-points."praisonai.conversation_stores"]
 mybackend = "my_pkg.factory:create_store"
-
-[project.entry-points."praisonai.knowledge_stores"]
-mybackend = "my_pkg.factory:create_kstore"
-
-[project.entry-points."praisonai.state_stores"]
-mybackend = "my_pkg.factory:create_sstore"
 ```
+
 </Step>
 </Steps>
 
@@ -64,245 +85,70 @@ mybackend = "my_pkg.factory:create_sstore"
 
 ## How It Works
 
+Three global registries cover each storage kind:
+
+| Registry | Entry-point group | Purpose |
+|----------|-------------------|---------|
+| `CONVERSATION_STORES` | `praisonai.conversation_stores` | Chat history and sessions |
+| `KNOWLEDGE_STORES` | `praisonai.knowledge_stores` | Vector databases and RAG |
+| `STATE_STORES` | `praisonai.state_stores` | Application state and cache |
+
 ```mermaid
 sequenceDiagram
-    participant App as Application
+    participant App
     participant Registry as StoreRegistry
-    participant Factory as Backend Factory
-    participant Store as Store Instance
-    
+    participant Factory
+    participant Store
+
     App->>Registry: create("backend", **kwargs)
-    Registry->>Registry: resolve alias → canonical
-    Registry->>Factory: factory(**kwargs)
-    Factory->>Store: instantiate store
-    Store-->>Factory: store instance
-    Factory-->>Registry: store instance
-    Registry-->>App: store instance
+    Registry->>Factory: resolve alias → factory
+    Factory->>Store: instantiate
+    Store-->>App: store instance
 ```
-
-The plugin system provides three global registries for different storage types:
-
-| Registry | Kind | Entry-point Group | Purpose |
-|----------|------|-------------------|---------|
-| `CONVERSATION_STORES` | `"conversation"` | `praisonai.conversation_stores` | Chat history and sessions |
-| `KNOWLEDGE_STORES` | `"knowledge"` | `praisonai.knowledge_stores` | Vector databases and RAG |
-| `STATE_STORES` | `"state"` | `praisonai.state_stores` | Application state and cache |
 
 ---
 
-## Registry API Reference
+## Configuration Options
 
-Each `StoreRegistry` provides a thread-safe API for backend management:
+### StoreRegistry API
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `register` | `register(name: str, factory: Callable, *, aliases=()) -> None` | Register a backend factory with optional aliases |
-| `create` | `create(name: str, **kwargs) -> Any` | Create a store instance by name or alias |
-| `list_registered` | `() -> list[str]` | Get all registered backend names (sorted) |
-| `list_aliases` | `() -> dict[str, str]` | Get alias → canonical name mappings |
-| `default` | `@classmethod default(cls) -> "PluginRegistry[T]"` | **New in PR #1829**: Process-default registry instance (thread-safe, per-subclass) |
+| `register` | `register(name, factory, *, aliases=())` | Register a backend factory with optional aliases |
+| `create` | `create(name, **kwargs)` | Create a store instance by name or alias |
+| `list_registered` | `() -> list[str]` | All registered backend names |
+| `list_aliases` | `() -> dict[str, str]` | Alias → canonical name mappings |
 
----
+### Built-in conversation backends
 
-## Built-in Backends
+`postgres`, `async_postgres`, `mysql`, `async_mysql`, `sqlite`, `sync_sqlite`, `async_sqlite`, `json`, `singlestore`, `supabase`, `surrealdb`, `turso`
 
-### Conversation Stores
+Common aliases: `neon`, `cockroachdb`, `crdb` → `postgres`; `aiomysql` → `async_mysql`; `libsql` → `turso`.
 
-**Primary backends:** `postgres`, `async_postgres`, `mysql`, `async_mysql`, `MySQLConversationStore`, `sqlite`, `sync_sqlite`, `async_sqlite`, `json`, `singlestore`, `supabase`, `surrealdb`, `turso`
+### Built-in knowledge backends
 
-<Note>
-**New in PR #1829**: `MySQLConversationStore` is available from `praisonai.persistence.conversation.mysql_new` but not re-exported from the main package. It inherits the unified schema from `_SQLConversationStoreBase`.
-</Note>
+`chroma`, `qdrant`, `pinecone`, `weaviate`, `lancedb`, `milvus`, `pgvector`, `redis`, `cassandra`, `clickhouse`, and others.
 
-**Aliases available:**
-- `neon`, `cockroachdb`, `crdb`, `cockroach`, `xata` → `postgres`
-- `asyncpg`, `postgres_async` → `async_postgres` 
-- `aiomysql`, `mysql_async` → `async_mysql`
-- `sqlite_sync` → `sync_sqlite`
-- `aiosqlite`, `sqlite_async` → `async_sqlite`
-- `libsql` → `turso`
+### Built-in state backends
 
-### Knowledge Stores
-
-**Primary backends:** `chroma`, `qdrant`, `pinecone`, `weaviate`, `lancedb`, `milvus`, `pgvector`, `redis`, `cassandra`, `clickhouse`, `mongodb_vector`, `couchbase`, `singlestore_vector`, `surrealdb_vector`, `upstash_vector`, `lightrag`, `langchain`, `llamaindex`, `cosmosdb`
-
-**Aliases available:**
-- `chromadb` → `chroma`
-- `mongodb_atlas`, `mongo_vector` → `mongodb_vector`
-- `singlestore_v` → `singlestore_vector`
-- `surrealdb_v` → `surrealdb_vector`
-- `upstash_v` → `upstash_vector`
-- `langchain_adapter` → `langchain`
-- `llama_index`, `llamaindex_adapter` → `llamaindex`
-- `cosmos`, `azure_cosmos`, `cosmosdb_vector` → `cosmosdb`
-
-### State Stores
-
-**Primary backends:** `redis`, `dynamodb`, `firestore`, `mongodb`, `async_mongodb`, `upstash`, `memory`, `gcs`
-
-**Aliases available:**
-- `motor`, `mongodb_async` → `async_mongodb`
-
----
-
-## Extending SQL Backends
-
-For building new SQL conversation stores, inherit from `_SQLConversationStoreBase` to get unified schema and retry logic:
-
-```python
-from praisonai.persistence.conversation._sql_base import _SQLConversationStoreBase
-
-class MyDBConversationStore(_SQLConversationStoreBase):
-    # Constants for this dialect
-    SCHEMA_VERSION = "1.0.0"  # Inherited from base
-    _id_type = "UUID"
-    _json_type = "JSONB"
-    _float_type = "DOUBLE PRECISION"
-    _serverless_hosts = (".mydb.cloud",)
-    
-    # Required dialect hooks
-    def _param(self, n: int) -> str:
-        return f"${n}"  # PostgreSQL-style parameters
-    
-    async def _connect(self, **kwargs):
-        # Return connection for this dialect
-        pass
-    
-    def _get_conn(self):
-        # Get connection from pool
-        pass
-    
-    def _put_conn(self, conn):
-        # Return connection to pool  
-        pass
-    
-    async def _execute(self, conn, query: str, *args):
-        # Execute query with this dialect
-        pass
-    
-    # ... implement other dialect hooks
-```
-
-The base class provides:
-- Unified table schema with `SCHEMA_VERSION = "1.0.0"`
-- Retry logic with configurable `max_retries` and `retry_delay`  
-- Serverless detection and exponential backoff
-- Standard CRUD operations for sessions and messages
-
----
-
-## Process-Default Registry
-
-Use `PluginRegistry.default()` for thread-safe per-subclass singleton registries:
-
-```python
-from praisonai._registry import PluginRegistry
-
-class MyRegistry(PluginRegistry["MyThing"]):
-    pass
-
-# Thread-safe, per-subclass lazy initialization
-reg = MyRegistry.default()
-
-# Alternative registries are independent
-class OtherRegistry(PluginRegistry["OtherThing"]):
-    pass
-
-other_reg = OtherRegistry.default()  # Different instance
-```
-
-This replaces the manual singleton pattern used in previous versions. Both `LLMProviderRegistry.default()` and `FrameworkAdapterRegistry.default()` now use this unified approach.
-
-The legacy module-level functions (`get_default_registry()`, `get_default_llm_registry()`) remain for backward compatibility and delegate to the respective `cls.default()` methods.
-
----
-
-## Common Patterns
-
-<AccordionGroup>
-<Accordion title="Custom Database Adapter">
-```python
-from praisonai.persistence.registry import CONVERSATION_STORES
-
-class CustomDBConversationStore:
-    def __init__(self, url=None, **kwargs):
-        self.url = url
-        # Initialize your database connection
-        
-    def save_session(self, session):
-        # Save implementation
-        pass
-        
-    def load_session(self, session_id):
-        # Load implementation  
-        pass
-
-def create_custom_db(url=None, **kwargs):
-    return CustomDBConversationStore(url=url, **kwargs)
-
-# Register at runtime
-CONVERSATION_STORES.register("customdb", create_custom_db)
-
-# Use it
-store = CONVERSATION_STORES.create("customdb", url="custom://localhost:5432/db")
-```
-</Accordion>
-
-<Accordion title="Multi-Backend Package">
-```python
-# my_storage_package/__init__.py
-def register_all_backends():
-    from praisonai.persistence.registry import (
-        CONVERSATION_STORES, KNOWLEDGE_STORES, STATE_STORES
-    )
-    
-    CONVERSATION_STORES.register("myconv", create_conversation_store)
-    KNOWLEDGE_STORES.register("myknow", create_knowledge_store) 
-    STATE_STORES.register("mystate", create_state_store)
-
-# Auto-register on import
-register_all_backends()
-```
-</Accordion>
-
-<Accordion title="Listing Available Backends">
-```python
-from praisonai.persistence.registry import (
-    CONVERSATION_STORES, KNOWLEDGE_STORES, STATE_STORES,
-)
-
-print("Conversation backends:", CONVERSATION_STORES.list_registered())
-print("Knowledge backends:", KNOWLEDGE_STORES.list_registered())
-print("State backends:", STATE_STORES.list_registered())
-
-# Check aliases
-print("Aliases:", CONVERSATION_STORES.list_aliases())
-```
-</Accordion>
-</AccordionGroup>
+`redis`, `dynamodb`, `firestore`, `mongodb`, `async_mongodb`, `upstash`, `memory`, `gcs`
 
 ---
 
 ## Best Practices
 
 <AccordionGroup>
-<Accordion title="Thread Safety">
-All registries are thread-safe with `threading.Lock` protection. Registrations and creations can be called concurrently without external synchronization. Factory functions should also be thread-safe if used in multi-threaded environments.
+<Accordion title="Use lazy imports in factories">
+Follow built-in backends — import heavy dependencies inside the factory function, not at module level.
 </Accordion>
-
-<Accordion title="Error Handling">
-Registry creation raises `ValueError` for unknown backends with a list of available options. Factory functions should handle their own connection errors and invalid parameters appropriately.
+<Accordion title="Provide meaningful aliases">
+Register short aliases (`mb`, `pg`) alongside canonical names for easier CLI and config usage.
 </Accordion>
-
-<Accordion title="Lazy Loading">
-Built-in backends use lazy imports to avoid loading unused dependencies. Follow this pattern in custom backends to minimize startup time and reduce import-time failures.
+<Accordion title="Handle unknown backends clearly">
+Factory functions should raise clear errors with connection hints — the registry lists available backends on `ValueError`.
 </Accordion>
-
-<Accordion title="Naming Conventions">
-- Use lowercase names without special characters
-- Provide meaningful aliases for user convenience  
-- Follow existing patterns: `async_*` for async variants, `*_vector` for vector stores
-- Avoid conflicts with built-in backend names
+<Accordion title="Keep factories thread-safe">
+Registries use `threading.Lock` — factory functions should also be safe for concurrent creation.
 </Accordion>
 </AccordionGroup>
 
@@ -311,10 +157,10 @@ Built-in backends use lazy imports to avoid loading unused dependencies. Follow 
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Database Persistence" icon="database" href="/docs/features/persistence">
+  Overview of all persistence backends
+</Card>
 <Card title="Framework Adapter Plugins" icon="plug" href="/docs/features/framework-adapter-plugins">
   Plugin system for multi-agent frameworks
-</Card>
-<Card title="Persistence Overview" icon="database" href="/docs/persistence/overview">
-  Storage backends and configuration
 </Card>
 </CardGroup>

--- a/docs/features/persistence-clickhouse.mdx
+++ b/docs/features/persistence-clickhouse.mdx
@@ -1,87 +1,86 @@
 ---
 title: "ClickHouse Persistence"
 sidebarTitle: "ClickHouse"
-description: "High-performance analytics database for large-scale data processing and real-time analytics"
+description: "Columnar vector store for large-scale knowledge retrieval and analytics"
 icon: "chart-line"
 ---
 
-ClickHouse provides columnar analytics database storage, designed for high-performance analytics on large volumes of conversation data and real-time reporting.
+ClickHouse stores knowledge embeddings for fast vector search at scale — ideal for large document collections and analytics workloads.
+
+```python
+import os
+from praisonaiagents import Agent
+
+os.environ["PRAISONAI_KNOWLEDGE_STORE"] = "clickhouse"
+os.environ["CLICKHOUSE_HOST"] = "localhost"
+
+agent = Agent(
+    name="Analyst",
+    instructions="Answer from our knowledge base",
+    knowledge=["docs/"],
+)
+agent.start("Summarise our refund policy")
+```
 
 ```mermaid
 graph LR
-    subgraph "ClickHouse Analytics"
-        A[🧠 Agent] --> B[📊 Analytics Data]
-        B --> C[📈 ClickHouse]
-        C --> D[🏛️ Columnar Storage]
-        A --> E[⚡ Fast Analytics]
-        E --> C
-        C --> F[📋 Reports]
-    end
-    
+    Agent[🤖 Agent] --> Knowledge[📚 Knowledge]
+    Knowledge --> CH[📊 ClickHouse]
+    CH --> Vectors[🔢 Vector Search]
+
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef data fill:#189AB4,stroke:#7C90A0,color:#fff
     classDef storage fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A agent
-    class B,E data
-    class C,D,F storage
+
+    class Agent agent
+    class Knowledge data
+    class CH,Vectors storage
 ```
 
 ## Quick Start
 
 <Steps>
-<Step title="Basic Analytics Setup">
+<Step title="Simple Usage">
+
+```bash
+pip install clickhouse-connect praisonai
+export PRAISONAI_KNOWLEDGE_STORE=clickhouse
+export CLICKHOUSE_HOST=localhost
+export CLICKHOUSE_PORT=8123
+```
+
 ```python
-import clickhouse_connect
 from praisonaiagents import Agent
 
-# ClickHouse is typically used for analytics, not primary storage
-client = clickhouse_connect.get_client(
+agent = Agent(
+    name="Analyst",
+    instructions="Answer from docs",
+    knowledge=["docs/"],
+)
+agent.start("What are our key metrics?")
+```
+
+</Step>
+
+<Step title="With Configuration">
+
+Create the store directly for full control:
+
+```python
+from praisonai.persistence import create_knowledge_store
+
+store = create_knowledge_store(
+    "clickhouse",
     host="localhost",
     port=8123,
     username="default",
-    password=""
+    password="",
+    database="praisonai",
+    secure=False,
 )
-
-# Create agent with primary storage elsewhere
-agent = Agent(
-    name="AnalyticsBot",
-    instructions="You are a helpful assistant.",
-    # Use SQLite/PostgreSQL for conversations
-    db=db(database_url="sqlite:///conversations.db"),
-    session_id="analytics-session"
-)
-
-# Agent conversations stored in primary DB
-response = agent.chat("Generate analytics on our conversation patterns")
-print(response)
+store.create_collection("docs", dimension=1536)
 ```
-</Step>
 
-<Step title="Analytics Table Setup">
-```python
-import clickhouse_connect
-from datetime import datetime
-
-client = clickhouse_connect.get_client(host="localhost", port=8123)
-
-# Create analytics table for conversation metrics
-client.command("""
-    CREATE TABLE IF NOT EXISTS conversation_analytics (
-        session_id String,
-        agent_name String,
-        message_count UInt32,
-        total_tokens UInt32,
-        response_time Float64,
-        user_satisfaction UInt8,
-        timestamp DateTime,
-        metadata String
-    ) ENGINE = MergeTree()
-    ORDER BY (timestamp, session_id)
-""")
-
-print("Analytics table created successfully")
-```
 </Step>
 </Steps>
 
@@ -92,445 +91,45 @@ print("Analytics table created successfully")
 ```mermaid
 sequenceDiagram
     participant Agent
-    participant Primary as Primary DB (PostgreSQL)
-    participant Analytics as Analytics Pipeline
-    participant ClickHouse
-    participant Dashboard
-    
-    Agent->>Primary: Store conversation
-    Primary->>Analytics: ETL pipeline
-    Analytics->>ClickHouse: Aggregate metrics
-    Dashboard->>ClickHouse: Query analytics
-    ClickHouse-->>Dashboard: Fast results
-    
-    Note over Analytics,ClickHouse: Batch or streaming ETL
-    Note over ClickHouse,Dashboard: Real-time analytics
+    participant RAG as Knowledge / RAG
+    participant CH as ClickHouseKnowledgeStore
+
+    Agent->>RAG: Query with knowledge sources
+    RAG->>CH: Vector search (cosine distance)
+    CH-->>RAG: Top-k documents
+    RAG-->>Agent: Retrieved context
 ```
 
-ClickHouse optimizes for analytical queries on large datasets:
-
-| Table Type | Use Case | Performance |
-|------------|----------|-------------|
-| **conversation_metrics** | Message counts, response times | Aggregations in milliseconds |
-| **user_behavior** | Usage patterns, preferences | Complex analytics at scale |
-| **system_performance** | Agent performance, errors | Real-time monitoring |
-| **business_intelligence** | KPIs, trends, forecasting | Historical analysis |
+ClickHouse is a **knowledge store** (vector search), not a primary conversation backend. Pair it with SQLite or PostgreSQL for chat history via `db()`.
 
 ---
 
 ## Configuration Options
 
-### Connection Setup
-```python
-import clickhouse_connect
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `host` | `str` | `"localhost"` | ClickHouse server hostname |
+| `port` | `int` | `8123` | HTTP port |
+| `username` | `str` | `"default"` | Database username |
+| `password` | `str` | `""` | Database password |
+| `database` | `str` | `"praisonai"` | Database name (created if missing) |
+| `secure` | `bool` | `False` | Use HTTPS connection |
 
-# Basic connection
-client = clickhouse_connect.get_client(
-    host="localhost",
-    port=8123,
-    username="default",
-    password="password"
-)
-
-# Secure connection
-client = clickhouse_connect.get_client(
-    host="clickhouse.example.com",
-    port=8443,
-    username="analytics_user", 
-    password="secure_password",
-    secure=True,
-    verify=True
-)
-
-# Connection with settings
-client = clickhouse_connect.get_client(
-    host="localhost",
-    port=8123,
-    settings={
-        'max_execution_time': 60,
-        'max_memory_usage': 10000000000,
-        'use_numpy': True
-    }
-)
-```
-
-### Advanced Configuration
-```python
-import clickhouse_connect
-from praisonaiagents import Agent, db
-
-class ClickHouseAnalytics:
-    def __init__(self, host="localhost", port=8123, database="praisonai_analytics"):
-        self.client = clickhouse_connect.get_client(
-            host=host,
-            port=port, 
-            database=database,
-            settings={
-                'max_execution_time': 300,
-                'max_memory_usage': 20000000000,
-                'allow_experimental_object_type': 1
-            }
-        )
-        self.setup_tables()
-    
-    def setup_tables(self):
-        """Create analytics tables with optimal schemas"""
-        
-        # Conversation events table
-        self.client.command("""
-            CREATE TABLE IF NOT EXISTS conversation_events (
-                event_id String,
-                session_id String,
-                agent_name String,
-                event_type Enum('message', 'response', 'error', 'tool_call'),
-                content String,
-                tokens UInt32,
-                response_time_ms Float64,
-                timestamp DateTime64(3),
-                user_id String,
-                metadata String
-            ) ENGINE = ReplacingMergeTree()
-            ORDER BY (timestamp, session_id, event_id)
-            PARTITION BY toYYYYMM(timestamp)
-        """)
-        
-        # Aggregated metrics table
-        self.client.command("""
-            CREATE MATERIALIZED VIEW IF NOT EXISTS daily_metrics
-            ENGINE = SummingMergeTree()
-            ORDER BY (date, agent_name)
-            AS SELECT
-                toDate(timestamp) as date,
-                agent_name,
-                count() as total_events,
-                sum(tokens) as total_tokens,
-                avg(response_time_ms) as avg_response_time
-            FROM conversation_events
-            GROUP BY date, agent_name
-        """)
-
-# Initialize analytics
-analytics = ClickHouseAnalytics()
-```
+Environment variables: `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`.
 
 ---
 
 ## Docker Setup
 
-Quick ClickHouse setup with Docker:
-
 ```bash
-# Start ClickHouse container
 docker run -d \
-    --name praisonai-clickhouse \
-    --ulimit nofile=262144:262144 \
-    -p 8123:8123 \
-    -p 9000:9000 \
-    clickhouse/clickhouse-server:latest
+  --name praisonai-clickhouse \
+  --ulimit nofile=262144:262144 \
+  -p 8123:8123 \
+  -p 9000:9000 \
+  clickhouse/clickhouse-server:latest
 
-# Connect and verify
 curl "http://localhost:8123/?query=SELECT%20version()"
-```
-
-With persistence:
-```bash
-# ClickHouse with persistent storage
-docker run -d \
-    --name praisonai-clickhouse-persistent \
-    --ulimit nofile=262144:262144 \
-    -p 8123:8123 \
-    -p 9000:9000 \
-    -v $(pwd)/clickhouse_data:/var/lib/clickhouse \
-    -v $(pwd)/clickhouse_logs:/var/log/clickhouse-server \
-    clickhouse/clickhouse-server:latest
-```
-
-Then use in your analytics:
-```python
-import clickhouse_connect
-
-client = clickhouse_connect.get_client(
-    host="localhost", 
-    port=8123,
-    username="default"
-)
-```
-
----
-
-## Analytics Patterns
-
-### Real-Time Conversation Metrics
-```python
-import clickhouse_connect
-from datetime import datetime
-import json
-
-client = clickhouse_connect.get_client(host="localhost", port=8123)
-
-def log_conversation_event(session_id, agent_name, event_type, data):
-    """Log conversation events for analytics"""
-    
-    event = {
-        'event_id': f"{session_id}_{datetime.now().timestamp()}",
-        'session_id': session_id,
-        'agent_name': agent_name,
-        'event_type': event_type,
-        'content': data.get('content', ''),
-        'tokens': data.get('tokens', 0),
-        'response_time_ms': data.get('response_time_ms', 0.0),
-        'timestamp': datetime.now(),
-        'user_id': data.get('user_id', 'anonymous'),
-        'metadata': json.dumps(data.get('metadata', {}))
-    }
-    
-    client.insert('conversation_events', [event])
-
-# Example usage with agent
-from praisonaiagents import Agent, db
-
-agent = Agent(
-    name="MetricsBot",
-    instructions="You are a helpful assistant.",
-    db=db(database_url="sqlite:///conversations.db"),
-    session_id="metrics-session"
-)
-
-# Log conversation start
-log_conversation_event(
-    session_id="metrics-session",
-    agent_name="MetricsBot",
-    event_type="message",
-    data={
-        'content': "User message",
-        'tokens': 10,
-        'user_id': 'user123',
-        'metadata': {'source': 'web_app'}
-    }
-)
-
-response = agent.chat("What are our usage patterns?")
-
-# Log response
-log_conversation_event(
-    session_id="metrics-session",
-    agent_name="MetricsBot", 
-    event_type="response",
-    data={
-        'content': response,
-        'tokens': 50,
-        'response_time_ms': 1200.5,
-        'user_id': 'user123'
-    }
-)
-```
-
-### Advanced Analytics Queries
-```python
-import clickhouse_connect
-import pandas as pd
-
-client = clickhouse_connect.get_client(host="localhost", port=8123)
-
-def get_conversation_analytics(days=30):
-    """Get comprehensive conversation analytics"""
-    
-    # Daily conversation trends
-    daily_trends = client.query_df(f"""
-        SELECT 
-            toDate(timestamp) as date,
-            agent_name,
-            count() as conversations,
-            sum(tokens) as total_tokens,
-            avg(response_time_ms) as avg_response_time,
-            countDistinct(user_id) as unique_users
-        FROM conversation_events 
-        WHERE timestamp >= now() - INTERVAL {days} DAY
-        GROUP BY date, agent_name
-        ORDER BY date DESC
-    """)
-    
-    # Peak hours analysis
-    hourly_patterns = client.query_df(f"""
-        SELECT 
-            toHour(timestamp) as hour,
-            count() as message_count,
-            avg(response_time_ms) as avg_response_time
-        FROM conversation_events
-        WHERE timestamp >= now() - INTERVAL {days} DAY
-        GROUP BY hour
-        ORDER BY hour
-    """)
-    
-    # User behavior analysis
-    user_behavior = client.query_df(f"""
-        SELECT
-            user_id,
-            count() as total_interactions,
-            countDistinct(session_id) as unique_sessions,
-            sum(tokens) as total_tokens,
-            first_value(timestamp) OVER (PARTITION BY user_id ORDER BY timestamp) as first_seen,
-            max(timestamp) as last_seen
-        FROM conversation_events
-        WHERE timestamp >= now() - INTERVAL {days} DAY
-        GROUP BY user_id
-        HAVING total_interactions > 5
-        ORDER BY total_interactions DESC
-    """)
-    
-    return {
-        'daily_trends': daily_trends,
-        'hourly_patterns': hourly_patterns,
-        'user_behavior': user_behavior
-    }
-
-# Get analytics
-analytics = get_conversation_analytics()
-
-print("Top conversation days:")
-print(analytics['daily_trends'].head())
-
-print("\nPeak hours:")
-print(analytics['hourly_patterns'])
-
-print(f"\nActive users: {len(analytics['user_behavior'])}")
-```
-
-### Time-Series Analysis
-```python
-import clickhouse_connect
-from datetime import datetime, timedelta
-
-client = clickhouse_connect.get_client(host="localhost", port=8123)
-
-def create_time_series_tables():
-    """Create optimized time-series tables"""
-    
-    # Performance metrics table
-    client.command("""
-        CREATE TABLE IF NOT EXISTS performance_metrics (
-            timestamp DateTime64(3),
-            metric_name String,
-            metric_value Float64,
-            agent_name String,
-            session_id String,
-            labels Map(String, String)
-        ) ENGINE = MergeTree()
-        ORDER BY (timestamp, metric_name, agent_name)
-        PARTITION BY toYYYYMM(timestamp)
-        TTL timestamp + INTERVAL 90 DAY
-    """)
-    
-    # Continuous aggregation for real-time dashboards
-    client.command("""
-        CREATE MATERIALIZED VIEW IF NOT EXISTS performance_metrics_1min
-        ENGINE = AggregatingMergeTree()
-        ORDER BY (timestamp, metric_name, agent_name)
-        AS SELECT
-            toStartOfMinute(timestamp) as timestamp,
-            metric_name,
-            agent_name,
-            avgState(metric_value) as avg_value,
-            maxState(metric_value) as max_value,
-            minState(metric_value) as min_value,
-            countState() as count_value
-        FROM performance_metrics
-        GROUP BY timestamp, metric_name, agent_name
-    """)
-
-def record_performance_metric(agent_name, session_id, metric_name, value, labels=None):
-    """Record performance metrics"""
-    
-    metric = {
-        'timestamp': datetime.now(),
-        'metric_name': metric_name,
-        'metric_value': float(value),
-        'agent_name': agent_name,
-        'session_id': session_id,
-        'labels': labels or {}
-    }
-    
-    client.insert('performance_metrics', [metric])
-
-# Example usage
-create_time_series_tables()
-
-# Record metrics during agent operation
-record_performance_metric(
-    agent_name="PerformanceBot",
-    session_id="perf-session",
-    metric_name="response_time", 
-    value=1.25,
-    labels={'model': 'gpt-4', 'region': 'us-east-1'}
-)
-
-record_performance_metric(
-    agent_name="PerformanceBot",
-    session_id="perf-session",
-    metric_name="token_usage",
-    value=150,
-    labels={'type': 'completion'}
-)
-
-# Query real-time metrics
-recent_performance = client.query_df("""
-    SELECT 
-        timestamp,
-        metric_name,
-        agent_name,
-        avgMerge(avg_value) as avg_value,
-        maxMerge(max_value) as max_value
-    FROM performance_metrics_1min
-    WHERE timestamp >= now() - INTERVAL 1 HOUR
-    GROUP BY timestamp, metric_name, agent_name
-    ORDER BY timestamp DESC
-""")
-
-print("Recent performance metrics:")
-print(recent_performance.head())
-```
-
----
-
-## Production Deployment
-
-### Cluster Setup
-```python
-import clickhouse_connect
-
-# Connect to ClickHouse cluster
-cluster_client = clickhouse_connect.get_client(
-    host="clickhouse-lb.example.com",
-    port=8123,
-    username="analytics_user",
-    password="secure_password",
-    settings={
-        'distributed_product_mode': 'global',
-        'max_execution_time': 600
-    }
-)
-
-# Create distributed table
-cluster_client.command("""
-    CREATE TABLE IF NOT EXISTS conversation_events_distributed AS conversation_events
-    ENGINE = Distributed(analytics_cluster, default, conversation_events, rand())
-""")
-
-# Query across cluster
-cluster_analytics = cluster_client.query_df("""
-    SELECT 
-        agent_name,
-        count() as total_events,
-        uniq(user_id) as unique_users,
-        avg(response_time_ms) as avg_response_time
-    FROM conversation_events_distributed
-    WHERE timestamp >= today() - 30
-    GROUP BY agent_name
-    ORDER BY total_events DESC
-""")
-
-print("Cluster-wide analytics:")
-print(cluster_analytics)
 ```
 
 ---
@@ -538,32 +137,17 @@ print(cluster_analytics)
 ## Best Practices
 
 <AccordionGroup>
-<Accordion title="Schema Design">
-- Use appropriate data types (UInt32 for counts, Float64 for metrics)
-- Partition tables by time (toYYYYMM for monthly partitions)
-- Order by time first, then by commonly filtered dimensions
-- Use TTL for automatic data cleanup
+<Accordion title="Use ClickHouse for knowledge, not conversations">
+Store embeddings and retrieval in ClickHouse; keep conversation history in PostgreSQL, MySQL, or SQLite.
 </Accordion>
-
-<Accordion title="Query Optimization">
-- Leverage materialized views for pre-aggregated data
-- Use SAMPLE for approximate analytics on large datasets
-- Avoid SELECT * queries, specify only needed columns
-- Use appropriate compression (LZ4 for speed, ZSTD for space)
+<Accordion title="Batch inserts for throughput">
+Insert documents in batches of 1000+ rows for better write performance on large corpora.
 </Accordion>
-
-<Accordion title="Data Pipeline">
-- Batch inserts for better performance (1000+ rows per insert)
-- Use ReplacingMergeTree for deduplication
-- Implement proper error handling and retry logic
-- Monitor insert rates and query performance
+<Accordion title="Partition large tables by time">
+Use `PARTITION BY toYYYYMM(timestamp)` when logging retrieval events for analytics.
 </Accordion>
-
-<Accordion title="Monitoring and Maintenance">
-- Monitor system metrics (CPU, memory, disk I/O)
-- Set up alerts for failed queries and slow performance
-- Regular OPTIMIZE TABLE operations for better compression
-- Plan for data archival and backup strategies
+<Accordion title="Set secure=True in production">
+Enable TLS and authentication when connecting to remote ClickHouse clusters.
 </Accordion>
 </AccordionGroup>
 
@@ -572,10 +156,10 @@ print(cluster_analytics)
 ## Related
 
 <CardGroup cols={2}>
-<Card title="PostgreSQL Analytics" icon="elephant" href="/docs/features/persistence-postgres">
-  Use PostgreSQL for smaller-scale analytics and reporting
+<Card title="Database Persistence" icon="database" href="/docs/features/persistence">
+  Compare all persistence backends
 </Card>
-<Card title="Database Persistence Overview" icon="database" href="/docs/features/persistence">
-  Compare all available persistence backends
+<Card title="Persistence Backend Plugins" icon="puzzle-piece" href="/docs/features/persistence-backend-plugins">
+  Register custom storage backends
 </Card>
 </CardGroup>

--- a/docs/features/persistence-conversation-mysql.mdx
+++ b/docs/features/persistence-conversation-mysql.mdx
@@ -1,88 +1,84 @@
 ---
 title: "MySQL Conversation Store"
 sidebarTitle: "MySQL Conversation Store"
-description: "Direct MySQL conversation persistence with PlanetScale auto-retry support"
+description: "Direct MySQL conversation persistence with connection pooling"
 icon: "database"
 ---
 
-MySQL conversation store provides direct persistence for conversation sessions and messages with built-in serverless database optimization and retry logic.
+MySQL conversation store persists agent sessions and messages with automatic schema creation and connection pooling.
+
+```python
+from praisonaiagents import Agent, db
+
+agent = Agent(
+    name="MySQL Agent",
+    instructions="Store conversations in MySQL",
+    db=db(database_url="mysql://user:pass@localhost:3306/praisonai"),
+    session_id="mysql-session",
+)
+agent.start("Hello — save this conversation")
+```
 
 ```mermaid
 graph LR
-    subgraph "MySQL Conversation Store"
-        A[🤖 Agent] --> B[🗃️ MySQLConversationStore]
-        B --> C{🌐 PlanetScale?}
-        C -->|Yes| D[⚡ Auto-retry]
-        C -->|No| E[🔄 Standard]
-        D --> F[🐬 MySQL DB]
-        E --> F
-    end
-    
+    Agent[🤖 Agent] --> Store[🗃️ MySQL Store]
+    Store --> Pool[🔗 Connection Pool]
+    Pool --> DB[(🐬 MySQL)]
+
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef store fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef serverless fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef database fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A agent
-    class B store
-    class C,D serverless
-    class E,F database
+
+    class Agent agent
+    class Store,Pool store
+    class DB database
 ```
 
 ## Quick Start
 
 <Steps>
-<Step title="Install Dependencies">
-Install the required MySQL driver:
+<Step title="Simple Usage">
 
 ```bash
-pip install mysql-connector-python
+pip install mysql-connector-python praisonai
 ```
-</Step>
-
-<Step title="Basic Usage">
-Use MySQL conversation store with URL connection:
 
 ```python
-from praisonaiagents import Agent
-from praisonai.persistence.conversation.mysql_new import MySQLConversationStore
+from praisonaiagents import Agent, db
 
 agent = Agent(
     name="MySQL Agent",
-    instructions="Store conversations in MySQL",
-    conversation_store=MySQLConversationStore(
-        url="mysql://user:password@localhost:3306/praisonai"
-    )
+    db=db(database_url="mysql://user:pass@localhost:3306/praisonai"),
+    session_id="session-1",
 )
-
-result = agent.start("Hello, store this conversation!")
+agent.start("Hello!")
 ```
+
 </Step>
 
 <Step title="With Configuration">
-Configure MySQL with all available options:
+
+Use `MySQLConversationStore` directly when you need table prefixes or pool tuning:
 
 ```python
-from praisonai.persistence.conversation.mysql_new import MySQLConversationStore
+from praisonai.persistence.conversation.mysql import MySQLConversationStore
+from praisonai.persistence import create_conversation_store
 
 store = MySQLConversationStore(
     host="localhost",
     port=3306,
-    database="praisonai", 
+    database="praisonai",
     user="root",
     password="secret",
     table_prefix="praison_",
     auto_create_tables=True,
     pool_size=5,
-    max_retries=3,
-    retry_delay=0.5
 )
 
-agent = Agent(
-    name="Configured Agent",
-    conversation_store=store
-)
+# Or via the registry
+store = create_conversation_store("mysql", url="mysql://user:pass@localhost/praisonai")
 ```
+
 </Step>
 </Steps>
 
@@ -95,27 +91,18 @@ sequenceDiagram
     participant Agent
     participant Store as MySQLConversationStore
     participant MySQL
-    
-    Agent->>Store: create_session(session)
-    Store->>Store: Detect serverless (.psdb.cloud)
+
+    Agent->>Store: save session / message
     Store->>MySQL: CREATE TABLE IF NOT EXISTS
-    Store->>MySQL: INSERT INTO sessions
-    MySQL-->>Store: session_id
-    Store-->>Agent: ConversationSession
-    
-    Note over Store,MySQL: Auto-retry for serverless
-    Agent->>Store: add_message(message)
-    Store->>MySQL: INSERT INTO messages (retry if needed)
-    MySQL-->>Store: message_id
-    Store-->>Agent: ConversationMessage
+    Store->>MySQL: INSERT (pooled connection)
+    MySQL-->>Agent: persisted
 ```
 
 | Feature | Description |
 |---------|-------------|
-| **Auto-retry** | Exponential backoff for `.psdb.cloud` hosts |
-| **Schema Management** | Automatic table creation with `SCHEMA_VERSION = "1.0.0"` |
-| **Connection Pooling** | Configurable pool size for high concurrency |
-| **SQL Base** | Inherits unified schema from `_SQLConversationStoreBase` |
+| **Schema management** | Auto-creates sessions and messages tables (`SCHEMA_VERSION = "1.0.0"`) |
+| **Connection pooling** | Configurable `pool_size` for concurrent agents |
+| **URL parsing** | `mysql://user:pass@host:port/database` format supported |
 
 ---
 
@@ -123,7 +110,7 @@ sequenceDiagram
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `url` | `str` | `None` | Complete MySQL URL (overrides individual options) |
+| `url` | `str` | `None` | Full MySQL URL (overrides individual options) |
 | `host` | `str` | `"localhost"` | MySQL server hostname |
 | `port` | `int` | `3306` | MySQL server port |
 | `database` | `str` | `"praisonai"` | Database name |
@@ -132,141 +119,37 @@ sequenceDiagram
 | `table_prefix` | `str` | `"praison_"` | Prefix for table names |
 | `auto_create_tables` | `bool` | `True` | Create tables automatically |
 | `pool_size` | `int` | `5` | Connection pool size |
-| `max_retries` | `int` | `3` | Maximum retry attempts for failed operations |
-| `retry_delay` | `float` | `0.5` | Base delay between retries (seconds) |
 
-<Note>
-**Import Path**: Due to current implementation, you must import from the submodule:
-```python
-from praisonai.persistence.conversation.mysql_new import MySQLConversationStore
-```
-This will be improved in a future release to be available from the main package.
-</Note>
-
----
-
-## Common Patterns
-
-### PlanetScale Configuration
-
-For PlanetScale serverless MySQL, use optimized retry settings:
-
-```python
-store = MySQLConversationStore(
-    url="mysql://user:pass@gateway.psdb.cloud:3306/mydb",
-    max_retries=5,      # Higher retries for cold starts
-    retry_delay=1.0,    # Longer initial delay
-    pool_size=3         # Smaller pool for serverless
-)
-```
-
-### Connection URL Formats
-
-Support for various MySQL URL formats:
-
-```python
-# Standard MySQL
-url="mysql://user:pass@localhost:3306/dbname"
-
-# PlanetScale (auto-detected for retry behavior)
-url="mysql://user:pass@gateway.psdb.cloud:3306/dbname"
-
-# MySQL with SSL
-url="mysql://user:pass@host:3306/db?ssl_mode=REQUIRED"
-```
-
-### Async Context Manager
-
-Use with async context manager for resource management:
-
-```python
-from praisonai.persistence.conversation.mysql_new import MySQLConversationStore
-
-async def main():
-    async with MySQLConversationStore(
-        url="mysql://user:pass@localhost/db"
-    ) as store:
-        # Store will be automatically closed
-        session = await store.create_session(session_obj)
-```
+For async workloads, use `create_conversation_store("async_mysql", ...)` with `aiomysql`.
 
 ---
 
 ## Best Practices
 
 <AccordionGroup>
-<Accordion title="Tune Retries for Serverless">
-Serverless MySQL databases benefit from higher retry counts:
-
-```python
-# For PlanetScale, Neon, or other serverless
-store = MySQLConversationStore(
-    max_retries=5,
-    retry_delay=1.0,  # Exponential backoff: 1s, 2s, 4s, 8s, 16s
-)
-```
+<Accordion title="Use db() for most agents">
+`Agent(db=db(database_url="mysql://..."))` is the simplest path — no manual store wiring needed.
 </Accordion>
-
-<Accordion title="Use Connection Pooling">
-Configure appropriate pool size for your workload:
-
-```python
-# High concurrency workload
-store = MySQLConversationStore(pool_size=10)
-
-# Serverless or low traffic  
-store = MySQLConversationStore(pool_size=2)
-```
+<Accordion title="Set table_prefix for multi-tenancy">
+Isolate apps on one database with different prefixes: `table_prefix="prod_"` vs `table_prefix="staging_"`.
 </Accordion>
-
-<Accordion title="Table Prefix for Multi-tenancy">
-Use table prefixes to isolate different applications:
-
-```python
-# Production app
-prod_store = MySQLConversationStore(table_prefix="prod_")
-
-# Staging app  
-staging_store = MySQLConversationStore(table_prefix="staging_")
-```
+<Accordion title="Tune pool_size for concurrency">
+Increase `pool_size` for high-traffic deployments; use smaller pools for serverless MySQL hosts.
 </Accordion>
-
-<Accordion title="Monitor Schema Version">
-The store uses `SCHEMA_VERSION = "1.0.0"` for migration tracking:
-
-```python
-# Check current schema version
-store = MySQLConversationStore()
-print(store.SCHEMA_VERSION)  # "1.0.0"
-```
+<Accordion title="Use SSL in production">
+Append `?ssl_mode=REQUIRED` to the connection URL for encrypted connections.
 </Accordion>
 </AccordionGroup>
-
----
-
-## Error Handling
-
-The store automatically handles common MySQL errors:
-
-```python
-try:
-    store = MySQLConversationStore(url="mysql://invalid")
-    session = store.create_session(session_obj)
-except Exception as e:
-    print(f"Connection failed: {e}")
-```
-
-For PlanetScale hosts (`.psdb.cloud`), transient errors trigger exponential backoff retry automatically.
 
 ---
 
 ## Related
 
 <CardGroup cols={2}>
-<Card title="Async Conversation Store" icon="database" href="/docs/features/async-conversation-store">
-  Async conversation persistence protocol
+<Card title="MySQL Persistence" icon="database" href="/docs/features/persistence-mysql">
+  MySQL overview with SSL and production patterns
 </Card>
 <Card title="Persistence Backend Plugins" icon="puzzle-piece" href="/docs/features/persistence-backend-plugins">
-  Extending SQL backends with _SQLConversationStoreBase
+  Extend SQL backends via the registry
 </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Upgraded 5 feature pages to AGENTS.md §9: agent-centric intros, config tables, AccordionGroup, CardGroup
- Fixed invalid `mysql_new` import — use `praisonai.persistence.conversation.mysql`
- Rewrote ClickHouse page as knowledge vector store (not conversation analytics)

Fixes #1000

## Pages
- permission-modes.mdx
- permissions.mdx
- persistence-backend-plugins.mdx
- persistence-clickhouse.mdx
- persistence-conversation-mysql.mdx

## Test plan
- [x] Skipped docs/concepts/, #648, #909, #928
- [x] Verified SDK imports against synced praisonaiagents/ and praisonai/
- [x] British English, minimal Mintlify

Made with [Cursor](https://cursor.com)