### PR TITLE
docs: AGENTS.md §9 compliance batch 25 (#1000)

### DIFF
--- a/docs/features/persistence-sqlite.mdx
+++ b/docs/features/persistence-sqlite.mdx
@@ -5,35 +5,113 @@ description: "Local file database persistence for development and single-instanc
 icon: "database"
 ---
 
-SQLite provides local file-based SQL database persistence, perfect for development, prototypes, and single-instance applications that need reliable data storage without external dependencies. Choose between sync and async implementations based on your use case.
+SQLite saves agent conversations to a local `.db` file — no external database required.
+
+```python
+from praisonaiagents import Agent, db
+
+agent = Agent(
+    name="Assistant",
+    instructions="You are a helpful assistant.",
+    db=db(database_url="sqlite:///conversations.db"),
+    session_id="dev-session",
+)
+agent.start("Hello — saved to SQLite")
+```
 
 ```mermaid
 graph LR
-    subgraph "SQLite Persistence"
-        A[🧠 Agent] --> B[💬 Conversations]
-        B --> C[📄 SQLite File]
-        C --> D[💾 Local Disk]
-        A --> E[🔍 Query History]
-        E --> C
-    end
-    
+    Agent[🤖 Agent] --> Store[💬 Conversation Store]
+    Store --> File[📄 SQLite File]
+    File --> Disk[💾 Local Disk]
+
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef data fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef storage fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A agent
-    class B,E data
-    class C,D storage
+    classDef store fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef disk fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Agent agent
+    class Store store
+    class File,Disk disk
 ```
+
+## Quick Start
+
+<Steps>
+<Step title="Simple Usage">
+
+```python
+from praisonaiagents import Agent, db
+
+agent = Agent(
+    name="Assistant",
+    db=db(database_url="sqlite:///conversations.db"),
+    session_id="session-1",
+)
+agent.start("Remember my favourite colour is blue")
+```
+
+</Step>
+
+<Step title="With Configuration">
+
+Choose sync or async when using the factory directly:
+
+```python
+from praisonai.persistence.factory import create_conversation_store
+
+# Sync — scripts and multi-threaded agents
+store = create_conversation_store(
+    "sqlite",
+    path="./conversations.db",
+    mode="sync",
+)
+
+# Async — FastAPI / asyncio apps
+store = create_conversation_store(
+    "sqlite",
+    path="./conversations.db",
+    mode="async",
+)
+```
+
+</Step>
+</Steps>
+
+<Warning>
+Before PR #1763, `AsyncSQLiteConversationStore` exposed sync wrappers callable from regular functions. Those wrappers were removed — use `mode="sync"` (`sync_sqlite` backend) when calling from sync code.
+</Warning>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant SQLite as SQLite Store
+    participant File as .db File
+
+    Agent->>SQLite: save message
+    SQLite->>File: INSERT
+    Agent->>SQLite: load history
+    File-->>Agent: prior messages
+```
+
+| Table | Purpose |
+|-------|---------|
+| `sessions` | Session metadata |
+| `messages` | User and agent messages |
+| `runs` | Agent execution runs |
+| `tool_calls` | Tool usage records |
+
+---
 
 ## Sync vs Async
 
-Choose the right SQLite implementation for your needs:
-
 ```mermaid
 graph TB
-    Q1{Plain Python script<br/>or multi-agent?} -->|Sync script / multi-thread| SYNC[sync_sqlite<br/>mode="sync"]
-    Q1 -->|Inside FastAPI / asyncio| ASYNC[async_sqlite<br/>mode="async"]
+    Q1{Plain Python script<br/>or multi-agent?} -->|Sync / multi-thread| SYNC[mode="sync"]
+    Q1 -->|FastAPI / asyncio| ASYNC[mode="async"]
     Q1 -->|Not sure| AUTO[mode="auto"<br/>legacy behaviour]
 
     classDef sync fill:#10B981,stroke:#7C90A0,color:#fff
@@ -45,222 +123,40 @@ graph TB
     class AUTO auto
 ```
 
-## Quick Start
-
-<Steps>
-<Step title="Sync - Multi-Agent Safe">
-```python
-from praisonai.persistence.factory import create_conversation_store
-
-store = create_conversation_store(
-    "sqlite",
-    path="./conversations.db",
-    mode="sync",
-)
-```
-</Step>
-
-<Step title="Async - FastAPI/Asyncio">
-```python
-store = create_conversation_store(
-    "sqlite",
-    path="./conversations.db",
-    mode="async",
-)
-```
-</Step>
-
-<Step title="Auto (Legacy)">
-```python
-store = create_conversation_store(
-    "sqlite",
-    path="./conversations.db",
-)
-```
-</Step>
-</Steps>
-
-<Warning>
-Before PR #1763, `AsyncSQLiteConversationStore` exposed sync wrappers like `get_session(...)` you could call from a regular function. Those wrappers were removed. If you were calling the async SQLite store from sync code, switch to `mode="sync"` (the new `sync_sqlite` backend) — it's purpose-built for that.
-</Warning>
-
----
-
-## How It Works
-
-```mermaid
-sequenceDiagram
-    participant Agent
-    participant SQLiteDB as SQLite Database
-    participant File as Database File
-    
-    Agent->>SQLiteDB: Initialize connection
-    SQLiteDB->>File: Create/open .db file
-    Agent->>SQLiteDB: Save message
-    SQLiteDB->>File: INSERT INTO messages
-    Agent->>SQLiteDB: Query history
-    SQLiteDB->>File: SELECT FROM messages
-    File-->>SQLiteDB: Return rows
-    SQLiteDB-->>Agent: Conversation history
-```
-
-SQLite stores conversation data in tables within a single file:
-
-| Table | Content | Purpose |
-|-------|---------|---------|
-| `sessions` | Session metadata | Track conversation sessions |
-| `messages` | User and agent messages | Complete conversation history |
-| `runs` | Agent execution runs | Track agent processing steps |
-| `tool_calls` | Tool usage | Record function calls and results |
-
 ---
 
 ## Configuration Options
 
-### Mode Parameter
-
 | Option | Type | Default | Description |
-|---|---|---|---|
-| `mode` | `"sync" \| "async" \| "auto"` | `"auto"` | Pick the sync (`sync_sqlite`) or async (`async_sqlite`) implementation. `"auto"` preserves pre-#1763 behaviour. Invalid values raise `ValueError`. |
-| `path` (sync store) | `str` | `"praisonai_conversations.db"` | SQLite file path. Falls back to `url` if both are passed. |
-| `table_prefix` (sync store) | `str` | `"praison_"` | Validated identifier; rejected if non-alphanumeric. |
+|--------|------|---------|-------------|
+| `mode` | `"sync" \| "async" \| "auto"` | `"auto"` | Backend variant; invalid values raise `ValueError` |
+| `path` | `str` | `"praisonai_conversations.db"` | SQLite file path (sync store) |
+| `table_prefix` | `str` | `"praison_"` | Table name prefix (alphanumeric only) |
 
-### Database URL Format
+### URL formats
+
 ```python
-# Simple file path
-db(database_url="sqlite:///conversations.db")
-
-# Absolute path
-db(database_url="sqlite:////absolute/path/to/database.db")
-
-# Relative path with subdirectory
-db(database_url="sqlite:///data/agent_storage.db")
-
-# In-memory database (temporary)
-db(database_url="sqlite:///:memory:")
-```
-
-### Advanced Configuration
-```python
-from praisonai.persistence.factory import create_conversation_store
-
-# Sync store with custom table prefix
-store = create_conversation_store(
-    "sqlite",
-    path="./data/agents.db",
-    mode="sync",
-    table_prefix="custom_"
-)
-
-# Async store
-store = create_conversation_store(
-    "sqlite", 
-    path="./data/agents.db",
-    mode="async"
-)
+db(database_url="sqlite:///conversations.db")          # relative path
+db(database_url="sqlite:////absolute/path/to/db.db") # absolute path
+db(database_url="sqlite:///:memory:")                # in-memory (temporary)
 ```
 
 ---
 
-## Session Resume Example
-
-```python
-from praisonaiagents import Agent, db
-
-# First conversation
-agent1 = Agent(
-    name="Assistant",
-    db=db(database_url="sqlite:///memory.db"),
-    session_id="user-alice"
-)
-
-agent1.chat("My favorite color is blue")
-agent1.chat("I work as a software engineer")
-
-# Simulate application restart
-agent1 = None
-
-# Resume conversation - automatically loads history
-agent2 = Agent(
-    name="Assistant", 
-    db=db(database_url="sqlite:///memory.db"),
-    session_id="user-alice"  # Same session ID
-)
-
-response = agent2.chat("What's my favorite color and job?")
-print(response)  # Will reference blue color and software engineering
-```
-
----
-
-## Direct Database Access
-
-For advanced use cases, query the SQLite database directly:
-
-```python
-import sqlite3
-from praisonaiagents import Agent, db
-
-# Create agent and have conversation
-agent = Agent(
-    name="DataBot",
-    db=db(database_url="sqlite:///analytics.db"),
-    session_id="data-session"
-)
-
-agent.chat("Analyze quarterly sales data")
-
-# Direct database access for reporting
-conn = sqlite3.connect("analytics.db")
-cursor = conn.cursor()
-
-# Query conversation history
-cursor.execute("""
-    SELECT role, content, created_at 
-    FROM messages 
-    WHERE session_id = 'data-session'
-    ORDER BY created_at
-""")
-
-messages = cursor.fetchall()
-for role, content, timestamp in messages:
-    print(f"[{timestamp}] {role}: {content}")
-
-conn.close()
-```
-
----
-
-## Production Considerations
+## Best Practices
 
 <AccordionGroup>
-<Accordion title="File Permissions and Location">
-- Ensure the application has write permissions to the database directory
-- Use absolute paths for production deployments
-- Consider using environment variables for database paths
-- Back up the .db file regularly
+<Accordion title="Use sync mode for multi-agent scripts">
+The `sync_sqlite` backend (`mode="sync"`) uses per-call connection locking for multi-threaded agents.
 </Accordion>
-
-<Accordion title="Concurrent Access">
-- SQLite supports multiple readers but only one writer
-- The `sync_sqlite` backend (`mode="sync"`) provides per-call connection locking (`threading.RLock`) for multi-agent scenarios
-- Use WAL mode for better concurrency: `PRAGMA journal_mode=WAL`
-- Consider connection pooling for multi-threaded applications
-- For high concurrency, migrate to PostgreSQL or MySQL
+<Accordion title="Use absolute paths in production">
+Set the database path via environment variables and use absolute paths for deployments.
 </Accordion>
-
-<Accordion title="Database Maintenance">
-- Monitor database file size growth
-- Use `VACUUM` periodically to reclaim space
-- Implement log rotation for old conversations
-- Set up automated backups of the .db file
+<Accordion title="Enable WAL for better concurrency">
+Run `PRAGMA journal_mode=WAL` when multiple readers share the same file.
 </Accordion>
-
-<Accordion title="Migration Path">
-- Start with SQLite for development and MVP
-- SQLite can handle thousands of conversations efficiently
-- Migrate to PostgreSQL when you need multi-instance deployment
-- Export data using SQL dumps for migration
+<Accordion title="Migrate to PostgreSQL at scale">
+SQLite handles thousands of conversations; move to PostgreSQL for multi-instance deployments.
 </Accordion>
 </AccordionGroup>
 
@@ -270,9 +166,9 @@ conn.close()
 
 <CardGroup cols={2}>
 <Card title="PostgreSQL Persistence" icon="elephant" href="/docs/features/persistence-postgres">
-  Scale up to production PostgreSQL when you outgrow SQLite
+  Scale up when you outgrow SQLite
 </Card>
-<Card title="Database Persistence Overview" icon="database" href="/docs/features/persistence">
-  Compare all available persistence backends
+<Card title="Database Persistence" icon="database" href="/docs/features/persistence">
+  Compare all persistence backends
 </Card>
 </CardGroup>

--- a/docs/features/persistence.mdx
+++ b/docs/features/persistence.mdx
@@ -5,33 +5,8 @@ description: "Persist agent conversations and state across sessions with 7 suppo
 icon: "database"
 ---
 
-Database persistence enables agents to maintain conversation history and application state across restarts, supporting production deployments and long-running applications.
+Database persistence keeps conversation history and state across restarts — pick a backend for your scale.
 
-```mermaid
-graph LR
-    subgraph "Database Persistence Options"
-        A[🧠 Agent] --> B[💬 Conversations]
-        A --> C[🔄 State]
-        B --> D[📊 SQL Stores]
-        C --> E[🗃️ Key-Value Stores]
-        D --> F[SQLite, PostgreSQL, MySQL]
-        E --> G[Redis, MongoDB]
-        A --> H[📁 JSON Files]
-    end
-    
-    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef data fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef storage fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A agent
-    class B,C data
-    class D,E,F,G,H storage
-```
-
-## Quick Start
-
-<Steps>
-<Step title="Simple SQLite Setup">
 ```python
 from praisonaiagents import Agent, db
 
@@ -39,27 +14,66 @@ agent = Agent(
     name="Assistant",
     instructions="You are a helpful assistant.",
     db=db(database_url="sqlite:///conversations.db"),
-    session_id="my-session"
+    session_id="my-session",
 )
-
-agent.chat("Hello!")  # Automatically persisted
+agent.start("Hello — saved automatically")
 ```
-</Step>
 
-<Step title="Production PostgreSQL">
+```mermaid
+graph LR
+    Agent[🤖 Agent] --> Conv[💬 Conversations]
+    Agent --> State[🔄 State]
+    Conv --> SQL[📊 SQL Stores]
+    State --> KV[🗃️ Key-Value Stores]
+    SQL --> SQLite[SQLite / Postgres / MySQL]
+    KV --> Redis[Redis / MongoDB]
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef data fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef storage fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Agent agent
+    class Conv,State data
+    class SQL,KV,SQLite,Redis storage
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Simple Usage">
+
 ```python
 from praisonaiagents import Agent, db
 
 agent = Agent(
-    name="Assistant", 
-    instructions="You are a helpful assistant.",
-    db=db(database_url="postgresql://user:pass@localhost/mydb"),
-    session_id="production-session"
+    name="Assistant",
+    db=db(database_url="sqlite:///conversations.db"),
+    session_id="session-1",
 )
-
-response = agent.chat("Remember my preferences")
-# Conversation automatically saved to PostgreSQL
+agent.start("Hello!")
 ```
+
+</Step>
+
+<Step title="With Configuration">
+
+Hybrid setup — SQL for conversations, Redis for state:
+
+```python
+import os
+from praisonaiagents import Agent, db
+
+agent = Agent(
+    name="Assistant",
+    db=db(
+        database_url=os.getenv("PRAISON_CONVERSATION_URL", "sqlite:///conversations.db"),
+        state_url=os.getenv("PRAISON_STATE_URL", "redis://localhost:6379"),
+    ),
+    session_id="hybrid-session",
+)
+agent.start("Conversations in SQL, state in Redis")
+```
+
 </Step>
 </Steps>
 
@@ -71,141 +85,96 @@ response = agent.chat("Remember my preferences")
 sequenceDiagram
     participant User
     participant Agent
-    participant DB as Database
     participant Store as Storage Backend
-    
-    User->>Agent: Send message
-    Agent->>DB: Save message
-    DB->>Store: Persist data
-    Agent->>Agent: Process & respond
-    Agent->>DB: Save response
-    DB->>Store: Persist response
-    Agent-->>User: Return response
-    
-    Note over User,Store: Session resume later...
-    User->>Agent: New session
-    Agent->>DB: Load history
-    DB->>Store: Retrieve data
-    Store-->>DB: Return history
-    DB-->>Agent: Conversation context
+
+    User->>Agent: start(prompt)
+    Agent->>Store: load history
+    Store-->>Agent: prior messages
+    Agent->>Store: save user + agent messages
+    Agent-->>User: reply
 ```
 
-| Component | Purpose | Storage Type |
-|-----------|---------|--------------|
-| **ConversationStore** | Messages, sessions, metadata | SQL databases (SQLite, PostgreSQL, MySQL) |
-| **StateStore** | Application state, key-value data | NoSQL stores (Redis, MongoDB) |  
+| Component | Purpose | Example backends |
+|-----------|---------|------------------|
+| **ConversationStore** | Messages, sessions, metadata | SQLite, PostgreSQL, MySQL |
+| **StateStore** | Application state, key-value data | Redis, MongoDB |
 | **DefaultSessionStore** | File-based sessions | JSON files on disk |
 
 ---
 
 ## Storage Backend Options
 
-Choose the right backend for your use case:
-
 <CardGroup cols={2}>
 <Card title="SQLite" icon="database" href="/docs/features/persistence-sqlite">
-  Local file database - perfect for development and single-instance apps
+  Local file database for development and single-instance apps
 </Card>
 <Card title="PostgreSQL" icon="elephant" href="/docs/features/persistence-postgres">
-  Production SQL database with advanced features and scalability
+  Production SQL with JSONB and connection pooling
 </Card>
 <Card title="MySQL" icon="database" href="/docs/features/persistence-mysql">
-  Popular SQL database with excellent tooling and ecosystem
+  Popular SQL database with broad tooling support
 </Card>
 <Card title="Redis" icon="cubes-stacked" href="/docs/features/persistence-redis">
-  Fast in-memory state store for high-performance applications
+  Fast in-memory state store
 </Card>
 <Card title="MongoDB" icon="leaf" href="/docs/features/persistence-mongodb">
-  Flexible document store for complex state and metadata
+  Flexible document store for complex state
 </Card>
 <Card title="ClickHouse" icon="chart-line" href="/docs/features/persistence-clickhouse">
-  Analytics database for large-scale data processing
+  Analytics database for large-scale data
 </Card>
 <Card title="JSON Files" icon="file-code" href="/docs/features/persistence-json">
-  Simple file-based storage with cross-platform locking — works on macOS, Linux, and Windows
+  Simple file-based storage with cross-platform locking
 </Card>
 </CardGroup>
 
 ---
 
-## Common Patterns
+## Configuration Options
 
-### Multi-Backend Setup
-Use different backends for conversations and state:
+| Parameter | Description |
+|-----------|-------------|
+| `database_url` | Conversation store URL |
+| `state_url` | State / run history store |
+| `knowledge_url` | Vector or knowledge store |
 
-```python
-from praisonaiagents import Agent, db
-
-# SQL for conversations, Redis for state
-agent = Agent(
-    name="Assistant",
-    db=db(
-        database_url="postgresql://localhost/conversations",
-        state_url="redis://localhost:6379"
-    ),
-    session_id="hybrid-session"
-)
-```
-
-### Session Resume Workflow
-```python
-# Initial session
-agent = Agent(name="Assistant", db=db_instance, session_id="user-123")
-agent.chat("My name is Alice")
-
-# Later session - automatically resumes
-agent2 = Agent(name="Assistant", db=db_instance, session_id="user-123") 
-agent2.chat("What's my name?")  # Knows it's Alice
-```
-
-### Production Configuration
 ```python
 import os
-from praisonaiagents import Agent, db
+from praisonaiagents import Agent, MemoryConfig, db
 
-# Environment-based configuration
 agent = Agent(
-    name="ProdAssistant",
-    db=db(
-        database_url=os.getenv("DATABASE_URL"),
-        state_url=os.getenv("REDIS_URL")
+    name="Researcher",
+    memory=MemoryConfig(
+        db=db(
+            database_url=os.getenv("PRAISON_CONVERSATION_URL"),
+            state_url=os.getenv("PRAISON_STATE_URL"),
+        ),
+        session_id="research-42",
     ),
-    session_id=f"user-{user_id}"
 )
+agent.start("Continue our research thread")
 ```
+
+<Note>
+Database backends require the `praisonai` wrapper (`pip install praisonai`). The core SDK defines `DbAdapter`; implementations live in `praisonai.persistence`.
+</Note>
 
 ---
 
 ## Best Practices
 
 <AccordionGroup>
-<Accordion title="Choose the Right Backend">
-- **SQLite**: Development, prototypes, single-user apps
-- **PostgreSQL/MySQL**: Multi-user production applications  
-- **Redis**: High-frequency state updates, caching
-- **MongoDB**: Complex metadata, document storage
-- **JSON Files**: Simple scripts, minimal dependencies
+<Accordion title="Choose the right backend">
+SQLite for development; PostgreSQL or MySQL for multi-user production; Redis for fast state; JSON files for minimal dependencies.
 </Accordion>
-
-<Accordion title="Session Management">
-- Use meaningful session IDs (user-123, conversation-abc)
-- Consider session expiration for privacy compliance
-- Group related conversations under the same session
-- Clean up old sessions periodically
+<Accordion title="Use meaningful session IDs">
+Set `session_id="user-123"` so conversations resume reliably across restarts.
 </Accordion>
-
-<Accordion title="Error Handling">
-- Always handle database connection failures gracefully
-- Implement retry logic for transient network issues
-- Provide fallback to in-memory storage if database unavailable
-- Monitor database performance and connection pools
+<Accordion title="Read credentials from the environment">
+Never hardcode database URLs — use `os.getenv("PRAISON_CONVERSATION_URL")`.
 </Accordion>
-
-<Accordion title="Performance Optimization">
-- Use connection pooling for production deployments
-- Configure appropriate timeouts for your use case
-- Consider read replicas for high-read workloads
-- Monitor database metrics and query performance
+<Accordion title="Separate stores by concern">
+Conversation history, run traces, and vectors scale differently — configure each URL independently.
 </Accordion>
 </AccordionGroup>
 
@@ -214,10 +183,10 @@ agent = Agent(
 ## Related
 
 <CardGroup cols={2}>
-<Card title="Session Management" icon="clock" href="/docs/concepts/session-management">
-  Learn about session lifecycle and management
+<Card title="Database Persistence (Advanced)" icon="database" href="/docs/features/database-persistence">
+  MemoryConfig, CLI commands, and Docker setup
 </Card>
-<Card title="Memory vs Context" icon="brain" href="/docs/concepts/memory-vs-learning">
-  Understand the difference between persistence and memory
+<Card title="Session Persistence" icon="floppy-disk" href="/docs/features/session-persistence">
+  JSON file sessions without a database
 </Card>
 </CardGroup>

--- a/docs/features/planning-mode.mdx
+++ b/docs/features/planning-mode.mdx
@@ -5,23 +5,34 @@ description: "Enable agents to research and plan before executing — review and
 icon: "list-check"
 ---
 
-Planning Mode separates research from execution so agents create a reviewable plan before taking any action.
+Planning Mode separates research from execution so agents create a reviewable plan before taking action.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Planner",
+    instructions="Research and write about topics",
+    planning=True,
+)
+agent.start("Research AI trends in 2025 and write a summary")
+```
 
 ```mermaid
 graph LR
     subgraph "Planning Phase"
-        ANALYZE["🔍 Analyze Request"]
-        PLAN["📝 Create Plan"]
+        ANALYZE[🔍 Analyse Request]
+        PLAN[📝 Create Plan]
     end
 
     subgraph "Review Phase"
-        REVIEW["👀 User Review"]
-        APPROVE["✅ Approve"]
+        REVIEW[👀 User Review]
+        APPROVE[✅ Approve]
     end
 
     subgraph "Execution Phase"
-        EXECUTE["⚡ Execute"]
-        RESULT["✅ Result"]
+        EXECUTE[⚡ Execute]
+        RESULT[✅ Result]
     end
 
     ANALYZE --> PLAN
@@ -33,7 +44,6 @@ graph LR
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef success fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
 
     class ANALYZE,PLAN agent
     class REVIEW,APPROVE process
@@ -44,7 +54,6 @@ graph LR
 
 <Steps>
 <Step title="Simple Usage">
-Enable planning with a single parameter:
 
 ```python
 from praisonaiagents import Agent
@@ -52,15 +61,14 @@ from praisonaiagents import Agent
 agent = Agent(
     name="Planner",
     instructions="Research and write about topics",
-    planning=True
+    planning=True,
 )
-
-result = agent.start("Research AI trends in 2025 and write a summary")
+agent.start("Research AI trends in 2025 and write a summary")
 ```
+
 </Step>
 
 <Step title="With Configuration">
-Control the planning LLM, tools, and approval flow:
 
 ```python
 from praisonaiagents import Agent, PlanningConfig
@@ -76,11 +84,11 @@ agent = Agent(
         tools=[search_web],
         reasoning=True,
         auto_approve=True,
-    )
+    ),
 )
-
-result = agent.start("Research AI trends in 2025 and write a summary")
+agent.start("Research AI trends in 2025 and write a summary")
 ```
+
 </Step>
 </Steps>
 
@@ -92,24 +100,24 @@ result = agent.start("Research AI trends in 2025 and write a summary")
 sequenceDiagram
     participant User
     participant Agent
-    participant PlanningAgent
+    participant Planner as Planning Agent
     participant Tools
 
-    User->>Agent: start("task")
-    Agent->>PlanningAgent: create_plan(task)
-    PlanningAgent->>Tools: research (read-only)
-    Tools-->>PlanningAgent: context
-    PlanningAgent-->>Agent: Plan with steps
-    Agent-->>User: Present plan for review
+    User->>Agent: start(task)
+    Agent->>Planner: create_plan(task)
+    Planner->>Tools: research (read-only)
+    Tools-->>Planner: context
+    Planner-->>Agent: numbered steps
+    Agent-->>User: present plan
     User->>Agent: approve
-    Agent->>Agent: Execute each step
-    Agent-->>User: Final result
+    Agent->>Agent: execute each step
+    Agent-->>User: final result
 ```
 
 | Step | What Happens |
 |------|-------------|
-| 1. Analyze | Agent reads the request and gathers context |
-| 2. Plan | A dedicated PlanningAgent creates numbered steps |
+| 1. Analyse | Agent reads the request and gathers context |
+| 2. Plan | A dedicated planning agent creates numbered steps |
 | 3. Review | Plan is presented to the user (or auto-approved) |
 | 4. Execute | Agent runs each step sequentially |
 
@@ -117,43 +125,24 @@ sequenceDiagram
 
 ## Configuration Options
 
-`PlanningConfig` is exported from `praisonaiagents`:
-
-```python
-from praisonaiagents import Agent, PlanningConfig
-
-agent = Agent(
-    instructions="...",
-    planning=PlanningConfig(
-        llm="gpt-4o",
-        tools=[my_tool],
-        reasoning=True,
-        auto_approve=False,
-        read_only=False,
-    )
-)
-```
-
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `llm` | `str` | `None` | LLM for the planning step (defaults to agent's LLM) |
+| `llm` | `str` | `None` | LLM for planning (defaults to agent's LLM) |
 | `tools` | `List` | `None` | Tools available during planning research |
-| `reasoning` | `bool` | `False` | Enable chain-of-thought reasoning during planning |
-| `auto_approve` | `bool` | `False` | Skip user review and approve plans automatically |
-| `read_only` | `bool` | `False` | Restrict planning agent to read-only tools |
-
-### Configuration Precedence
+| `reasoning` | `bool` | `False` | Chain-of-thought reasoning during planning |
+| `auto_approve` | `bool` | `False` | Skip user review and approve automatically |
+| `read_only` | `bool` | `False` | Restrict planning to read-only tools |
 
 ```python
-agent = Agent(planning=True)                          # Bool — safe defaults
-agent = Agent(planning=PlanningConfig(llm="gpt-4o"))  # Config — full control
+agent = Agent(planning=True)                          # bool — safe defaults
+agent = Agent(planning=PlanningConfig(llm="gpt-4o"))  # config — full control
 ```
 
 ---
 
 ## Common Patterns
 
-### Read-Only Planning (Safe Research)
+### Read-only planning
 
 ```python
 from praisonaiagents import Agent, PlanningConfig
@@ -161,50 +150,38 @@ from praisonaiagents import Agent, PlanningConfig
 agent = Agent(
     name="SafeResearcher",
     instructions="Investigate and report findings",
-    planning=PlanningConfig(
-        read_only=True,
-        reasoning=True,
-    )
+    planning=PlanningConfig(read_only=True, reasoning=True),
 )
-
-result = agent.start("Analyze the codebase and suggest improvements")
+agent.start("Analyse the codebase and suggest improvements")
 ```
 
-### Auto-Approved Pipeline
+### Auto-approved pipeline
 
 ```python
-from praisonaiagents import Agent, PlanningConfig
-
 agent = Agent(
     name="AutoPlanner",
-    instructions="Handle complex multi-step tasks",
-    planning=PlanningConfig(
-        llm="gpt-4o",
-        auto_approve=True,
-    )
+    planning=PlanningConfig(llm="gpt-4o", auto_approve=True),
 )
-
-result = agent.start("Write and test a Python script to sort files by date")
+agent.start("Write and test a Python script to sort files by date")
 ```
 
-### Multi-Agent with Planning
+### Multi-agent with planning
 
 ```python
-from praisonaiagents import Agent, Task, PraisonAIAgents
+from praisonaiagents import Agent, AgentTeam, Task
 
 researcher = Agent(name="Researcher", instructions="Research topics thoroughly")
 writer = Agent(name="Writer", instructions="Write clear articles")
 
-task1 = Task(description="Research AI in healthcare", agent=researcher)
-task2 = Task(description="Write a summary article", agent=writer)
-
-agents = PraisonAIAgents(
+team = AgentTeam(
     agents=[researcher, writer],
-    tasks=[task1, task2],
-    planning=True
+    tasks=[
+        Task(description="Research AI in healthcare", agent=researcher),
+        Task(description="Write a summary article", agent=writer),
+    ],
+    planning=True,
 )
-
-result = agents.start()
+team.start()
 ```
 
 ---
@@ -212,18 +189,18 @@ result = agents.start()
 ## Best Practices
 
 <AccordionGroup>
-  <Accordion title="Use planning for complex multi-step tasks">
-    Planning shines when the path to a solution is unclear. For simple one-step tasks, direct execution is faster.
-  </Accordion>
-  <Accordion title="Enable read_only for safe exploration">
-    Set `read_only=True` when you want the agent to research your codebase or documents without risk of modification.
-  </Accordion>
-  <Accordion title="Provide research tools during planning">
-    Pass `tools=[search_web, read_file]` to `PlanningConfig` so the planning phase has access to relevant context.
-  </Accordion>
-  <Accordion title="Enable reasoning for complex requests">
-    Set `reasoning=True` to get chain-of-thought analysis in the plan. Useful for debugging and understanding agent decisions.
-  </Accordion>
+<Accordion title="Use planning for complex multi-step tasks">
+Planning shines when the path to a solution is unclear. For simple one-step tasks, direct execution is faster.
+</Accordion>
+<Accordion title="Enable read_only for safe exploration">
+Set `read_only=True` when the agent should research code or documents without risk of modification.
+</Accordion>
+<Accordion title="Provide research tools during planning">
+Pass `tools=[search_web, read_file]` so the planning phase has relevant context.
+</Accordion>
+<Accordion title="Enable reasoning for complex requests">
+Set `reasoning=True` for chain-of-thought analysis in the plan.
+</Accordion>
 </AccordionGroup>
 
 ---
@@ -231,10 +208,10 @@ result = agents.start()
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="Workflows" icon="diagram-project" href="/docs/features/workflows">
-    Create reusable multi-step workflows
-  </Card>
-  <Card title="Hooks" icon="webhook" href="/docs/features/hooks">
-    Intercept and modify agent behavior at lifecycle points
-  </Card>
+<Card title="Workflows" icon="diagram-project" href="/docs/features/workflows">
+  Create reusable multi-step workflows
+</Card>
+<Card title="Hooks" icon="webhook" href="/docs/features/hooks">
+  Intercept agent behaviour at lifecycle points
+</Card>
 </CardGroup>

--- a/docs/features/platform-aware-agents.mdx
+++ b/docs/features/platform-aware-agents.mdx
@@ -5,35 +5,10 @@ description: "Gateway agents automatically know which platform they're on and wh
 icon: "satellite-dish"
 ---
 
-Gateway agents are automatically told where a message came from and which channels they can deliver to — no extra code required.
-
-```mermaid
-graph LR
-    subgraph "Platform Awareness"
-        Msg[📨 Incoming Message] --> Origin[🌐 Detect Origin<br/>platform + chat type]
-        Origin --> Targets[📡 List Targets<br/>home + aliases]
-        Targets --> Prompt[🧠 Inject into<br/>System Prompt]
-        Prompt --> Agent[🤖 Agent acts<br/>with awareness]
-    end
-
-    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
-
-    class Msg input
-    class Origin,Targets process
-    class Prompt config
-    class Agent result
-```
-
-## Quick Start
-
-<Steps>
-<Step title="Basic Bot (Platform Awareness On by Default)">
+Gateway agents automatically know where a message came from and which channels they can deliver to — no extra code required.
 
 ```python
-from praisonai.bots import TelegramBot
+from praisonai.bots import Bot
 from praisonaiagents import Agent
 
 agent = Agent(
@@ -41,27 +16,55 @@ agent = Agent(
     instructions="Help users across platforms.",
 )
 
-bot = TelegramBot(
-    token="your-telegram-token",
-    agent=agent,
-)
-
-import asyncio
-asyncio.run(bot.start())
+bot = Bot("telegram", agent=agent)
+bot.run()
 ```
 
-The agent's system prompt automatically includes:
-- Which platform the message came from
-- What chat type (DM, group, channel)
-- Which channels it can reach
-</Step>
+```mermaid
+graph LR
+    Msg[📨 Incoming Message] --> Origin[🌐 Detect Origin]
+    Origin --> Targets[📡 List Targets]
+    Targets --> Prompt[🧠 Session Context]
+    Prompt --> Agent[🤖 Agent Response]
 
-<Step title="With Channel Directory (Cross-Platform Delivery)">
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
 
-Configure named aliases so the agent can deliver to other platforms by friendly name:
+    class Msg input
+    class Origin,Targets,Prompt process
+    class Agent result
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Simple Usage">
 
 ```python
-from praisonai.bots import TelegramBot
+from praisonai.bots import Bot
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="gateway",
+    instructions="Help users across platforms.",
+)
+
+# Token from TELEGRAM_BOT_TOKEN env var
+bot = Bot("telegram", agent=agent)
+bot.run()
+```
+
+The agent's system prompt automatically includes the source platform, chat type, and reachable delivery targets.
+
+</Step>
+
+<Step title="With Configuration">
+
+Add a channel directory for cross-platform delivery:
+
+```python
+from praisonai.bots import Bot
 from praisonai.bots.delivery import ChannelDirectory
 from praisonaiagents import Agent
 
@@ -75,22 +78,10 @@ directory.set_home_channel("slack", "C0123456")
 directory.add_alias("team", "slack", "C0123456")
 directory.add_alias("ops", "discord", "987654321")
 
-bot = TelegramBot(
-    token="your-telegram-token",
-    agent=agent,
-    channel_directory=directory,
-)
-
-import asyncio
-asyncio.run(bot.start())
+bot = Bot("telegram", agent=agent, channel_directory=directory)
+bot.run()
 ```
 
-The agent now sees in its system prompt:
-```
-## Session Context
-You are replying on telegram (group "Project Alpha") in thread 123.
-Reachable delivery targets: slack:home (slack, home channel), team (slack:C0123456), ops (discord:987654321).
-```
 </Step>
 </Steps>
 
@@ -98,192 +89,84 @@ Reachable delivery targets: slack:home (slack, home channel), team (slack:C01234
 
 ## How It Works
 
-Each incoming message triggers a per-turn context injection into the agent's system prompt.
-
 ```mermaid
 sequenceDiagram
     participant User
-    participant Telegram
     participant Bot as Gateway Bot
     participant Agent
     participant Slack
 
-    User->>Telegram: "post this summary to Slack"
-    Telegram->>Bot: message + chat_id + thread_id
-    Bot->>Bot: detect_chat_type() → "group"
-    Bot->>Bot: directory.describe_targets()
-    Bot->>Agent: chat() + injected Session Context
-    Note over Agent: System prompt now contains:<br/>"You are replying on telegram (group)."<br/>"Reachable targets: slack:#general (home)..."
+    User->>Bot: "post this summary to Slack"
+    Bot->>Bot: detect_chat_type() + describe_targets()
+    Bot->>Agent: chat() + Session Context
+    Note over Agent: "Replying on telegram (group)"<br/>"Targets: team (slack), ops (discord)"
     Agent->>Slack: deliver(target="team")
     Slack-->>User: posted
 ```
 
 | Step | What Happens |
 |------|-------------|
-| **Origin detection** | `detect_chat_type(platform, chat_id)` classifies the chat as `"group"`, `"direct"`, `"channel"`, or `"unknown"` |
-| **Target listing** | `ChannelDirectory.describe_targets()` lists home channels, named aliases, and reachable-but-unnamed channels from live traffic or `refresh_from_adapters()` |
-| **Prompt injection** | A `## Session Context` block is appended to the system prompt for this turn only |
-| **Agent responds** | The agent uses the context to make decisions (e.g. reply here vs. post there) |
+| **Origin detection** | `detect_chat_type(platform, chat_id)` classifies as group, direct, channel, or unknown |
+| **Target listing** | `ChannelDirectory.describe_targets()` lists home channels and aliases |
+| **Prompt injection** | A `## Session Context` block is appended per turn |
+| **Agent responds** | The agent uses context to reply here or deliver elsewhere |
 
 <Note>
-Prompt injection happens **after** the system prompt is cached. The per-turn `## Session Context` block is never stored in the cache — this keeps the cache valid across turns while still giving the agent fresh context every time.
+Prompt injection happens after the system prompt cache boundary — the per-turn `## Session Context` block is never cached.
 </Note>
 
 ---
 
 ## Configuration Options
 
-### `Origin`
-
-Describes where the incoming message came from. Populated automatically by the bot runtime.
+### BotSessionManager
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `platform` | `str` | `""` | Platform name (`"telegram"`, `"discord"`, `"slack"`, `"whatsapp"`, …) |
-| `chat_type` | `str` | `""` | `"group"`, `"direct"`, `"channel"`, or `"unknown"` |
-| `display_name` | `str` | `""` | Channel name, group name, or user name |
-| `thread_id` | `str` | `""` | Thread / topic id |
+| `channel_directory` | `ChannelDirectory` | `None` | Named aliases and home channels for delivery |
+| `inject_session_context` | `bool` | `True` | When `False`, suppress per-turn prompt injection |
 
-### `ReachableTarget`
-
-Represents a channel the agent can deliver to. Built from the `ChannelDirectory`.
+### BotConfig media
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `name` | `str` | — | Friendly name or alias |
-| `platform` | `str` | — | Target platform |
-| `channel_id` | `str` | — | Platform channel id |
-| `kind` | `str` | `"alias"` | `"home"`, `"alias"`, or `"observed"` |
+| `max_inbound_media_bytes` | `int` | `20971520` | Max inbound media size; set `0` to disable |
 
-### `BotSessionManager` Parameters
+### Chat-type detection
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `channel_directory` | `Optional[ChannelDirectory]` | `None` | Directory of reachable channels; if set, `describe_targets()` populates `reachable_targets` |
-| `inject_session_context` | `bool` | `True` | When `False`, suppress per-turn prompt injection (origin + targets are still passed to tools) |
-
-### `BotSessionManager.chat()` Parameters
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `agent` | `Agent` | — | Agent to run |
-| `user_id` | `str` | — | Per-user session key |
-| `prompt` | `str` | — | User message text |
-| `chat_id` | `str` | `""` | Platform channel/chat id |
-| `user_name` | `str` | `""` | Display name of the sender |
-| `message_id` | `str` | `""` | Platform message id (used for dedup/journal) |
-| `account` | `str` | `""` | Bot account identifier |
-| `stream_callback` | `Optional[Any]` | `None` | Async callback for streaming events |
-| `attachments` | `Optional[list]` | `None` | List of validated local file paths forwarded to `agent.chat(attachments=…)`. Populated by the WhatsApp and Telegram adapters when the user sends a photo or document. Gracefully skipped when the agent's `chat()` does not accept `attachments`. |
-
-### `BotConfig` Media Parameters
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `max_inbound_media_bytes` | `int` | `20971520` (20 MiB) | Maximum allowed size for inbound media files. Set to `0` to disable inbound media entirely for text-only deployments. |
-
----
-
-## Chat-Type Detection
-
-`detect_chat_type(platform, chat_id)` returns a string classifying the chat context. Used to fill `Origin.chat_type`.
-
-| Platform | Pattern | Returned Type |
-|---|---|---|
-| `telegram` | `chat_id` starts with `-100` | `"unknown"` (supergroup/channel ambiguous) |
-| `telegram` | `chat_id` starts with `-` | `"group"` |
+| Platform | Pattern | Type |
+|----------|---------|------|
+| `telegram` | starts with `-100` | `"unknown"` |
+| `telegram` | starts with `-` | `"group"` |
 | `telegram` | otherwise | `"direct"` |
-| `discord` | any | `"channel"` |
-| `slack` | starts with `C` | `"channel"` |
-| `slack` | starts with `G` | `"group"` |
-| `slack` | starts with `D` or `U` | `"direct"` |
-| `whatsapp` | contains `@g.us` | `"group"` |
-| `whatsapp` | contains `@c.us` | `"direct"` |
-| anything else | — | `"unknown"` |
-
----
-
-## Choosing Your Setup
-
-```mermaid
-graph TB
-    Start([Start]) --> Q1{Need cross-platform<br/>delivery?}
-    Q1 -->|No| Simple[Basic bot<br/>no ChannelDirectory needed]
-    Q1 -->|Yes| Q2{Agent should refer<br/>to channels by name?}
-    Q2 -->|Yes| Alias[Add aliases via<br/>directory.add_alias()]
-    Q2 -->|No| Home[Set home channels via<br/>directory.set_home_channel()]
-    Home --> Q3{Privacy-sensitive<br/>deployment?}
-    Alias --> Q3
-    Q3 -->|Yes| Disable[Set inject_session_context=False<br/>context still passed to tools]
-    Q3 -->|No| Default[Leave inject_session_context=True<br/>default]
-
-    classDef decision fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef action fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef start fill:#8B0000,stroke:#7C90A0,color:#fff
-
-    class Q1,Q2,Q3 decision
-    class Simple,Alias,Home,Disable,Default action
-    class Start start
-```
+| `slack` | starts with `C` / `G` / `D` | channel / group / direct |
+| `whatsapp` | contains `@g.us` / `@c.us` | group / direct |
 
 ---
 
 ## Common Patterns
 
-### Cross-Platform Delivery via Natural Language
-
-The agent can deliver to another platform when the user says "post this to Slack":
+### Cross-platform delivery
 
 ```python
-from praisonai.bots import TelegramBot
-from praisonai.bots.delivery import ChannelDirectory
-from praisonaiagents import Agent
-
 directory = ChannelDirectory()
 directory.set_home_channel("slack", "C0123456")
 directory.add_alias("team", "slack", "C0123456")
 
 agent = Agent(
     name="cross-platform",
-    instructions="""
-    Help users. When asked to post somewhere, use the delivery targets listed
-    in your Session Context. Targets are available by their friendly names.
-    """,
+    instructions="When asked to post somewhere, use delivery targets from Session Context.",
 )
-
-bot = TelegramBot(
-    token="your-telegram-token",
-    agent=agent,
-    channel_directory=directory,
-)
+bot = Bot("telegram", agent=agent, channel_directory=directory)
 ```
 
-### Referring to "Here"
-
-The agent knows what "here" means because `Origin` includes the current platform and chat type:
+### Disable injection for privacy
 
 ```python
-agent = Agent(
-    name="location-aware",
-    instructions="""
-    You know which platform you are on and whether you are in a DM or group.
-    When users say 'post it here', use the current platform and chat from your
-    Session Context.
-    """,
-)
+bot = Bot("telegram", agent=agent, inject_session_context=False)
 ```
 
-### Disabling Injection for Privacy
-
-Keep context away from the agent's visible system prompt (it still flows to tools via `get_session_context()`):
-
-```python
-bot = TelegramBot(
-    token="your-telegram-token",
-    agent=agent,
-    inject_session_context=False,
-)
-```
+Context still flows to tools via `get_session_context()` — only the visible prompt block is suppressed.
 
 ---
 
@@ -291,19 +174,16 @@ bot = TelegramBot(
 
 <AccordionGroup>
 <Accordion title="Per-turn data is never cached">
-The `## Session Context` block is injected after the system prompt cache boundary. Changing the origin or reachable targets never invalidates the cache for previous turns — each turn gets a fresh block without paying a re-cache penalty.
+The `## Session Context` block is injected after the cache boundary — each turn gets fresh context without invalidating prior cache entries.
 </Accordion>
-
-<Accordion title="Use friendly alias names the model can guess">
-Prefer short, descriptive names like `"team"`, `"ops"`, or `"alerts"` over raw channel IDs like `"C0123456"`. The model matches user intent to alias names — the closer the alias is to how users talk, the more reliably it routes.
+<Accordion title="Use friendly alias names">
+Prefer `"team"` or `"ops"` over raw channel IDs — the model matches user intent to alias names.
 </Accordion>
-
+<Accordion title="Set home channels before aliases">
+`set_home_channel(platform, channel_id)` designates the default delivery target; agents refer to it as `"<platform>:home"`.
+</Accordion>
 <Accordion title="Disable injection for privacy-sensitive deployments">
-Set `inject_session_context=False` when you don't want the agent to see platform metadata in its system prompt. The context is still available to tools via `get_session_context()` — only the visible prompt block is suppressed.
-</Accordion>
-
-<Accordion title="Set home channels before adding aliases">
-`set_home_channel(platform, channel_id)` designates the default delivery target for a platform. Agents can refer to it as `"<platform>:home"`. Add aliases for any additional channels that need friendly names.
+Set `inject_session_context=False` when platform metadata should not appear in the system prompt.
 </Accordion>
 </AccordionGroup>
 
@@ -313,18 +193,15 @@ Set `inject_session_context=False` when you don't want the agent to see platform
 
 <CardGroup cols={2}>
 <Card title="Cross-Platform Sessions" icon="users" href="/docs/features/cross-platform-mirror">
-  Unified conversation history across platforms — same human, one history.
+  Unified conversation history across platforms
 </Card>
 <Card title="Channels Gateway" icon="comments" href="/docs/features/channels-gateway">
-  Connect agents to Telegram, Discord, Slack, and WhatsApp.
+  Connect agents to Telegram, Discord, Slack, and WhatsApp
 </Card>
 <Card title="Bot Message Routing" icon="route" href="/docs/features/bot-routing">
-  Route messages from DMs, groups, and channels to different agents.
-</Card>
-<Card title="Messaging Bots" icon="robot" href="/docs/features/messaging-bots">
-  Deploy AI agents to messaging platforms.
+  Route messages to different agents by channel
 </Card>
 <Card title="Gateway Tool Policy" icon="shield-check" href="/docs/features/gateway-tool-policy">
-  Scope the toolset per route — control what tools the model can use from different channels.
+  Scope the toolset per route
 </Card>
 </CardGroup>

--- a/docs/features/platform-client-sdk-testing.mdx
+++ b/docs/features/platform-client-sdk-testing.mdx
@@ -1,82 +1,83 @@
 ---
 title: "Platform Client SDK Testing"
 sidebarTitle: "Platform Client SDK Testing"
-description: "Comprehensive integration tests for the PlatformClient SDK covering all API endpoints"
+description: "Integration tests for the PlatformClient SDK covering authentication, workspaces, and RBAC"
 icon: "vial"
 ---
 
-Platform Client SDK integration tests verify all API endpoints including authentication, workspaces, projects, issues, agents, and RBAC enforcement.
+Run integration tests against the real FastAPI app to verify every PlatformClient endpoint and RBAC rule.
+
+```bash
+pip install praisonai-platform pytest pytest-asyncio httpx
+pytest praisonai_platform/tests/ -v
+```
+
+```python
+import pytest
+from praisonai_platform.client import PlatformClient
+
+@pytest.mark.asyncio
+async def test_register_and_workspace():
+    client = PlatformClient("http://localhost:8000")
+    await client.register("test@example.com", "password")
+    workspace = await client.create_workspace("Test Workspace")
+    assert workspace["name"] == "Test Workspace"
+```
 
 ```mermaid
 graph LR
-    subgraph "SDK Integration Testing"
-        A[📝 Register] --> B[🏢 Create Workspace]
-        B --> C[🛠️ CRUD Resources]
-        C --> D[🔒 RBAC Tests]
-        D --> E[✅ Verification]
-    end
-    
-    classDef auth fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef workspace fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef crud fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef rbac fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef verify fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A auth
-    class B workspace
-    class C crud
-    class D rbac
-    class E verify
+    Tests[🧪 Test Suite] --> SDK[📦 PlatformClient]
+    SDK --> API[🔌 FastAPI App]
+    API --> DB[(SQLite Memory)]
+
+    classDef test fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef sdk fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef api fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef db fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Tests test
+    class SDK sdk
+    class API api
+    class DB db
 ```
 
 ## Quick Start
 
 <Steps>
-<Step title="Basic SDK Test">
-```python
-from praisonai_platform.client import PlatformClient
+<Step title="Simple Usage">
 
-# Test authentication and basic operations
-async def test_basic_flow():
-    client = PlatformClient("http://localhost:8000")
-    
-    # Register and authenticate
-    user = await client.register("test@example.com", "password")
-    
-    # Create workspace and resources
-    workspace = await client.create_workspace("Test Workspace")
-    project = await client.create_project(
-        workspace["id"], "Test Project"
-    )
-    
-    # Verify operations
-    workspaces = await client.list_workspaces()
-    assert len(workspaces) >= 1
+Start the platform server, then run client tests:
+
+```bash
+python -m praisonai_platform --port 8000 &
+pytest praisonai_platform/tests/test_client.py -v
 ```
+
 </Step>
 
-<Step title="Integration Test Suite">
+<Step title="With Configuration">
+
+Test against the in-process FastAPI app with ASGITransport — no server required:
+
 ```python
 import pytest
 import httpx
 from httpx import ASGITransport
-from praisonai_platform.api.app import app
+from praisonai_platform.api.app import create_app
 from praisonai_platform.client import PlatformClient
 
 @pytest.mark.asyncio
-async def test_full_sdk_lifecycle():
-    # Use ASGITransport for testing against real FastAPI app
-    async with httpx.AsyncClient(
-        transport=ASGITransport(app=app),
-        base_url="http://test"
-    ) as client:
-        sdk = PlatformClient("http://test")
-        
-        # Test complete workflow
-        await test_auth_workflow(sdk)
-        await test_workspace_management(sdk)
-        await test_rbac_enforcement(sdk)
+async def test_full_lifecycle():
+    app = create_app()
+    transport = ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as http:
+        client = PlatformClient("http://test")
+        await client.register("user@test.com", "password")
+        workspace = await client.create_workspace("My Workspace")
+        assert workspace["name"] == "My Workspace"
 ```
+
 </Step>
 </Steps>
 
@@ -86,222 +87,60 @@ async def test_full_sdk_lifecycle():
 
 ```mermaid
 sequenceDiagram
-    participant Test as Test Suite
+    participant Test
     participant SDK as PlatformClient
-    participant API as FastAPI App
-    participant DB as SQLite (Memory)
-    
+    participant API as FastAPI
+    participant DB as In-Memory DB
+
     Test->>SDK: register()
     SDK->>API: POST /auth/register
-    API->>DB: Create user
-    DB-->>API: User created
+    API->>DB: create user
     API-->>SDK: JWT token
-    SDK-->>Test: Authentication data
-    
     Test->>SDK: create_workspace()
     SDK->>API: POST /workspaces/
-    API->>DB: Create workspace
-    DB-->>API: Workspace created
-    API-->>SDK: Workspace data
-    SDK-->>Test: Workspace object
-    
-    Test->>SDK: CRUD operations
-    SDK->>API: Various endpoints
-    API->>DB: Database operations
-    DB-->>API: Results
-    API-->>SDK: Response data
-    SDK-->>Test: Verified results
+    API-->>Test: workspace object
 ```
 
-| Component | Purpose | Technology |
-|-----------|---------|-------------|
-| **Test Suite** | Comprehensive integration tests | pytest-asyncio |
-| **SDK Client** | HTTP client for platform API | httpx.AsyncClient |
-| **ASGI Transport** | In-memory testing against real app | ASGITransport |
-| **Database** | Isolated test storage | SQLite (in-memory) |
+| Layer | Purpose |
+|-------|---------|
+| **pytest-asyncio** | Async test runner |
+| **ASGITransport** | In-memory requests against the real app |
+| **PlatformClient** | HTTP wrapper with auto-authentication |
+| **SQLite memory** | Isolated database per test run |
 
 ---
 
-## Test Coverage Matrix
+## Test Coverage
 
-### Authentication Tests
-
-| Test Case | Endpoint | Verification |
-|-----------|----------|-------------|
-| User registration | `POST /auth/register` | User created, JWT returned |
-| User login | `POST /auth/login` | Authentication successful |
-| Get current user | `GET /auth/me` | User data retrieved |
-
-### Workspace Management
-
-| Test Case | Endpoint | Verification |
-|-----------|----------|-------------|
-| Create workspace | `POST /workspaces/` | Workspace created with owner |
-| List workspaces | `GET /workspaces/` | User's workspaces returned |
-| Get workspace | `GET /workspaces/{id}` | Workspace details retrieved |
-| Update workspace | `PATCH /workspaces/{id}` | Workspace modified |
-| Delete workspace | `DELETE /workspaces/{id}` | Workspace removed |
-
-### Project Operations
-
-| Test Case | Endpoint | Verification |
-|-----------|----------|-------------|
-| Create project | `POST /workspaces/{id}/projects/` | Project created in workspace |
-| List projects | `GET /workspaces/{id}/projects/` | Workspace projects returned |
-| Get project | `GET /workspaces/{id}/projects/{id}` | Project details retrieved |
-| Update project | `PATCH /workspaces/{id}/projects/{id}` | Project modified |
-| Delete project | `DELETE /workspaces/{id}/projects/{id}` | Project removed |
-| Project statistics | `GET /workspaces/{id}/projects/{id}/stats` | Issue counts returned |
-
-### Issue Management
-
-| Test Case | Endpoint | Verification |
-|-----------|----------|-------------|
-| Create issue | `POST /workspaces/{id}/issues/` | Issue created with number |
-| List issues | `GET /workspaces/{id}/issues/` | Workspace issues returned |
-| Get issue | `GET /workspaces/{id}/issues/{id}` | Issue details retrieved |
-| Update issue | `PATCH /workspaces/{id}/issues/{id}` | Issue modified |
-| Delete issue | `DELETE /workspaces/{id}/issues/{id}` | Issue removed |
+| Area | Endpoints | Verification |
+|------|-----------|-------------|
+| **Authentication** | `/auth/register`, `/auth/login`, `/auth/me` | JWT returned, user retrieved |
+| **Workspaces** | CRUD on `/workspaces/` | Owner membership enforced |
+| **Projects** | CRUD on `/workspaces/{id}/projects/` | Scoped to workspace |
+| **Issues** | CRUD on `/workspaces/{id}/issues/` | Issue numbers assigned |
+| **RBAC** | All workspace-scoped routes | Non-members receive 403 |
 
 ---
 
-## RBAC Enforcement Tests
-
-```mermaid
-graph TB
-    subgraph "RBAC Test Scenarios"
-        A[👤 Member User] --> B{Access Workspace?}
-        C[🚫 Non-Member User] --> D{Access Workspace?}
-        
-        B -->|✅ Authorized| E[200 Success]
-        D -->|❌ Forbidden| F[403 Forbidden]
-        
-        subgraph "Protected Endpoints"
-            G[Workspaces]
-            H[Projects] 
-            I[Issues]
-            J[Agents]
-            K[Labels]
-            L[Dependencies]
-            M[Activities]
-        end
-        
-        F --> G
-        F --> H
-        F --> I
-        F --> J
-        F --> K
-        F --> L
-        F --> M
-    end
-    
-    classDef member fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef nonmember fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef forbidden fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef endpoint fill:#6366F1,stroke:#7C90A0,color:#fff
-    
-    class A member
-    class C nonmember
-    class E success
-    class F forbidden
-    class G,H,I,J,K,L,M endpoint
-```
-
-### RBAC Test Implementation
+## RBAC enforcement test
 
 ```python
+import pytest
+import httpx
+from praisonai_platform.client import PlatformClient
+
 @pytest.mark.asyncio
-async def test_rbac_enforcement():
-    # Create workspace with member user
-    member_client = PlatformClient()
-    await member_client.register("member@test.com", "password")
-    workspace = await member_client.create_workspace("RBAC Test")
-    
-    # Create non-member user
-    nonmember_client = PlatformClient()
-    await nonmember_client.register("nonmember@test.com", "password")
-    
-    # Test: Non-member should get 403 on workspace access
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        await nonmember_client.get_workspace(workspace["id"])
-    assert exc_info.value.response.status_code == 403
-    
-    # Test: Non-member blocked on all workspace-scoped endpoints
-    endpoints_to_test = [
-        lambda: nonmember_client.list_projects(workspace["id"]),
-        lambda: nonmember_client.list_issues(workspace["id"]),
-        lambda: nonmember_client.list_agents(workspace["id"]),
-        lambda: nonmember_client.list_labels(workspace["id"]),
-    ]
-    
-    for endpoint_call in endpoints_to_test:
-        with pytest.raises(httpx.HTTPStatusError) as exc:
-            await endpoint_call()
-        assert exc.value.response.status_code == 403
-```
+async def test_nonmember_blocked():
+    member = PlatformClient("http://localhost:8000")
+    await member.register("member@test.com", "password")
+    workspace = await member.create_workspace("RBAC Test")
 
----
+    outsider = PlatformClient("http://localhost:8000")
+    await outsider.register("outsider@test.com", "password")
 
-## Common Patterns
-
-### Test Data Setup
-
-```python
-# Pattern: Create isolated test environment
-async def setup_test_data(client: PlatformClient):
-    """Create common test data structure"""
-    user = await client.register("test@example.com", "password")
-    workspace = await client.create_workspace("Test Workspace")
-    project = await client.create_project(
-        workspace["id"], 
-        "Test Project"
-    )
-    return user, workspace, project
-```
-
-### Error Handling Tests
-
-```python
-# Pattern: Verify proper error responses
-async def test_error_handling(client: PlatformClient):
-    # Test 404 for non-existent resources
     with pytest.raises(httpx.HTTPStatusError) as exc:
-        await client.get_workspace("nonexistent-id")
-    assert exc.value.response.status_code == 404
-    
-    # Test 422 for invalid data
-    with pytest.raises(httpx.HTTPStatusError) as exc:
-        await client.create_workspace("")  # Empty name
-    assert exc.value.response.status_code == 422
-```
-
-### End-to-End Workflows
-
-```python
-# Pattern: Test complete user journey
-async def test_complete_workflow(client: PlatformClient):
-    # Authentication
-    await client.register("user@test.com", "password")
-    
-    # Workspace setup  
-    workspace = await client.create_workspace("My Workspace")
-    project = await client.create_project(workspace["id"], "My Project")
-    
-    # Issue management
-    issue = await client.create_issue(
-        workspace["id"], 
-        "Fix bug",
-        project_id=project["id"]
-    )
-    
-    # Add comments and labels
-    await client.add_comment(workspace["id"], issue["id"], "Working on it")
-    
-    # Verify final state
-    issues = await client.list_issues(workspace["id"])
-    assert len(issues) == 1
-    assert issues[0]["title"] == "Fix bug"
+        await outsider.get_workspace(workspace["id"])
+    assert exc.value.response.status_code == 403
 ```
 
 ---
@@ -309,62 +148,17 @@ async def test_complete_workflow(client: PlatformClient):
 ## Best Practices
 
 <AccordionGroup>
-<Accordion title="Use In-Memory Database">
-Configure SQLite with in-memory database for fast, isolated tests:
-
-```python
-# conftest.py
-@pytest.fixture
-async def session():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    
-    async_session = async_sessionmaker(engine)
-    async with async_session() as session:
-        yield session
-```
+<Accordion title="Use in-memory database for speed">
+Configure SQLite with `:memory:` in test fixtures for fast, isolated runs.
 </Accordion>
-
-<Accordion title="Test Against Real FastAPI App">
-Use ASGITransport to test against the actual FastAPI application:
-
-```python
-async with httpx.AsyncClient(
-    transport=ASGITransport(app=app),
-    base_url="http://test"
-) as http_client:
-    # Tests run against real app logic
-    client = PlatformClient("http://test")
-```
+<Accordion title="Test against the real FastAPI app">
+Use `ASGITransport(app=create_app())` so tests exercise actual route logic and dependencies.
 </Accordion>
-
-<Accordion title="Verify RBAC Comprehensively">
-Test authorization on every workspace-scoped endpoint:
-
-```python
-# Test all protected endpoints systematically
-protected_endpoints = [
-    "workspaces", "projects", "issues", 
-    "agents", "labels", "dependencies"
-]
-
-for endpoint in protected_endpoints:
-    await verify_403_for_nonmember(endpoint)
-```
+<Accordion title="Verify RBAC on every workspace route">
+Assert 403 for non-members on projects, issues, agents, labels, and dependencies.
 </Accordion>
-
-<Accordion title="Clean Test Isolation">
-Each test should create its own data to avoid conflicts:
-
-```python
-@pytest.mark.asyncio
-async def test_isolated_data():
-    # Use unique email for each test
-    email = f"test-{uuid.uuid4()}@example.com"
-    client = PlatformClient()
-    await client.register(email, "password")
-```
+<Accordion title="Isolate test data with unique emails">
+Use `f"test-{uuid.uuid4()}@example.com"` per test to avoid collisions.
 </Accordion>
 </AccordionGroup>
 
@@ -373,10 +167,10 @@ async def test_isolated_data():
 ## Related
 
 <CardGroup cols={2}>
-<Card title="Platform API Reference" icon="code" href="/docs/features/platform/sdk-client">
-  Complete API endpoint documentation
+<Card title="Platform SDK Client" icon="code" href="/docs/features/platform/sdk-client">
+  Complete PlatformClient API reference
 </Card>
-<Card title="Authentication & RBAC" icon="shield" href="/docs/features/platform/auth-configuration">
-  Security and access control details
+<Card title="RBAC Enforcement" icon="shield" href="/docs/features/platform/rbac-enforcement">
+  Workspace membership and role checks
 </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Upgraded five feature pages per AGENTS.md §9: agent-centric openers, hero mermaid, Steps, AccordionGroup, CardGroup
- `persistence.mdx` / `persistence-sqlite.mdx`: aligned with batch 24 patterns; removed concepts links; `start()` not `chat()`
- `planning-mode.mdx`: agent opener; `AgentTeam` for multi-agent example
- `platform-aware-agents.mdx`: `Bot` API; trimmed config tables
- `platform-client-sdk-testing.mdx`: concise test patterns with ASGITransport

Refs #1000

## Test plan
- [x] All five pages follow AGENTS.md §9 structure
- [x] No edits under `docs/concepts/`
- [x] Related links point to `docs/features/` only

Made with [Cursor](https://cursor.com)