### PR TITLE
docs: AGENTS.md §9 compliance batch 27 (#1000)

### DIFF
--- a/docs/features/policy-engine.mdx
+++ b/docs/features/policy-engine.mdx
@@ -1,22 +1,16 @@
 ---
 title: "Policy Engine"
+sidebarTitle: "Policy Engine"
 description: "Policy-based execution control for agent operations"
 icon: "shield-check"
 ---
 
-# Policy Engine
-
-Define and enforce policies that control what agents can and cannot do. Block dangerous operations, require approval for sensitive actions, and implement fine-grained access control.
-
-## Quick Start
-
-### Agent-Centric Usage
+Define allow/deny rules so agents cannot run dangerous tools — attach a `PolicyEngine` before the agent starts.
 
 ```python
 from praisonaiagents import Agent
 from praisonaiagents.policy import PolicyEngine, Policy, PolicyRule, PolicyAction
 
-# Create policy engine with rules
 engine = PolicyEngine()
 engine.add_policy(Policy(
     name="no_delete",
@@ -24,162 +18,150 @@ engine.add_policy(Policy(
         PolicyRule(
             action=PolicyAction.DENY,
             resource="tool:delete_*",
-            reason="Delete operations blocked"
+            reason="Delete operations blocked",
         )
-    ]
+    ],
 ))
 
-# Agent with policy enforcement
 agent = Agent(
     name="SecureAgent",
     instructions="You are a file management assistant.",
-    policy=engine
 )
-
-# Policy is enforced during agent operations
-agent.start("Help me organize and clean up my files")
-# Delete operations will be blocked by policy
+agent.policy = engine
+agent.start("Help me organise my project files")
 ```
 
-## Features
+```mermaid
+graph LR
+    Agent[🤖 Agent] --> Engine[🛡️ PolicyEngine]
+    Engine --> Check{Rule match?}
+    Check -->|deny| Block[🚫 Blocked]
+    Check -->|allow| Tool[🔧 Tool runs]
 
-- **Rule-Based Control**: Define allow/deny rules with patterns
-- **Priority System**: Higher priority policies take precedence
-- **Strict Mode**: Deny unknown operations by default
-- **Serialization**: Save/load policies as JSON
-- **Convenience Functions**: Pre-built common policies
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef policy fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef deny fill:#F59E0B,stroke:#7C90A0,color:#fff
 
-## Policy Rules
-
-### Rule Structure
-
-```python
-from praisonaiagents.policy import PolicyRule, PolicyAction
-
-rule = PolicyRule(
-    name="block_shell",           # Rule identifier
-    action=PolicyAction.DENY,     # ALLOW, DENY, or ASK
-    resource="tool:shell_*",      # Pattern to match
-    reason="Shell commands blocked",  # Explanation
-    conditions={"env": "production"}  # Optional conditions
-)
+    class Agent agent
+    class Engine,Check policy
+    class Tool result
+    class Block deny
 ```
 
-### Pattern Matching
+## Quick Start
+
+<Steps>
+<Step title="Simple Usage">
+
+Block delete tools on a file-management agent:
 
 ```python
-# Exact match
-resource="tool:read_file"
-
-# Wildcard suffix
-resource="tool:delete_*"
-
-# Wildcard prefix
-resource="*:dangerous"
-
-# All tools
-resource="tool:*"
-```
-
-## Convenience Functions
-
-```python
+from praisonaiagents import Agent
 from praisonaiagents.policy import (
+    PolicyEngine, Policy, PolicyRule, PolicyAction,
     create_read_only_policy,
-    create_deny_tools_policy,
-    create_allow_tools_policy
 )
 
-# Read-only mode - block all write operations
-read_only = create_read_only_policy()
+engine = PolicyEngine()
+engine.add_policy(create_read_only_policy())
 
-# Block specific tools
-deny_dangerous = create_deny_tools_policy(
-    ["execute_*", "shell_*", "system_*"],
-    reason="System commands are blocked"
-)
-
-# Allow only specific tools
-allow_safe = create_allow_tools_policy(
-    ["read_file", "list_directory", "search"]
-)
+agent = Agent(name="Assistant", instructions="Manage files safely.")
+agent.policy = engine
+agent.start("List files in the current directory")
 ```
 
-## CLI Usage
+</Step>
 
-```bash
-praisonai policy list                  # List policies
-praisonai policy check "tool:name"     # Check if allowed
-praisonai policy init                  # Create template
+<Step title="With Configuration">
+
+Use strict mode and custom deny lists:
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.policy import (
+    PolicyEngine, PolicyConfig, create_deny_tools_policy,
+)
+
+engine = PolicyEngine(PolicyConfig(strict_mode=True))
+engine.add_policy(create_deny_tools_policy(
+    ["execute_*", "shell_*"],
+    reason="System commands are blocked",
+))
+
+agent = Agent(name="Reviewer", instructions="Read and summarise code only.")
+agent.policy = engine
 ```
+
+</Step>
+</Steps>
 
 ---
 
-## Low-level API Reference
+## How It Works
 
-### PolicyEngine Direct Usage
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Engine as PolicyEngine
+    participant Tool
 
-```python
-from praisonaiagents.policy import (
-    PolicyEngine, Policy, PolicyRule, PolicyAction
-)
-
-# Create engine
-engine = PolicyEngine()
-
-# Add a policy to block delete operations
-policy = Policy(
-    name="no_delete",
-    rules=[
-        PolicyRule(
-            action=PolicyAction.DENY,
-            resource="tool:delete_*",
-            reason="Delete operations are blocked"
-        )
-    ]
-)
-engine.add_policy(policy)
-
-# Check if action is allowed
-result = engine.check("tool:delete_file", context={})
-if not result.allowed:
-    print(f"Blocked: {result.reason}")
+    Agent->>Engine: check("tool:delete_file")
+    alt denied
+        Engine-->>Agent: PolicyResult(allowed=false)
+    else allowed
+        Engine-->>Agent: PolicyResult(allowed=true)
+        Agent->>Tool: execute
+    end
 ```
 
-### Strict Mode
+| Component | Purpose |
+|-----------|---------|
+| `PolicyRule` | Wildcard resource patterns with `ALLOW`, `DENY`, `ASK`, or `LOG` |
+| `PolicyEngine` | Evaluates rules by priority; optional strict mode |
+| `agent.policy` | Attach the engine before `start()` |
 
-In strict mode, any operation not explicitly allowed is denied:
+Pattern examples: `tool:read_file`, `tool:delete_*`, `tool:*`.
 
-```python
-from praisonaiagents.policy import PolicyEngine, PolicyConfig
+---
 
-engine = PolicyEngine(PolicyConfig(strict_mode=True))
+## Configuration Options
 
-# Unknown operations are denied
-result = engine.check("tool:unknown", {})
-assert not result.allowed
-```
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `strict_mode` | `bool` | `False` | Deny operations not explicitly allowed |
+| `action` | `PolicyAction` | — | `ALLOW`, `DENY`, `ASK`, `LOG`, `RATE_LIMIT` |
+| `resource` | `str` | `None` | Glob pattern (e.g. `tool:shell_*`) |
+| `priority` | `int` | `0` | Higher priority rules evaluate first |
 
-### Policy Serialization
+---
 
-```python
-# Save to dict
-policy_data = policy.to_dict()
+## Best Practices
 
-# Load from dict
-restored = Policy.from_dict(policy_data)
+<AccordionGroup>
+<Accordion title="Attach policy before the first turn">
+Set `agent.policy = engine` immediately after creating the agent.
+</Accordion>
+<Accordion title="Start with read-only presets">
+Use `create_read_only_policy()` before writing custom rules.
+</Accordion>
+<Accordion title="Use wildcards sparingly">
+Prefer `tool:delete_*` over `tool:*` deny rules so read tools keep working.
+</Accordion>
+<Accordion title="Enable strict mode in production">
+`PolicyConfig(strict_mode=True)` blocks unknown tool names by default.
+</Accordion>
+</AccordionGroup>
 
-# Save to JSON file
-import json
-with open("policies.json", "w") as f:
-    json.dump([p.to_dict() for p in engine.policies], f)
-```
+---
 
-## Zero Performance Impact
+## Related
 
-Policies are only evaluated when explicitly checked:
-
-```python
-# No overhead until check() is called
-from praisonaiagents.policy import PolicyEngine
-```
+<CardGroup cols={2}>
+<Card title="Guardrails" icon="shield" href="/docs/features/guardrails">
+  Validate agent output before returning to users
+</Card>
+<Card title="Approval" icon="hand" href="/docs/features/approval">
+  Require human confirmation for sensitive actions
+</Card>
+</CardGroup>

--- a/docs/features/post-edit-formatter.mdx
+++ b/docs/features/post-edit-formatter.mdx
@@ -1,46 +1,52 @@
 ---
 title: "Post-Edit Formatter"
 sidebarTitle: "Post-Edit Formatter"
-description: "Automatically format files after agent edits using language-appropriate formatters like ruff, prettier, gofmt, and rustfmt"
+description: "Automatically format files after agent edits using ruff, prettier, gofmt, or rustfmt"
 icon: "wand-magic-sparkles"
 ---
 
-The post-edit formatter runs your preferred code formatter automatically after every agent file edit — keeping code style consistent without any extra steps.
+Run your project's formatter after every agent file edit so style stays consistent without extra steps.
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools.edit_tools import create_edit_tools
+
+edit_tools = create_edit_tools(post_edit_format="auto")
+
+coder = Agent(
+    name="Coder",
+    instructions="Edit files cleanly and keep formatting consistent.",
+    tools=edit_tools,
+)
+coder.start("Refactor utils.py to use list comprehensions")
+```
 
 ```mermaid
 graph LR
-    subgraph "Post-Edit Formatter Pipeline"
-        A[🤖 Agent] --> B[edit_file / apply_patch]
-        B --> C{post_edit_format?}
-        C -->|off| D[✅ Done]
-        C -->|auto/on| E[🔍 Detect formatter]
-        E --> F{Formatter found?}
-        F -->|no| D
-        F -->|yes| G[⚙️ Run formatter]
-        G --> H{Exit 0?}
-        H -->|no| D
-        H -->|yes| I[🔄 Re-read file]
-        I --> D
-    end
+    A[🤖 Agent] --> B[edit_file]
+    B --> C{post_edit_format?}
+    C -->|off| D[✅ Done]
+    C -->|auto| E[⚙️ Formatter]
+    E --> D
 
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
     classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef result fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef process fill:#6366F1,stroke:#7C90A0,color:#fff
 
     class A agent
-    class B tool
-    class C,F,H decision
+    class B,E tool
+    class C decision
     class D result
-    class E,G,I process
 ```
 
 ## Quick Start
 
 <Steps>
+<Step title="Simple Usage">
 
-<Step title="Enable auto-formatting (simplest)">
+Enable auto-formatting on edit tools:
+
 ```python
 from praisonaiagents import Agent
 from praisonaiagents.tools.edit_tools import create_edit_tools
@@ -52,14 +58,17 @@ coder = Agent(
     instructions="Edit the file as requested.",
     tools=edit_tools,
 )
-
-coder.start("Refactor utils.py to use list comprehensions")
+coder.start("Add type hints to models.py")
 ```
-Files are formatted automatically after each edit.
+
 </Step>
 
-<Step title="With a project-specific formatter map">
+<Step title="With Configuration">
+
+Pin formatters per extension:
+
 ```python
+from praisonaiagents import Agent
 from praisonaiagents.tools.edit_tools import create_edit_tools
 
 edit_tools = create_edit_tools(
@@ -69,221 +78,70 @@ edit_tools = create_edit_tools(
         ".ts": ["./node_modules/.bin/prettier", "--write", "{path}"],
     },
 )
+
+coder = Agent(name="PolyglotCoder", instructions="Edit Python and TypeScript.", tools=edit_tools)
 ```
+
 </Step>
-
-<Step title="Disable formatting (default)">
-```python
-from praisonaiagents.tools.edit_tools import create_edit_tools
-
-edit_tools = create_edit_tools(post_edit_format="off")
-```
-</Step>
-
 </Steps>
+
+<Note>
+A missing or failing formatter never fails the edit — the original write is kept and errors are logged at debug level.
+</Note>
 
 ---
 
 ## How It Works
 
-After a successful `edit_file` or `apply_patch`, the formatter pipeline runs:
+After a successful `edit_file` or `apply_patch`, the pipeline detects a formatter by file extension, runs it, and re-reads the file on exit code 0.
 
-```mermaid
-sequenceDiagram
-    participant A as Agent
-    participant ET as EditTools
-    participant F as Formatter Process
-    participant FS as File System
+| Extension | Default command |
+|-----------|-----------------|
+| `.py` | `ruff format {path}` (falls back to `black`) |
+| `.js`, `.ts`, `.tsx`, `.json`, `.css`, `.md` | `prettier --no-config --no-editorconfig --write {path}` |
+| `.go` | `gofmt -w {path}` |
+| `.rs` | `rustfmt {path}` |
 
-    A->>ET: edit_file("utils.py", old, new)
-    ET->>FS: write updated content
-    ET->>ET: detect formatter for .py extension
-    ET->>F: ruff format utils.py
-    F-->>ET: exit code 0
-    ET->>FS: re-read file (formatted content)
-    ET-->>A: success (formatted content is now baseline)
-
-    Note over ET,F: If formatter exits non-zero or is missing,<br/>the edit still succeeds — error is logged at debug level
-```
-
-**Key guarantees:**
-- A failing or missing formatter **never** turns a successful edit into a failure
-- File hash is refreshed **only on formatter exit 0** — partial output is never adopted
-- Formatted result is re-read so the agent sees the final clean version
+The `{path}` placeholder is the absolute path to the edited file. If omitted from your argv list, it is appended automatically.
 
 ---
 
 ## Configuration Options
 
-### `create_edit_tools` parameters
-
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `post_edit_format` | `str` | `"off"` | `"off"` — disabled; `"auto"` or `"on"` — run formatter if detected. Invalid value falls back to `"off"` |
-| `formatters` | `dict[str, list[str]]` | Built-in map | Per-extension formatter argv. Supports `{path}` placeholder; appended to args if absent |
-| `post_edit_diagnostics` | `str` | `"auto"` | Diagnostics mode — separate from formatting |
-
----
-
-## Built-in Formatter Defaults
-
-| Extension | Default formatter command |
-|-----------|--------------------------|
-| `.py` | `ruff format {path}` (falls back to `black`) |
-| `.js`, `.jsx`, `.mjs`, `.cjs` | `prettier --no-config --no-editorconfig --write {path}` |
-| `.ts`, `.tsx` | `prettier --no-config --no-editorconfig --write {path}` |
-| `.json`, `.css`, `.md`, `.yaml`, `.yml` | `prettier --no-config --no-editorconfig --write {path}` |
-| `.go` | `gofmt -w {path}` |
-| `.rs` | `rustfmt {path}` |
-
-<Note>
-`prettier` is always invoked with `--no-config --no-editorconfig` so repo-controlled config cannot execute arbitrary plugins. This is a security measure.
-</Note>
-
----
-
-## Common Patterns
-
-### Python project with ruff
-
-```python
-from praisonaiagents import Agent
-from praisonaiagents.tools.edit_tools import create_edit_tools
-
-edit_tools = create_edit_tools(
-    post_edit_format="auto",
-    formatters={
-        ".py": ["ruff", "format", "{path}"],
-    },
-)
-
-coder = Agent(
-    name="PythonCoder",
-    instructions="Write clean, well-formatted Python code.",
-    tools=edit_tools,
-)
-
-coder.start("Add type hints to all functions in models.py")
-```
-
-### TypeScript project with local prettier
-
-```python
-from praisonaiagents import Agent
-from praisonaiagents.tools.edit_tools import create_edit_tools
-
-edit_tools = create_edit_tools(
-    post_edit_format="auto",
-    formatters={
-        ".ts": ["./node_modules/.bin/prettier", "--write", "{path}"],
-        ".tsx": ["./node_modules/.bin/prettier", "--write", "{path}"],
-    },
-)
-
-coder = Agent(
-    name="TSCoder",
-    instructions="Write TypeScript components.",
-    tools=edit_tools,
-)
-
-coder.start("Refactor Button.tsx to use functional components")
-```
-
-### Multi-language project
-
-```python
-from praisonaiagents import Agent
-from praisonaiagents.tools.edit_tools import create_edit_tools
-
-edit_tools = create_edit_tools(
-    post_edit_format="auto",
-    formatters={
-        ".py": ["ruff", "format", "{path}"],
-        ".go": ["gofmt", "-w", "{path}"],
-        ".rs": ["rustfmt", "{path}"],
-    },
-)
-
-coder = Agent(
-    name="PolyglotCoder",
-    instructions="Edit code across Python, Go, and Rust files.",
-    tools=edit_tools,
-)
-```
-
----
-
-## The `{path}` Placeholder
-
-The `{path}` placeholder is replaced with the absolute path to the edited file at runtime.
-
-```python
-formatters={
-    ".py": ["ruff", "format", "{path}"],
-}
-```
-
-If `{path}` is not included in the args list, it is automatically appended:
-
-```python
-formatters={
-    ".py": ["ruff", "format"],
-}
-```
-
-Both forms are equivalent.
-
----
-
-## Project-Local Formatter Paths
-
-Relative formatter paths are resolved relative to the **edited file's directory**, not the working directory:
-
-```python
-formatters={
-    ".ts": ["./node_modules/.bin/prettier", "--write", "{path}"],
-}
-```
-
-This means a formatter installed in `my-project/node_modules/.bin/prettier` is found when editing any file under `my-project/`.
+| `post_edit_format` | `str` | `"off"` | `"off"`, `"auto"`, or `"on"` |
+| `formatters` | `dict[str, list[str]]` | Built-in map | Per-extension formatter argv |
+| `post_edit_diagnostics` | `str` | `"auto"` | Separate linter/diagnostics pass |
 
 ---
 
 ## Best Practices
 
 <AccordionGroup>
-
-<Accordion title="Start with 'auto' mode">
-Use `post_edit_format="auto"` — it runs the formatter only when one is available, never breaks existing edits, and costs nothing when no formatter is installed.
+<Accordion title="Start with auto mode">
+`post_edit_format="auto"` runs a formatter only when one is on `PATH` — zero cost when none is installed.
 </Accordion>
-
-<Accordion title="Pin formatter versions in CI">
-The formatter is discovered from `PATH` at runtime. In CI, ensure the formatter version matches your local setup to avoid diff churn between formatter versions.
-</Accordion>
-
 <Accordion title="Use project-local prettier">
-For JavaScript/TypeScript projects, prefer `./node_modules/.bin/prettier` over a global install. This ensures the version matches your `package.json` and respects project plugins — while the `--no-config --no-editorconfig` flags prevent arbitrary plugin execution.
+Prefer `./node_modules/.bin/prettier` so the version matches `package.json`.
 </Accordion>
-
-<Accordion title="Formatter failures are silent by default">
-If the formatter is missing, crashes, or exits non-zero, the edit still succeeds and the original result is kept. Check your formatter's PATH and version if formatting seems not to run.
+<Accordion title="Pin formatter versions in CI">
+Match local and CI formatter versions to avoid diff churn between runs.
 </Accordion>
-
-<Accordion title="Don't double-format">
-If your CI already runs a formatter on commit, you don't need `post_edit_format`. It's most useful for interactive agent sessions where you want immediate, clean output.
+<Accordion title="Skip when CI already formats">
+Most useful for interactive agent sessions where you want immediate clean output.
 </Accordion>
-
 </AccordionGroup>
 
 ---
 
-## See Also
+## Related
 
 <CardGroup cols={2}>
-  <Card title="File Editing" icon="pen-to-square" href="/docs/features/file-editing">
-    Core file editing tools and operations
-  </Card>
-  <Card title="Code Agent" icon="code" href="/docs/features/code">
-    Code assistant agent configuration
-  </Card>
+<Card title="File Editing" icon="pen-to-square" href="/docs/features/file-editing">
+  Core edit and patch tools
+</Card>
+<Card title="Code Agent" icon="code" href="/docs/features/code">
+  Code assistant configuration
+</Card>
 </CardGroup>

--- a/docs/features/prepared-turn-context.mdx
+++ b/docs/features/prepared-turn-context.mdx
@@ -5,62 +5,77 @@ description: "One immutable plan per agent turn, shared by every runtime (native
 icon: "layers"
 ---
 
-One immutable plan describes a single agent turn — every runtime (native, plugin, CLI) reads the same plan.
+Build one frozen turn plan from an `Agent` and prompt — any runtime (native, plugin, CLI) executes the same context.
 
-```mermaid
-graph LR
-    subgraph Before["Before — scattered prep"]
-        A1[chat_mixin]:::warn --> X[run_attempt]:::process
-        A2[chat_handler]:::warn --> X
-        A3[agent.py]:::warn --> X
-        A4[handoff.py]:::warn --> X
-    end
-    subgraph After["After — one plan"]
-        B[Agent + prompt]:::input --> C[DefaultTurnContextBuilder]:::config
-        C --> D[(PreparedTurnContext)]:::process
-        D --> R1[Native runtime]:::result
-        D --> R2[Plugin harness]:::result
-        D --> R3[CLI backend]:::result
-    end
-
-    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef warn fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
-```
-
-## Quick Start
-
-<Steps>
-<Step title="Default — nothing to change">
-Existing `Agent(...)` code paths are unchanged. `PreparedTurnMixin` / `TurnExecutionMixin` on `Agent` can prepare context behind the scenes when you opt in explicitly.
-</Step>
-
-<Step title="Inspect what the agent will do">
 ```python
 from praisonaiagents import Agent
 from praisonaiagents.runtime import default_context_builder
 
 agent = Agent(name="Researcher", instructions="Find facts and cite sources.")
-
 context = default_context_builder.build_context(agent, "Who built the Eiffel Tower?")
 print(context.to_dict())
 ```
+
+```mermaid
+graph LR
+    Agent[🤖 Agent] --> Builder[📋 ContextBuilder]
+    Builder --> Plan[(PreparedTurnContext)]
+    Plan --> Native[Native runtime]
+    Plan --> Plugin[Plugin harness]
+    Plan --> CLI[CLI backend]
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Agent input
+    class Builder,Plan process
+    class Native,Plugin,CLI result
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Simple Usage">
+
+Inspect what the agent will send on the next turn:
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.runtime import default_context_builder
+
+agent = Agent(name="Writer", instructions="Summarise pull requests.")
+context = default_context_builder.build_context(agent, "Summarise this PR")
+
+print(context.has_tools(), context.get_message_count())
+print(context.to_dict())
+```
+
 </Step>
 
-<Step title="Run with your own harness">
+<Step title="With Configuration">
+
+Run the same context through a custom harness:
+
 ```python
+import asyncio
 from praisonaiagents import Agent
 from praisonaiagents.runtime import default_context_builder
 from praisonaiagents.runtime.example_harness import PluginHarnessRuntime
 
 agent = Agent(name="Writer", instructions="Summarise pull requests.")
 context = default_context_builder.build_context(agent, "Summarise this PR")
-result = await PluginHarnessRuntime().run_turn(context)
+
+async def run():
+    return await PluginHarnessRuntime().run_turn(context)
+
+asyncio.run(run())
 ```
+
 </Step>
 </Steps>
+
+---
 
 ## How It Works
 
@@ -70,7 +85,7 @@ sequenceDiagram
     participant Agent
     participant Builder as DefaultTurnContextBuilder
     participant Context as PreparedTurnContext
-    participant Runtime as TurnRuntimeProtocol
+    participant Runtime
 
     User->>Agent: prompt
     Agent->>Builder: build_context(agent, prompt)
@@ -81,208 +96,40 @@ sequenceDiagram
 
 | Stage | What happens |
 |-------|--------------|
-| Build | `default_context_builder.build_context(agent, prompt, **kwargs)` resolves model, tools, transcript, delivery, correlation |
-| Freeze | Context is immutable (`frozen=True`, `MappingProxyType` on dict fields) |
-| Execute | Any `TurnRuntimeProtocol` implementation runs the same context |
+| Build | Resolves model, tools, transcript, delivery, correlation |
+| Freeze | Context is immutable after construction |
+| Execute | Any `TurnRuntimeProtocol` runs the same plan |
 
-### Public imports
+Key imports: `PreparedTurnContext`, `default_context_builder`, `RuntimeMode`, `DeliveryChannels`.
 
-```python
-from praisonaiagents.runtime import (
-    PreparedTurnContext,
-    TurnRuntimeProtocol,
-    TurnContextBuilderProtocol,
-    ModelReference,
-    ToolSchema,
-    TranscriptWindow,
-    DeliveryChannels,
-    SessionCorrelation,
-    RuntimeMode,
-    DefaultTurnContextBuilder,
-    default_context_builder,
-    create_default_model_ref,
-    create_empty_transcript,
-    create_default_delivery,
-    create_session_correlation,
-)
-```
-
-## Picking a Runtime Mode
-
-```mermaid
-graph TD
-    Start[How will you run the turn?] --> Sync{Blocking script?}
-    Sync -->|yes| M1[SYNC]
-    Sync -->|no| Async{Inside async app?}
-    Async -->|yes, no stream| M2[ASYNC]
-    Async -->|yes, stream to UI| M4[ASYNC_STREAM]
-    Async -->|no, stream to UI| M3[STREAM]
-
-    classDef decide fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef mode fill:#189AB4,stroke:#7C90A0,color:#fff
-
-    class Start decide
-    class M1,M2,M3,M4 mode
-```
-
-| Use case | `RuntimeMode` |
-|----------|---------------|
-| Script, one-shot reply | `SYNC` |
-| Inside async app | `ASYNC` |
-| Streaming to UI | `STREAM` (requires `DeliveryChannels(enable_streaming=True, ...)`) |
-| Streaming inside async app | `ASYNC_STREAM` |
-
-`STREAM` and `ASYNC_STREAM` raise `ValueError` if `delivery.has_streaming()` is false.
+---
 
 ## Configuration Options
 
-### `PreparedTurnContext`
+| Field | Type | Notes |
+|-------|------|-------|
+| `runtime_mode` | `RuntimeMode` | `SYNC`, `ASYNC`, `STREAM`, `ASYNC_STREAM` |
+| `delivery` | `DeliveryChannels` | Required for streaming modes |
+| `correlation` | `SessionCorrelation` | `session_id`, `turn_id`, `agent_id`, `run_id` |
 
-| Field | Type | Default | Notes |
-|-------|------|---------|-------|
-| `model_ref` | `ModelReference` | — | Resolved model id, provider, capabilities |
-| `agent_runtime` | `AgentProtocol` | — | Runtime instance for the turn |
-| `tools` | `Tuple[ToolSchema, ...]` | `()` | Normalised tool schemas |
-| `transcript` | `TranscriptWindow` | — | Conversation slice + system prompt |
-| `delivery` | `DeliveryChannels` | — | Stream emitter, callbacks, formatter |
-| `correlation` | `SessionCorrelation` | — | session_id / turn_id / agent_id / run_id |
-| `runtime_mode` | `RuntimeMode` | `SYNC` | `sync`, `async`, `stream`, `async_stream` |
-| `turn_metadata` | `Mapping[str, Any]` | `{}` | Immutable after construction |
-| `created_at` | `float` | `time.time()` | Preparation timestamp |
+`STREAM` and `ASYNC_STREAM` raise `ValueError` if `delivery.has_streaming()` is false.
 
-Helpers: `get_tool_by_name(name)`, `has_tools()`, `has_system_prompt()`, `get_message_count()`, `to_dict()`.
-
-### `ModelReference`
-
-| Field | Type | Default |
-|-------|------|---------|
-| `model_id` | `str` | required |
-| `provider` | `str` | required |
-| `supports_streaming` | `bool` | `False` |
-| `supports_tools` | `bool` | `False` |
-| `supports_system_prompts` | `bool` | `True` |
-| `max_tokens` | `Optional[int]` | `None` |
-| `temperature` | `Optional[float]` | `None` |
-| `model_config` | `Mapping[str, Any]` | `{}` |
-
-Raises `ValueError` if `model_id` or `provider` is missing.
-
-### `ToolSchema`
-
-| Field | Type | Default |
-|-------|------|---------|
-| `name` | `str` | required |
-| `description` | `str` | required |
-| `parameters` | `dict` | required |
-| `callable` | `Optional[Any]` | `None` |
-| `source_type` | `str` | `"unknown"` |
-| `metadata` | `Mapping[str, Any]` | `{}` |
-
-### `TranscriptWindow`
-
-| Field | Type | Default |
-|-------|------|---------|
-| `messages` | `Tuple[Mapping, ...]` | required |
-| `total_tokens` | `int` | `0` |
-| `system_prompt` | `Optional[str]` | `None` |
-| `context_metadata` | `Mapping[str, Any]` | `{}` |
-
-### `DeliveryChannels`
-
-| Field | Type | Default |
-|-------|------|---------|
-| `stream_emitter` | `Optional[StreamEventEmitter]` | `None` |
-| `output_formatter` | `Optional[Any]` | `None` |
-| `callbacks` | `Tuple` | `()` |
-| `async_callbacks` | `Tuple` | `()` |
-| `enable_streaming` | `bool` | `False` |
-| `enable_metrics` | `bool` | `False` |
-
-Helper: `has_streaming()`.
-
-### `SessionCorrelation`
-
-| Field | Type | Default |
-|-------|------|---------|
-| `session_id` | `Optional[str]` | `None` |
-| `turn_id` | `Optional[str]` | `None` |
-| `agent_id` | `Optional[str]` | `None` |
-| `run_id` | `Optional[str]` | `None` |
-| `parent_id` | `Optional[str]` | `None` |
-| `trace_metadata` | `Mapping[str, Any]` | `{}` |
-
-### Utility constructors
-
-- `create_default_model_ref(model_id="gpt-3.5-turbo", provider="openai")`
-- `create_empty_transcript(system_prompt=None)`
-- `create_default_delivery()`
-- `create_session_correlation(session_id=None, agent_id=None)`
-
-## Common Patterns
-
-### Build your own harness
-
-```python
-from typing import List
-from praisonaiagents.runtime import TurnRuntimeProtocol, PreparedTurnContext, RuntimeMode
-
-class EchoHarness:
-    async def run_turn(self, context: PreparedTurnContext) -> str:
-        return f"Echo: {context.get_message_count()} messages"
-
-    def supports_runtime_mode(self, mode: RuntimeMode) -> bool:
-        return mode in (RuntimeMode.SYNC, RuntimeMode.ASYNC)
-
-    def get_supported_modes(self) -> List[RuntimeMode]:
-        return [RuntimeMode.SYNC, RuntimeMode.ASYNC]
-```
-
-Implement `TurnRuntimeProtocol`: `async run_turn(context)`, `supports_runtime_mode(mode)`, `get_supported_modes()`.
-
-### Stream to a UI
-
-```python
-from praisonaiagents.runtime import DeliveryChannels, RuntimeMode, PreparedTurnContext
-
-delivery = DeliveryChannels(enable_streaming=True, stream_emitter=my_emitter)
-# Pass delivery into build_context kwargs; set runtime_mode=RuntimeMode.STREAM
-```
-
-### Track turns across services
-
-```python
-from praisonaiagents.runtime import create_session_correlation, default_context_builder
-
-correlation = create_session_correlation(session_id="prod-chat-42", agent_id="researcher")
-context = default_context_builder.build_context(agent, prompt, session_id=correlation.session_id)
-print(context.correlation.turn_id)
-```
-
-### Example harness templates
-
-Reference implementations in `praisonaiagents.runtime.example_harness`:
-
-- `PluginHarnessRuntime` — plugin pattern, streaming-aware
-- `CLIBackendHarness` — CLI backend pattern
-- `demonstrate_harness_integration()` — run with `python -m praisonaiagents.runtime.example_harness`
+---
 
 ## Best Practices
 
 <AccordionGroup>
-<Accordion title="Treat the context as read-only">
-Fields are frozen. Mutations must go through hooks, not field assignment.
+<Accordion title="Treat context as read-only">
+Fields are frozen — mutate via hooks, not assignment.
 </Accordion>
-
-<Accordion title="Build a context per turn, not per agent">
-The plan is per-turn for multi-agent safety. Do not cache it across turns.
+<Accordion title="Build one context per turn">
+Do not cache plans across turns in multi-agent setups.
 </Accordion>
-
 <Accordion title="Reuse default_context_builder">
-It is a module-level singleton — no need to instantiate `DefaultTurnContextBuilder` yourself.
+It is a module-level singleton — no need to instantiate your own builder.
 </Accordion>
-
 <Accordion title="Match runtime_mode to delivery">
-`STREAM` / `ASYNC_STREAM` require `DeliveryChannels.has_streaming()` — otherwise construction raises `ValueError`.
+Enable `DeliveryChannels(enable_streaming=True, ...)` before choosing stream modes.
 </Accordion>
 </AccordionGroup>
 
@@ -292,7 +139,7 @@ It is a module-level singleton — no need to instantiate `DefaultTurnContextBui
 
 <CardGroup cols={2}>
 <Card title="Runtime Selection" icon="play" href="/docs/features/runtime-selection">
-  Model-scoped runtime configuration for each turn
+  Model-scoped runtime configuration
 </Card>
 <Card title="Streaming" icon="signal-stream" href="/docs/features/streaming">
   Stream agent output token-by-token

--- a/docs/features/proactive-delivery.mdx
+++ b/docs/features/proactive-delivery.mdx
@@ -5,56 +5,14 @@ description: "Send messages from your bot to any channel — by origin, platform
 icon: "paper-plane"
 ---
 
-Proactive delivery lets your bot push messages outbound — reply back to the requesting chat, deliver to a **home channel** set with `/sethome`, or target explicit delivery tokens without hardcoding IDs in every job.
-
-## Home Channels (`/sethome`)
-
-Mark a chat once as the platform default for scheduled deliveries. Settings persist to `~/.praisonai/state/home_channels.json`.
-
-```bash
-# In Telegram (or any bot chat):
-/sethome
-
-# Then schedule without a numeric chat id:
-praisonai schedule add "daily-news" -s daily -m "Summarise AI news" --deliver telegram
-```
-
-| Delivery token | Resolves to |
-|---|---|
-| `origin` | Chat where the job was created (`--channel` + `--channel-id` required at creation) |
-| `<platform>` (e.g. `telegram`) | That platform's home channel from `/sethome` |
-| `<platform>:<chat_id>[:<thread_id>]` | Explicit target |
-| `all` | Fan-out to every platform with a configured home channel |
-
-See [Bot Chat Commands](/docs/features/bot-commands#sethome) for the `/sethome` command.
-
-```mermaid
-graph LR
-    T[Target] --> R[DeliveryRouter]
-    R --> D[ChannelDirectory]
-    R --> B[Bot Adapter]
-    B --> C[Channel]
-
-    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
-
-    class T input
-    class R,D process
-    class B,C output
-```
-
-## Quick Start
-
-<Steps>
-<Step title="Reply to where the request came from">
+Push outbound messages from an agent-backed bot — reply to the requesting chat, a home channel, or a named alias.
 
 ```python
+import asyncio
 from praisonai.bots import BotOS, Bot, SessionSource
 from praisonaiagents import Agent
-import asyncio
 
-agent = Agent(name="ops", instructions="You alert humans about incidents.")
+agent = Agent(name="ops", instructions="Alert humans about incidents.")
 botos = BotOS(bots=[Bot("telegram", agent=agent)])
 
 botos.configure_channels({
@@ -68,26 +26,62 @@ async def notify():
 asyncio.run(notify())
 ```
 
-</Step>
+```mermaid
+graph LR
+    Agent[🤖 Agent] --> BotOS[BotOS]
+    BotOS --> Router[DeliveryRouter]
+    Router --> Channel[📨 Channel]
 
-<Step title="Send to a platform's default channel">
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
 
-```python
-await botos.deliver("telegram", "Nightly digest ready")
+    class Agent agent
+    class BotOS,Router process
+    class Channel output
 ```
 
-Requires `home_channel` configured for that platform.
+## Quick Start
+
+<Steps>
+<Step title="Simple Usage">
+
+Reply to where the request came from:
+
+```python
+import asyncio
+from praisonai.bots import BotOS, Bot, SessionSource
+from praisonaiagents import Agent
+
+agent = Agent(name="ops", instructions="Send status updates.")
+botos = BotOS(bots=[Bot("telegram", agent=agent)])
+
+async def notify():
+    src = SessionSource(platform="telegram", channel_id="123456")
+    await botos.deliver("origin", "Build finished!", origin=src)
+
+asyncio.run(notify())
+```
 
 </Step>
 
-<Step title="Send to a named alias">
+<Step title="With Configuration">
+
+Set home channels and deliver by alias:
 
 ```python
+botos.configure_channels({
+    "telegram": {"home_channel": "123456", "aliases": {"ops-alerts": "123456"}},
+})
+
+await botos.deliver("telegram", "Nightly digest ready")
 await botos.deliver("ops-alerts", "Disk usage at 90%")
 ```
 
 </Step>
 </Steps>
+
+---
 
 ## How It Works
 
@@ -96,52 +90,27 @@ sequenceDiagram
     participant Agent
     participant BotOS
     participant Router as DeliveryRouter
-    participant Dir as ChannelDirectory
-    participant Bot
     participant Channel
 
     Agent->>BotOS: deliver(target, text, origin?)
     BotOS->>Router: resolve(target)
-    Router->>Dir: lookup home / alias
-    Dir-->>Router: platform + channel_id
-    Router->>Bot: send_message
-    Bot->>Channel: outbound message
+    Router->>Channel: outbound message
 ```
 
-| Target | Resolves to | Example |
-|--------|-------------|---------|
-| `origin` | Chat that triggered the request | `deliver("origin", text, origin=src)` |
-| `<platform>` | Platform's `home_channel` | `deliver("telegram", text)` |
-| `<platform>:<id>` | Explicit channel | `deliver("telegram:123456", text)` |
-| `<alias>` | Friendly name from directory | `deliver("ops-alerts", text)` |
-| `<platform>:<id>` | Observed channel from traffic or adapter refresh | Surfaced in `describe_targets()` as `kind: "observed"` |
+| Target | Resolves to |
+|--------|-------------|
+| `origin` | Chat that triggered the request (`origin=SessionSource(...)`) |
+| `<platform>` | Platform home channel from `/sethome` or config |
+| `<platform>:<id>` | Explicit channel ID |
+| `<alias>` | Friendly name from `configure_channels` or overlay file |
 
-Resolution order: `origin` → `platform:channel_id` → bare platform name → alias. Platform names win over aliases — do not name an alias the same as a platform.
+Resolution order: `origin` → `platform:id` → bare platform → alias. Platform names win over aliases.
 
-Scheduled jobs use `DeliveryRouter` automatically, defaulting to `"origin"` when delivery context is present.
+Home and observed channels persist to `~/.praisonai/state/channel_directory.json`.
 
-## Choosing a Target Form
+---
 
-```mermaid
-graph TB
-    A{What do you need?} --> B[Reply to requester]
-    A --> C[One channel per platform]
-    A --> D[Known channel ID]
-    A --> E[Human-friendly name]
-
-    B --> F["origin + SessionSource"]
-    C --> G["telegram / slack / ..."]
-    D --> H["telegram:123456"]
-    E --> I["ops-alerts alias"]
-
-    classDef question fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef simple fill:#10B981,stroke:#7C90A0,color:#fff
-
-    class A question
-    class F,G,H,I simple
-```
-
-## Configuration
+## Configuration Options
 
 ### YAML
 
@@ -152,85 +121,11 @@ channels:
     home_channel: "123456"
     aliases:
       ops-alerts: "123456"
-      dev-chat: "789012"
 ```
 
-### Python
+### Alias overlay
 
-```python
-botos.configure_channels({
-    "telegram": {"home_channel": "123456", "aliases": {"ops-alerts": "123456"}},
-    "discord": {"home_channel": "789012"},
-})
-
-# Or use the directory directly
-botos.delivery_router.directory.add_alias("ops-alerts", "telegram", "123456")
-botos.delivery_router.directory.set_home_channel("telegram", "123456")
-```
-
-## Persistence
-
-Home and observed channels auto-persist to `~/.praisonai/state/channel_directory.json` and reload on start — reachable targets survive restarts.
-
-```python
-from pathlib import Path
-from praisonai.bots.delivery import ChannelDirectory
-
-# Default paths — channels survive restarts automatically
-directory = ChannelDirectory()
-directory.set_home_channel("telegram", "123456")
-directory.observe_channel("discord", "555")
-
-# Restart your process — channels are still reachable
-directory2 = ChannelDirectory()
-# telegram:home and discord:555 are immediately available
-```
-
-Custom paths for multi-tenant or containerised deployments:
-
-```python
-directory = ChannelDirectory(
-    persist_path=Path("/var/lib/myapp/dir.json"),
-    aliases_path=Path("/var/lib/myapp/aliases.json"),
-)
-```
-
-| Arg | Type | Default | Description |
-|---|---|---|---|
-| `persist_path` | `Optional[Path]` | `~/.praisonai/state/channel_directory.json` | Home + observed channels. Atomic write via temp file + `os.replace`. |
-| `aliases_path` | `Optional[Path]` | `~/.praisonai/state/channel_aliases.json` | Hand-editable alias overlay re-applied on every load + refresh. |
-
-<Note>
-Persistence is best-effort — failures are logged and never raised. Your bot keeps running even if the state directory is read-only.
-</Note>
-
-```mermaid
-graph LR
-    subgraph "Lifecycle"
-        Start([Start]) --> Load[Load channel_directory.json]
-        Load --> Overlay[Apply channel_aliases.json]
-        Overlay --> Ready([Ready])
-        Ready --> Traffic[Observe traffic]
-        Traffic --> Save[Persist]
-        Save --> Ready
-        Ready --> Refresh[refresh_from_adapters]
-        Refresh --> Overlay2[Re-apply overlay]
-        Overlay2 --> Save
-    end
-
-    classDef start fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef io fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef ready fill:#10B981,stroke:#7C90A0,color:#fff
-
-    class Start,Ready start
-    class Traffic,Refresh process
-    class Load,Overlay,Overlay2,Save io
-```
-
-## Pre-Naming Channels (Alias Overlay)
-
-Drop a JSON file at `~/.praisonai/state/channel_aliases.json` to pre-name channels before they produce any traffic.
+Pre-name channels in `~/.praisonai/state/channel_aliases.json`:
 
 ```json
 {
@@ -239,187 +134,36 @@ Drop a JSON file at `~/.praisonai/state/channel_aliases.json` to pre-name channe
 }
 ```
 
-Both long form and shorthand (`"platform:channel_id"`) are accepted. Invalid entries are skipped with a warning.
+Call `botos.delivery_router.refresh_directory()` periodically so adapters enumerate channels the bot has not yet heard from.
 
-With the overlay in place, the agent can deliver to `"engineering"` even without prior messages from that channel:
-
-```python
-from praisonai.bots.delivery import ChannelDirectory
-
-directory = ChannelDirectory()
-# engineering and ops are already reachable — no traffic needed
-await botos.deliver("engineering", "Deploy complete")
-```
-
-Editing the file and calling `refresh_directory()` (or restarting) honours alias deletions. Aliases added in code via `add_alias()` are never pruned by the overlay.
-
-## Refreshing from Live Adapters
-
-`refresh_directory()` enumerates every configured adapter and merges their channels into the directory — channels the agent has never been messaged from become reachable immediately.
-
-```python
-# Gateway background loop — call this periodically
-botos.delivery_router.refresh_directory()
-```
-
-Lower-level API for direct adapter access:
-
-```python
-from praisonai.bots.delivery import ChannelDirectory
-
-directory = ChannelDirectory()
-directory.refresh_from_adapters({
-    "discord": discord_bot,
-    "slack": slack_bot,
-})
-```
-
-Adapter contract: adapters must expose `list_channels()` returning an iterable of objects with a `.id` attribute (or plain strings). Adapters without `list_channels` are silently skipped; adapter errors are caught and logged, never raised.
-
-**User flow this enables:**
-
-1. User asks the agent: *"Post a summary to the engineering channel."*
-2. The agent has never received traffic from that channel.
-3. Because the gateway's background `refresh_directory()` already enumerated the Discord adapter, `"engineering"` is in the directory.
-4. `deliver("engineering", summary)` succeeds.
-
-## Common Patterns
-
-### Scheduled digest to a named channel
-
-```python
-summary = agent.start("Summarise today's incidents")
-await botos.deliver("ops-alerts", summary)
-```
-
-### Cross-channel notification from a tool
-
-```python
-await botos.deliver("slack:C123ABC", "FYI: deploy complete")
-```
-
-### Periodic refresh in a gateway loop
-
-```python
-import asyncio
-
-async def background_refresh(botos, interval=300):
-    while True:
-        botos.delivery_router.refresh_directory()
-        await asyncio.sleep(interval)
-
-asyncio.create_task(background_refresh(botos))
-```
+---
 
 ## Best Practices
 
 <AccordionGroup>
-<Accordion title="Prefer aliases over raw IDs in agent code">
-Aliases survive channel renumbering and read better in logs.
+<Accordion title="Prefer aliases over raw IDs">
+Aliases survive renumbering and read better in logs.
 </Accordion>
-
-<Accordion title="Always set home_channel for platforms you target by name">
-Bare-platform targets fail loudly without a configured home channel.
+<Accordion title="Set home_channel for each platform">
+Bare-platform targets fail without a configured home channel.
 </Accordion>
-
-<Accordion title="Do not name an alias the same as a platform">
-Platform-name lookup wins; the alias becomes unreachable by bare name.
+<Accordion title="Do not name aliases after platforms">
+`telegram` as an alias will never resolve — platform lookup wins.
 </Accordion>
-
 <Accordion title="Handle the bool return">
-`deliver()` returns `False` on resolution or send failure — log and retry as appropriate.
-</Accordion>
-
-<Accordion title="Use the alias overlay for pre-production setup">
-Pre-populate `channel_aliases.json` before deploying — channels become reachable without needing to send a message first.
-</Accordion>
-
-<Accordion title="Call refresh_directory() on a background loop">
-Adapters enumerate live channels; a 5-minute refresh keeps the directory current without hammering APIs.
+`deliver()` returns `False` on resolution or send failure — log and retry as needed.
 </Accordion>
 </AccordionGroup>
 
-## Friendly Aliases for Scheduled Delivery
-
-The gateway `DeliveryResolver` now accepts an optional `directory=` parameter backed by `ChannelDirectory`. This means the same friendly alias names you define for interactive chat work as scheduled-delivery targets — no more hardcoding platform IDs in cron jobs.
-
-**Backward compatibility:** when `directory=` is not passed (any existing code that builds its own `DeliveryResolver`), behaviour is byte-for-byte unchanged. Aliases only ever resolve names that are not already known platform names.
-
-### Worked Example
-
-**1. Define aliases in the overlay file** (`~/.praisonai/state/channel_aliases.json`):
-
-```json
-{
-  "family": { "platform": "telegram", "channel_id": "-1001234567890" },
-  "ops": "slack:C0123ABCDEF"
-}
-```
-
-**2. Schedule a job using the alias as the delivery target:**
-
-```python
-import asyncio
-from praisonai.bots import BotOS, Bot
-from praisonaiagents import Agent
-
-agent = Agent(name="digest", instructions="Summarise today's news")
-botos = BotOS(bots=[Bot("telegram", agent=agent), Bot("slack", agent=agent)])
-
-summary = agent.start("Summarise today's top AI news")
-asyncio.run(botos.deliver("family", summary))
-```
-
-The resolver looks up `"family"` in `ChannelDirectory` and routes to `telegram:-1001234567890`.
-
-**3. Resolved target:**
-
-| Alias | Resolved platform | Resolved channel_id |
-|---|---|---|
-| `family` | `telegram` | `-1001234567890` |
-| `ops` | `slack` | `C0123ABCDEF` |
-
-### Resolution Order
-
-```mermaid
-sequenceDiagram
-    participant Scheduler
-    participant Resolver as DeliveryResolver
-    participant Registry as HomeChannelRegistry
-    participant Dir as ChannelDirectory
-
-    Scheduler->>Resolver: resolve("family")
-    Resolver->>Resolver: "origin"? No
-    Resolver->>Resolver: "all"? No
-    Resolver->>Resolver: "platform:id" format? No
-    Resolver->>Registry: get_home("family")? No (not a platform)
-    Resolver->>Dir: resolve_alias("family")
-    Dir-->>Resolver: (telegram, -1001234567890)
-    Resolver-->>Scheduler: [DeliveryTarget(telegram, -1001234567890)]
-```
-
-### Alias Resolution Order Table
-
-| Step | Token form | Resolves to |
-|---|---|---|
-| 1 | `origin` | The chat where the job was created (requires `origin=` to be set) |
-| 2 | `all` | Every connected platform's home channel (fan-out) |
-| 3 | `platform:chat_id[:thread_id]` | Validated explicit target |
-| 4 | Bare platform name (e.g. `telegram`) | That platform's home channel from `/sethome` |
-| 5 | **Bare alias name** (not a platform) | Looked up via `directory.resolve_alias(name)` |
-| 6 | Unknown | Warning logged; returns `[]` |
-
-<Warning>
-Platform-home tokens always win over aliases. An alias named `telegram`, `slack`, or `discord` will resolve as the platform home — never as the alias. Choose alias names that cannot be confused with platform names.
-</Warning>
+---
 
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="BotOS" icon="robot" href="/docs/features/botos">
-    Multi-platform orchestration
-  </Card>
-  <Card title="Bot Gateway" icon="server" href="/docs/features/bot-gateway">
-    Run multiple bots from one server
-  </Card>
+<Card title="BotOS" icon="robot" href="/docs/features/botos">
+  Multi-platform orchestration
+</Card>
+<Card title="Bot Gateway" icon="server" href="/docs/features/bot-gateway">
+  Run multiple bots from one server
+</Card>
 </CardGroup>

--- a/docs/features/profiler.mdx
+++ b/docs/features/profiler.mdx
@@ -5,85 +5,85 @@ description: "Per-agent profiler isolation for multi-agent performance monitorin
 icon: "gauge-high"
 ---
 
-Per-agent profiler isolation enables independent performance monitoring across multiple concurrent agents using context-aware profiling.
-
-```mermaid
-graph LR
-    subgraph "Profiler Isolation"
-        A[🤖 Agent A] --> B[📊 Profiler A]
-        C[🤖 Agent B] --> D[📊 Profiler B]
-        B --> E[📈 Bounded Buffer A]
-        D --> F[📈 Bounded Buffer B]
-        E --> G[📋 Report A]
-        F --> H[📋 Report B]
-    end
-    
-    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef profiler fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef buffer fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A,C agent
-    class B,D profiler
-    class E,F buffer
-    class G,H output
-```
-
-## Quick Start
-
-<Steps>
-<Step title="Enable Per-Agent Profiling">
-Create isolated profilers for different agents to avoid mixing performance data.
+Give each agent its own profiler so concurrent runs do not mix timing data.
 
 ```python
 from praisonaiagents import Agent
 from praisonai.profiler import _ProfilerImpl, set_profiler, get_profiler
 
-# Create agent-specific profiler
-agent_profiler = _ProfilerImpl(max_records=5000)
-set_profiler(agent_profiler)
+profiler = _ProfilerImpl(max_records=5000)
+set_profiler(profiler)
 
-agent = Agent(
-    name="DataAgent",
-    instructions="Process data efficiently"
-)
-
-# Run with isolated profiling
-response = agent.start("Analyze quarterly sales")
+agent = Agent(name="DataAgent", instructions="Process data efficiently")
+response = agent.start("Analyse quarterly sales")
+stats = get_profiler().get_statistics()
+print(f"P95: {stats['p95']:.2f}ms")
 ```
+
+```mermaid
+graph LR
+    A[🤖 Agent A] --> PA[📊 Profiler A]
+    B[🤖 Agent B] --> PB[📊 Profiler B]
+    PA --> RA[📋 Report A]
+    PB --> RB[📋 Report B]
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef profiler fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A,B agent
+    class PA,PB profiler
+    class RA,RB output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Simple Usage">
+
+Profile a single agent turn:
+
+```python
+from praisonaiagents import Agent
+from praisonai.profiler import _ProfilerImpl, set_profiler, get_profiler
+
+profiler = _ProfilerImpl(max_records=5000)
+set_profiler(profiler)
+
+agent = Agent(name="DataAgent", instructions="Process data efficiently")
+agent.start("Analyse quarterly sales")
+
+print(get_profiler().get_statistics())
+```
+
 </Step>
 
-<Step title="Multi-Agent Isolated Profiling">
-Use separate profilers for concurrent agents to prevent performance data mixing.
+<Step title="With Configuration">
+
+Isolate profilers across concurrent agents:
 
 ```python
 import asyncio
 from praisonaiagents import Agent
-from praisonai.profiler import _ProfilerImpl, set_profiler
+from praisonai.profiler import _ProfilerImpl, set_profiler, get_profiler
 
-async def run_agent_with_profiler(name, task):
-    # Each agent gets its own profiler instance
-    profiler = _ProfilerImpl(max_records=10000)
-    set_profiler(profiler)
-    
+async def run_with_profiler(name, task):
+    set_profiler(_ProfilerImpl(max_records=10000))
     agent = Agent(name=name, instructions=f"Handle {name} tasks")
     result = await agent.run_async(task)
-    
-    # Get isolated performance data
-    stats = get_profiler().get_statistics()
-    return result, stats
+    return result, get_profiler().get_statistics()
 
 async def main():
-    # Run multiple agents concurrently with isolated profiling
     results = await asyncio.gather(
-        run_agent_with_profiler("SalesAgent", "Process Q4 sales data"),
-        run_agent_with_profiler("MarketAgent", "Analyze market trends"),
-        run_agent_with_profiler("ReportAgent", "Generate monthly report")
+        run_with_profiler("SalesAgent", "Process Q4 sales data"),
+        run_with_profiler("MarketAgent", "Analyse market trends"),
     )
-    
-    for result, stats in results:
-        print(f"Performance - P95: {stats['p95']:.2f}ms")
+    for _, stats in results:
+        print(f"P95: {stats['p95']:.2f}ms")
+
+asyncio.run(main())
 ```
+
 </Step>
 </Steps>
 
@@ -91,266 +91,55 @@ async def main():
 
 ## How It Works
 
-```mermaid
-sequenceDiagram
-    participant App as Application
-    participant CV as ContextVar
-    participant PA as Profiler A
-    participant PB as Profiler B
-    
-    App->>CV: set_profiler(profiler_a)
-    CV->>PA: Store in context
-    App->>PA: Enable profiling
-    
-    par Agent A Execution
-        PA->>PA: Record function timings
-        PA->>PA: Store in bounded buffer
-    and Agent B Execution  
-        App->>CV: set_profiler(profiler_b) 
-        CV->>PB: Store in context
-        PB->>PB: Record separate timings
-        PB->>PB: Store in separate buffer
-    end
-    
-    App->>PA: get_statistics()
-    App->>PB: get_statistics()
-```
+Profilers live in a `ContextVar` — each async task or thread sees its own instance when you call `set_profiler()`.
 
-| Component | Purpose | Context Scope |
-|-----------|---------|--------------|
-| `_ProfilerImpl` | Per-instance profiler class | Agent-specific |
-| `get_profiler()` | Get current context profiler | Thread/async local |
-| `set_profiler()` | Install profiler in context | Thread/async local |
-| `max_records` | Bounded buffer size | Per instance |
+| API | Purpose |
+|-----|---------|
+| `_ProfilerImpl(max_records=...)` | Bounded buffer per profiler instance |
+| `set_profiler(profiler)` | Install profiler in current context |
+| `get_profiler()` | Read context profiler (creates default if unset) |
+| `profiler.block("name")` | Time a code block |
+| `get_statistics()` | P50, P95, P99 latency summaries |
+
+The legacy `Profiler` class delegates to `get_profiler()` — existing `Profiler.block()` calls still work.
 
 ---
 
 ## Configuration Options
 
-### ProfilerImpl Constructor
-
-```python
-from praisonai.profiler import _ProfilerImpl
-
-profiler = _ProfilerImpl(
-    max_records=10000  # Buffer size per profiler (default: 10k)
-)
-```
-
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `max_records` | `int` | `10000` | Maximum records per buffer before rotation |
-
-### Context Management
-
-```python
-from praisonai.profiler import get_profiler, set_profiler
-
-# Get current profiler
-current = get_profiler()
-
-# Install new profiler in current context
-set_profiler(my_profiler)
-
-# Context-aware: different async tasks see different profilers
-```
-
----
-
-## Common Patterns
-
-### Agent-Specific Performance Monitoring
-
-```python
-from praisonaiagents import Agent
-from praisonai.profiler import _ProfilerImpl, set_profiler, get_profiler
-
-class PerformanceAgent:
-    def __init__(self, name, max_records=5000):
-        self.name = name
-        self.profiler = _ProfilerImpl(max_records=max_records)
-        
-    async def run_with_profiling(self, task):
-        # Set agent-specific profiler
-        set_profiler(self.profiler)
-        
-        agent = Agent(name=self.name, instructions="Complete tasks efficiently")
-        
-        # All operations in this context use this profiler
-        with self.profiler.block("task_execution"):
-            result = await agent.run_async(task)
-            
-        return result
-        
-    def get_performance_report(self):
-        stats = self.profiler.get_statistics()
-        return {
-            "agent": self.name,
-            "p50_ms": stats['p50'],
-            "p95_ms": stats['p95'], 
-            "p99_ms": stats['p99'],
-            "total_operations": stats['count']
-        }
-
-# Usage
-sales_agent = PerformanceAgent("SalesAgent")
-marketing_agent = PerformanceAgent("MarketingAgent")
-
-# Run with isolated profiling
-await sales_agent.run_with_profiling("Process Q4 data")
-await marketing_agent.run_with_profiling("Analyze campaigns")
-
-# Get separate performance reports
-sales_perf = sales_agent.get_performance_report()
-marketing_perf = marketing_agent.get_performance_report()
-```
-
-### Function-Level Profiling
-
-```python
-from praisonai.profiler import get_profiler
-
-async def data_processing_task():
-    profiler = get_profiler()  # Get context profiler
-    
-    with profiler.block("data_loading"):
-        data = await load_data()
-        
-    with profiler.block("data_transformation"):
-        transformed = await transform(data)
-        
-    with profiler.block("data_storage"):
-        await store_results(transformed)
-        
-    return transformed
-```
-
-### Bounded Buffer Management
-
-```python
-# Large buffer for long-running agents
-long_runner = _ProfilerImpl(max_records=50000)
-
-# Smaller buffer for quick tasks  
-quick_task = _ProfilerImpl(max_records=1000)
-
-# Buffer automatically rotates when full
-set_profiler(long_runner)
-for i in range(60000):  # More than max_records
-    with get_profiler().block(f"operation_{i}"):
-        pass  # Only last 50k operations kept
-```
+| `max_records` | `int` | `10000` | Buffer size before rotation |
+| `PRAISONAI_PROFILE_MAX` | env | `10000` | Global default buffer cap |
 
 ---
 
 ## Best Practices
 
 <AccordionGroup>
-<Accordion title="Create profiler per agent for isolation">
-Always use separate profiler instances for different agents to prevent data mixing:
-
-```python
-# ✅ Good: Isolated profilers
-agent1_profiler = _ProfilerImpl(max_records=10000)
-agent2_profiler = _ProfilerImpl(max_records=10000)
-
-async def run_agent1():
-    set_profiler(agent1_profiler)
-    # Agent 1 operations...
-
-async def run_agent2():
-    set_profiler(agent2_profiler) 
-    # Agent 2 operations...
-
-# ❌ Bad: Shared profiler
-shared = _ProfilerImpl()
-# Both agents would mix performance data
-```
+<Accordion title="Create one profiler per agent">
+Separate `_ProfilerImpl` instances prevent mixed timings in concurrent runs.
 </Accordion>
-
-<Accordion title="Size buffers appropriately for workload">
-Choose buffer sizes based on expected operation count:
-
-```python
-# High-frequency agent: Large buffer
-high_freq = _ProfilerImpl(max_records=100000)
-
-# Batch processing: Medium buffer  
-batch = _ProfilerImpl(max_records=10000)
-
-# Quick tasks: Small buffer
-quick = _ProfilerImpl(max_records=1000)
-```
+<Accordion title="Size buffers for workload">
+Use larger `max_records` for high-frequency agents; smaller for quick tasks.
 </Accordion>
-
-<Accordion title="Use context blocks for granular timing">
-Profile specific operations with descriptive block names:
-
-```python
-profiler = get_profiler()
-
-with profiler.block("llm_call"):
-    response = await llm.generate(prompt)
-    
-with profiler.block("tool_execution"):
-    result = await tool.execute(args)
-    
-with profiler.block("response_formatting"):
-    formatted = format_response(response, result)
-```
+<Accordion title="Use descriptive block names">
+`profiler.block("llm_call")` and `profiler.block("tool_execution")` make reports readable.
 </Accordion>
-
-<Accordion title="Monitor memory with profiler isolation">
-Each profiler tracks memory independently:
-
-```python
-with get_profiler().memory("memory_intensive_task"):
-    # Large data processing
-    process_large_dataset()
-    
-# Memory tracking is per-profiler instance
-memory_stats = get_profiler().get_memory_records()
-```
+<Accordion title="Prefer get_profiler over global Profiler">
+New code should call `get_profiler()` for context-aware isolation.
 </Accordion>
 </AccordionGroup>
-
----
-
-## Backward Compatibility
-
-<Note>
-The global `Profiler` class is now a `ProfilerCompat` instance that delegates to `get_profiler()`. 
-Existing code using `Profiler.enable()`, `Profiler.block()`, etc. continues to work unchanged:
-
-```python
-# Still works - uses context profiler
-from praisonai.profiler import Profiler
-
-Profiler.enable()
-with Profiler.block("legacy_operation"):
-    do_work()
-
-# Equivalent new style
-from praisonai.profiler import get_profiler
-
-profiler = get_profiler()
-profiler.enable()
-with profiler.block("new_operation"):
-    do_work()
-```
-
-However, `isinstance(x, Profiler)` and `class Foo(Profiler):` will break as `Profiler` is no longer a class.
-</Note>
 
 ---
 
 ## Related
 
 <CardGroup cols={2}>
-<Card title="Agent Architecture" icon="user" href="/docs/concepts/agents">
-  Learn about multi-agent patterns
-</Card>
 <Card title="Observability Overview" icon="chart-line" href="/docs/observability/overview">
-  Complete observability system
+  Traces, metrics, and logging
+</Card>
+<Card title="Profiling" icon="gauge" href="/docs/features/profiling">
+  Broader performance profiling options
 </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Upgraded five feature pages per AGENTS.md §9: agent-centric openers, hero mermaid, Steps, AccordionGroup, CardGroup
- `policy-engine.mdx`: corrected `agent.policy` attachment; trimmed low-level API duplication
- `post-edit-formatter.mdx`, `prepared-turn-context.mdx`, `proactive-delivery.mdx`, `profiler.mdx`: trimmed verbose sections; agent-first quick starts

Refs #1000

## Test plan
- [x] All five pages follow AGENTS.md §9 structure
- [x] No edits under `docs/concepts/`
- [x] Related links point to valid pages
- [x] `docs.json` remains valid JSON

Made with [Cursor](https://cursor.com)