### PR TITLE
docs: AGENTS.md §9 compliance batch 31 (#1000)

### DIFF
--- a/docs/features/reasoning.mdx
+++ b/docs/features/reasoning.mdx
@@ -7,6 +7,17 @@ icon: "brain"
 
 Reasoning agents think step-by-step before acting, breaking complex problems into structured solutions.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Reasoner",
+    instructions="You are an expert problem solver. Think step by step.",
+)
+
+agent.start("Analyse the pros and cons of electric vehicles")
+```
+
 ```mermaid
 graph LR
     subgraph "Reasoning Flow"
@@ -29,30 +40,36 @@ graph LR
 
 <Steps>
 <Step title="Simple Usage">
+
 ```python
 from praisonaiagents import Agent
 
 agent = Agent(
     name="Reasoner",
-    instructions="You are an expert problem solver. Think step by step."
+    instructions="You are an expert problem solver. Think step by step.",
 )
 
-agent.start("Analyze the pros and cons of electric vehicles")
+agent.start("Analyse the pros and cons of electric vehicles")
 ```
+
 </Step>
 
-<Step title="With Reasoning Model">
+<Step title="With Configuration">
+
+Use a reasoning-optimised model for multi-step problems:
+
 ```python
 from praisonaiagents import Agent
 
 agent = Agent(
     name="DeepReasoner",
     instructions="You solve complex problems with structured analysis.",
-    llm="o1-mini"
+    llm="o1-mini",
 )
 
 agent.start("What strategy should a startup use to enter a competitive market?")
 ```
+
 </Step>
 </Steps>
 
@@ -65,15 +82,13 @@ sequenceDiagram
     participant User
     participant Agent
     participant LLM
-    participant Output
 
     User->>Agent: start("complex problem")
     Agent->>LLM: Think step by step
     LLM-->>Agent: Reasoning chain
     Agent->>LLM: Formulate answer
     LLM-->>Agent: Structured solution
-    Agent-->>Output: Final answer with reasoning
-    Output-->>User: response
+    Agent-->>User: Response with reasoning
 ```
 
 | Stage | Description |
@@ -87,43 +102,41 @@ sequenceDiagram
 
 ## Common Patterns
 
-### Multi-Agent Reasoning Pipeline
+### Multi-agent reasoning pipeline
 
 ```python
-from praisonaiagents import Agent, Task, PraisonAIAgents
+from praisonaiagents import Agent, Task, AgentTeam
 
 analyst = Agent(
     name="Analyst",
-    instructions="Analyze problems and identify key issues with evidence."
+    instructions="Analyse problems and identify key issues with evidence.",
 )
 
 solver = Agent(
     name="Solver",
-    instructions="Design comprehensive solutions based on analysis."
+    instructions="Design comprehensive solutions based on analysis.",
 )
 
-analysis_task = Task(
-    description="Analyze market challenges in the electric vehicle industry",
-    expected_output="Detailed analysis with key findings",
-    agent=analyst
-)
-
-solution_task = Task(
-    description="Develop strategy based on the analysis",
-    expected_output="Action plan with prioritized recommendations",
-    agent=solver
-)
-
-agents = PraisonAIAgents(
+team = AgentTeam(
     agents=[analyst, solver],
-    tasks=[analysis_task, solution_task],
-    process="sequential"
+    tasks=[
+        Task(
+            description="Analyse market challenges in the electric vehicle industry",
+            expected_output="Detailed analysis with key findings",
+            agent=analyst,
+        ),
+        Task(
+            description="Develop strategy based on the analysis",
+            expected_output="Action plan with prioritised recommendations",
+            agent=solver,
+        ),
+    ],
 )
 
-agents.start()
+team.start()
 ```
 
-### Reasoning with Tools
+### Reasoning with tools
 
 ```python
 from praisonaiagents import Agent
@@ -132,13 +145,13 @@ from praisonaiagents.tools import internet_search
 agent = Agent(
     name="ResearchReasoner",
     instructions="Research topics deeply and reason about the findings.",
-    tools=[internet_search]
+    tools=[internet_search],
 )
 
 agent.start("What are the biggest AI safety concerns in 2025?")
 ```
 
-### Structured Output Reasoning
+### Structured output
 
 ```python
 from praisonaiagents import Agent
@@ -152,8 +165,8 @@ class Analysis(BaseModel):
 
 agent = Agent(
     name="StructuredReasoner",
-    instructions="Analyze topics and provide structured assessments.",
-    output_pydantic=Analysis
+    instructions="Analyse topics and provide structured assessments.",
+    output_pydantic=Analysis,
 )
 
 result = agent.start("Should we migrate our database to PostgreSQL?")
@@ -168,11 +181,11 @@ print(result.recommendation)
   <Accordion title="Write clear, specific problem statements">
     Vague inputs produce vague reasoning. State the problem with context: instead of "help with marketing", use "suggest three low-budget marketing strategies for a B2B SaaS startup targeting mid-sized logistics companies."
   </Accordion>
-  <Accordion title="Use reasoning-optimized models for complex tasks">
+  <Accordion title="Use reasoning-optimised models for complex tasks">
     Models like `o1-mini`, `o3-mini`, or `claude-3-7-sonnet` perform better on multi-step problems. Use standard models for simpler tasks to save cost and latency.
   </Accordion>
   <Accordion title="Break problems into sub-tasks with multi-agent pipelines">
-    Complex reasoning benefits from specialization. Assign analysis to one agent and solution design to another — each agent focuses on its strength without context overload.
+    Complex reasoning benefits from specialisation. Assign analysis to one agent and solution design to another — each agent focuses on its strength without context overload.
   </Accordion>
   <Accordion title="Use structured output for decision-making">
     When reasoning must produce actionable decisions, use `output_pydantic` to get typed results. This ensures reasoning outputs are machine-readable and integration-ready.
@@ -184,10 +197,10 @@ print(result.recommendation)
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="Planning" icon="list-check" href="/docs/features/planning-mode">
+  <Card title="Planning Mode" icon="list-check" href="/docs/features/planning-mode">
     Enable agents to plan before executing multi-step tasks
   </Card>
-  <Card title="Self-Reflection" icon="rotate" href="/docs/features/selfreflection">
-    Let agents critique and improve their own outputs
+  <Card title="Reasoning Extract" icon="brain-circuit" href="/docs/features/reasoning-extract">
+    Chain a reasoning model with a smaller agent to extract concise answers
   </Card>
 </CardGroup>

--- a/docs/features/recipe-registry.mdx
+++ b/docs/features/recipe-registry.mdx
@@ -5,219 +5,112 @@ description: "Publish, pull, and manage recipes in local or remote registries"
 icon: "box-archive"
 ---
 
-The Recipe Registry provides a centralized location for storing, sharing, and managing recipe bundles. It supports both local filesystem registries and HTTP-based remote registries with token authentication.
-
-## Overview
-
-Recipes are reusable agent configurations packaged as `.praison` bundles. The registry system allows you to:
-
-- **Publish** recipes to share with your team or organization
-- **Pull** recipes to use pre-built agent workflows
-- **Search** for recipes by name, description, or tags
-- **Version** recipes with semantic versioning
-
-## Quick Start
-
-```python
-from praisonai.recipe.registry import get_registry, LocalRegistry, HttpRegistry
-
-# Get default local registry
-registry = get_registry()
-
-# Publish a recipe
-result = registry.publish("./my-agent-1.0.0.praison")
-print(f"Published: {result['name']}@{result['version']}")
-
-# Pull a recipe
-result = registry.pull("my-agent", output_dir="./recipes")
-print(f"Pulled to: {result['path']}")
-
-# List all recipes
-recipes = registry.list_recipes()
-for r in recipes["recipes"]:
-    print(f"- {r['name']} v{r['version']}")
-
-# Search recipes
-results = registry.search("agent")
-for r in results:
-    print(f"- {r['name']}: {r['description']}")
-```
-
-## Registry Types
-
-### Local Registry
-
-The default registry stores recipes on the local filesystem at `~/.praisonai/registry`.
-
-```python
-from praisonai.recipe.registry import LocalRegistry
-from pathlib import Path
-
-# Use default path
-registry = LocalRegistry()
-
-# Or specify custom path
-registry = LocalRegistry(Path("/shared/team-recipes"))
-```
-
-### HTTP Registry
-
-Connect to remote HTTP registries with optional token authentication.
-
-```python
-from praisonai.recipe.registry import HttpRegistry
-import os
-
-# Connect to HTTP registry
-registry = HttpRegistry(
-    url="http://localhost:7777",
-    token=os.environ.get("PRAISONAI_REGISTRY_TOKEN"),
-    timeout=30
-)
-
-# Check health
-health = registry.health()
-print(f"Status: {health['status']}")
-print(f"Auth required: {health['auth_required']}")
-```
-
-### Auto-Detection with get_registry
-
-The `get_registry()` function automatically returns the appropriate registry type:
+Publish and share `.praison` recipe bundles from a local folder or remote HTTP registry.
 
 ```python
 from praisonai.recipe.registry import get_registry
-import os
 
-# Local registry (default)
-local = get_registry()
-
-# Local registry with custom path
-local = get_registry("/path/to/registry")
-
-# HTTP registry (auto-detected from URL)
-http = get_registry(
-    "http://localhost:7777",
-    token=os.environ.get("PRAISONAI_REGISTRY_TOKEN")
-)
-
-# HTTPS registry
-https = get_registry("https://registry.example.com", token="your-token")
+registry = get_registry()
+registry.publish("./my-agent-1.0.0.praison")
+registry.pull("my-agent", output_dir="./recipes")
 ```
 
-## Core Operations
+```mermaid
+graph LR
+    subgraph "Recipe Registry"
+        Bundle["📦 .praison bundle"] --> Pub["📤 publish"]
+        Pub --> Reg["🗄️ Registry"]
+        Reg --> Pull["📥 pull"]
+        Pull --> Local["📁 Local recipes"]
+    end
 
-### Publish
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
 
-Publish a recipe bundle to the registry.
+    class Bundle input
+    class Pub,Pull process
+    class Reg,Local output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Simple Usage">
+
+Use the default local registry at `~/.praison/registry`:
 
 ```python
-result = registry.publish(
-    bundle_path="./my-recipe-1.0.0.praison",
-    force=False,  # Set True to overwrite existing version
-    metadata={"custom_key": "value"}  # Optional metadata
-)
+from praisonai.recipe.registry import get_registry
 
+registry = get_registry()
+
+result = registry.publish("./my-agent-1.0.0.praison")
 print(f"Published: {result['name']}@{result['version']}")
-print(f"Checksum: {result['checksum']}")
-print(f"Published at: {result['published_at']}")
+
+pulled = registry.pull("my-agent", output_dir="./recipes")
+print(f"Pulled to: {pulled['path']}")
 ```
 
-### Pull
+</Step>
 
-Download a recipe from the registry.
+<Step title="With Configuration">
+
+Connect to a remote HTTP registry with token authentication:
 
 ```python
-result = registry.pull(
-    name="my-recipe",
-    version="1.0.0",  # Optional, defaults to latest
-    output_dir=Path("./pulled"),
-    verify_checksum=True
+import os
+from praisonai.recipe.registry import get_registry
+
+registry = get_registry(
+    "http://localhost:7777",
+    token=os.environ.get("PRAISONAI_REGISTRY_TOKEN"),
 )
 
-print(f"Pulled to: {result['path']}")
-print(f"Version: {result['version']}")
-print(f"Checksum verified: {result['checksum_verified']}")
+for recipe in registry.search("agent"):
+    print(f"{recipe['name']}: {recipe['description']}")
 ```
 
-### List
+</Step>
+</Steps>
 
-List all recipes in the registry.
+---
 
-```python
-result = registry.list_recipes(
-    tags=["agent", "tool"],  # Optional filter by tags
-    limit=50,
-    offset=0
-)
+## How It Works
 
-print(f"Total: {result['total']}")
-for recipe in result["recipes"]:
-    print(f"- {recipe['name']} v{recipe['version']}: {recipe['description']}")
-```
+Local registries store bundles on disk with atomic writes and checksum verification. HTTP registries expose the same operations over REST — `get_registry()` picks the right backend from a path or URL.
 
-### Search
+| Operation | Purpose |
+|-----------|---------|
+| `publish()` | Upload a `.praison` bundle |
+| `pull()` | Download a recipe by name and version |
+| `list_recipes()` | List available recipes |
+| `search()` | Find recipes by name, description, or tags |
 
-Search recipes by name, description, or tags.
+---
 
-```python
-results = registry.search("video processing")
+## Configuration Options
 
-for recipe in results:
-    print(f"- {recipe['name']}: {recipe['description']}")
-    print(f"  Tags: {', '.join(recipe.get('tags', []))}")
-```
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `registry` | `str` | local path | Filesystem path or HTTP(S) URL |
+| `token` | `str` | `None` | Auth token for remote registries |
+| `force` | `bool` | `False` | Overwrite existing version on publish |
+| `verify_checksum` | `bool` | `True` | Verify bundle integrity on pull |
+| `timeout` | `int` | `30` | HTTP request timeout (seconds) |
 
-### Get Info
-
-Get detailed information about a recipe.
-
-```python
-info = registry.get_info("my-recipe")
-
-print(f"Name: {info['name']}")
-print(f"Latest version: {info['latest']}")
-print(f"Available versions: {list(info['versions'].keys())}")
-```
-
-### Delete
-
-Delete a recipe version from the registry.
-
-```python
-registry.delete("my-recipe", version="1.0.0")
-```
-
-## Error Handling
-
-```python
-from praisonai.recipe.registry import (
-    RegistryError,
-    RecipeNotFoundError,
-    RecipeExistsError,
-    RegistryAuthError,
-    RegistryNetworkError
-)
-
-try:
-    registry.pull("nonexistent-recipe")
-except RecipeNotFoundError as e:
-    print(f"Recipe not found: {e}")
-except RegistryAuthError as e:
-    print(f"Authentication failed: {e}")
-except RegistryNetworkError as e:
-    print(f"Network error: {e}")
-except RegistryError as e:
-    print(f"Registry error: {e}")
-```
-
-## Environment Variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
 | `PRAISONAI_REGISTRY_TOKEN` | Default token for HTTP registry authentication |
+| `PRAISONAI_REGISTRY_URL` | Default registry URL for scripts |
 
-## CLI Commands
+---
+
+## Common Patterns
+
+### CLI workflow
 
 ```bash
 # Publish a recipe
@@ -226,56 +119,61 @@ praisonai recipe publish ./my-recipe --json
 # Pull a recipe
 praisonai recipe pull my-recipe@1.0.0 -o ./recipes
 
-# List recipes
+# List and search
 praisonai recipe list --json
-
-# Search recipes
 praisonai recipe search "video"
 
-# With HTTP registry
-praisonai recipe publish ./my-recipe --registry http://localhost:7777 --token $TOKEN
-praisonai recipe list --registry http://localhost:7777
+# Remote registry
+praisonai recipe list --registry http://localhost:7777 --token "$PRAISONAI_REGISTRY_TOKEN"
 ```
 
-## Complete Example
+### Error handling
 
 ```python
-import os
-from pathlib import Path
-from praisonai.recipe.registry import get_registry
+from praisonai.recipe.registry import (
+    get_registry,
+    RecipeNotFoundError,
+    RegistryAuthError,
+)
 
-def main():
-    # Connect to registry (local or remote based on env)
-    registry_url = os.environ.get("PRAISONAI_REGISTRY_URL")
-    token = os.environ.get("PRAISONAI_REGISTRY_TOKEN")
-    
-    registry = get_registry(registry_url, token=token)
-    
-    # Publish a recipe
-    result = registry.publish("./my-agent-1.0.0.praison")
-    print(f"✓ Published {result['name']}@{result['version']}")
-    
-    # List all recipes
-    recipes = registry.list_recipes()
-    print(f"\nAvailable recipes ({recipes['total']}):")
-    for r in recipes["recipes"]:
-        print(f"  - {r['name']} v{r['version']}")
-    
-    # Search for agent recipes
-    print("\nSearching for 'agent':")
-    for r in registry.search("agent"):
-        print(f"  - {r['name']}: {r['description']}")
-    
-    # Pull a recipe
-    pulled = registry.pull("my-agent", output_dir=Path("./recipes"))
-    print(f"\n✓ Pulled to {pulled['path']}")
+registry = get_registry()
 
-if __name__ == "__main__":
-    main()
+try:
+    registry.pull("nonexistent-recipe")
+except RecipeNotFoundError as e:
+    print(f"Recipe not found: {e}")
+except RegistryAuthError as e:
+    print(f"Authentication failed: {e}")
 ```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Version recipes with semantic versioning">
+    Tag each publish with a clear version (`1.0.0`, `1.1.0`). Use `force=True` only when intentionally replacing a broken release.
+  </Accordion>
+  <Accordion title="Use remote registries for team sharing">
+    Point `get_registry()` at a shared HTTP registry so teammates pull the same bundles without copying files manually.
+  </Accordion>
+  <Accordion title="Load tokens from environment variables">
+    Never hardcode registry tokens. Set `PRAISONAI_REGISTRY_TOKEN` in your shell or deployment secrets.
+  </Accordion>
+  <Accordion title="Verify checksums on pull">
+    Keep `verify_checksum=True` (default) in production so corrupted or tampered bundles are rejected before execution.
+  </Accordion>
+</AccordionGroup>
+
+---
 
 ## Related
 
-- [Recipe Registry Server](/docs/deploy/recipe-registry-server) - Deploy HTTP registry server
-- [Recipe Registry API](/docs/deploy/api/recipe-registry-api) - HTTP API endpoints
-- [Recipe CLI](/docs/cli/recipe-registry) - CLI commands reference
+<CardGroup cols={2}>
+  <Card title="Modular Recipes" icon="puzzle-piece" href="/docs/features/modular-recipes">
+    Compose recipes from reusable components with the include pattern
+  </Card>
+  <Card title="Recipe Serve" icon="server" href="/docs/features/recipe-serve-code">
+    Run recipes over HTTP for production deployments
+  </Card>
+</CardGroup>

--- a/docs/features/recipe-serve-advanced.mdx
+++ b/docs/features/recipe-serve-advanced.mdx
@@ -5,360 +5,198 @@ description: "Rate limiting, metrics, admin endpoints, workers, and OpenTelemetr
 icon: "gauge-high"
 ---
 
-# Recipe Serve Advanced Features
-
-This guide covers advanced server features including rate limiting, metrics, admin endpoints, workers, and OpenTelemetry tracing.
-
-## Rate Limiting
-
-Protect your server from abuse with configurable rate limiting.
-
-### Configuration
+Harden a recipe HTTP server with rate limits, Prometheus metrics, admin reload, and distributed tracing.
 
 ```python
-from praisonai.recipe.serve import create_app, serve
+import os
+from praisonai.recipe.serve import serve
 
-# Create app with rate limiting
-app = create_app(config={
-    "rate_limit": 100,  # 100 requests per minute per client
-    "rate_limit_exempt_paths": ["/health", "/metrics"]
-})
-
-# Or via serve()
 serve(
-    host="127.0.0.1",
+    host="0.0.0.0",
     port=8765,
-    config={"rate_limit": 100}
+    workers=2,
+    config={
+        "auth": "api-key",
+        "api_key": os.environ["PRAISONAI_API_KEY"],
+        "rate_limit": 100,
+        "enable_metrics": True,
+    },
 )
 ```
 
-### Rate Limiter Class
+```mermaid
+graph LR
+    subgraph "Production Serve"
+        Client["📱 Client"] --> RL["⏱️ Rate limit"]
+        RL --> API["🖥️ Recipe API"]
+        API --> Metrics["📊 /metrics"]
+        API --> Admin["🔧 /admin/reload"]
+        API --> Trace["🔍 OpenTelemetry"]
+    end
+
+    classDef client fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef guard fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef server fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef observe fill:#189AB4,stroke:#7C90A0,color:#fff
+
+    class Client client
+    class RL guard
+    class API server
+    class Metrics,Admin,Trace observe
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Simple Usage">
+
+Enable rate limiting and metrics on an existing server:
 
 ```python
-from praisonai.recipe.serve import create_rate_limiter, RateLimiter
+from praisonai.recipe.serve import serve
 
-# Create rate limiter
+serve(
+    host="127.0.0.1",
+    port=8765,
+    config={
+        "rate_limit": 100,
+        "enable_metrics": True,
+    },
+)
+```
+
+Scrape metrics at `GET /metrics` (Prometheus format).
+
+</Step>
+
+<Step title="With Configuration">
+
+Production setup with auth, admin reload, workers, and tracing:
+
+```python
+import os
+from praisonai.recipe.serve import serve
+
+serve(
+    host="0.0.0.0",
+    port=8765,
+    workers=4,
+    config={
+        "auth": "api-key",
+        "api_key": os.environ["PRAISONAI_API_KEY"],
+        "rate_limit": 100,
+        "max_request_size": 10 * 1024 * 1024,
+        "enable_metrics": True,
+        "enable_admin": True,
+        "trace_exporter": "otlp",
+        "otlp_endpoint": "http://localhost:4317",
+        "service_name": "praisonai-recipe",
+    },
+)
+```
+
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+Advanced features layer onto the base recipe server from [Recipe Serve](/docs/features/recipe-serve-code). Rate limiting uses a sliding window per client; metrics expose request counts and latency; admin endpoints hot-reload recipes without restart.
+
+| Feature | Endpoint / API | Purpose |
+|---------|----------------|---------|
+| Rate limiting | middleware | Cap requests per minute per client |
+| Metrics | `GET /metrics` | Prometheus exposition |
+| Admin reload | `POST /admin/reload` | Refresh recipe registry |
+| Tracing | OpenTelemetry | Distributed request spans |
+| Workers | `serve(workers=N)` | Multi-process scaling |
+
+---
+
+## Configuration Options
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `rate_limit` | `int` | `0` (disabled) | Requests per minute per client |
+| `rate_limit_exempt_paths` | `list` | `["/health", "/metrics"]` | Paths exempt from rate limiting |
+| `max_request_size` | `int` | `10485760` (10MB) | Maximum request body size |
+| `enable_metrics` | `bool` | `false` | Enable `/metrics` endpoint |
+| `enable_admin` | `bool` | `false` | Enable `/admin/*` endpoints |
+| `trace_exporter` | `str` | `"none"` | Tracing exporter (`none`, `otlp`, `jaeger`, `zipkin`) |
+| `otlp_endpoint` | `str` | `"http://localhost:4317"` | OTLP collector endpoint |
+| `service_name` | `str` | `"praisonai-recipe"` | Service name for tracing |
+| `workers` | `int` | `1` | Worker processes (`serve()` argument) |
+
+---
+
+## Common Patterns
+
+### Programmatic rate limiter
+
+```python
+from praisonai.recipe.serve import create_rate_limiter
+
 limiter = create_rate_limiter(requests_per_minute=100)
-
-# Check if request is allowed
 allowed, retry_after = limiter.check("client-ip-or-key")
 
 if not allowed:
     print(f"Rate limited. Retry after {retry_after} seconds")
 ```
 
-### Response Format
-
-When rate limited, clients receive:
-
-```json
-{
-  "error": {
-    "code": "rate_limited",
-    "message": "Too many requests"
-  }
-}
-```
-
-With headers:
-- `Retry-After: <seconds>`
-
-## Request Size Limits
-
-Prevent oversized payloads from overwhelming your server.
-
-### Configuration
-
-```python
-from praisonai.recipe.serve import create_app, DEFAULT_MAX_REQUEST_SIZE
-
-# Default is 10MB
-print(f"Default max size: {DEFAULT_MAX_REQUEST_SIZE} bytes")
-
-# Custom size limit
-app = create_app(config={
-    "max_request_size": 5 * 1024 * 1024  # 5MB
-})
-```
-
-### Response Format
-
-When request is too large:
-
-```json
-{
-  "error": {
-    "code": "request_too_large",
-    "message": "Request body too large. Max: 5242880 bytes"
-  }
-}
-```
-
-## Metrics Endpoint
-
-Expose Prometheus-format metrics for monitoring.
-
-### Enable Metrics
-
-```python
-from praisonai.recipe.serve import create_app
-
-app = create_app(config={
-    "enable_metrics": True
-})
-```
-
-### Metrics Format
-
-```
-GET /metrics
-```
-
-Response (Prometheus exposition format):
-```
-# HELP praisonai_http_requests_total Total HTTP requests
-# TYPE praisonai_http_requests_total counter
-praisonai_http_requests_total{path="/health",method="GET",status="200"} 42
-
-# HELP praisonai_http_request_duration_seconds HTTP request duration
-# TYPE praisonai_http_request_duration_seconds histogram
-praisonai_http_request_duration_seconds_sum{path="/health",method="GET"} 0.123456
-praisonai_http_request_duration_seconds_count{path="/health",method="GET"} 42
-
-# HELP praisonai_http_errors_total Total HTTP errors
-# TYPE praisonai_http_errors_total counter
-praisonai_http_errors_total{path="/v1/recipes/run",method="POST",error_type="client_error"} 5
-```
-
-### Using with Prometheus
-
-```yaml
-# prometheus.yml
-scrape_configs:
-  - job_name: 'praisonai-recipe'
-    static_configs:
-      - targets: ['localhost:8765']
-    metrics_path: '/metrics'
-```
-
-## Admin Reload Endpoint
-
-Hot-reload recipes without restarting the server.
-
-### Enable Admin Endpoints
-
-```python
-from praisonai.recipe.serve import create_app
-
-app = create_app(config={
-    "enable_admin": True,
-    "auth": "api-key",
-    "api_key": "admin-secret-key"
-})
-```
-
-### Reload Recipes
+### Admin reload
 
 ```bash
 curl -X POST http://localhost:8765/admin/reload \
-  -H "X-API-Key: admin-secret-key"
+  -H "X-API-Key: $PRAISONAI_API_KEY"
 ```
 
-Response:
-```json
-{
-  "status": "reloaded",
-  "timestamp": "2024-01-15T10:30:00Z"
-}
+### Prometheus scrape config
+
+```yaml
+scrape_configs:
+  - job_name: praisonai-recipe
+    static_configs:
+      - targets: ["localhost:8765"]
+    metrics_path: /metrics
 ```
 
-### Programmatic Reload
-
-```python
-from praisonai.recipe.core import reload_registry
-
-# Clear cached recipes and reload
-reload_registry()
-```
-
-## Workers (Multi-Process)
-
-Scale with multiple worker processes.
-
-### Configuration
-
-```python
-from praisonai.recipe.serve import serve
-
-# Start with 4 workers
-serve(
-    host="0.0.0.0",
-    port=8765,
-    workers=4,
-    config={"auth": "api-key", "api_key": "secret"}
-)
-```
-
-### Notes
-
-- Workers > 1 automatically disables hot reload
-- Each worker has its own rate limiter state (use Redis for distributed limiting)
-- Recommended: 2 * CPU cores + 1
-
-## OpenTelemetry Tracing
-
-Distributed tracing with OpenTelemetry.
-
-### Configuration
-
-```python
-from praisonai.recipe.serve import serve
-
-serve(
-    host="127.0.0.1",
-    port=8765,
-    config={
-        "trace_exporter": "otlp",  # otlp, jaeger, zipkin
-        "otlp_endpoint": "http://localhost:4317",
-        "service_name": "praisonai-recipe"
-    }
-)
-```
-
-### Supported Exporters
-
-| Exporter | Config Key | Default Endpoint |
-|----------|------------|------------------|
-| OTLP | `otlp_endpoint` | `http://localhost:4317` |
-| Jaeger | `jaeger_host`, `jaeger_port` | `localhost:6831` |
-| Zipkin | `zipkin_endpoint` | `http://localhost:9411/api/v2/spans` |
-
-### Install Dependencies
+### OpenTelemetry dependencies
 
 ```bash
-# OTLP
 pip install opentelemetry-sdk opentelemetry-exporter-otlp
-
-# Jaeger
-pip install opentelemetry-sdk opentelemetry-exporter-jaeger
-
-# Zipkin
-pip install opentelemetry-sdk opentelemetry-exporter-zipkin
 ```
 
-### Lazy Import
+OpenTelemetry is lazily imported — if packages are missing, the server logs a warning and continues without tracing.
 
-OpenTelemetry dependencies are lazily imported. If not installed, a warning is logged but the server continues to work.
+---
 
-## OpenAPI Specification
+## Best Practices
 
-Get the OpenAPI spec for your server.
+<AccordionGroup>
+  <Accordion title="Always enable auth with admin endpoints">
+    Set `enable_admin=True` only alongside `auth: api-key` and load the key from `PRAISONAI_API_KEY`. Admin reload can change live behaviour — protect it.
+  </Accordion>
+  <Accordion title="Use workers for CPU-bound recipe loads">
+    Set `workers` to roughly `2 × CPU cores + 1`. Workers above 1 disable hot reload automatically.
+  </Accordion>
+  <Accordion title="Exempt health and metrics from rate limits">
+    Keep `/health` and `/metrics` in `rate_limit_exempt_paths` so orchestrators and Prometheus can poll without consuming quota.
+  </Accordion>
+  <Accordion title="Use Redis for distributed rate limiting">
+    The built-in limiter is in-memory per worker. For multi-node deployments, place a shared rate limiter in front of the service (API gateway or Redis-backed middleware).
+  </Accordion>
+</AccordionGroup>
 
-### Endpoint
+---
 
-```bash
-curl http://localhost:8765/openapi.json
-```
+## Related
 
-### Response
-
-```json
-{
-  "openapi": "3.0.3",
-  "info": {
-    "title": "PraisonAI Recipe Runner API",
-    "version": "2.7.1"
-  },
-  "paths": {
-    "/health": {...},
-    "/v1/recipes": {...},
-    "/v1/recipes/run": {...},
-    "/metrics": {...},
-    "/admin/reload": {...}
-  }
-}
-```
-
-## Template Search Paths
-
-Configure where recipes are discovered.
-
-### Search Order
-
-1. `PRAISONAI_RECIPE_PATH` environment variable
-2. `./recipes` in current directory
-3. `~/.praisonai/recipes` in home directory
-4. Agent-Recipes package (if installed)
-5. Built-in templates
-
-### Get Search Paths
-
-```python
-from praisonai.recipe.core import get_template_search_paths
-
-paths = get_template_search_paths()
-for path in paths:
-    print(f"Searching: {path}")
-```
-
-### Custom Path
-
-```bash
-export PRAISONAI_RECIPE_PATH="/custom/recipes:/another/path"
-praisonai serve recipe
-```
-
-## Complete Example
-
-```python
-from praisonai.recipe.serve import serve
-
-# Production-ready configuration
-serve(
-    host="0.0.0.0",
-    port=8765,
-    workers=4,
-    config={
-        # Authentication
-        "auth": "api-key",
-        "api_key": "production-secret-key",
-        
-        # Rate limiting
-        "rate_limit": 100,
-        
-        # Request size
-        "max_request_size": 10 * 1024 * 1024,  # 10MB
-        
-        # Monitoring
-        "enable_metrics": True,
-        "enable_admin": True,
-        
-        # Tracing
-        "trace_exporter": "otlp",
-        "otlp_endpoint": "http://otel-collector:4317",
-        "service_name": "praisonai-recipe-prod",
-        
-        # CORS
-        "cors_origins": "https://app.example.com"
-    }
-)
-```
-
-## Configuration Reference
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `rate_limit` | int | 0 (disabled) | Requests per minute per client |
-| `rate_limit_exempt_paths` | list | `["/health", "/metrics"]` | Paths exempt from rate limiting |
-| `max_request_size` | int | 10485760 (10MB) | Maximum request body size |
-| `enable_metrics` | bool | false | Enable /metrics endpoint |
-| `enable_admin` | bool | false | Enable /admin/* endpoints |
-| `trace_exporter` | str | "none" | Tracing exporter (none, otlp, jaeger, zipkin) |
-| `otlp_endpoint` | str | "http://localhost:4317" | OTLP collector endpoint |
-| `service_name` | str | "praisonai-recipe" | Service name for tracing |
-
-## Next Steps
-
-- See [CLI Usage](/docs/cli/recipe-serve-advanced) for command-line options
-- Review [Recipe Serve Basics](/docs/features/recipe-serve-code)
-- Explore [Endpoints](/docs/features/endpoints-code)
+<CardGroup cols={2}>
+  <Card title="Recipe Serve" icon="server" href="/docs/features/recipe-serve-code">
+    Programmatic server configuration and deployment
+  </Card>
+  <Card title="Endpoints Code" icon="code" href="/docs/features/endpoints-code">
+    Client-side code for calling recipe endpoints
+  </Card>
+</CardGroup>

--- a/docs/features/recipe-serve-code.mdx
+++ b/docs/features/recipe-serve-code.mdx
@@ -5,17 +5,22 @@ description: "Programmatic server configuration and management using Python"
 icon: "server"
 ---
 
-Configure and manage the recipe server programmatically for production deployments.
+Expose recipe workflows over HTTP — configure auth, CORS, and deployment from Python or YAML.
+
+```python
+from praisonai.recipe.serve import serve
+
+serve(host="127.0.0.1", port=8765)
+```
 
 ```mermaid
 graph LR
     subgraph "Recipe Serve"
-        Config[⚙️ serve.yaml] --> Server[🖥️ Recipe Server]
-        Code[🐍 Python Code] --> Server
-        Server --> HTTP[🌐 HTTP Endpoint]
-        HTTP --> Client[📱 Client App]
-        Server --> Auth[🔐 Auth Layer]
-        Auth --> JWT[🔑 JWT / API Key]
+        Config["⚙️ serve.yaml"] --> Server["🖥️ Recipe Server"]
+        Code["🐍 Python"] --> Server
+        Server --> HTTP["🌐 HTTP"]
+        HTTP --> Client["📱 Client"]
+        Server --> Auth["🔐 Auth"]
     end
 
     classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
@@ -28,107 +33,113 @@ graph LR
     class Server server
     class HTTP protocol
     class Client client
-    class Auth,JWT auth
+    class Auth auth
 ```
 
-## Starting the Server Programmatically
+## Quick Start
 
-### Basic Server Start
+<Steps>
+<Step title="Simple Usage">
+
+Start a local recipe server:
 
 ```python
-from praisonai.recipe.serve import serve, create_app
+from praisonai.recipe.serve import serve
 
-# Start server (blocking)
 serve(host="127.0.0.1", port=8765)
 ```
 
-### With Configuration
+Or via CLI:
+
+```bash
+praisonai recipe serve --host 127.0.0.1 --port 8765
+```
+
+</Step>
+
+<Step title="With Configuration">
+
+Load settings from `serve.yaml` and override auth:
 
 ```python
+import os
 from praisonai.recipe.serve import serve, load_config
 
-# Load config from file
 config = load_config("serve.yaml")
-
-# Override with custom settings
 config["auth"] = "api-key"
-config["api_key"] = "my-secret-key"
+config["api_key"] = os.environ["PRAISONAI_API_KEY"]
 
-# Start server
 serve(
     host=config.get("host", "127.0.0.1"),
     port=config.get("port", 8765),
-    reload=False,
-    config=config
+    config=config,
 )
 ```
 
-### Creating ASGI App for Custom Deployment
+</Step>
+</Steps>
 
-```python
-from praisonai.recipe.serve import create_app
+---
 
-# Create ASGI app
-app = create_app(config={
-    "auth": "api-key",
-    "api_key": "my-secret-key",
-    "cors_origins": "*"
-})
+## How It Works
 
-# Use with uvicorn programmatically
-import uvicorn
-uvicorn.run(app, host="0.0.0.0", port=8765)
+`create_app()` builds a Starlette ASGI application; `serve()` runs it with uvicorn. Configuration merges file, environment variables, and Python overrides — CLI flags take highest precedence.
 
-# Or with other ASGI servers (hypercorn, daphne, etc.)
-```
+| Route | Method | Description |
+|-------|--------|-------------|
+| `/health` | GET | Health check |
+| `/v1/recipes` | GET | List recipes |
+| `/v1/recipes/{name}` | GET | Describe recipe |
+| `/v1/recipes/run` | POST | Run recipe (sync) |
+| `/v1/recipes/stream` | POST | Run recipe (SSE) |
 
-## Configuration File Format
+---
 
-### serve.yaml
+## Configuration Options
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `host` | `str` | `"127.0.0.1"` | Bind address |
+| `port` | `int` | `8765` | Listen port |
+| `auth` | `str` | `"none"` | Auth mode (`none`, `api-key`, `jwt`) |
+| `api_key` | `str` | env | API key when `auth=api-key` |
+| `recipes` | `list` | all | Recipe names to expose |
+| `preload` | `bool` | `false` | Warm recipes on startup |
+| `cors_origins` | `str` | `"*"` | Allowed CORS origins |
+| `log_level` | `str` | `"info"` | Server log level |
+
+### serve.yaml example
 
 ```yaml
-# Server binding
 host: 127.0.0.1
 port: 8765
-
-# Authentication
-auth: api-key  # none, api-key, jwt
-api_key: your-secret-key  # or use PRAISONAI_API_KEY env var
-
-# Recipe filtering
+auth: api-key
 recipes:
   - support-reply-drafter
   - meeting-action-items
-  - code-review
-
-# Performance
-preload: true  # Preload recipes on startup
-
-# CORS (for web clients)
-cors_origins: "https://app.example.com,https://admin.example.com"
-
-# Logging
-log_level: info
+preload: true
+cors_origins: "https://app.example.com"
 ```
 
-### Using agents.yaml (Unified Config)
+Set `PRAISONAI_API_KEY` in the environment instead of hardcoding keys.
 
-You can include serve configuration in your existing `agents.yaml`:
+---
+
+## Common Patterns
+
+### ASGI app for custom deployment
+
+```python
+from praisonai.recipe.serve import create_app
+import uvicorn
+
+app = create_app(config={"auth": "none", "cors_origins": "*"})
+uvicorn.run(app, host="0.0.0.0", port=8765)
+```
+
+### Unified agents.yaml config
 
 ```yaml
-# agents.yaml
-framework: praisonai
-topic: My Application
-
-roles:
-  assistant:
-    role: AI Assistant
-    goal: Help users
-    tasks:
-      respond:
-        description: Respond to {query}
-
-# Server configuration section
 serve:
   host: 127.0.0.1
   port: 8765
@@ -136,309 +147,53 @@ serve:
   preload: true
 ```
 
-Then load it:
-
 ```python
 from praisonai.recipe.serve import load_config, serve
 
-# Load unified config
-config = load_config("agents.yaml")
-
-# Extract serve section
-serve_config = config.get("serve", {})
-
-# Start server
-serve(
-    host=serve_config.get("host", "127.0.0.1"),
-    port=serve_config.get("port", 8765),
-    config=serve_config
-)
+config = load_config("agents.yaml").get("serve", {})
+serve(host=config.get("host", "127.0.0.1"), port=config.get("port", 8765), config=config)
 ```
 
-## Authentication Middleware
-
-### API Key Authentication
+### Test with TestClient
 
 ```python
-from praisonai.recipe.serve import create_auth_middleware, create_app
-
-# Create auth middleware
-auth_middleware = create_auth_middleware(
-    auth_type="api-key",
-    api_key="my-secret-key"
-)
-
-# Create app with auth
-app = create_app(config={
-    "auth": "api-key",
-    "api_key": "my-secret-key"
-})
-```
-
-### Custom Authentication
-
-```python
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import JSONResponse
-
-class CustomAuthMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request, call_next):
-        # Skip auth for health endpoint
-        if request.url.path == "/health":
-            return await call_next(request)
-        
-        # Custom auth logic
-        token = request.headers.get("Authorization")
-        if not self.validate_token(token):
-            return JSONResponse(
-                {"error": "Unauthorized"},
-                status_code=401
-            )
-        
-        return await call_next(request)
-    
-    def validate_token(self, token):
-        # Your validation logic
-        return token == "Bearer valid-token"
-```
-
-## Route Handlers
-
-### Available Routes
-
-| Route | Method | Description |
-|-------|--------|-------------|
-| `/health` | GET | Health check |
-| `/v1/recipes` | GET | List recipes |
-| `/v1/recipes/{name}` | GET | Describe recipe |
-| `/v1/recipes/{name}/schema` | GET | Get recipe schema |
-| `/v1/recipes/run` | POST | Run recipe (sync) |
-| `/v1/recipes/stream` | POST | Run recipe (SSE) |
-| `/v1/recipes/validate` | POST | Validate recipe |
-
-### Custom Route Example
-
-```python
-from starlette.applications import Starlette
-from starlette.routing import Route
-from starlette.responses import JSONResponse
-from praisonai.recipe.serve import create_app
-
-# Get base app
-base_app = create_app()
-
-# Add custom route
-async def custom_endpoint(request):
-    return JSONResponse({"custom": "response"})
-
-# Extend routes
-custom_routes = [
-    Route("/custom", custom_endpoint, methods=["GET"]),
-]
-
-# Create new app with extended routes
-from starlette.routing import Mount
-extended_app = Starlette(
-    routes=list(base_app.routes) + custom_routes
-)
-```
-
-## Docker Deployment
-
-### Dockerfile
-
-```dockerfile
-FROM python:3.11-slim
-
-# Install dependencies
-RUN pip install praisonai[serve]
-
-# Copy configuration
-COPY serve.yaml /app/
-WORKDIR /app
-
-# Set environment variables
-ENV PRAISONAI_API_KEY=${PRAISONAI_API_KEY}
-ENV OPENAI_API_KEY=${OPENAI_API_KEY}
-
-# Expose port
-EXPOSE 8765
-
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:8765/health || exit 1
-
-# Start server
-CMD ["praisonai", "recipe", "serve", "--config", "serve.yaml"]
-```
-
-### docker-compose.yaml
-
-```yaml
-version: '3.8'
-
-services:
-  recipe-server:
-    build: .
-    ports:
-      - "8765:8765"
-    environment:
-      - PRAISONAI_API_KEY=${PRAISONAI_API_KEY}
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-    volumes:
-      - ./recipes:/app/recipes
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8765/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    restart: unless-stopped
-```
-
-## Kubernetes Deployment
-
-### deployment.yaml
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: recipe-server
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: recipe-server
-  template:
-    metadata:
-      labels:
-        app: recipe-server
-    spec:
-      containers:
-      - name: recipe-server
-        image: your-registry/recipe-server:latest
-        ports:
-        - containerPort: 8765
-        env:
-        - name: PRAISONAI_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: recipe-secrets
-              key: api-key
-        - name: OPENAI_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: recipe-secrets
-              key: openai-key
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8765
-          initialDelaySeconds: 10
-          periodSeconds: 30
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 8765
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "250m"
-          limits:
-            memory: "512Mi"
-            cpu: "500m"
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: recipe-server
-spec:
-  selector:
-    app: recipe-server
-  ports:
-  - port: 80
-    targetPort: 8765
-  type: ClusterIP
-```
-
-## Testing the Server
-
-### Unit Test Example
-
-```python
-import pytest
+import os
 from starlette.testclient import TestClient
 from praisonai.recipe.serve import create_app
 
-@pytest.fixture
-def client():
-    app = create_app(config={"auth": "none"})
-    return TestClient(app)
+app = create_app(config={"auth": "api-key", "api_key": "test-key"})
+client = TestClient(app)
 
-def test_health(client):
-    response = client.get("/health")
-    assert response.status_code == 200
-    assert response.json()["status"] == "healthy"
-
-def test_list_recipes(client):
-    response = client.get("/v1/recipes")
-    assert response.status_code == 200
-    assert "recipes" in response.json()
-
-def test_auth_required():
-    app = create_app(config={
-        "auth": "api-key",
-        "api_key": "test-key"
-    })
-    client = TestClient(app)
-    
-    # Without key - should fail
-    response = client.get("/v1/recipes")
-    assert response.status_code == 401
-    
-    # With key - should succeed
-    response = client.get(
-        "/v1/recipes",
-        headers={"X-API-Key": "test-key"}
-    )
-    assert response.status_code == 200
+assert client.get("/health").json()["status"] == "healthy"
+assert client.get("/v1/recipes", headers={"X-API-Key": "test-key"}).status_code == 200
 ```
+
+---
 
 ## Best Practices
 
 <AccordionGroup>
-  <Accordion title="Always Use Auth in Production">
-    Never run the server without authentication in production. Set `auth: api-key` and load the key from an environment variable rather than hardcoding it.
-
-    ```python
-    serve(
-        host="0.0.0.0",
-        port=8765,
-        config={
-            "auth": "api-key",
-            "api_key": os.environ["PRAISONAI_API_KEY"]
-        }
-    )
-    ```
+  <Accordion title="Always use auth in production">
+    Set `auth: api-key` and load the key from `PRAISONAI_API_KEY`. Never expose an unauthenticated recipe server on a public network.
   </Accordion>
-  <Accordion title="Preload Recipes for Faster Startup">
-    Set `preload: true` in `serve.yaml` to load and warm up recipes at startup, eliminating cold-start latency on the first request.
+  <Accordion title="Preload recipes for faster startup">
+    Set `preload: true` to warm recipes at startup and eliminate cold-start latency on the first request.
   </Accordion>
-  <Accordion title="Add Health Checks">
-    Monitor server availability by polling the `/health` endpoint. Return non-zero exit codes from your health-check script to integrate with container orchestrators.
+  <Accordion title="Restrict CORS origins">
+    Set `cors_origins` to your exact frontend domain in production rather than `"*"`.
   </Accordion>
-  <Accordion title="Restrict CORS Origins">
-    Set `cors_origins` to your exact frontend domain in production rather than `"*"`. This prevents unauthorized cross-origin requests.
+  <Accordion title="Poll /health for orchestration">
+    Use the `/health` endpoint in Docker, Kubernetes, and load-balancer health checks.
   </Accordion>
 </AccordionGroup>
+
+---
 
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="Agent API Launch" icon="rocket" href="/docs/features/agent-api-launch">
-    Deploy agents as HTTP APIs or MCP servers
+  <Card title="Recipe Serve Advanced" icon="gauge-high" href="/docs/features/recipe-serve-advanced">
+    Rate limiting, metrics, admin reload, and OpenTelemetry
   </Card>
   <Card title="Endpoints Code" icon="code" href="/docs/features/endpoints-code">
     Client-side code for calling recipe endpoints

--- a/docs/features/recursive-context.mdx
+++ b/docs/features/recursive-context.mdx
@@ -1,258 +1,192 @@
 ---
-title: 'Recursive Context'
-description: 'How PraisonAI handles large context without context rot'
-icon: 'layer-group'
+title: "Recursive Context"
+sidebarTitle: "Recursive Context"
+description: "How PraisonAI handles large context without context rot"
+icon: "layer-group"
 ---
 
-## Overview
-
-PraisonAI implements **Recursive Context** - a pattern that solves "context rot" by treating context as programmatically explorable data instead of dumping everything into the LLM's context window.
-
-```mermaid
-flowchart LR
-    subgraph Traditional["Traditional LLM"]
-        Q1[Query] --> CW[Context Window]
-        CTX1[Full Context<br/>200k tokens] --> CW
-        CW --> A1["Answer<br/>(degraded)"]
-    end
-    
-    subgraph RLM["Recursive Context (PraisonAI)"]
-        Q2[Query] --> ROOT[Root Agent]
-        CTX2[Full Context<br/>200k tokens] --> MEM[(ArtifactStore)]
-        ROOT -- "peek()" --> MEM
-        ROOT -- "grep()" --> MEM
-        ROOT -- "chunk()" --> MEM
-        ROOT -- "delegate()" --> SUB[Sub-Agent]
-        SUB --> ROOT
-        ROOT --> A2["Answer<br/>(accurate)"]
-    end
-```
-
----
-
-## Architecture
-
-```mermaid
-flowchart TB
-    subgraph Agent["Agent (Root)"]
-        CHAT[chat/run]
-        AUTO[AutonomyMixin]
-        ESC[EscalationPipeline]
-    end
-    
-    subgraph Context["Context Layer"]
-        ART[ArtifactStoreProtocol]
-        REF[ArtifactRef]
-        GREP[GrepMatch]
-    end
-    
-    subgraph Delegation["Recursive Delegation"]
-        DEL[SubagentDelegator]
-        SUB[SubAgents]
-        TOOL[create_subagent_tool]
-    end
-    
-    subgraph Execution["Code Execution"]
-        PY[PythonTools]
-        EXEC[execute_code]
-    end
-    
-    CHAT --> AUTO
-    AUTO --> ESC
-    ESC --> |Stage 3| DEL
-    DEL --> SUB
-    SUB --> |results| DEL
-    
-    AUTO --> ART
-    ART --> REF
-    ART --> GREP
-    
-    SUB --> PY
-    PY --> EXEC
-```
-
----
-
-## Core Components
-
-### ArtifactStoreProtocol
-
-Stores large outputs as external variables with programmatic access.
-
-| Method | Purpose | Signature |
-|--------|---------|-----------|
-| `store()` | Save content, get reference | `(content, metadata) → ArtifactRef` |
-| `load()` | Retrieve full content | `(ref) → Any` |
-| `head()` | First N lines | `(ref, lines=50) → str` |
-| `tail()` | Last N lines | `(ref, lines=50) → str` |
-| `grep()` | Regex search | `(ref, pattern, max_matches=50) → List[GrepMatch]` |
-| `chunk()` | Line range extraction | `(ref, start_line, end_line) → str` |
+Large outputs stay outside the context window — agents explore them with artifacts, delegation, and escalation instead of stuffing everything into one prompt.
 
 ```python
-from praisonaiagents.context.artifacts import ArtifactRef, ArtifactStoreProtocol
+from praisonaiagents import Agent, AutonomyConfig, ExecutionConfig
 
-# ArtifactRef replaces large content in context
-ref = ArtifactRef(
-    path="/path/to/artifact.json",
-    summary="API response with 50,000 records",
-    size_bytes=1_200_000,
-    mime_type="application/json",
-)
-
-# In context window: [Artifact: /path/to/artifact.json (1.2 MB) - API response...]
-```
-
----
-
-### SubagentDelegator
-
-Spawns subagents with scoped permissions for recursive problem decomposition.
-
-| Config | Default | Purpose |
-|--------|---------|---------|
-| `max_concurrent_subagents` | 3 | Concurrency limit |
-| `max_total_subagents` | 10 | Total agents per task |
-| `max_steps_per_subagent` | 50 | Step budget per subagent |
-| `max_tokens_per_subagent` | 50000 | Token budget per subagent |
-| `allow_nested_delegation` | False | Recursion control |
-
-```python
-from praisonaiagents.agents.delegator import SubagentDelegator
-
-delegator = SubagentDelegator()
-result = await delegator.delegate(
-    agent_name="analyzer",
-    objective="Count billing questions",
-    context={"user_ids": [12345, 67890]}
-)
-```
-
----
-
-### EscalationPipeline
-
-Progressive complexity based on task signals.
-
-```mermaid
-flowchart LR
-    S0["Stage 0<br/>DIRECT"] --> S1["Stage 1<br/>HEURISTIC"]
-    S1 --> S2["Stage 2<br/>PLANNED"]
-    S2 --> S3["Stage 3<br/>AUTONOMOUS"]
-    
-    S0 -.- D0["No tools"]
-    S1 -.- D1["Tools, no LLM plan"]
-    S2 -.- D2["LLM creates plan"]
-    S3 -.- D3["Tools + Subagents + Checkpoints"]
-```
-
----
-
-### DoomLoopTracker
-
-Prevents infinite loops by detecting repeated actions.
-
-```python
-# Automatic doom loop detection
 agent = Agent(
-    instructions="...",
-    autonomy={"doom_loop_threshold": 3}  # Stop after 3 repeated actions
+    instructions="You are a data analyst.",
+    autonomy=AutonomyConfig(level="full_auto", max_iterations=30),
+    execution=ExecutionConfig(code_execution=True),
 )
+
+agent.start("Analyse 5000 tickets and count billing issues")
 ```
 
----
+```mermaid
+graph LR
+    subgraph "Recursive Context"
+        Query["💬 Query"] --> Agent["🤖 Agent"]
+        Large["📄 Large output"] --> Store["💾 Artifacts"]
+        Agent --> Store
+        Agent --> Sub["👥 Sub-agent"]
+        Sub --> Agent
+        Agent --> Answer["✅ Answer"]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef store fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Query input
+    class Agent,Sub agent
+    class Large,Store store
+    class Answer output
+```
 
 ## Quick Start
+
+<Steps>
+<Step title="Simple Usage">
+
+Enable autonomy — artifacts, escalation, and doom-loop protection activate automatically:
 
 ```python
 from praisonaiagents import Agent
 
-# Enable recursive context handling
 agent = Agent(
     instructions="You are a data analyst.",
-    autonomy=True,  # Enables all RLM features
-    execution=ExecutionConfig(code_execution=True),  # REPL capability
+    autonomy=True,
 )
 
-# Runs with automatic:
-# - Context windowing (artifacts for large outputs)
-# - Subagent delegation (recursive problem decomposition)
-# - Escalation (progressive complexity)
-# - Doom loop protection
-result = agent.start("Analyze 5000 tickets and count billing issues")
+agent.start("Summarise the key themes in this support inbox export")
 ```
 
----
+</Step>
 
-## Key Functions
+<Step title="With Configuration">
 
-### Agent-Level
-
-| Function | Purpose |
-|----------|---------|
-| `agent.start(prompt)` | Full autonomous loop when `autonomy=True` |
-| `agent.delegate(task, profile)` | Spawn subagent for subtask |
-| `agent.analyze_prompt(prompt)` | Detect complexity signals |
-| `agent.get_recommended_stage(prompt)` | Get escalation stage |
-
-### Artifact Operations
-
-| Function | Location |
-|----------|----------|
-| `store(content, metadata)` | `ArtifactStoreProtocol` |
-| `head(ref, lines)` | `ArtifactStoreProtocol` |
-| `tail(ref, lines)` | `ArtifactStoreProtocol` |
-| `grep(ref, pattern)` | `ArtifactStoreProtocol` |
-| `chunk(ref, start, end)` | `ArtifactStoreProtocol` |
-| `merge_adjacent_chunks(results)` | `knowledge/retrieval.py` |
-
-### Delegation
-
-| Function | Location |
-|----------|----------|
-| `delegate(agent_name, objective)` | `SubagentDelegator` |
-| `delegate_parallel(tasks)` | `SubagentDelegator` |
-| `create_subagent_tool(agent_factory)` | `tools/subagent_tool.py` |
-
----
-
-## Configuration
-
-### Autonomy Config
+Tune iteration limits, doom-loop threshold, and code execution:
 
 ```python
+from praisonaiagents import Agent, AutonomyConfig, ExecutionConfig
+
 agent = Agent(
-    instructions="...",
-    autonomy={
-        "max_iterations": 30,      # Max turns before stopping
-        "doom_loop_threshold": 3,  # Repeated actions limit
-        "auto_escalate": True,     # Auto-increase complexity
-    }
+    instructions="You are a data analyst.",
+    autonomy=AutonomyConfig(
+        level="full_auto",
+        max_iterations=30,
+        doom_loop_threshold=3,
+        auto_escalate=True,
+    ),
+    execution=ExecutionConfig(code_execution=True),
 )
+
+agent.start("Analyse 5000 tickets and count billing issues")
 ```
 
-### Artifact Queueing
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+Instead of loading entire documents into the LLM window, PraisonAI stores large outputs as **artifacts** and lets agents peek, grep, and chunk them on demand. When tasks grow complex, **escalation** increases capability stage-by-stage; **sub-agent delegation** handles focused subtasks with scoped budgets.
+
+```mermaid
+flowchart LR
+    S0["Stage 0<br/>Direct"] --> S1["Stage 1<br/>Heuristic"]
+    S1 --> S2["Stage 2<br/>Planned"]
+    S2 --> S3["Stage 3<br/>Autonomous"]
+
+    classDef stage fill:#F59E0B,stroke:#7C90A0,color:#fff
+    class S0,S1,S2,S3 stage
+```
+
+| Component | Role |
+|-----------|------|
+| **Artifact store** | Holds large outputs; agents query with `head`, `grep`, `chunk` |
+| **Escalation pipeline** | Progresses from direct answer → tools → plan → sub-agents |
+| **Sub-agent delegator** | Spawns focused agents with token and step budgets |
+| **Doom loop tracker** | Stops repeated identical actions |
+
+---
+
+## Configuration Options
+
+### AutonomyConfig
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `level` | `str` | `"suggest"` | Autonomy level (`suggest`, `auto_edit`, `full_auto`) |
+| `max_iterations` | `int` | `20` | Maximum turns before stopping |
+| `doom_loop_threshold` | `int` | `3` | Repeated actions before doom-loop stop |
+| `auto_escalate` | `bool` | `True` | Automatically increase complexity stage |
+| `mode` | `str` | auto | `caller` or `iterative` execution mode |
+
+### Artifact queueing
+
+Large tool outputs above `inline_max_bytes` (default 32 KB) are stored as artifacts automatically when queueing is enabled on the agent's tool configuration.
+
+---
+
+## Common Patterns
+
+### Explore a large artifact
+
+Agents with autonomy enabled can inspect stored outputs without loading the full content:
 
 ```python
-from praisonaiagents.context.artifacts import QueueConfig
+from praisonaiagents import Agent, AutonomyConfig
 
-config = QueueConfig(
-    enabled=True,
-    inline_max_bytes=32 * 1024,  # >32KB → artifact
-    redact_secrets=True,          # Auto-redact API keys
-    summary_max_chars=200,
+agent = Agent(
+    instructions="Search large logs for error patterns.",
+    autonomy=AutonomyConfig(level="full_auto"),
 )
+
+agent.start("Find all timeout errors in the latest deployment log")
+```
+
+### Delegate a subtask
+
+```python
+from praisonaiagents import Agent, AutonomyConfig
+
+agent = Agent(
+    instructions="Coordinate analysis across data sources.",
+    autonomy=AutonomyConfig(level="full_auto"),
+)
+
+# Delegation runs inside the autonomy loop when escalation reaches Stage 3
+agent.start("Count billing questions per region in the ticket export")
 ```
 
 ---
 
-## Module Reference
+## Best Practices
 
-| Module | Path | Purpose |
-|--------|------|---------|
-| Artifacts | `praisonaiagents/context/artifacts.py` | ArtifactRef, ArtifactStoreProtocol |
-| Delegator | `praisonaiagents/agents/delegator.py` | SubagentDelegator, DelegationConfig |
-| Autonomy | `praisonaiagents/agent/autonomy.py` | AutonomyMixin, DoomLoopTracker |
-| Escalation | `praisonaiagents/escalation/pipeline.py` | EscalationPipeline, stages |
-| Retrieval | `praisonaiagents/knowledge/retrieval.py` | merge_adjacent_chunks, RRF |
-| Python Tools | `praisonaiagents/tools/python_tools.py` | execute_code (REPL) |
-| Subagent Tool | `praisonaiagents/tools/subagent_tool.py` | create_subagent_tool |
+<AccordionGroup>
+  <Accordion title="Enable autonomy for large or multi-step tasks">
+    Set `autonomy=True` or `AutonomyConfig(level="full_auto")` when inputs exceed a few pages or require tool loops. Simple one-shot questions do not need it.
+  </Accordion>
+  <Accordion title="Set doom_loop_threshold for long runs">
+    Keep `doom_loop_threshold` at 3–5 so agents stop when repeating the same tool call instead of burning tokens indefinitely.
+  </Accordion>
+  <Accordion title="Use full_auto for repository-scale work">
+    `level="full_auto"` enables iterative mode, filesystem tracking, and sub-agent delegation — appropriate for code and data analysis over large corpora.
+  </Accordion>
+  <Accordion title="Combine with code execution for structured data">
+    Pair `ExecutionConfig(code_execution=True)` with autonomy so agents can run Python over artifact contents rather than reasoning over raw text alone.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Autonomous Loops" icon="rotate" href="/docs/features/autonomy-loop">
+    Run agents in iterative loops with completion signals and escalation
+  </Card>
+  <Card title="Context Compaction" icon="compress" href="/docs/features/context-compaction">
+    Automatically trim context when the window fills up
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Upgraded five feature pages per AGENTS.md §9: agent-centric openers, hero mermaid, Steps, AccordionGroup, CardGroup
- `reasoning.mdx`: agent-centric opener; `AgentTeam` instead of deprecated alias; Related links to features pages
- `recipe-registry.mdx`: trimmed to publish/pull workflow; fixed `list_recipes` return shape; `os.environ` for tokens
- `recipe-serve-advanced.mdx`: production config table; removed placeholder secrets
- `recipe-serve-code.mdx`: added Steps; trimmed Docker/K8s boilerplate; env-based API keys
- `recursive-context.mdx`: friendly `AutonomyConfig` imports; removed low-level API duplication

Refs #1000

## Test plan
- [x] All five pages pass hero/Steps/AccordionGroup/CardGroup scan
- [x] No edits under `docs/concepts/`
- [x] Skipped #648, #909, #928
- [x] `docs.json` valid JSON

Made with [Cursor](https://cursor.com)