### PR TITLE
docs(features): AGENTS.md §9 compliance batch 34 (#1000)

### DIFF
--- a/docs/features/rules.mdx
+++ b/docs/features/rules.mdx
@@ -1,12 +1,19 @@
 ---
 title: "Rules & Instructions"
+sidebarTitle: "Rules"
 description: "Auto-discover and apply persistent rules like Cursor, Windsurf, Claude, and Codex"
 icon: "scroll"
 ---
 
-# Rules & Instructions
+PraisonAI auto-discovers instruction files and injects them into the agent system prompt.
 
-PraisonAI automatically discovers and applies rules/instructions from multiple sources, similar to Cursor, Windsurf, Claude Code, and Codex CLI.
+```python
+from praisonaiagents import Agent
+
+# Create CLAUDE.md or AGENTS.md in your project root — loaded automatically
+agent = Agent(name="Assistant", instructions="You are helpful.")
+agent.start("Help me with Python")
+```
 
 ```mermaid
 graph TB
@@ -76,21 +83,40 @@ PraisonAI automatically loads these files from your project root and git root:
 
 ## Quick Start
 
-Rules are automatically loaded when you create an Agent:
+<Steps>
+<Step title="Simple Usage">
+
+Create an instruction file in your project root — the agent loads it automatically:
 
 ```python
 from praisonaiagents import Agent
 
-# Create CLAUDE.md in your project root
-# Agent auto-discovers and applies it
-agent = Agent(
-    name="Assistant",
-    instructions="You are helpful."
-)
-
-# Rules are injected into system prompt automatically
-response = agent.chat("Help me with Python")
+agent = Agent(name="Assistant", instructions="You are helpful.")
+agent.start("Help me with Python")
 ```
+
+</Step>
+
+<Step title="With Configuration">
+
+Add frontmatter to scope a rule to Python files:
+
+```markdown
+---
+description: Python coding guidelines
+globs: ["**/*.py"]
+activation: glob
+priority: 10
+---
+
+# Python Guidelines
+
+- Use type hints for all functions
+- Follow PEP 8
+```
+
+</Step>
+</Steps>
 
 ## Rule File Format
 
@@ -276,7 +302,7 @@ The `praisonai.rules.show`, `create`, and `delete` MCP tools validate rule names
 ## Programmatic Rules Management
 
 ```python
-from praisonaiagents import RulesManager
+from praisonaiagents.memory import RulesManager
 
 # Create manager for your workspace
 rules = RulesManager(workspace_path="/path/to/project")
@@ -305,7 +331,7 @@ context = rules.build_rules_context(
 ## Creating Rules Programmatically
 
 ```python
-from praisonaiagents import RulesManager
+from praisonaiagents.memory import RulesManager
 
 rules = RulesManager(workspace_path="/path/to/project")
 
@@ -355,7 +381,7 @@ print(stats)
 For `ai_decision` rules, PraisonAI can use an LLM to decide if a rule should be applied:
 
 ```python
-from praisonaiagents import RulesManager
+from praisonaiagents.memory import RulesManager
 
 rules = RulesManager(workspace_path="/path/to/project")
 
@@ -492,19 +518,13 @@ PraisonAI reads the same instruction files used by other AI coding assistants, m
   </Accordion>
 </AccordionGroup>
 
-## See Also
+## Related
 
 <CardGroup cols={2}>
-  <Card title="Agent Memory" icon="memory" href="/features/memory">
-    Persistent memory for agents with session save/resume
-  </Card>
-  <Card title="Workflows" icon="diagram-project" href="/docs/features/workflows">
-    Create reusable multi-step workflows
+  <Card title="Context Files" icon="file-lines" href="/docs/features/context-files">
+    CLI auto-loading of AGENTS.md and CLAUDE.md
   </Card>
   <Card title="Hooks" icon="plug" href="/docs/features/hooks">
     Pre/post operation hooks for custom actions
-  </Card>
-  <Card title="Advanced Memory" icon="brain" href="/docs/features/advanced-memory">
-    Multi-tiered memory with quality scoring and vector search
   </Card>
 </CardGroup>

--- a/docs/features/run-history.mdx
+++ b/docs/features/run-history.mdx
@@ -5,7 +5,19 @@ description: "Read back persisted run and trace data from your state store"
 icon: "clock-rotate-left"
 ---
 
-Query the runs and traces your agents have written to the state store.
+Query runs and traces your agents have written to the state store.
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.db import PraisonAIDB
+
+agent = Agent(name="Research Agent", instructions="Research the topic")
+agent.start("What is quantum computing?")
+
+db = PraisonAIDB(state_url="sqlite:///agent_state.db")
+runs = db.get_runs(session_id=agent.session_id)
+print(f"{len(runs)} run(s) for this session")
+```
 
 ```mermaid
 graph LR
@@ -173,11 +185,10 @@ Otherwise you get `[]` and a warning: `"get_runs() called but no state_url confi
 
 Configure via environment variable or constructor:
 ```python
-# Environment variable (recommended)
-os.environ["PRAISONAI_STATE_URL"] = "postgresql://user:pass@host/db"
+import os
+os.environ["PRAISONAI_STATE_URL"] = os.getenv("DATABASE_URL", "sqlite:///data.db")
 
-# Or via constructor
-db = PraisonAIDB(state_url="sqlite:///data.db")
+db = PraisonAIDB(state_url=os.getenv("DATABASE_URL", "sqlite:///data.db"))
 ```
 </Accordion>
 
@@ -213,8 +224,5 @@ def get_cached_runs(session_id: str, limit: int = 10):
 </Card>
 <Card title="Session Management" icon="users" href="/docs/features/persistence">
   Manage agent sessions and state
-</Card>
-<Card title="Langfuse Observability" icon="chart-line" href="/docs/observability/langfuse">
-  Advanced trace analysis and monitoring
 </Card>
 </CardGroup>

--- a/docs/features/run-stream-events.mdx
+++ b/docs/features/run-stream-events.mdx
@@ -5,7 +5,11 @@ description: "Follow a praisonai run live as a versioned NDJSON event stream"
 icon: "rss"
 ---
 
-`praisonai run --output stream-json` emits a per-step NDJSON event stream you can pipe into CI pipelines, scripts, or observability tools.
+`praisonai run --output stream-json` emits a per-step NDJSON event stream for CI pipelines, scripts, and observability tools.
+
+```bash
+praisonai run --output stream-json "Find the weather in London"
+```
 
 ```mermaid
 graph LR
@@ -377,10 +381,10 @@ Concatenating `text.delta` chunks is useful for live display, but `run.result.da
 ## Related
 
 <CardGroup cols={2}>
-  <Card icon="play" href="/docs/cli/run">
-    CLI Run Reference
+  <Card title="CLI Run" icon="play" href="/docs/cli/run">
+    CLI run reference and output modes
   </Card>
-  <Card icon="plug" href="/docs/features/cli-backend-protocol">
-    CLI Backend Protocol
+  <Card title="CLI Backend Protocol" icon="plug" href="/docs/features/cli-backend-protocol">
+    Backend protocol for custom CLI integrations
   </Card>
 </CardGroup>

--- a/docs/features/runtime-capabilities.mdx
+++ b/docs/features/runtime-capabilities.mdx
@@ -5,7 +5,20 @@ description: "Declare what your agent needs and validate runtime support before 
 icon: "shield-check"
 ---
 
-Agents declare which capabilities they need, and the framework validates runtime support at construction time — failing fast instead of breaking mid-conversation.
+Agents declare required capabilities and the framework validates runtime support at construction — failing fast instead of mid-conversation.
+
+```python
+from praisonaiagents import Agent, RuntimeConfig
+
+agent = Agent(
+    instructions="You are a research assistant",
+    runtime=RuntimeConfig(
+        preferred_runtime="native",
+        required_capabilities=["tool_loop", "mcp_tools", "streaming_deltas"],
+    ),
+)
+agent.start("Find the top 3 papers on RLHF this month")
+```
 
 ```mermaid
 graph LR

--- a/docs/features/runtime-mcp.mdx
+++ b/docs/features/runtime-mcp.mdx
@@ -7,6 +7,14 @@ icon: "plug"
 
 Add or remove MCP integrations on a running agent — no restart, no lost session state.
 
+```python
+from praisonaiagents import Agent, MCP
+
+agent = Agent(instructions="You are a helpful assistant")
+agent.add_mcp_server("notion", MCP("npx -y @notionhq/notion-mcp-server"))
+agent.start("Summarise my latest Notion page about Q3 planning")
+```
+
 ```mermaid
 graph LR
     subgraph "Runtime MCP Management"
@@ -33,8 +41,7 @@ graph LR
 <Steps>
 <Step title="Attach an MCP server at runtime">
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 
 agent = Agent(instructions="You are a helpful assistant")
 
@@ -96,8 +103,7 @@ Runtime-attached MCPs live in a private `_mcp_servers` registry on the agent. Ea
 ### Gateway agent adds Notion mid-session
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 
 agent = Agent(instructions="You are a helpful assistant")
 agent.add_mcp_server("notion", MCP("npx -y @notionhq/notion-mcp-server"))
@@ -161,8 +167,10 @@ Long-running services should still call `close()` or `aclose()` when the agent s
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="MCP" icon="plug" href="/concepts/mcp">Static MCP setup at construction time</Card>
-  <Card title="Tools" icon="wrench" href="/concepts/tools">Function tools and tool registry</Card>
-  <Card title="MCP Lifecycle" icon="arrows-rotate" href="/docs/features/mcp-lifecycle">Context manager and connection cleanup</Card>
-  <Card title="Load MCP Tools" icon="download" href="/docs/features/load-mcp-tools">Load MCP tools into an agent at build time</Card>
+  <Card title="Load MCP Tools" icon="download" href="/docs/features/load-mcp-tools">
+    Load MCP tools into an agent at build time
+  </Card>
+  <Card title="MCP Lifecycle" icon="arrows-rotate" href="/docs/features/mcp-lifecycle">
+    Context manager and connection cleanup
+  </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Upgrade , , , ,  per AGENTS.md §9
- Agent-centric openers, Steps Quick Start, two-card Related sections
- Fix  import () and friendly                                                                                 
 Usage: MCP [OPTIONS] COMMAND [ARGS]...                                         
                                                                                
 MCP development tools                                                          
                                                                                
╭─ Options ────────────────────────────────────────────────────────────────────╮
│ --help          Show this message and exit.                                  │
╰──────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ───────────────────────────────────────────────────────────────────╮
│ version  Show the MCP version.                                               │
│ dev      Run an MCP server with the MCP Inspector.                           │
│ run      Run an MCP server.                                                  │
│ install  Install an MCP server in the Claude desktop app.                    │
╰──────────────────────────────────────────────────────────────────────────────╯ import
- Replace placeholder DB credentials with 

Refs #1000

## Test plan
- [x] Hero mermaid, Steps, AccordionGroup, CardGroup present on all five pages
- [x] No edits under 