### PR TITLE
docs(features): AGENTS.md §9 compliance batch 35 (#1000)

### DIFF
--- a/docs/features/runtime-preflight.mdx
+++ b/docs/features/runtime-preflight.mdx
@@ -5,7 +5,19 @@ description: "Validate multi-agent team YAML for runtime compatibility before Ag
 icon: "shield-check"
 ---
 
-Validate team YAML for runtime compatibility, handoffs, and installed frameworks **without LLM calls or API keys**. Run this as a preflight step before `AgentTeam.start()` or a workflow run.
+Validate team YAML for runtime compatibility, handoffs, and installed frameworks **without LLM calls or API keys**.
+
+```python
+from praisonaiagents import Agent, AgentTeam, Task
+
+researcher = Agent(name="researcher", instructions="Research topics")
+writer = Agent(name="writer", instructions="Write content")
+task = Task(description="Research and write", agent=researcher)
+
+team = AgentTeam(agents=[researcher, writer], tasks=[task])
+# Run `praisonai doctor runtime --team agents.yaml` before team.start()
+team.start()
+```
 
 ```mermaid
 graph LR
@@ -27,7 +39,10 @@ graph LR
 ## Quick Start
 
 <Steps>
-<Step title="Define your team">
+<Step title="Simple Usage">
+
+Define your team YAML, then run preflight before starting:
+
 ```yaml
 # agents.yaml
 framework: praisonai
@@ -39,15 +54,21 @@ roles:
   writer:
     role: Writer
 ```
-</Step>
 
-<Step title="Run preflight (no API keys required)">
 ```bash
 praisonai doctor runtime --team agents.yaml
 ```
+
 </Step>
 
-<Step title="Start the team when checks pass">
+<Step title="With Configuration">
+
+Use `--json` in CI and start the team only when exit code is `0`:
+
+```bash
+praisonai doctor runtime --team agents.yaml --json
+```
+
 ```python
 from praisonaiagents import Agent, AgentTeam, Task
 
@@ -56,8 +77,9 @@ writer = Agent(name="writer", instructions="Write content")
 task = Task(description="Research and write", agent=researcher)
 
 team = AgentTeam(agents=[researcher, writer], tasks=[task])
-team.start()  # safe to run after preflight passes
+team.start()  # safe after preflight passes
 ```
+
 </Step>
 </Steps>
 
@@ -229,14 +251,8 @@ Only `praisonai` and `autogen_v4` support handoffs. Mixed-runtime teams with han
 ## Related
 
 <CardGroup cols={2}>
-<Card title="Doctor CLI" icon="stethoscope" href="/docs/cli/doctor">
-  Full reference for praisonai doctor subcommands and check categories
-</Card>
-<Card title="AgentTeam" icon="users" href="/docs/concepts/agentteam">
-  Multi-agent orchestration with AgentTeam and Task
-</Card>
-<Card title="PraisonAI Agents Framework" icon="robot" href="/docs/framework/praisonaiagents">
-  Framework options including handoffs and runtime selection
+<Card title="Runtime Selection" icon="play" href="/docs/features/runtime-selection">
+  Choose which runtime executes each model
 </Card>
 <Card title="Runtime Config Migration" icon="arrow-right-arrow-left" href="/docs/features/doctor-runtime-migration">
   Migrate legacy cli_backend fields with praisonai doctor runtime --fix

--- a/docs/features/runtime-resolution.mdx
+++ b/docs/features/runtime-resolution.mdx
@@ -7,6 +7,25 @@ icon: "rotate"
 
 The runtime-resolution subsystem maps agent and model references to concrete runtime instances at turn-time, enabling dynamic model switching and custom routing logic.
 
+```python
+from praisonaiagents import Agent
+
+researcher = Agent(
+    name="Researcher",
+    instructions="Research the topic and summarise it",
+    llm="gpt-4o-mini",
+)
+writer = Agent(
+    name="Writer",
+    instructions="Write a polished article",
+    llm="gpt-4o-mini",
+    handoffs=[researcher],
+)
+
+researcher.llm = "claude-3-sonnet"  # picked up on the next turn
+writer.start("Research and write about ocean currents")
+```
+
 <Warning>
 **Handoffs no longer use this subsystem.** As of [PR #2178](https://github.com/MervinPraison/PraisonAI/pull/2178), handoffs always delegate directly to `agent.chat()` / `agent.achat()`. The runtime-resolution layer is used by other parts of the SDK for agent-level runtime configuration. If you came here for handoff execution behaviour, see [Agent Handoffs](/docs/features/handoffs).
 </Warning>
@@ -36,84 +55,42 @@ graph LR
 ## Quick Start
 
 <Steps>
-<Step title="Swap an agent model mid-conversation">
+<Step title="Simple Usage">
 
-Update the target model at any time — the next invocation automatically picks up the change because `agent.chat()` reads the live `llm` value.
+Update the target model at any time — the next invocation reads the live `llm` value.
 
 ```python
 from praisonaiagents import Agent
 
-researcher = Agent(
-    name="Researcher",
-    instructions="Research the topic and summarise it",
-    llm="gpt-4o-mini",
-)
+analyst = Agent(name="Analyst", instructions="Analyse data", llm="gpt-4o-mini")
+coordinator = Agent(name="Coordinator", instructions="Coordinate", handoffs=[analyst])
 
-writer = Agent(
-    name="Writer",
-    instructions="Write a polished article",
-    llm="gpt-4o-mini",
-    handoffs=[researcher],
-)
+coordinator.start("Quick summary of Q1 sales")
 
-# Swap the researcher to a different model at any point
-researcher.llm = "claude-3-sonnet"
-
-# The next invocation automatically uses claude-3-sonnet for the researcher
-writer.start("Research and write about ocean currents")
+analyst.llm = "gpt-4o"
+coordinator.start("Full analysis of Q1 vs Q2 with trend forecasting")
 ```
 
 </Step>
 
-<Step title="Inspect the runtime cache">
+<Step title="With Configuration">
 
-Use `get_runtime_cache` and `clear_runtime_cache` to debug or force a fresh resolution.
-
-```python
-from praisonaiagents.runtime import get_runtime_cache, clear_runtime_cache
-
-# See what runtimes are cached across sessions
-cache = get_runtime_cache()
-for session_id, entries in cache.items():
-    for cache_key, (runtime, cached_at) in entries.items():
-        print(f"{cache_key}: {runtime.provider}/{runtime.model_ref}")
-
-# Force fresh resolution for a specific session
-clear_runtime_cache(session_id="session_123")
-
-# Clear all cached runtimes
-clear_runtime_cache()
-```
-
-</Step>
-
-<Step title="Custom resolver (advanced)">
-
-Override the built-in resolver to control how models map to runtimes.
+Clear the runtime cache after credential rotation or register a custom resolver:
 
 ```python
 from praisonaiagents import Agent
-from praisonaiagents.runtime import (
-    set_global_resolver,
-    SessionContext,
-)
-from praisonaiagents.runtime.resolve import (
-    RuntimeResolver,
-    AgentRuntimeProtocol,
-    LLMRuntimeWrapper,
-)
+from praisonaiagents.runtime import clear_runtime_cache, set_global_resolver
+from praisonaiagents.runtime.resolve import RuntimeResolver, LLMRuntimeWrapper
 from praisonaiagents.llm.llm import LLM
+
+clear_runtime_cache()  # force fresh resolution
 
 class MyResolver(RuntimeResolver):
     def supports_model(self, model_ref: str) -> bool:
-        return model_ref.startswith(("gpt-", "claude-", "my-model-"))
+        return model_ref.startswith("my-model-")
 
     def resolve(self, agent_id, model_ref, session_ctx, **kwargs):
-        # Route "my-model-*" to a custom endpoint
-        if model_ref.startswith("my-model-"):
-            llm = LLM(model="gpt-4o-mini", api_base="https://my.endpoint/v1")
-        else:
-            llm = LLM(model=model_ref)
+        llm = LLM(model="gpt-4o-mini", api_base="https://my.endpoint/v1")
         return LLMRuntimeWrapper(llm=llm, model_ref=model_ref, agent_id=agent_id)
 
 set_global_resolver(MyResolver())
@@ -299,16 +276,10 @@ class AgentRuntimeProtocol(RuntimeProtocol):
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Runtime Selection" icon="play" href="/docs/features/runtime-selection">
+  Choose which runtime executes each model
+</Card>
 <Card title="Agent Handoffs" icon="handshake" href="/docs/features/handoffs">
   Agent-to-agent delegation — handoffs always use agent.chat()
-</Card>
-<Card title="HandoffConfig reference" icon="sliders" href="/docs/configuration/handoff-config">
-  HandoffConfig reference
-</Card>
-<Card title="Secure tool boundaries during handoff" icon="shield-check" href="/docs/features/handoff-tool-policy">
-  Secure tool boundaries during handoff
-</Card>
-<Card title="Filter context passed during handoff" icon="filter" href="/docs/features/handoff-filters">
-  Filter context passed during handoff
 </Card>
 </CardGroup>

--- a/docs/features/runtime-selection.mdx
+++ b/docs/features/runtime-selection.mdx
@@ -7,6 +7,17 @@ icon: "play"
 
 Runtime selection lets you pick which execution backend (Claude Code, Codex CLI, the built-in PraisonAI runtime) runs each model — declared on the model map, not the agent.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Coder",
+    instructions="Write Python code",
+    runtime="claude-code",
+)
+agent.start("Build a CLI tool that lists open PRs")
+```
+
 ```mermaid
 graph LR
     subgraph "Runtime Resolution Order"
@@ -29,7 +40,7 @@ graph LR
 ## Quick Start
 
 <Steps>
-<Step title="Simplest">
+<Step title="Simple Usage">
 ```python
 from praisonaiagents import Agent
 
@@ -43,7 +54,7 @@ agent.start("Build a CLI tool that lists open PRs")
 ```
 </Step>
 
-<Step title="With config">
+<Step title="With Configuration">
 ```python
 from praisonaiagents import Agent
 from praisonaiagents.runtime import AgentRuntimeConfig
@@ -264,18 +275,9 @@ Use the migration table above or `praisonai doctor runtime --fix` before 2.0.0 r
 
 <CardGroup cols={2}>
 <Card title="Agent Runtime Protocol" icon="plug" href="/docs/features/agent-runtime-protocol">
-  Plugin harness registry, `register_runtime`, and `praisonai.runtimes` entry points
-</Card>
-<Card title="CLI Backend Protocol" icon="plug" href="/docs/features/cli-backend-protocol">
-  Legacy cli_backend reference (deprecated — see Runtime Selection)
-</Card>
-<Card title="YAML Configuration Reference" icon="file-code" href="/docs/features/yaml-configuration-reference">
-  Full YAML field reference including models.*.runtime
+  Plugin harness registry, register_runtime, and praisonai.runtimes entry points
 </Card>
 <Card title="Runtime Preflight" icon="shield-check" href="/docs/features/runtime-preflight">
   Validate team YAML before AgentTeam.start()
-</Card>
-<Card title="Runtime Config Migration" icon="arrow-right-arrow-left" href="/docs/features/doctor-runtime-migration">
-  Migrate legacy cli_backend with praisonai doctor runtime --fix
 </Card>
 </CardGroup>

--- a/docs/features/runtime-tool-result-middleware.mdx
+++ b/docs/features/runtime-tool-result-middleware.mdx
@@ -7,6 +7,13 @@ icon: "shuffle"
 
 Runtime tool result middleware converts vendor-shaped tool outputs from plugin harnesses into a standard format before hooks and memory adapters run.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="Be helpful")
+agent.start("What is 2 + 2?")  # native praisonai runtime — no middleware needed
+```
+
 ```mermaid
 graph LR
     H[Plugin Harness] --> T[Tool Execution]
@@ -31,7 +38,8 @@ graph LR
 ## Quick Start
 
 <Steps>
-<Step title="Default (zero config)">
+<Step title="Simple Usage">
+
 The native `praisonai` runtime needs no middleware — results pass straight to hooks:
 
 ```python
@@ -40,10 +48,12 @@ from praisonaiagents import Agent
 agent = Agent(name="assistant", instructions="Be helpful")
 agent.start("What is 2 + 2?")
 ```
+
 </Step>
 
-<Step title="Register harness middleware">
-Implement `normalize`, register once, then set `agent._runtime_id`:
+<Step title="With Configuration">
+
+Register harness middleware once, then set `agent._runtime_id`:
 
 ```python
 from typing import Any
@@ -80,9 +90,10 @@ def lookup(query: str) -> dict:
     return {"status": "ok", "data": f"Results for {query}"}
 
 agent = Agent(name="assistant", tools=[lookup])
-agent._runtime_id = "my_plugin_harness"  # triggers middleware lookup
+agent._runtime_id = "my_plugin_harness"
 agent.start("Look up Python tutorials")
 ```
+
 </Step>
 </Steps>
 
@@ -198,16 +209,10 @@ Do not register middleware for `"praisonai"` — the core runtime bypasses it fo
 ## Related
 
 <CardGroup cols={2}>
-<Card title="Hooks" icon="webhook" href="/docs/concepts/hooks">
-  Hooks receive the normalised payload via `AfterToolInput`.
-</Card>
-<Card title="Managed Runtime Protocol" icon="server" href="/docs/features/managed-runtime-protocol">
-  Remote agent loops on managed infrastructure — a different runtime concept.
+<Card title="Hooks" icon="webhook" href="/docs/features/hooks">
+  Hooks receive the normalised payload via AfterToolInput
 </Card>
 <Card title="Agent Runtime Protocol" icon="plug" href="/docs/features/agent-runtime-protocol">
-  Pluggable agent execution runtimes (turn/stream abstraction).
-</Card>
-<Card title="Memory Lifecycle Hooks" icon="brain" href="/docs/features/memory-lifecycle-hooks">
-  Memory backends that react to tool and session events.
+  Pluggable agent execution runtimes (turn/stream abstraction)
 </Card>
 </CardGroup>

--- a/docs/features/sandbox-backends.mdx
+++ b/docs/features/sandbox-backends.mdx
@@ -7,6 +7,17 @@ icon: "shield"
 
 Sandbox backends provide isolated command execution environments with explicit shell control to prevent injection attacks while enabling shell features when needed.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Coder",
+    instructions="Run shell commands safely",
+    sandbox=True,
+)
+agent.start("List Python files in the current directory")
+```
+
 ```mermaid
 graph LR
     subgraph "Sandbox Command Execution"
@@ -31,49 +42,42 @@ graph LR
 ## Quick Start
 
 <Steps>
-<Step title="Safe Command Execution">
-Execute commands safely without shell features:
+<Step title="Simple Usage">
+
+Enable sandbox on the agent — subprocess backend is the default:
 
 ```python
 from praisonaiagents import Agent
-from praisonai.sandbox import SubprocessSandbox
 
-# Create agent with safe command execution
 agent = Agent(
     name="System Agent",
     instructions="Execute system commands safely",
+    sandbox=True,
 )
-
-# Create sandbox for safe execution
-sandbox = SubprocessSandbox()
-
-# Execute without shell (default, safe)
-result = await sandbox.run_command("ls -la")
-print(result.stdout)
+agent.start("List files in the current directory")
 ```
+
 </Step>
 
-<Step title="With Shell Features">
-Enable shell features when needed:
+<Step title="With Configuration">
+
+Pick a specific backend via `SandboxConfig` or the CLI `--sandbox-type` flag:
 
 ```python
-from praisonaiagents import Agent
-from praisonai.sandbox import DockerSandbox
+from praisonaiagents import Agent, SandboxConfig
 
 agent = Agent(
-    name="Data Agent", 
-    instructions="Process data with shell pipelines"
+    name="Data Agent",
+    instructions="Process data in an isolated container",
+    sandbox=SandboxConfig.docker("python:3.11-slim"),
 )
-
-sandbox = DockerSandbox()
-
-# Execute with shell features (explicit opt-in)
-result = await sandbox.run_command(
-    "cat data.txt | grep 'error' | wc -l",
-    shell=True
-)
-print(f"Error count: {result.stdout.strip()}")
+agent.start("Run pip list and summarise installed packages")
 ```
+
+```bash
+praisonai sandbox run --code "print('hello')" --type docker
+```
+
 </Step>
 </Steps>
 
@@ -466,13 +470,10 @@ praisonai sandbox run --code "print('hello')" --type docker
 ## Related
 
 <CardGroup cols={2}>
-<Card title="Resource Limits" icon="gauge" href="/docs/cli/sandbox-execution">
-  Configure timeouts and memory limits for sandbox execution
-</Card>
-<Card title="Thread Safety" icon="lock" href="/docs/features/thread-safety">
-  Understanding thread-safe operations across PraisonAI components
+<Card title="Sandbox" icon="shield-halved" href="/docs/features/sandbox">
+  Agent-level sandbox=True and SandboxConfig
 </Card>
 <Card title="Sandbox CLI" icon="terminal" href="/docs/cli/sandbox">
-  CLI reference for `praisonai sandbox run` and `praisonai sandbox shell`
+  CLI reference for praisonai sandbox run and praisonai sandbox shell
 </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Upgrade `runtime-preflight`, `runtime-resolution`, `runtime-selection`, `runtime-tool-result-middleware`, `sandbox-backends` per AGENTS.md §9
- Agent-centric openers before hero Mermaid, Steps Quick Start (Simple Usage + With Configuration), two-card Related sections
- Fix sandbox Quick Start (remove broken bare `await` examples; use Agent + SandboxConfig)
- Point Related hooks link to `/docs/features/hooks` instead of concepts

Refs #1000

## Test plan
- [x] Hero mermaid, Steps, AccordionGroup, CardGroup present on all five pages
- [x] No edits under `docs/concepts/`, `docs/js/`, or `docs/rust/`

Made with [Cursor](https://cursor.com)