### PR TITLE
docs(features): AGENTS.md §9 compliance batch 39 (#1000)

### DIFF
--- a/docs/features/session-runtime-state.mdx
+++ b/docs/features/session-runtime-state.mdx
@@ -7,6 +7,16 @@ icon: "clone"
 
 Runtime state mirroring lets sessions remember lightweight per-turn execution artefacts (tool call IDs, transcript slices) so the native runtime and plugin harnesses can hand off, replay, or debug each other's turns.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    memory={"session_id": "my-session"},
+)
+agent.start("Run a tool turn — enable mirror_runtime_state on your gateway SessionConfig")
+```
+
 ```mermaid
 graph LR
     N[Native Runtime] --> S[(Session runtime_state)]
@@ -40,7 +50,7 @@ config = GatewayConfig(
 
 <Step title="Read what was mirrored">
 ```python
-from praisonaiagents.session.store import DefaultSessionStore
+from praisonaiagents.session import DefaultSessionStore
 
 store = DefaultSessionStore()
 turns = store.get_runtime_state(session_id="my-session", runtime_id="native")
@@ -120,15 +130,18 @@ store.set_runtime_state(
 ```
 </Tab>
 
-<Tab title="after_turn export">
+<Tab title="after_agent export">
 ```python
-from praisonaiagents.hooks import after_turn
+from praisonaiagents.hooks import add_hook
+from praisonaiagents.session import DefaultSessionStore
 
-@after_turn
+@add_hook("after_agent")
 def export_runtime_state(event):
     store = DefaultSessionStore()
-    turns = store.get_runtime_state(event.session_id, "native")
-    # Push lightweight slices to your observability backend
+    session_id = getattr(event, "session_id", None)
+    if session_id:
+        turns = store.get_runtime_state(session_id, "native")
+        # Push lightweight slices to your observability backend
     return event
 ```
 </Tab>

--- a/docs/features/session-store.mdx
+++ b/docs/features/session-store.mdx
@@ -7,6 +7,17 @@ icon: "database"
 
 Session stores persist chat history and metadata — swap the default JSON backend or use hierarchical forks without changing your agent code.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    memory={"session_id": "user-42-chat"},
+)
+agent.start("Remember I like tea.")
+agent.start("What do I like?")  # History restored from ~/.praisonai/sessions/
+```
+
 ```mermaid
 graph LR
     A[Agent] --> P[SessionStoreProtocol]
@@ -22,6 +33,26 @@ graph LR
 
 ## Quick Start
 
+<Steps>
+<Step title="Persist with session_id">
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    memory={"session_id": "user-42-chat"},
+)
+agent.start("Remember I like tea.")
+agent.start("What do I like?")
+```
+
+Default files live at `~/.praisonai/sessions/{session_id}.json`.
+
+</Step>
+
+<Step title="Use the store directly">
+
 ```python
 from praisonaiagents import Agent
 from praisonaiagents.session import get_default_session_store
@@ -29,16 +60,12 @@ from praisonaiagents.session import get_default_session_store
 store = get_default_session_store()
 session_id = "user-42-chat"
 
-agent = Agent(
-    name="Assistant",
-    memory={"session_id": session_id},
-)
-agent.start("Remember I like tea.")
-
-store.add_message(session_id, "assistant", agent.start("What do I like?"))
+agent = Agent(name="Assistant", memory={"session_id": session_id})
+store.add_message(session_id, "assistant", agent.start("Summarise our chat"))
 ```
 
-Default files live at `~/.praisonai/sessions/{session_id}.json`.
+</Step>
+</Steps>
 
 ## Core Exports
 
@@ -62,6 +89,22 @@ set_session_context(session_id="batch-job-1", user_id="operator")
 ctx = get_session_context()
 print(ctx.session_id)
 ```
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Prefer session_id on Agent over manual store calls">
+Let `Agent(memory={"session_id": "..."})` handle persistence — use the store directly only for admin, migration, or custom backends.
+</Accordion>
+
+<Accordion title="Use hierarchical store for forks and snapshots">
+Switch to `get_hierarchical_session_store()` when you need branching conversations or revert — see [Session Hierarchy](/features/session-hierarchy).
+</Accordion>
+
+<Accordion title="Set task-local context in async workers">
+Call `set_session_context()` at the start of each async task so downstream code reads the correct session without threading IDs through every call.
+</Accordion>
+</AccordionGroup>
 
 ## Related
 

--- a/docs/features/sessions.mdx
+++ b/docs/features/sessions.mdx
@@ -6,30 +6,15 @@ icon: "clock-rotate-left"
 
 Sessions enable agents to remember conversations across restarts and connect to remote agents.
 
-## Quick Start with Agent
-
-The simplest way to use sessions is with the `Agent` class:
-
 ```python
 from praisonaiagents import Agent
 
-# Create agent with session persistence
 agent = Agent(
     name="Assistant",
     instructions="You are a helpful assistant",
-    memory={"session_id": "my-session-123"}
+    memory={"session_id": "my-session-123"},
 )
-
-# First conversation
 agent.start("My name is Alice")
-
-# Later, in a new process - history restored automatically!
-agent = Agent(
-    name="Assistant",
-    instructions="You are a helpful assistant",
-    memory={"session_id": "my-session-123"}
-)
-agent.start("What's my name?")  # Remembers: "Alice"
 ```
 
 ```mermaid
@@ -47,6 +32,38 @@ graph LR
     class Agent,Memory agent
     class Store store
 ```
+
+## Quick Start
+
+<Steps>
+<Step title="Start with session_id">
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    instructions="You are a helpful assistant",
+    memory={"session_id": "my-session-123"},
+)
+agent.start("My name is Alice")
+```
+
+</Step>
+
+<Step title="Resume in a new process">
+
+```python
+agent = Agent(
+    name="Assistant",
+    instructions="You are a helpful assistant",
+    memory={"session_id": "my-session-123"},
+)
+agent.start("What's my name?")  # Remembers: "Alice"
+```
+
+</Step>
+</Steps>
 
 ## Using the Session Class
 
@@ -626,28 +643,23 @@ For database-backed persistence without manual session management, see the [Host
 
 ## Best Practices
 
-<CardGroup cols={2}>
-  <Card icon="id-card" title="Session Management">
-    - Use meaningful session IDs
-    - Clean up old sessions periodically
-    - Implement session expiry policies
-  </Card>
-  <Card icon="save" title="State Handling">
-    - Save state after important interactions
-    - Implement regular auto-save
-    - Handle restore failures gracefully
-  </Card>
-  <Card icon="shield-check" title="Remote Connections">
-    - Implement proper error handling
-    - Use timeouts for remote calls
-    - Add retry logic for failures
-  </Card>
-  <Card icon="lock" title="Security">
-    - Validate session IDs
-    - Implement authentication for remote agents
-    - Encrypt sensitive session data
-  </Card>
-</CardGroup>
+<AccordionGroup>
+<Accordion title="Use meaningful session IDs">
+Prefer stable IDs such as `support_{ticket_id}` or `assistant_{user_id}` so resume and cleanup stay predictable.
+</Accordion>
+
+<Accordion title="Save state after important interactions">
+Call `session.save_state()` or use `MemoryConfig(auto_save=...)` so long-running workflows survive restarts.
+</Accordion>
+
+<Accordion title="Handle remote failures gracefully">
+Wrap `session.chat()` in try/except for `TimeoutError` and `ConnectionError`; set explicit `timeout=` on remote sessions.
+</Accordion>
+
+<Accordion title="Validate session IDs and authenticate remotes">
+Treat session IDs as opaque handles — authenticate remote agent URLs with headers or tokens, not shared IDs alone.
+</Accordion>
+</AccordionGroup>
 
 ## Auto-Save Sessions
 

--- a/docs/features/single-source-config.mdx
+++ b/docs/features/single-source-config.mdx
@@ -7,6 +7,10 @@ icon: "gear"
 
 One `.praisonai/config.yaml` wires your project's full agent runtime — model, MCP servers, permissions — for every `praisonai run` in the directory.
 
+```bash
+praisonai run "Open the docs site and screenshot the home page"
+```
+
 ```mermaid
 graph LR
     subgraph "Single-Source Config"

--- a/docs/features/skill-capability-gates.mdx
+++ b/docs/features/skill-capability-gates.mdx
@@ -7,6 +7,17 @@ icon: "shield-check"
 
 Skill Capability Gates allow you to declare tool, server, and environment variable requirements in your skills and enforce them at runtime with configurable strictness levels.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="PDF Assistant",
+    instructions="Process PDFs for the user",
+    skills=["./skills/pdf-processor"],
+)
+agent.start("Extract text from invoice.pdf")
+```
+
 ```mermaid
 graph LR
     subgraph "Skill Capability Gates"


### PR DESCRIPTION
## Summary
- Upgrade `session-runtime-state`, `session-store`, `sessions`, `single-source-config`, and `skill-capability-gates` per AGENTS.md §9
- Agent-centric openers, Steps, AccordionGroup where missing
- Fix `DefaultSessionStore` import path and replace non-existent `after_turn` with `add_hook("after_agent")`

Refs #1000

## Test plan
- [x] Hero mermaid, Steps, AccordionGroup, CardGroup on all five pages
- [x] No edits under `docs/concepts/`
- [x] `docs.json` valid JSON

Made with [Cursor](https://cursor.com)