### PR TITLE
docs(features): AGENTS.md §9 compliance batch 40 (#1000)

### DIFF
--- a/docs/features/skill-lifecycle.mdx
+++ b/docs/features/skill-lifecycle.mdx
@@ -7,6 +7,17 @@ icon: "rotate"
 
 Agent-created skills carry provenance metadata and usage telemetry that lets you track, archive, restore, and roll back skills across their entire lifetime.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Self-Improving Agent",
+    instructions="Create skills when you learn something new; archive stale ones.",
+    tools=["skill_manage", "skills_list"],
+)
+agent.start("Learn how to summarise weekly reports, then save that as a skill.")
+```
+
 ```mermaid
 graph LR
     subgraph "Skill Lifecycle"
@@ -375,7 +386,7 @@ After `restore_skill()`, call `mgr.discover()` (or `mgr.add_skill(path)`) to re-
 <Card title="Skill Manage" icon="wand-magic-sparkles" href="/docs/features/skill-manage">
   Create, edit, patch, archive, and delete skills — full action reference
 </Card>
-<Card title="Skills (Concepts)" icon="puzzle-piece" href="/docs/concepts/skills">
-  What skills are and how they work
+<Card title="Agent Skills" icon="puzzle-piece" href="/docs/features/skills">
+  Load specialised knowledge from SKILL.md files
 </Card>
 </CardGroup>

--- a/docs/features/skill-manage.mdx
+++ b/docs/features/skill-manage.mdx
@@ -7,6 +7,17 @@ icon: "wand-magic-sparkles"
 
 Self-improving skills enable agents to create, edit, and manage their own capabilities dynamically — with mutations staged for human approval before they touch disk.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Skill Builder",
+    instructions="When users teach you something, save it as a skill for next time.",
+    tools=["skill_manage", "skills_list", "skill_view"],
+)
+agent.start("Create a skill called 'weekly-summary' that summarises the week's work.")
+```
+
 <Tip>
 To trigger skill creation **automatically** after every task instead of having the model call `skill_manage` on its own, see [Self-Improving Agents](/docs/features/self-improve).
 </Tip>
@@ -340,14 +351,12 @@ mgr.reject("weekly-summary")
 
 ```python
 from praisonaiagents import SkillManager
-from praisonaiagents.skills.protocols import SkillMutatorProtocol
 
 mgr = SkillManager()
-assert isinstance(mgr, SkillMutatorProtocol)  # True
 
-# Use short-form aliases in wrappers and plugins — type against the protocol
-def propose_skill(mutator: SkillMutatorProtocol, name: str, content: str):
-    return mutator.create(name, content)
+# Short-form aliases — same methods as create_skill, edit_skill, etc.
+mgr.create("weekly-summary", "# Weekly Summary\nSteps...")
+mgr.patch("weekly-summary", old_string="v1", new_string="v2", propose=False)
 ```
 
 ---
@@ -539,10 +548,6 @@ Direct writes are convenient for rapid iteration in local development or a contr
 `approve("skl-a1b2c3d4")` is exact — it targets one specific proposal. `approve("weekly-summary")` uses a most-recent-wins fallback and can silently target the wrong proposal if multiple are pending for the same skill.
 </Accordion>
 
-<Accordion title="Type wrappers against SkillMutatorProtocol">
-If you write a plugin or wrapper around skill mutation, accept `SkillMutatorProtocol` rather than `SkillManager`. This makes your code compatible with future alternative implementations (e.g., HTTP registry backends).
-</Accordion>
-
 <Accordion title="Security-First Design">
 All skill operations are workspace-contained and use atomic writes via temp files. Never bypass name validation or path checks. Skills inherit workspace security automatically.
 </Accordion>
@@ -560,8 +565,8 @@ All skill operations return detailed JSON results with success flags and error m
 <Card title="Skill Lifecycle" icon="rotate" href="/docs/features/skill-lifecycle">
   Provenance, telemetry, archive/restore, and rollback for agent-created skills
 </Card>
-<Card title="Skills (Concepts)" icon="puzzle-piece" href="/docs/concepts/skills">
-  Understanding what skills are and how they work
+<Card title="Agent Skills" icon="puzzle-piece" href="/docs/features/skills">
+  Load and configure SKILL.md skills on agents
 </Card>
 <Card title="Workspace" icon="folder-lock" href="/docs/features/workspace">
   How workspace containment secures skill operations

--- a/docs/features/skills-invocation.mdx
+++ b/docs/features/skills-invocation.mdx
@@ -1,24 +1,74 @@
 ---
 title: "Skill Invocation"
 sidebarTitle: "Skill Invocation"
-description: "Run agent skills via /slash commands, $ARGUMENTS substitution, and inline shell."
+description: "Run agent skills via /slash commands, $ARGUMENTS substitution, and inline shell"
 icon: "slash"
 ---
 
-Skills can be invoked **three ways**: auto-triggered by the LLM from the
-system-prompt listing, manually by the user via ``/skill-name`` slash
-commands, or programmatically through ``SkillManager.invoke()``.
+Skills can be invoked three ways: auto-triggered by the LLM from the system-prompt listing, manually via `/skill-name` slash commands, or programmatically through `SkillManager.invoke()`.
 
-<Note>
-Skill files are read as UTF-8. If your editor saved `SKILL.md` in another encoding (common on Windows), `praisonai skills validate` will flag it. See **[File Encoding](/features/skills#file-encoding)** in the Skills page.
-</Note>
+```python
+from praisonaiagents import Agent
 
-<Note>
-This page covers the invocation layer added in v1.5+. For how to *author*
-skills, see **[Agent Skills](/concepts/skills)**.
-</Note>
+agent = Agent(
+    name="assistant",
+    skills=["./skills/deploy"],
+)
+agent.start("/deploy staging prod")
+```
 
-## How invocation works
+```mermaid
+graph LR
+    subgraph "Skill Invocation"
+        U[👤 User] --> R{Route}
+        R -->|"/skill args"| S[🔧 invoke]
+        R -->|normal prompt| L[🤖 LLM]
+        S --> L
+        L --> O[📤 Response]
+    end
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class U,L agent
+    class R,S tool
+    class O output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Slash command">
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="assistant",
+    skills=["./skills/deploy"],
+)
+agent.start("/deploy staging prod")
+# Renders the skill body with $ARGUMENTS substituted, then continues the turn
+```
+</Step>
+
+<Step title="Auto-trigger">
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="assistant",
+    skills=["./skills/csv-summary"],
+)
+agent.start("Summarise this CSV for me")
+# LLM sees skill descriptions in the system prompt and activates the matching skill
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
 
 ```mermaid
 flowchart LR
@@ -32,59 +82,58 @@ flowchart LR
     classDef tool  fill:#189AB4,stroke:#111,color:#fff
 ```
 
-<CardGroup cols={2}>
-  <Card title="Auto-trigger" icon="wand-magic-sparkles">
-    Skill ``description`` is included in the system prompt. The LLM decides
-    when to follow it.
-  </Card>
-  <Card title="Slash command" icon="slash">
-    ``/deploy staging`` renders the skill body with ``$ARGUMENTS``
-    substituted and short-circuits the LLM call path.
-  </Card>
-</CardGroup>
+| Mode | When to use |
+|------|-------------|
+| **Auto-trigger** | Skill `description` is in the system prompt; the LLM decides when to follow it |
+| **Slash command** | User types `/deploy staging`; body is rendered with `$ARGUMENTS` substituted |
 
-## Argument substitution
+<Note>
+Skill files are read as UTF-8. Run `praisonai skills validate --path ./my-skill` to catch encoding issues before deploy.
+</Note>
 
-Inside ``SKILL.md`` bodies you can reference arguments passed after the
-skill name:
+---
+
+## Argument Substitution
+
+Inside `SKILL.md` bodies you can reference arguments passed after the skill name:
 
 <Tabs>
   <Tab title="$ARGUMENTS">
     ```markdown
     Deploy $ARGUMENTS now.
     ```
-    ``/deploy staging prod`` becomes ``Deploy staging prod now.``
+    `/deploy staging prod` becomes `Deploy staging prod now.`
   </Tab>
 
   <Tab title="Indexed">
     ```markdown
     Migrate $ARGUMENTS[0] from $ARGUMENTS[1] to $ARGUMENTS[2].
     ```
-    ``/migrate SearchBar React Vue`` expands each positional argument.
+    `/migrate SearchBar React Vue` expands each positional argument.
   </Tab>
 
   <Tab title="Shorthand">
     ```markdown
     Hello $0, meet $1.
     ```
-    ``$N`` is shorthand for ``$ARGUMENTS[N]``. Quotes group tokens:
-    ``/greet "hello world" friend`` sets ``$0 = "hello world"``.
+    `$N` is shorthand for `$ARGUMENTS[N]`. Quotes group tokens:
+    `/greet "hello world" friend` sets `$0 = "hello world"`.
   </Tab>
 
   <Tab title="Context vars">
     ```markdown
     Working inside ${PRAISON_SKILL_DIR}. Session ${PRAISON_SESSION_ID}.
     ```
-    ``${CLAUDE_SKILL_DIR}`` / ``${CLAUDE_SESSION_ID}`` are supported as
-    aliases so existing Claude Code skills work unchanged.
+    `${CLAUDE_SKILL_DIR}` / `${CLAUDE_SESSION_ID}` are supported as aliases so existing Claude Code skills work unchanged.
   </Tab>
 </Tabs>
 
-## Inline shell substitution
+---
+
+## Inline Shell Substitution
 
 <Warning>
-Disabled by default. Skills that embed ``!`cmd` `` blocks render as
-``[shell execution disabled]`` until you explicitly opt in.
+Disabled by default. Skills that embed ``!`cmd` `` blocks render as `[shell execution disabled]` until you explicitly opt in.
 </Warning>
 
 ```python
@@ -111,47 +160,40 @@ rendered = mgr.invoke("pr-summary", raw_args="42", shell_exec=True)
   </Accordion>
 </AccordionGroup>
 
-## Invocation policy
+---
+
+## Invocation Policy
 
 <ParamField path="disable-model-invocation" type="boolean" default="false">
-  When ``true`` the skill is **hidden from the system-prompt listing**, so
-  the LLM cannot auto-trigger it. Users can still invoke it via
-  ``/skill-name``. Use for side-effecting commands like ``/deploy``.
+  When `true` the skill is **hidden from the system-prompt listing**, so the LLM cannot auto-trigger it. Users can still invoke it via `/skill-name`. Use for side-effecting commands like `/deploy`.
 </ParamField>
 
 <ParamField path="user-invocable" type="boolean" default="true">
-  When ``false`` the slash-router ignores the skill. Use for background
-  knowledge you want auto-triggered by the LLM but not exposed as a user
-  command.
+  When `false` the slash-router ignores the skill. Use for background knowledge you want auto-triggered by the LLM but not exposed as a user command.
 </ParamField>
 
-## Allowed tools pre-approval
+---
+
+## Allowed Tools Pre-approval
 
 <ParamField path="allowed-tools" type="string | list[str]">
-  Space-separated string (``Read Grep``) or YAML list. When a user invokes
-  the skill, those tool names are **pre-approved** via the approval
-  registry for the current agent so the LLM can run them without the
-  interactive confirmation prompt.
+  Space-separated string (`Read Grep`) or YAML list. When a user invokes the skill, those tool names are **pre-approved** via the approval registry for the current agent so the LLM can run them without the interactive confirmation prompt.
 </ParamField>
 
-## Python API
+---
+
+## Common Patterns
+
+### Programmatic invoke
 
 ```python
 from praisonaiagents import Agent
 
-agent = Agent(
-    name="assistant",
-    skills=["./skills/deploy"],
-)
-
-# Slash command
-agent.start("/deploy staging prod")
-
-# Or directly
+agent = Agent(name="assistant", skills=["./skills/deploy"])
 rendered = agent.skill_manager.invoke("deploy", raw_args="staging prod")
 ```
 
-## YAML
+### YAML
 
 ```yaml
 # agents.yaml
@@ -165,7 +207,7 @@ agents:
       - ~/.praisonai/skills/csv-summary
 ```
 
-## CLI
+### CLI
 
 <CodeGroup>
 ```bash List installed
@@ -183,29 +225,63 @@ praisonai skills install ./local-skill --dest ~/.praisonai/skills
 </CodeGroup>
 
 <Tip>
-Set ``PRAISONAI_DISABLE_SKILL_TOOLS=1`` to stop the agent from
-auto-injecting ``run_skill_script`` and ``read_file`` when skills are
-configured. Useful for hermetic tests and hosts that want full control
-over the tool surface.
+Set `PRAISONAI_DISABLE_SKILL_TOOLS=1` to stop the agent from auto-injecting `run_skill_script` and `read_file` when skills are configured. Useful for hermetic tests and hosts that want full control over the tool surface.
 </Tip>
+
+---
 
 ## Precedence
 
 Skills are discovered in this order (first wins on name collision):
 
 <Steps>
-  <Step title="Project">``./.praisonai/skills/`` or ``./.claude/skills/``</Step>
-  <Step title="Ancestors">Every ``.praisonai/skills`` or ``.claude/skills`` in a parent directory (monorepo support)</Step>
-  <Step title="User">``~/.praisonai/skills/``</Step>
-  <Step title="System">``/etc/praison/skills/``</Step>
+  <Step title="Project">`./.praisonai/skills/` or `./.claude/skills/`</Step>
+  <Step title="Ancestors">Every `.praisonai/skills` or `.claude/skills` in a parent directory (monorepo support)</Step>
+  <Step title="User">`~/.praisonai/skills/`</Step>
+  <Step title="System">`/etc/praison/skills/`</Step>
 </Steps>
 
 <Info>
 Collisions are logged at INFO level so you can see which skill won.
 </Info>
 
-## See also
+---
 
-- [Agent Skills](/concepts/skills) — authoring format, SKILL.md structure
-- [Approval Protocol](/features/approval-protocol) — how ``allowed-tools`` plugs in
-- [Configuration](/configuration/skills-config) — ``SkillsConfig`` options
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Use slash commands for side effects">
+Set `disable-model-invocation: true` on deploy, restart, or delete skills so the LLM cannot trigger them accidentally — users invoke them explicitly with `/skill-name`.
+</Accordion>
+
+<Accordion title="Keep user-invocable false for background knowledge">
+Set `user-invocable: false` when a skill should only auto-activate from the system prompt, not appear as a slash command.
+</Accordion>
+
+<Accordion title="Opt in to shell blocks deliberately">
+Leave `shell_exec=False` (default) in production. Pass `shell_exec=True` only in trusted environments where inline ``!`cmd` `` blocks are required.
+</Accordion>
+
+<Accordion title="Validate encoding before deploy">
+Save `SKILL.md` as UTF-8. Run `praisonai skills validate --path ./my-skill` to catch Windows encoding issues early.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Agent Skills" icon="puzzle-piece" href="/docs/features/skills">
+  Author SKILL.md files and configure skills on agents
+</Card>
+<Card title="Skill Manage" icon="wand-magic-sparkles" href="/docs/features/skill-manage">
+  Create, edit, and approve agent-proposed skills
+</Card>
+<Card title="Approval Protocol" icon="shield-check" href="/docs/features/approval-protocol">
+  How `allowed-tools` pre-approval plugs into the approval registry
+</Card>
+<Card title="Skills Config" icon="gear" href="/docs/configuration/skills-config">
+  `SkillsConfig` options for discovery and paths
+</Card>
+</CardGroup>

--- a/docs/features/skills-vs-tools.mdx
+++ b/docs/features/skills-vs-tools.mdx
@@ -7,6 +7,18 @@ icon: "puzzle-piece"
 
 Skills and Tools are two distinct capability systems in PraisonAI that serve different purposes and operate at different levels.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Code Assistant",
+    instructions="Review code and scan for vulnerabilities",
+    skills=["./skills/code-review"],
+    tools=["read_file"],
+)
+agent.start("Review app.py for security issues")
+```
+
 ```mermaid
 graph LR
     subgraph "Skills vs Tools Overview"
@@ -411,10 +423,10 @@ def execute_shell_command(command: str) -> str:
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="Agent Skills" icon="puzzle-piece" href="/docs/concepts/skills">
-    Detailed skills documentation and API
+  <Card title="Agent Skills" icon="puzzle-piece" href="/docs/features/skills">
+    Load declarative knowledge from SKILL.md files
   </Card>
-  <Card title="Agent Tools" icon="wrench" href="/docs/concepts/tools">
-    Complete tools reference and built-ins
+  <Card title="Toolsets" icon="wrench" href="/docs/features/toolsets">
+    Add callable Python functions as agent tools
   </Card>
 </CardGroup>

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -1,11 +1,22 @@
 ---
 title: "Agent Skills"
 sidebarTitle: "Agent Skills"
-description: "Give agents modular, reusable capabilities through SKILL.md files — load specialized knowledge on demand"
+description: "Give agents modular, reusable capabilities through SKILL.md files — load specialised knowledge on demand"
 icon: "puzzle-piece"
 ---
 
-Skills extend agents with specialized knowledge and instructions loaded on demand, keeping context lean until the skill is needed.
+Skills extend agents with specialised knowledge and instructions loaded on demand, keeping context lean until the skill is needed.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="PDF Assistant",
+    instructions="You are a helpful assistant.",
+    skills=["./skills/pdf-processing"],
+)
+agent.start("Extract the main findings from report.pdf")
+```
 
 <Note>
 **Agent-created skills are staged for approval by default.** When an agent calls `skill_manage` to create, edit, or delete a skill, the mutation is held in a pending store until a human approves it — disk is not touched. Reading and using existing skills is unaffected. See [Skill Manage](/docs/features/skill-manage) for the full approval gate docs.
@@ -187,7 +198,7 @@ agent = Agent(skills=SkillsConfig(dirs=["./skills"]))   # Config with discovery
 ### Default Discovery Locations
 
 Skills auto-discovered (in order of precedence):
-1. `./.praison/skills/` or `./.claude/skills/`
+1. `./.praisonai/skills/` or `./.claude/skills/`
 2. `~/.praisonai/skills/`
 3. `/etc/praison/skills/`
 
@@ -255,8 +266,14 @@ This creates the directory structure and template `SKILL.md` you can fill in.
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="Tools" icon="wrench" href="/docs/features/toolsets">
-    Add callable Python functions as agent tools
+  <Card title="Skill Invocation" icon="slash" href="/docs/features/skills-invocation">
+    Slash commands, argument substitution, and invocation policy
+  </Card>
+  <Card title="Skill Manage" icon="wand-magic-sparkles" href="/docs/features/skill-manage">
+    Let agents create and edit skills with human approval
+  </Card>
+  <Card title="Skills vs Tools" icon="puzzle-piece" href="/docs/features/skills-vs-tools">
+    When to use SKILL.md knowledge vs executable tools
   </Card>
   <Card title="Knowledge" icon="book" href="/docs/features/knowledge">
     Give agents access to documents and vector search


### PR DESCRIPTION
## Summary
- Upgrade , , , , and  per AGENTS.md §9
- Agent-centric openers, hero mermaid, Steps, AccordionGroup, CardGroup where missing
- Replace  links with ; fix  typo; remove non-friendly  import

Refs #1000

## Test plan
- [x] Hero mermaid, Steps, AccordionGroup, CardGroup on all five pages
- [x] No edits under 
- [x]  valid JSON