### PR TITLE
docs(#1000): AGENTS.md §9 compliance batch 46

### DIFF
--- a/docs/features/tool-circuit-breaker.mdx
+++ b/docs/features/tool-circuit-breaker.mdx
@@ -7,6 +7,18 @@ icon: "shield-halved"
 
 Every tool call is automatically protected by a circuit breaker that stops repeated failures from wasting time.
 
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def flaky_api(query: str) -> str:
+    """Call an external API."""
+    return f"Results for: {query}"
+
+agent = Agent(name="Researcher", tools=[flaky_api])
+agent.start("Search quantum computing")  # circuit breaker protects automatically
+```
+
 <Note>
 **Sync and Async Parity**: Circuit breaker protection now applies uniformly to both sync and async tool execution paths. Previously, async calls bypassed circuit breaker checks.
 </Note>
@@ -48,12 +60,17 @@ graph LR
 Circuit breaker protection is automatically enabled for every tool call with zero configuration needed.
 
 ```python
-from praisonaiagents import Agent
+from praisonaiagents import Agent, tool
+
+@tool
+def flaky_api(query: str) -> str:
+    """Call an external API."""
+    return f"Results for: {query}"
 
 agent = Agent(
     name="Researcher",
     instructions="Research the topic",
-    tools=[my_tool],  # Circuit breaker protects my_tool automatically
+    tools=[flaky_api],
 )
 
 agent.start("Research quantum computing")

--- a/docs/features/tool-output-store.mdx
+++ b/docs/features/tool-output-store.mdx
@@ -7,6 +7,22 @@ icon: "database"
 
 When a tool output is too large for context, the full result is saved to disk so the agent can read it back on demand.
 
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def fetch_large_report(query: str) -> str:
+    """Return a very large text blob."""
+    return "x" * 100_000
+
+agent = Agent(
+    name="Researcher",
+    instructions="If output is truncated, read the full file from the stored path.",
+    tools=[fetch_large_report],
+)
+agent.start("Fetch the latest report")
+```
+
 ```mermaid
 graph LR
     Tool[🔧 Tool Output] --> Check{📏 Size Check}

--- a/docs/features/tool-parameter-types.mdx
+++ b/docs/features/tool-parameter-types.mdx
@@ -7,6 +7,19 @@ icon: "shapes"
 
 Use expressive Python type annotations in tool signatures and agents understand exactly what parameters they can pass.
 
+```python
+from typing import Literal
+from praisonaiagents import Agent, tool
+
+@tool
+def analyse(text: str, mode: Literal["fast", "deep"] = "fast") -> str:
+    """Analyse text with a fast or deep mode."""
+    return f"{mode} analysis of: {text}"
+
+agent = Agent(name="Analyst", tools=[analyse])
+agent.start("Analyse this document in deep mode")
+```
+
 ```mermaid
 graph LR
     subgraph "Tool Parameter Type System"

--- a/docs/features/tool-registry-autogen-migration.mdx
+++ b/docs/features/tool-registry-autogen-migration.mdx
@@ -5,23 +5,19 @@ description: "Migrate from ToolRegistry AutoGen methods to AutoGenAdapter for cl
 icon: "triangle-exclamation"
 ---
 
-```python
-from praisonai.agents_generator import AgentsGenerator
-from praisonai.framework_adapters import AutoGenAdapter
-from praisonai.tool_registry import ToolRegistry
+AutoGen integration now lives in `AutoGenAdapter` — the old `ToolRegistry` autogen methods were removed in PR #2248.
 
-# Create AutoGen tools using the adapter
-adapter = AutoGenAdapter()
-agent_gen = AgentsGenerator("agents.yaml", "autogen", config_list=[{"model": "gpt-4o"}])
-result = agent_gen.generate_crew_and_kickoff()
-print(result)
+```python
+from praisonai import PraisonAI
+
+# AutoGenAdapter is wired automatically when framework is autogen-family
+praison = PraisonAI(agent_file="agents.yaml", framework="autogen")
+praison.run()
 ```
 
 <Warning>
-**Breaking change (PR #2248):** `ToolRegistry` AutoGen adapter methods — `register_autogen_adapter`, `get_autogen_adapter`, `list_autogen_adapters`, and `register_builtin_autogen_adapters` — have been **removed**. They were previously available for backward compatibility (since PR #1780) but are no longer present in the codebase. Migrate to `praisonai.persistence.factory` or the `AutoGenAdapter` class.
+**Breaking change (PR #2248):** `ToolRegistry` AutoGen adapter methods — `register_autogen_adapter`, `get_autogen_adapter`, `list_autogen_adapters`, and `register_builtin_autogen_adapters` — have been **removed**. Migrate to `AutoGenAdapter` from `praisonai.framework_adapters` or `praisonai.persistence.factory`.
 </Warning>
-
-New code should use `AutoGenAdapter` from `praisonai.framework_adapters` for cleaner separation of concerns. For persistence, use `praisonai.persistence.factory`.
 
 ```mermaid
 graph LR
@@ -94,11 +90,8 @@ sequenceDiagram
     participant AutoGenAdapter
     participant AutoGen
     
-    User->>ToolRegistry: register_autogen_adapter()
-    ToolRegistry->>AutoGen: Configure AutoGen tools
-    AutoGen-->>User: Tool registered
-    
-    Note over User,AutoGen: Legacy path still works
+    User->>ToolRegistry: register_autogen_adapter() ❌ removed
+    Note over User,AutoGen: Do not use — raises AttributeError
     
     User->>AutoGenAdapter: Use AutoGenAdapter
     AutoGenAdapter->>AutoGen: Direct integration
@@ -140,58 +133,39 @@ Both approaches support the same configuration patterns for AutoGen tool integra
 ### Tool Registration
 
 ```python
-# Legacy approach (still works)
+# Removed (raises AttributeError)
 from praisonai.tool_registry import ToolRegistry
 
-def search_tool(query: str) -> str:
-    return f"Searched for: {query}"
-
 registry = ToolRegistry()
-registry.register_autogen_adapter("search", search_tool)
+registry.register_autogen_adapter("search", search_tool)  # ❌
 
-# Recommended approach
+# Recommended
 from praisonai.framework_adapters import AutoGenAdapter
-
-def search_tool(query: str) -> str:
-    return f"Searched for: {query}"
+from praisonai.tool_registry import ToolRegistry
 
 adapter = AutoGenAdapter()
+registry = ToolRegistry()
+registry.register_function("search", search_tool)
 ```
 
 ### Listing Available Tools
 
 ```python
-# Legacy approach
-from praisonai.tool_registry import ToolRegistry
+# Removed
+registry.list_autogen_adapters()  # ❌ AttributeError
 
-registry = ToolRegistry()
-autogen_tools = registry.list_autogen_adapters()
-print(f"Available tools: {autogen_tools}")
-
-# Recommended approach
+# Recommended
 from praisonai.framework_adapters import AutoGenAdapter
 
 adapter = AutoGenAdapter()
-# Use adapter's methods for AutoGen-specific functionality
+# Use adapter methods for AutoGen-specific functionality
 ```
 
 ### Builtin Registration
 
 <Warning>
-Since PR #2086, `AgentsGenerator.__init__` only calls `register_builtin_autogen_adapters()` when the chosen framework is in the autogen family (`autogen`, `autogen_v2`, `autogen_v4`, `ag2`). If you construct tools outside the orchestrator (e.g. using `ToolRegistry` directly with CrewAI or praisonai framework), and you want the autogen-shaped tool wrappers anyway, call `registry.register_builtin_autogen_adapters()` yourself.
+Since PR #2086, `AgentsGenerator.__init__` registers builtin AutoGen adapters only when the framework is in the autogen family (`autogen`, `autogen_v2`, `autogen_v4`, `ag2`). `register_builtin_autogen_adapters()` on `ToolRegistry` was removed in PR #2248 — use `AutoGenAdapter` instead.
 </Warning>
-
-```python
-from praisonai.tool_registry import ToolRegistry
-
-# Inside an autogen-family framework: orchestrator does this for you
-# (called automatically by AgentsGenerator.__init__ when framework in
-#  {"autogen", "autogen_v2", "autogen_v4", "ag2"})
-
-# Outside framework dispatch (e.g. you only use ToolRegistry directly):
-registry = ToolRegistry()
-registry.register_builtin_autogen_adapters()   # call this yourself if you want them
-```
 
 <Note>
 This change closes a hot-path regression where every `AgentsGenerator()` construction triggered the `praisonai_tools` import chain (`CodeDocsSearchTool`, `CSVSearchTool`, `DirectoryReadTool`, `PDFSearchTool`, `RagTool`, `ScrapeWebsiteTool`, `YoutubeChannelSearchTool`, ...) regardless of framework. CrewAI/praisonai users now skip the import entirely.
@@ -236,51 +210,29 @@ print("Tools registered using recommended pattern")
 </Accordion>
 
 <Accordion title="Migrate incrementally">
-Gradually move from ToolRegistry AutoGen methods to AutoGenAdapter:
+Replace autogen adapter calls one at a time — each removed method raises `AttributeError`:
 
 ```python
 from praisonai.tool_registry import ToolRegistry
 from praisonai.framework_adapters import AutoGenAdapter
 
-def search_tool(query: str) -> str:
-    return f"Found: {query}"
-
-def analyze_tool(data: str) -> str:
-    return f"Analyzed: {data}"
-
-# Step 1: Keep existing registrations
 registry = ToolRegistry()
-registry.register_autogen_adapter("search", search_tool)
-
-# Step 2: Add new tools using recommended pattern
 adapter = AutoGenAdapter()
-registry.register_function("analyze", analyze_tool)
 
-# Step 3: Gradually convert when ready
+# New tools: register_function
+registry.register_function("analyse", analyse_tool)
 ```
 </Accordion>
 
-<Accordion title="Test both approaches">
-Ensure compatibility by testing both legacy and recommended patterns:
+<Accordion title="Verify after migration">
+Confirm tools resolve through the registry, not removed autogen methods:
 
 ```python
 from praisonai.tool_registry import ToolRegistry
-from praisonai.framework_adapters import AutoGenAdapter
 
-def test_tool(input: str) -> str:
-    return f"Processed: {input}"
-
-# Test legacy approach
 registry = ToolRegistry()
-registry.register_autogen_adapter("test", test_tool)
-legacy_result = registry.get_autogen_adapter("test")
-
-# Test recommended approach  
-adapter = AutoGenAdapter()
 registry.register_function("test", test_tool)
-recommended_result = registry.get_function("test")
-
-print(f"Both approaches work: {legacy_result is not None and recommended_result is not None}")
+assert registry.get_function("test") is not None
 ```
 </Accordion>
 </AccordionGroup>

--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -7,6 +7,19 @@ icon: "wrench"
 
 `ToolResolver` is the one place PraisonAI looks for `tools.py` — whether it ships callables or `BaseTool` classes.
 
+```python
+import os
+from praisonaiagents import Agent
+
+os.environ["PRAISONAI_ALLOW_LOCAL_TOOLS"] = "true"
+
+agent = Agent(
+    name="Tool User",
+    instructions="Use available tools to help the user",
+)
+agent.start("Calculate something using my tools")
+```
+
 ```mermaid
 graph LR
     subgraph "Tool Resolution Flow"
@@ -729,8 +742,8 @@ export PRAISONAI_ALLOW_LOCAL_TOOLS=true
 <Card title="Tools Resolve (CLI)" icon="terminal" href="/docs/cli/tools-resolve">
   Recipe and template tool resolution via resolve_tools()
 </Card>
-<Card title="ToolRegistry API Reference" icon="code" href="/docs/sdk/reference/praisonai/classes/AgentScheduler">
-  Complete API reference for ToolRegistry
+<Card title="Create Custom Tools" icon="wrench" href="/docs/guides/tools/create-custom-tools">
+  Build tools for agents and YAML configs
 </Card>
 <Card title="Security Environment Variables" icon="shield-check" href="/docs/features/security-environment-variables">
   Environment variable security controls


### PR DESCRIPTION
## Summary
- Upgrade `tool-circuit-breaker.mdx`, `tool-output-store.mdx`, `tool-parameter-types.mdx`, `tool-registry-autogen-migration.mdx`, `tool-resolver.mdx` per AGENTS.md §9
- Agent-centric intros before hero Mermaid; fix autogen migration contradictions (removed methods no longer documented as working)
- Correct tool-resolver Related link

Refs #1000

## Test plan
- [x] Five batch-46 pages have hero Mermaid + Steps + AccordionGroup + CardGroup
- [x] Skipped docs/concepts/

Made with [Cursor](https://cursor.com)