### PR TITLE
docs(#1000): AGENTS.md §9 compliance batch 47

### DIFF
--- a/docs/features/tool-retry-backoff.mdx
+++ b/docs/features/tool-retry-backoff.mdx
@@ -7,6 +7,18 @@ icon: "rotate"
 
 `ExecutionConfig` retry settings re-run retryable tool failures and guardrail validation errors with exponential backoff and jitter.
 
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def fetch_report(query: str) -> str:
+    """Fetch a report from a flaky API."""
+    return f"Report for: {query}"
+
+agent = Agent(name="Resilient Agent", tools=[fetch_report], max_retry_limit=3)
+agent.start("Get me the latest report")
+```
+
 ```mermaid
 graph LR
     Request[📝 Request] --> Tool[🔧 Tool]
@@ -23,27 +35,43 @@ graph LR
 
 ## Quick Start
 
+<Steps>
+<Step title="Enable with defaults">
+Retries with backoff are automatic when you set `max_retry_limit`:
+
 ```python
-from praisonaiagents import Agent
+from praisonaiagents import Agent, tool
+
+@tool
+def fetch_report(query: str) -> str:
+    """Fetch a report from a flaky API."""
+    return f"Report for: {query}"
 
 agent = Agent(
     name="Resilient Agent",
     instructions="Fetch data from flaky APIs",
-    tools=[my_flaky_tool],
-    max_retry_limit=3,  # Retries with backoff are automatic
+    tools=[fetch_report],
+    max_retry_limit=3,
 )
 agent.start("Get me the latest report")
 ```
+</Step>
 
-Fine-tune backoff via `ExecutionConfig`:
+<Step title="Fine-tune backoff">
+Use `ExecutionConfig` for delay, factor, and jitter:
 
 ```python
-from praisonaiagents import Agent, ExecutionConfig
+from praisonaiagents import Agent, ExecutionConfig, tool
+
+@tool
+def fetch_report(query: str) -> str:
+    """Fetch a report from a flaky API."""
+    return f"Report for: {query}"
 
 agent = Agent(
     name="Resilient Agent",
     instructions="Fetch data from flaky APIs",
-    tools=[my_flaky_tool],
+    tools=[fetch_report],
     execution=ExecutionConfig(
         max_retry_limit=3,
         retry_initial_delay=0.5,
@@ -52,6 +80,8 @@ agent = Agent(
     ),
 )
 ```
+</Step>
+</Steps>
 
 ---
 

--- a/docs/features/tool-retry-policy.mdx
+++ b/docs/features/tool-retry-policy.mdx
@@ -7,6 +7,24 @@ icon: "rotate"
 
 Tool retry automatically re-runs a failing tool with exponential backoff so transient errors don't break your agent.
 
+```python
+from praisonaiagents import Agent, tool
+from praisonaiagents.tools import RetryPolicy
+
+@tool
+def web_search(query: str) -> str:
+    """Search the web."""
+    return f"Results for: {query}"
+
+agent = Agent(
+    name="researcher",
+    instructions="Research topics on the web",
+    tools=[web_search],
+    tool_retry_policy=RetryPolicy(),
+)
+agent.start("Find information about renewable energy")
+```
+
 ```mermaid
 graph LR
     Call[🔧 Tool Call] --> Try{🔄 Attempt}
@@ -34,7 +52,7 @@ Enable retry for all tools with safe defaults:
 
 ```python
 from praisonaiagents import Agent
-from praisonaiagents.tools.retry import RetryPolicy
+from praisonaiagents.tools import RetryPolicy
 
 agent = Agent(
     name="researcher",
@@ -52,7 +70,7 @@ Configure specific retry behavior:
 
 ```python
 from praisonaiagents import Agent
-from praisonaiagents.tools.retry import RetryPolicy
+from praisonaiagents.tools import RetryPolicy
 
 agent = Agent(
     name="api_agent", 
@@ -73,9 +91,8 @@ agent = Agent(
 Different tools may need different retry strategies:
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.tools import tool
-from praisonaiagents.tools.retry import RetryPolicy
+from praisonaiagents import Agent, tool
+from praisonaiagents.tools import RetryPolicy
 
 @tool(retry_policy=RetryPolicy(max_attempts=5, backoff_factor=3.0))
 def unreliable_api_call(query: str) -> str:
@@ -260,10 +277,11 @@ praisonai \
 Monitor retry attempts with hooks:
 
 ```python
-from praisonaiagents.hooks import HookEvent, OnRetryInput, HookResult
-from praisonaiagents.hooks.registry import registry
+from praisonaiagents import Agent
+from praisonaiagents.hooks import add_hook, HookEvent, HookResult, OnRetryInput
+from praisonaiagents.tools import RetryPolicy
 
-@registry.on(HookEvent.ON_RETRY)
+@add_hook(HookEvent.ON_RETRY)
 def log_retry(event: OnRetryInput) -> HookResult:
     print(f"[retry] {event.tool_name} attempt {event.attempt}/{event.max_attempts} "
           f"after {event.delay_ms}ms — {event.error_type}: {event.error}")

--- a/docs/features/tool-schema-validation.mdx
+++ b/docs/features/tool-schema-validation.mdx
@@ -7,6 +7,18 @@ icon: "shield-check"
 
 Schema validation catches broken custom tools at import time, before they confuse the LLM at runtime.
 
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def search(query: str) -> str:
+    """Search the web."""
+    return f"Results for: {query}"
+
+agent = Agent(instructions="You search the web", tools=[search])
+agent.start("Find AI news")
+```
+
 ```mermaid
 graph LR
     subgraph "Tool Schema Validation Flow"

--- a/docs/features/tool-search.mdx
+++ b/docs/features/tool-search.mdx
@@ -7,6 +7,17 @@ icon: "magnifying-glass"
 
 Tool Search enables progressive disclosure of tools when agents have many MCP or plugin tools, reducing context overhead and improving performance.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="MCP Agent",
+    instructions="You can search Slack, Google Drive, and GitHub",
+    tool_search=True,
+)
+agent.start("Find the design review thread on Slack")
+```
+
 ```mermaid
 graph LR
     subgraph "Tool Search Flow"
@@ -295,8 +306,8 @@ Don't use Tool Search for agents with fewer than 10 tools, or when all tools are
 ## Related
 
 <CardGroup cols={2}>
-<Card title="MCP Integration" icon="plug" href="/docs/concepts/mcp">
-  Connect to Model Context Protocol servers
+<Card title="Load MCP Tools" icon="plug" href="/docs/features/load-mcp-tools">
+  Connect MCP servers and load their tools
 </Card>
 <Card title="Allowed Tools" icon="filter" href="/docs/features/allowed-tools">
   Filter and control tool availability

--- a/docs/features/toolsets.mdx
+++ b/docs/features/toolsets.mdx
@@ -399,7 +399,7 @@ agent = Agent(
 <Card title="Load MCP Tools" icon="plug" href="/docs/features/load-mcp-tools">
   Model Context Protocol tool loading
 </Card>
-<Card title="Tools Concepts" icon="wrench" href="/docs/concepts/tools">
-  Core concepts of the tool system
+<Card title="Tool Resolver" icon="folder-open" href="/docs/features/tool-resolver">
+  Resolve tools from local tools.py
 </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Upgrade `tool-retry-backoff.mdx`, `tool-retry-policy.mdx`, `tool-schema-validation.mdx`, `tool-search.mdx`, `toolsets.mdx` per AGENTS.md §9
- Agent-centric intros before hero Mermaid; Steps wrapper for tool-retry-backoff; friendlier RetryPolicy/hooks imports
- Replace concepts/ Related links with feature pages

Refs #1000

## Test plan
- [x] Five batch-47 pages have hero Mermaid + Steps + AccordionGroup + CardGroup + agent-centric intro
- [x] Skipped docs/concepts/

Made with [Cursor](https://cursor.com)