### PR TITLE
docs(#1000): AGENTS.md §9 compliance batch 48

### DIFF
--- a/docs/features/turso.mdx
+++ b/docs/features/turso.mdx
@@ -7,6 +7,21 @@ icon: "bolt"
 
 Turso provides SQLite-compatible databases at the edge with embedded replicas, delivering microsecond reads and global distribution for your AI agents.
 
+```python
+import os
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Edge Agent",
+    instructions="You are a fast assistant with edge persistence.",
+    db={
+        "database_url": os.environ["TURSO_DATABASE_URL"],
+        "auth_token": os.environ["TURSO_AUTH_TOKEN"],
+    },
+)
+agent.start("Remember that I prefer concise answers")
+```
+
 ```mermaid
 graph LR
     subgraph "Turso Edge Architecture"
@@ -419,7 +434,7 @@ agent = Agent(name="Chat Agent", db=conversation_db)
 |----------|----------|--------|---------|
 | `TURSO_DATABASE_URL` | ✅ | `libsql://db-user.turso.io` | `libsql://mydb-user.turso.io` |
 | `TURSO_AUTH_TOKEN` | ✅ | JWT token | `eyJhbGciOiJFZERTQS...` |
-| `OPENAI_API_KEY` | ✅ | `sk-...` | `sk-1234567890abcdef...` |
+| `OPENAI_API_KEY` | ✅ | Set in environment | Your provider API key |
 
 ---
 

--- a/docs/features/typed-handoffs.mdx
+++ b/docs/features/typed-handoffs.mdx
@@ -7,6 +7,20 @@ icon: "shield-check"
 
 Schema-validated handoffs ensure data integrity between agents using Pydantic models, raising validation errors immediately instead of producing incorrect LLM output.
 
+```python
+from pydantic import BaseModel
+from praisonaiagents import Agent, TypedHandoff
+
+class Brief(BaseModel):
+    topic: str
+    summary: str
+
+writer = Agent(name="Writer", instructions="Write from the validated brief.")
+researcher = Agent(name="Researcher", instructions="Research and hand off structured results.")
+handoff = TypedHandoff(agent=writer, input_schema=Brief)
+handoff.execute_programmatic(researcher, Brief(topic="AI safety", summary="Key risks and mitigations"))
+```
+
 ```mermaid
 graph LR
     subgraph "Typed Handoff"

--- a/docs/features/ui-presets.mdx
+++ b/docs/features/ui-presets.mdx
@@ -7,6 +7,17 @@ icon: "display"
 
 `UIPreset` packages every UI knob into one object so `build_ui_app(preset)` returns a ready-to-serve app.
 
+```python
+from praisonaiagents import Agent
+from praisonai.integration.host_app import UIPreset, build_ui_app
+
+preset = UIPreset(
+    title="My Bot",
+    agent_kwargs={"name": "Helper", "instructions": "Be concise."},
+)
+app = build_ui_app(preset)
+```
+
 ```mermaid
 graph LR
     A[UIPreset config] --> B[build_ui_app]

--- a/docs/features/variable-substitution.mdx
+++ b/docs/features/variable-substitution.mdx
@@ -7,6 +7,13 @@ icon: "brackets-curly"
 
 Variable substitution enables dynamic content replacement using `{{variable}}` placeholders that resolve at runtime, supporting both flat variables and dot-notation for nested data structures.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="Daily Agent", instructions="Answer using today's date when asked.")
+agent.start("Summarise the top AI news for {{today}}")
+```
+
 ```mermaid
 graph LR
     subgraph "Variable Resolution"
@@ -27,58 +34,42 @@ graph LR
 ## Quick Start
 
 <Steps>
-<Step title="Simple Variable Substitution">
+<Step title="Dynamic placeholders in prompts">
+Built-in providers such as `{{today}}`, `{{now}}`, and `{{uuid}}` resolve when the agent runs:
+
 ```python
 from praisonaiagents import Agent
 
-agent = Agent(
-    name="Greeting Agent",
-    instructions="Say hello to {{name}}",
-    variables={"name": "World"}
-)
-
-result = agent.start("Greet the user")
-# Instructions become: "Say hello to World"
+agent = Agent(name="Daily Agent", instructions="Answer concisely.")
+agent.start("What is today's date? Reply with {{today}} only.")
 ```
 </Step>
 
-<Step title="Dot Notation for Nested Data">
+<Step title="Dot notation for nested data">
+Pass a variables dict when substituting text in workflows or templates:
+
 ```python
-from praisonaiagents import Agent
+from praisonaiagents.utils.variables import substitute_variables
 
-agent = Agent(
-    name="Profile Agent", 
-    instructions="Welcome {{user.name}}! Your role is {{user.role}}",
-    variables={
-        "user": {
-            "name": "Alice",
-            "role": "admin",
-            "settings": {"theme": "dark"}
-        }
-    }
+text = substitute_variables(
+    "Welcome {{user.name}}! Your role is {{user.role}}",
+    {"user": {"name": "Alice", "role": "admin", "settings": {"theme": "dark"}}},
 )
-
-result = agent.start("Welcome user")
-# Instructions become: "Welcome Alice! Your role is admin"
+# "Welcome Alice! Your role is admin"
 ```
 </Step>
 
-<Step title="Dynamic Variables with Graceful Fallback">
+<Step title="Graceful fallback for missing keys">
+Missing segments stay as literal placeholders — no error is raised:
+
 ```python
-from praisonaiagents import Agent
+from praisonaiagents.utils.variables import substitute_variables
 
-agent = Agent(
-    name="Flexible Agent",
-    instructions="Process {{data.value}} or use {{fallback}} if missing",
-    variables={
-        "data": {"other": "something"},  # Missing 'value' key
-        "fallback": "default"
-    }
+text = substitute_variables(
+    "Process {{data.value}} or use {{fallback}} if missing",
+    {"data": {"other": "something"}, "fallback": "default"},
 )
-
-result = agent.start("Process data")
-# Instructions become: "Process {{data.value}} or use default if missing"
-# Note: {{data.value}} remains unchanged since 'value' key doesn't exist
+# "Process {{data.value}} or use default if missing"
 ```
 </Step>
 </Steps>
@@ -135,19 +126,18 @@ graph TB
 
 ## Common Patterns
 
-### Pattern 1: User Configuration
+### Pattern 1: User configuration
 ```python
-agent = Agent(
-    instructions="Hello {{user.name}}! Theme: {{user.settings.theme}}",
-    variables={
+from praisonaiagents.utils.variables import substitute_variables
+
+instructions = substitute_variables(
+    "Hello {{user.name}}! Theme: {{user.settings.theme}}",
+    {
         "user": {
             "name": "Bob",
-            "settings": {
-                "theme": "light",
-                "notifications": True
-            }
+            "settings": {"theme": "light", "notifications": True},
         }
-    }
+    },
 )
 ```
 
@@ -257,8 +247,8 @@ Keep dot-notation paths reasonably short for maintainability.
 ## Related
 
 <CardGroup cols={2}>
-<Card title="Agent Configuration" icon="cog" href="/docs/concepts/agents">
-  Using variables in agent setup
+<Card title="YAML Template Variables" icon="code" href="/docs/features/yaml-template-variables">
+  Brace-safe `{topic}` placeholders in YAML
 </Card>
 <Card title="Workflow Variables" icon="diagram-project" href="/docs/features/workflows">
   Variable passing between workflow steps

--- a/docs/features/vector-store.mdx
+++ b/docs/features/vector-store.mdx
@@ -7,6 +7,17 @@ icon: "database"
 
 Store and retrieve text embeddings so your agent can recall relevant content instantly.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Researcher",
+    instructions="Answer using the indexed documents",
+    knowledge=["docs/manual.pdf"],
+)
+agent.start("How do I configure authentication?")
+```
+
 ```mermaid
 graph LR
     subgraph "Vector Store"
@@ -342,10 +353,10 @@ Any object that satisfies `VectorStoreProtocol` can be registered. Implement the
 ## Related
 
 <CardGroup cols={2}>
-<Card title="Knowledge" icon="book" href="/docs/concepts/knowledge">
+<Card title="Knowledge Base" icon="book" href="/docs/features/knowledge">
   How agents load and search knowledge sources
 </Card>
-<Card title="Store Types" icon="database" href="/docs/concepts/store-types">
-  Compare vector, graph, and relational storage backends
+<Card title="Knowledge Backends" icon="database" href="/docs/features/knowledge-backends">
+  Choose Chroma, LanceDB, Pinecone, and other backends
 </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Add agent-centric intro snippets to turso, typed-handoffs, ui-presets, variable-substitution, and vector-store
- Align variable-substitution Quick Start with SDK behaviour
- Point Related links at feature pages instead of concepts

Refs #1000

## Pages
- turso.mdx
- typed-handoffs.mdx
- ui-presets.mdx
- variable-substitution.mdx
- vector-store.mdx

## Test plan
- [x] Hero Mermaid, Steps, AccordionGroup, CardGroup present on all five pages
- [x] No edits under docs/concepts/
- [x] Related cards use /docs/features/ paths