### PR TITLE
docs(#1000): AGENTS.md §9 compliance batch 49

### DIFF
--- a/docs/features/web.mdx
+++ b/docs/features/web.mdx
@@ -7,6 +7,17 @@ icon: "globe"
 
 Web tools let any agent search the internet or read any webpage, with automatic provider fallback so it works even without an API key.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Researcher",
+    instructions="Answer questions using current information from the web.",
+    web=True,
+)
+agent.start("What are the latest developments in AI this week?")
+```
+
 ```mermaid
 graph LR
     subgraph "Web Feature"
@@ -256,8 +267,8 @@ Each search result adds tokens to the agent's context. Keep `max_results=5` (the
 ## Related
 
 <CardGroup cols={2}>
-<Card title="Tools" icon="wrench" href="/docs/concepts/tools">
-  How tools work and how to add custom tools to agents
+<Card title="Search Providers" icon="globe" href="/docs/features/search-provider-registry">
+  Choose DuckDuckGo, Tavily, or Serper for web search
 </Card>
 <Card title="Deep Research" icon="magnifying-glass" href="/docs/agents/deep-research">
   Multi-step research agents that synthesize information from many sources

--- a/docs/features/webhook-verification.mdx
+++ b/docs/features/webhook-verification.mdx
@@ -7,6 +7,12 @@ icon: "shield-check"
 
 Inbound webhooks are verified by default — misconfigured secrets return HTTP 401 instead of silently accepting unsigned traffic.
 
+```bash
+export LINEAR_WEBHOOK_SECRET=your-linear-signing-secret
+export LINEAR_OAUTH_TOKEN=your-linear-token
+praisonai bot linear --token "$LINEAR_OAUTH_TOKEN"
+```
+
 ```mermaid
 graph LR
     WH[Inbound Webhook] --> Gate[enforce_webhook_verification]

--- a/docs/features/whatsapp-bot.mdx
+++ b/docs/features/whatsapp-bot.mdx
@@ -7,6 +7,17 @@ icon: "whatsapp"
 
 Connect your AI agent to WhatsApp with a single command. Choose between the official **Cloud API** (production) or **Web mode** (scan a QR code, no tokens needed).
 
+```python
+from praisonaiagents import Agent
+from praisonai.bots import WhatsAppBot
+
+agent = Agent(name="assistant", instructions="Be helpful on WhatsApp.", llm="gpt-4o-mini")
+bot = WhatsAppBot(mode="web", agent=agent)
+
+import asyncio
+asyncio.run(bot.start())
+```
+
 ```mermaid
 graph LR
     subgraph "Cloud API (Production)"
@@ -519,7 +530,7 @@ Send WhatsApp messages from agents using MCP tools
 <Card title="Bot Commands" icon="terminal" href="/docs/features/bot-commands">
 Custom command registration and handling
 </Card>
-<Card title="Approval Protocol" icon="shield-check" href="/features/approval-protocol">
+<Card title="Approval Protocol" icon="shield-check" href="/docs/features/approval-protocol">
 Human-in-the-loop tool approval for bots
 </Card>
 </CardGroup>

--- a/docs/features/windows-openclaw-setup.mdx
+++ b/docs/features/windows-openclaw-setup.mdx
@@ -7,6 +7,17 @@ icon: "windows"
 
 OpenClaw bridges Windows user hosts to MCP/HTTP tool surfaces with proper venv isolation and PowerShell execution patterns.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="assistant",
+    instructions="You are a helpful assistant with OpenClaw tools.",
+    llm="gpt-4o-mini",
+)
+# After setup below: praisonai claw  →  http://localhost:8082
+```
+
 ```mermaid
 graph LR
     subgraph "Windows OpenClaw Architecture"
@@ -60,8 +71,9 @@ Claw onboarding expects search tools to be available. Set `TAVILY_API_KEY` (reco
 ```powershell
 # Create .env file
 @'
-OPENAI_API_KEY=your-api-key-here
-TAVILY_API_KEY=your-tavily-key-here
+# Set keys from your provider dashboards
+OPENAI_API_KEY=
+TAVILY_API_KEY=
 PYTHONPATH=.
 '@ | Out-File -FilePath .env -Encoding utf8
 ```
@@ -162,8 +174,8 @@ $EnvFile = Join-Path $ProjectDir ".env"
 if (!(Test-Path $EnvFile)) {
     Write-Host "Creating .env template..." -ForegroundColor Yellow
     @'
-# OpenAI API Key (required)
-OPENAI_API_KEY=your-api-key-here
+# OpenAI API Key (required) — paste your key after the equals sign
+OPENAI_API_KEY=
 
 # Optional: Other LLM providers
 # ANTHROPIC_API_KEY=your-anthropic-key
@@ -488,10 +500,10 @@ Register-ScheduledTask -TaskName "PraisonClawHealth" -Trigger (New-ScheduledTask
 ## Related
 
 <CardGroup cols={2}>
-<Card title="PraisonAI Claw" icon="lobster" href="/docs/concepts/claw">
-Core Claw concepts and features
+<Card title="Onboard CLI" icon="terminal" href="/docs/features/onboard">
+Interactive setup wizard including OpenClaw
 </Card>
-<Card title="MCP Integration" icon="plug" href="/docs/concepts/mcp">
-Model Context Protocol setup
+<Card title="MCP Lifecycle" icon="plug" href="/docs/features/mcp-lifecycle">
+Model Context Protocol setup on Windows
 </Card>
 </CardGroup>

--- a/docs/features/windows-sdk-quickstart.mdx
+++ b/docs/features/windows-sdk-quickstart.mdx
@@ -7,6 +7,16 @@ icon: "windows"
 
 Windows SDK setup for PraisonAI with virtual environments, environment variables, and UTF-8 configurations tailored for non-developers.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Windows Helper",
+    instructions="You are a helpful assistant running on Windows.",
+)
+agent.start("Hello from Windows!")
+```
+
 ```mermaid
 graph LR
     subgraph "Windows Setup Flow"
@@ -74,9 +84,9 @@ print(result)
 Create a `.env` file in your working directory:
 
 ```bash
-# .env file
-OPENAI_API_KEY=your_api_key_here
-ANTHROPIC_API_KEY=your_anthropic_key_here
+# .env file — paste keys after each equals sign
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
 PRAISONAI_LOG_LEVEL=INFO
 ```
 
@@ -234,7 +244,7 @@ echo $env:PYTHONPATH
 ### Environment Variable Security
 ```powershell
 # Session-scoped (recommended for development)
-$env:OPENAI_API_KEY = "your-key-here"
+$env:OPENAI_API_KEY = $env:OPENAI_API_KEY  # or assign for this session only
 
 # Avoid setx for API keys (hard to rotate, visible system-wide)
 # setx OPENAI_API_KEY "your-key" # DON'T DO THIS

--- a/docs/features/windows-sdk-quickstart.mdx
+++ b/docs/features/windows-sdk-quickstart.mdx
@@ -244,7 +244,7 @@ echo $env:PYTHONPATH
 ### Environment Variable Security
 ```powershell
 # Session-scoped (recommended for development)
-$env:OPENAI_API_KEY = $env:OPENAI_API_KEY  # or assign for this session only
+$env:OPENAI_API_KEY = "..."  # paste your OpenAI key
 
 # Avoid setx for API keys (hard to rotate, visible system-wide)
 # setx OPENAI_API_KEY "your-key" # DON'T DO THIS


### PR DESCRIPTION
## Summary
- Add agent-centric intro snippets to web, webhook-verification, whatsapp-bot, windows-openclaw-setup, and windows-sdk-quickstart
- Point Related links at feature pages instead of concepts
- Remove placeholder API key values from Windows setup examples

Refs #1000

## Pages
- web.mdx
- webhook-verification.mdx
- whatsapp-bot.mdx
- windows-openclaw-setup.mdx
- windows-sdk-quickstart.mdx

## Test plan
- [x] Hero Mermaid, Steps, AccordionGroup, CardGroup present on all five pages
- [x] No edits under docs/concepts/
- [x] Related cards use /docs/features/ paths

Made with [Cursor](https://cursor.com)