### PR TITLE
docs(#1000): AGENTS.md §9 compliance batch 50

### DIFF
--- a/docs/features/workflow-error-recovery.mdx
+++ b/docs/features/workflow-error-recovery.mdx
@@ -163,11 +163,11 @@ These constants are not user-configurable today; they are SDK defaults designed 
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="Process Types" icon="diagram-project" href="/docs/concepts/process">
-    Understanding hierarchical processes
+  <Card title="Hierarchical Workflows" icon="sitemap" href="/docs/features/workflow-hierarchical">
+    Manager-based validation and graceful failure handling
   </Card>
   
-  <Card title="Hooks" icon="anchor" href="/docs/concepts/hooks">
+  <Card title="Hooks" icon="anchor" href="/docs/features/hooks">
     Custom error handling with hooks
   </Card>
 </CardGroup>

--- a/docs/features/workflow-loop.mdx
+++ b/docs/features/workflow-loop.mdx
@@ -4,9 +4,7 @@ description: "Iterate over lists, CSV files, or text files using the loop() help
 icon: "arrows-rotate"
 ---
 
-# Workflow Loop Processing
-
-Execute a step for each item in a list, CSV file, or text file. This pattern is ideal for batch processing and data pipelines.
+The `loop()` helper runs a step for each item in a list, CSV, or text file — ideal for batch processing and data pipelines.
 
 ```mermaid
 graph TD
@@ -22,8 +20,8 @@ graph TD
 
 ## Quick Start
 
-### Loop Over List
-
+<Steps>
+<Step title="Loop Over a List">
 ```python
 from praisonaiagents import AgentFlow, WorkflowContext, StepResult
 from praisonaiagents import loop
@@ -38,7 +36,7 @@ workflow = AgentFlow(
     variables={"items": ["apple", "banana", "cherry"]}
 )
 
-result = workflow.start("Process fruits", )
+result = workflow.start("Process fruits")
 ```
 
 **Output:**
@@ -48,9 +46,9 @@ result = workflow.start("Process fruits", )
 ✅ process_item: [1] Processed: banana...
 ✅ process_item: [2] Processed: cherry...
 ```
+</Step>
 
-### Loop Over CSV
-
+<Step title="Loop Over a CSV">
 ```python
 def process_row(ctx: WorkflowContext) -> StepResult:
     row = ctx.variables["item"]  # Dict with column names as keys
@@ -64,9 +62,9 @@ workflow = AgentFlow(steps=[
 
 result = workflow.start("Process users")
 ```
+</Step>
 
-### Loop Over Text File
-
+<Step title="Loop Over a Text File">
 ```python
 def process_line(ctx: WorkflowContext) -> StepResult:
     line = ctx.variables["item"]  # String
@@ -76,6 +74,8 @@ workflow = AgentFlow(steps=[
     loop(process_line, from_file="tasks.txt")
 ])
 ```
+</Step>
+</Steps>
 
 ## API Reference
 
@@ -223,9 +223,19 @@ def safe_process(ctx: WorkflowContext) -> StepResult:
         return StepResult(output=f"Error: {e}")
 ```
 
-## See Also
+## Related
 
-- [Workflow Patterns Overview](/features/workflow-patterns)
-- [Workflow Routing](/features/workflow-routing)
-- [Parallel Execution](/features/workflow-parallel)
-- [Evaluator-Optimizer](/features/workflow-repeat)
+<CardGroup cols={2}>
+<Card title="Workflow Patterns" icon="diagram-project" href="/docs/features/workflow-patterns">
+  Overview of routing, parallel, loop, and repeat patterns
+</Card>
+<Card title="Workflow Routing" icon="code-branch" href="/docs/features/workflow-routing">
+  Decision-based branching in workflows
+</Card>
+<Card title="Workflow Parallel" icon="arrows-split-up-and-left" href="/docs/features/workflow-parallel">
+  Run independent steps concurrently
+</Card>
+<Card title="Workflow Repeat" icon="rotate" href="/docs/features/workflow-repeat">
+  Repeat steps until a condition is met
+</Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Add `<Steps>` Quick Start and `<CardGroup>` Related section to workflow-loop
- Point workflow-error-recovery Related links at `/docs/features/` instead of `/docs/concepts/`
- Other batch 50 pages (windows-terminal-encoding, workflow-errors, workflow-hierarchical) already compliant

Refs #1000

## Pages
- windows-terminal-encoding.mdx (verified)
- workflow-error-recovery.mdx
- workflow-errors.mdx (verified)
- workflow-hierarchical.mdx (verified)
- workflow-loop.mdx

## Test plan
- [x] Hero Mermaid, Steps, CardGroup present on all five pages
- [x] No edits under docs/concepts/
- [x] Related cards use /docs/features/ paths


Made with [Cursor](https://cursor.com)