### PR TITLE
docs(features): batch 53 Steps/CardGroup (#1000)

### DIFF
--- a/docs/features/channel-capabilities.mdx
+++ b/docs/features/channel-capabilities.mdx
@@ -24,17 +24,29 @@ graph LR
 
 ## Quick Start
 
+<Steps>
+<Step title="Create your agent">
+
 ```python
 from praisonaiagents import Agent
-from praisonai.bots import TelegramBot, SlackBot, DiscordBot
 
 agent = Agent(name="assistant", instructions="Helpful assistant")
+```
+
+</Step>
+<Step title="Start bots on each channel">
+
+```python
+from praisonai.bots import TelegramBot, SlackBot, DiscordBot
 
 # Same agent — each channel streams/reacts to whatever it supports
 TelegramBot(token="...", agent=agent, streaming=True, status_reactions=True).start()
 SlackBot(token="...", agent=agent, streaming=True, status_reactions=True).start()
 DiscordBot(token="...", agent=agent, streaming=True, status_reactions=True).start()
 ```
+
+</Step>
+</Steps>
 
 ## Capability Reference
 

--- a/docs/features/chat.mdx
+++ b/docs/features/chat.mdx
@@ -8,45 +8,41 @@ icon: "comments"
 
 PraisonAI Chat is a powerful, modern chat interface designed for AI agent interactions. It provides a beautiful UI for interacting with PraisonAI agents with features like streaming responses, tool call visualization, and session management.
 
-## Installation
+## Quick Start
+
+<Steps>
+<Step title="Install the chat extra">
 
 ```bash
 pip install praisonai[chat]
 ```
 
-## Quick Start
-
-### CLI Usage
-
-Start the chat interface with a single command:
+</Step>
+<Step title="Launch the UI">
 
 ```bash
 praisonai chat
 ```
 
-This starts the chat server at `http://localhost:8000`.
+Opens at `http://localhost:8000`. Use `--port 3000` for a custom port.
 
-### With Custom Port
-
-```bash
-praisonai chat --port 3000
-```
-
-### Programmatic Usage
+</Step>
+<Step title="Or start programmatically">
 
 ```python
 from praisonaiagents import Agent
 from praisonai.chat import start_chat_server
 
-# Create your agent
 agent = Agent(
     name="Assistant",
     instructions="You are a helpful AI assistant."
 )
 
-# Start the chat UI with your agent
 start_chat_server(agent=agent, port=8000)
 ```
+
+</Step>
+</Steps>
 
 ## Features
 

--- a/docs/features/chunking-strategies.mdx
+++ b/docs/features/chunking-strategies.mdx
@@ -30,6 +30,9 @@ PraisonAI integrates [chonkie](https://github.com/chonkie-inc/chonkie) for high-
 
 ## Quick Start
 
+<Steps>
+<Step title="Default chunking on an agent">
+
 <CodeGroup>
 ```python Agent with Chunking (Simplest)
 from praisonaiagents import Agent
@@ -78,6 +81,9 @@ for chunk in chunks:
     print(chunk.text[:100])
 ```
 </CodeGroup>
+
+</Step>
+</Steps>
 
 ## Available Strategies
 

--- a/docs/features/claude-memory-tool.mdx
+++ b/docs/features/claude-memory-tool.mdx
@@ -39,22 +39,32 @@ graph LR
 
 ## Quick Start
 
+<Steps>
+<Step title="Enable Claude memory">
+
 ```python
 from praisonaiagents import Agent
 
-# Enable Claude memory (Anthropic models only)
 agent = Agent(
     name="Research Assistant",
     llm="anthropic/claude-sonnet-4-20250514",
     memory={"claude_memory": True}
 )
+```
 
-# Claude will automatically:
-# 1. Check /memories directory before tasks
-# 2. Store progress/learnings in files
-# 3. Reference memories in future conversations
+Anthropic models only. Requires beta header `context-management-2025-06-27`.
+
+</Step>
+<Step title="Run and let Claude persist learnings">
+
+```python
 result = agent.start("Research AI trends and remember key findings")
 ```
+
+Claude checks `/memories`, stores progress in files, and recalls them in later sessions.
+
+</Step>
+</Steps>
 
 ## Supported Models
 

--- a/docs/features/code.mdx
+++ b/docs/features/code.mdx
@@ -35,25 +35,22 @@ graph LR
 
 ## Quick Start
 
+<Steps>
+<Step title="Set the workspace">
+
 ```python
-from praisonai.code import (
-    set_workspace,
-    code_read_file,
-    code_write_file,
-    code_apply_diff,
-    code_list_files,
-    code_execute_command,
-    CODE_TOOLS,
-)
+from praisonai.code import set_workspace, code_read_file, code_apply_diff
 
-# Set the workspace root
 set_workspace("/path/to/your/project")
+```
 
-# Read a file with line numbers
+</Step>
+<Step title="Read and patch a file">
+
+```python
 content = code_read_file("src/main.py")
 print(content)
 
-# Apply a precise diff
 diff = """<<<<<<< SEARCH
 :start_line:10
 -------
@@ -67,6 +64,9 @@ def new_function():
 result = code_apply_diff("src/main.py", diff)
 print(result)  # "Successfully applied 1 change(s) to src/main.py"
 ```
+
+</Step>
+</Steps>
 
 ## Available Tools
 


### PR DESCRIPTION
## Summary
- Add `<Steps>` to Quick Start on five `docs/features/` pages: channel-capabilities, chat, chunking-strategies, claude-memory-tool, code
- CardGroup already present on all five; closes batch 53 gap

Refs #1000

## Test plan
- [x] Verified Steps/CardGroup present on all five pages
- [x] Mintlify components valid (Steps, Step, CardGroup unchanged where present)


Made with [Cursor](https://cursor.com)