### PR TITLE
fix(docs): AccordionGroup batch 1 — features audit (#1042)

### DIFF
--- a/docs/features/a2a.mdx
+++ b/docs/features/a2a.mdx
@@ -452,6 +452,25 @@ uvicorn
 
 ---
 
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Protect production endpoints">
+    Set `auth_token` on any A2A server exposed beyond localhost. The discovery card stays public per spec — keep sensitive skills and tools out of the advertised card when auth is required.
+  </Accordion>
+  <Accordion title="Prefer streaming for long tasks">
+    Use `message/stream` when responses may take more than a few seconds. Clients receive progress via SSE instead of blocking on a single JSON-RPC response.
+  </Accordion>
+  <Accordion title="Use AgentTeam for multi-step work">
+    Route complex workflows through `AgentTeam` rather than chaining multiple single agents. One A2A endpoint can orchestrate monitor → act → feedback loops cleanly.
+  </Accordion>
+  <Accordion title="Publish accurate agent cards">
+    Keep `name`, `description`, and `url` aligned with your deployment. External agents discover capabilities via `GET /.well-known/agent.json` — stale URLs break inter-agent handoffs.
+  </Accordion>
+</AccordionGroup>
+
+---
+
 ## Related
 
 <CardGroup cols={2}>
@@ -461,7 +480,7 @@ uvicorn
 <Card title="A2A Client" icon="plug" href="/docs/features/a2a-client">
   A2A client for connecting to other agents
 </Card>
-<Card title="MCP Protocol" icon="puzzle-piece" href="/docs/concepts/mcp">
+<Card title="MCP Lifecycle" icon="puzzle-piece" href="/docs/features/mcp-lifecycle">
   Model Context Protocol for tool integration
 </Card>
 </CardGroup>

--- a/docs/features/audit-logging.mdx
+++ b/docs/features/audit-logging.mdx
@@ -93,6 +93,25 @@ enable_audit_log(
 
 ---
 
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Enable early in production">
+    Call `enable_audit_log()` before creating agents so every tool invocation is captured from the first turn — retrofitting mid-session misses earlier calls.
+  </Accordion>
+  <Accordion title="Close on shutdown">
+    Call `get_audit_log().close()` in your shutdown handler to flush the file handle. Long-running daemons that skip this may lose the last buffered line on crash.
+  </Accordion>
+  <Accordion title="Keep output logging selective">
+    Leave `include_output=False` unless you need forensic replay. When enabled, tune `max_output_chars` to avoid bloating the JSONL with large tool payloads.
+  </Accordion>
+  <Accordion title="Rotate and protect log files">
+    Store logs outside web-served directories. The audit path is protected by default — do not disable [Protected Paths](/docs/features/protected-paths) on production hosts.
+  </Accordion>
+</AccordionGroup>
+
+---
+
 ## Related
 
 <CardGroup cols={2}>

--- a/docs/features/autonomous-workflow.mdx
+++ b/docs/features/autonomous-workflow.mdx
@@ -211,6 +211,23 @@ feedback_task = Task(
   </Card>
 </CardGroup>
 
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Keep monitor instructions deterministic">
+    The monitor agent should return only discrete states (`normal`, `critical`, `optimal`). Vague prose breaks `route()` matching and causes wrong action agents to run.
+  </Accordion>
+  <Accordion title="Cap repeat iterations">
+    Always set `max_iterations` on `repeat()` loops. Without a ceiling, a misconfigured `until` condition can spin indefinitely and burn tokens.
+  </Accordion>
+  <Accordion title="Wire feedback into the loop">
+    Pass prior task outputs via `context=[...]` on the feedback step so the agent learns from outcomes rather than re-analysing from scratch each cycle.
+  </Accordion>
+  <Accordion title="Start with verbose logging">
+    Enable verbose output while tuning routes and exit conditions. Once the workflow stabilises, reduce logging for production runs.
+  </Accordion>
+</AccordionGroup>
+
 ## Next Steps
 
 <CardGroup cols={2}>

--- a/docs/features/bot-commands.mdx
+++ b/docs/features/bot-commands.mdx
@@ -631,6 +631,23 @@ asyncio.run(bot.start())
 ```
 </CodeGroup>
 
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Restrict privileged commands">
+    Configure `admin_users` and `user_allowed_commands` before enabling `/learn`, `/stop`, or `/queue` in production. See [Command Access Control](/docs/features/bot-command-access-control).
+  </Accordion>
+  <Accordion title="Enable run control for /stop and /queue">
+    `/stop` and `/queue` need [Bot Run Control](/docs/features/bot-run-control) with `busy_mode` for mid-run cancellation and follow-up queuing — without it, users get informational fallbacks only.
+  </Accordion>
+  <Accordion title="Compress before long sessions">
+    Run `/compress` when conversations exceed ~20 turns. It preserves recent context whilst reclaiming window space for research or coding tasks.
+  </Accordion>
+  <Accordion title="Document custom commands in /help">
+    Always pass a `description` to `register_command()`. Users discover extensions through `/help`, which filters to commands they are allowed to run.
+  </Accordion>
+</AccordionGroup>
+
 <Note>
 Bot tokens should never be hardcoded. Use environment variables or a `.env` file to store them securely.
 </Note>

--- a/docs/features/bot-gateway.mdx
+++ b/docs/features/bot-gateway.mdx
@@ -456,6 +456,23 @@ botos.run()
   </Card>
 </CardGroup>
 
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Lock down empty allowlists">
+    Leave `allowed_users` empty only with `unknown_user_policy: "deny"` for production. Pairing mode is fine for personal bots; public gateways need explicit allowlists.
+  </Accordion>
+  <Accordion title="Route by channel context">
+    Map `dm`, `group`, and `default` to different agents when support and personal assistants should not share memory or tools. Isolated clones prevent cross-channel leakage.
+  </Accordion>
+  <Accordion title="Use environment variables for tokens">
+    Reference tokens as `${TELEGRAM_BOT_TOKEN}` in YAML — never commit secrets. Gateway resolves env vars at load time on all platforms including Windows.
+  </Accordion>
+  <Accordion title="Monitor via /health and /metrics">
+    Poll the health endpoint during deploys and wire [Gateway Metrics](/docs/features/gateway-metrics) into Prometheus for message-flow visibility.
+  </Accordion>
+</AccordionGroup>
+
 ## Related
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary
- Add Best Practices `<AccordionGroup>` (3–4 accordions each) to the first 5 alphabetically missing `docs/features/*.mdx` files
- Replace `/docs/concepts/mcp` → `/docs/features/mcp-lifecycle` in `a2a.mdx`
- All 5 files already had `<Steps>` — no Steps gaps to fix

## Files
- `docs/features/a2a.mdx`
- `docs/features/audit-logging.mdx`
- `docs/features/autonomous-workflow.mdx`
- `docs/features/bot-commands.mdx`
- `docs/features/bot-gateway.mdx`

Refs #1042

## Test plan
- [x] Each file contains `<AccordionGroup>` with 4 accordions
- [x] Mintlify components render (AccordionGroup, Steps unchanged)
- [x] No remaining `/docs/concepts/` links in batch files


Made with [Cursor](https://cursor.com)