### PR TITLE
AccordionGroup batch 2: bot-routing through chat-with-pdf (#1042)

### DIFF
--- a/docs/features/bot-routing.mdx
+++ b/docs/features/bot-routing.mdx
@@ -248,6 +248,23 @@ flowchart TD
 Routing is configured per channel. Each platform can have completely different routing rules — Telegram DMs can go to one agent while Discord DMs go to another.
 </Note>
 
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Always define a default route">
+    Set `default` on every channel so unexpected contexts (new group types, API changes) still reach an agent instead of failing silently.
+  </Accordion>
+  <Accordion title="Isolate agents by context">
+    Route `dm` and `group` to different agents when personal and support workflows must not share memory or tools. See [Platform-Aware Agents](/features/platform-aware-agents).
+  </Accordion>
+  <Accordion title="Use bindings for fine-grained routing">
+    When chat-type routing is not enough, add priority-ordered [Gateway Route Bindings](/docs/features/gateway-route-bindings) for specific users, roles, or channel IDs.
+  </Accordion>
+  <Accordion title="Scope tools per route">
+    Pair routing with [Gateway Tool Policy](/docs/features/gateway-tool-policy) so public group chats cannot invoke dangerous tools available to trusted DMs.
+  </Accordion>
+</AccordionGroup>
+
 ---
 
 ## Related

--- a/docs/features/browser-agent-deep-dive.mdx
+++ b/docs/features/browser-agent-deep-dive.mdx
@@ -679,6 +679,23 @@ All actions return `{ success, error }`:
 
 The error is sent in the next observation, allowing the LLM to retry or try alternative actions.
 
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Pick the engine for your use case">
+    Use extension mode for interactive debugging, CDP for headless Chrome automation, and Playwright when you need Firefox or WebKit or reliable multi-session runs.
+  </Accordion>
+  <Accordion title="Isolate sessions with session_id">
+    Pass a unique `session_id` per task so `chat_history` does not leak between parallel or sequential automations. Call `agent.reset()` between unrelated goals.
+  </Accordion>
+  <Accordion title="Start Chrome with remote debugging for CDP">
+    CDP mode requires Chrome on `--remote-debugging-port=9222`. Run `praisonai browser pages` to confirm tabs before starting an agent run.
+  </Accordion>
+  <Accordion title="Diagnose failures with doctor and --debug">
+    Run `praisonai browser doctor` when extension sessions stall, and add `--debug` to surface CDP and bridge logs. Check `~/.praisonai/browser_sessions.db` for step history.
+  </Accordion>
+</AccordionGroup>
+
 ---
 
 ## Related

--- a/docs/features/callbacks.mdx
+++ b/docs/features/callbacks.mdx
@@ -1091,20 +1091,20 @@ Per-`Task` callbacks (set on the `Task(...)` constructor) keep their original 1-
 
 ## Best Practices
 
-<CardGroup cols={2}>
-  <Card title="Error Handling" icon="shield-check">
-    - Implement proper error handling
-    - Use try-catch blocks
-    - Log errors appropriately
-    - Handle edge cases
-  </Card>
-  <Card title="Performance" icon="gauge-high">
-    - Keep callbacks lightweight
-    - Avoid blocking operations
-    - Use async when appropriate
-    - Monitor resource usage
-  </Card>
-</CardGroup>
+<AccordionGroup>
+  <Accordion title="Keep callbacks lightweight">
+    Avoid blocking I/O or heavy computation in sync handlers — they run on the agent hot path. Offload work to async callbacks or background tasks.
+  </Accordion>
+  <Accordion title="Use async handlers in event loops">
+    Register with `is_async=True` inside FastAPI, Jupyter, or other running loops. The SDK schedules coroutines without nesting `asyncio.run()`.
+  </Accordion>
+  <Accordion title="Match multi-agent hook signatures">
+    `on_task_start(task, task_id)` and `on_task_complete(task, task_output)` at the `PraisonAIAgents` level; single-argument `on_task_complete(task_output)` on individual `Task` objects only.
+  </Accordion>
+  <Accordion title="Handle errors without breaking runs">
+    Wrap callback logic in try/except and log failures. Callback exceptions are swallowed at debug level and must not interrupt agent execution.
+  </Accordion>
+</AccordionGroup>
 
 ## Next Steps
 

--- a/docs/features/channel-capabilities.mdx
+++ b/docs/features/channel-capabilities.mdx
@@ -88,6 +88,23 @@ def capabilities(self):
     }
 ```
 
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Enable features once — engines adapt">
+    Turn on `streaming=True` and `status_reactions=True` on every bot; `DraftStreamer`, `StatusReactions`, and `TypingManager` no-op automatically when a channel lacks support.
+  </Accordion>
+  <Accordion title="Respect per-channel text limits">
+    Discord caps at 2000 characters, Telegram at 4096. Long replies are split or truncated — design agent output accordingly rather than assuming unlimited length.
+  </Accordion>
+  <Accordion title="Declare capabilities on custom adapters">
+    Implement the `capabilities` property on new platform bots so rate limits (`edit_rate_limit`, `reaction_rate_limit`) and feature flags propagate correctly.
+  </Accordion>
+  <Accordion title="Test degradation on limited channels">
+    Verify WhatsApp and Email bots still deliver a final message when live edits and reactions are unavailable — users should never see a silent failure.
+  </Accordion>
+</AccordionGroup>
+
 ## Related
 
 <CardGroup cols={2}>

--- a/docs/features/chat-with-pdf.mdx
+++ b/docs/features/chat-with-pdf.mdx
@@ -231,6 +231,23 @@ result = agents.start() # Retrieval
   </Card>
 </CardGroup>
 
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Install the knowledge extra">
+    Run `pip install "praisonaiagents[knowledge]"` before indexing PDFs. Core install alone lacks Chroma and document parsers needed for retrieval.
+  </Accordion>
+  <Accordion title="Use text-searchable PDFs">
+    Scanned image-only PDFs index poorly. Prefer native text PDFs or run OCR upstream so chunking and embedding capture meaningful content.
+  </Accordion>
+  <Accordion title="Pin a persistent vector store path">
+    Set `path` and `collection_name` in your Chroma config so re-indexing does not wipe prior embeddings between restarts.
+  </Accordion>
+  <Accordion title="Keep queries specific to the document">
+    Ask about sections, figures, or claims in the PDF rather than open-ended prompts — retrieval quality depends on query–chunk alignment.
+  </Accordion>
+</AccordionGroup>
+
 ## Next Steps
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary
- Add Best Practices `AccordionGroup` (4 accordions) to five feature docs: bot-routing, browser-agent-deep-dive, callbacks, channel-capabilities, chat-with-pdf
- Replace callbacks CardGroup Best Practices with AccordionGroup
- No `/docs/concepts/` links in these files

Refs #1042

## Test plan
- [x] Verify Mintlify AccordionGroup syntax in all five files
- [ ] Spot-check rendered pages on Mintlify preview


Made with [Cursor](https://cursor.com)