### PR TITLE
docs(features): Steps/CardGroup gaps + hero classDef batch 1 (#1042)

### DIFF
--- a/docs/features/a2a-client.mdx
+++ b/docs/features/a2a-client.mdx
@@ -18,12 +18,14 @@ graph LR
         Tasks --> Status[📊 Task Status]
     end
     
-    classDef client fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef client fill:#6366F1,stroke:#7C90A0,color:#fff
     classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class Client client
-    class Discovery,Messaging,Tasks process
+    class Client agent
+    class Discovery,Messaging,Tasks tool
     class Card,Stream,Status result
 ```
 

--- a/docs/features/a2a-push-notifications.mdx
+++ b/docs/features/a2a-push-notifications.mdx
@@ -26,11 +26,14 @@ graph LR
     classDef async fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef result fill:#10B981,stroke:#7C90A0,color:#fff
     classDef webhook fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class A request
-    class B,C async
+    class A agent
+    class C,E tool
+    class B async
     class D,F result
-    class E,G webhook
+    class G webhook
 ```
 
 ---

--- a/docs/features/a2a-security.mdx
+++ b/docs/features/a2a-security.mdx
@@ -22,10 +22,12 @@ graph LR
     classDef endpoint fill:#189AB4,stroke:#7C90A0,color:#fff
     classDef response fill:#10B981,stroke:#7C90A0,color:#fff
     classDef discovery fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class Client client
+    class Client agent
+    class A2A tool
     class Auth,Deny auth
-    class A2A endpoint
     class Response response
     class Discovery,Card discovery
 ```

--- a/docs/features/a2a-tasks.mdx
+++ b/docs/features/a2a-tasks.mdx
@@ -24,9 +24,11 @@ graph LR
     classDef failed fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef cancelled fill:#189AB4,stroke:#7C90A0,color:#fff
     classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class A submitted
-    class B working
+    class A agent
+    class B tool
     class C completed
     class D failed
     class E cancelled

--- a/docs/features/a2a.mdx
+++ b/docs/features/a2a.mdx
@@ -21,9 +21,10 @@ graph LR
     classDef protocol fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
     class Client client
-    class JSONRPC,A2AServer protocol
+    class JSONRPC,A2AServer tool
     class Agent agent
     class Response result
 ```

--- a/docs/features/conditional-branching.mdx
+++ b/docs/features/conditional-branching.mdx
@@ -24,6 +24,8 @@ flowchart TD
 
 ## Quick Start
 
+<Steps>
+<Step title="Python or YAML">
 <CodeGroup>
 ```python Python
 from praisonaiagents import AgentFlow, WorkflowContext, StepResult, if_
@@ -64,6 +66,8 @@ workflow:
             action: "Reject the application"
 ```
 </CodeGroup>
+</Step>
+</Steps>
 
 ## Condition Syntax
 

--- a/docs/features/conditions.mdx
+++ b/docs/features/conditions.mdx
@@ -18,6 +18,8 @@ Conditional execution allows you to control workflow branching based on variable
 
 ## Quick Start
 
+<Steps>
+<Step title="Task or AgentFlow">
 <CodeGroup>
 ```python Task with when (Recommended)
 from praisonaiagents import Task
@@ -54,6 +56,8 @@ flow = AgentFlow(
 )
 ```
 </CodeGroup>
+</Step>
+</Steps>
 
 ## Condition Syntax
 

--- a/docs/features/config-file.mdx
+++ b/docs/features/config-file.mdx
@@ -34,6 +34,21 @@ graph LR
 3. Config file
 4. Built-in defaults
 
+<CardGroup cols={2}>
+  <Card title="Project Config" icon="folder">
+    `.praisonai/config.toml` — project-specific defaults
+  </Card>
+  <Card title="Root Config" icon="file">
+    `praisonai.toml` — project root alternative
+  </Card>
+  <Card title="User Global" icon="user">
+    `~/.praisonai/config.toml` — applies across projects
+  </Card>
+  <Card title="Environment Override" icon="globe">
+    `PRAISONAI_*` env vars beat config file values
+  </Card>
+</CardGroup>
+
 ---
 
 ## Quick Start

--- a/docs/features/context-cli-reference.mdx
+++ b/docs/features/context-cli-reference.mdx
@@ -30,6 +30,29 @@ graph LR
     class Reduce action
 ```
 
+## Quick Start
+
+<Steps>
+<Step title="Interactive CLI">
+Launch chat or code mode, then inspect context:
+
+```bash
+praisonai chat
+> /context
+> /context stats
+```
+</Step>
+
+<Step title="Compact When Full">
+Reduce token usage without losing key history:
+
+```bash
+> /context compact
+> /context compact --strategy smart
+```
+</Step>
+</Steps>
+
 ## Interactive Commands
 
 Use these commands in `praisonai chat` or `praisonai code` interactive mode.

--- a/docs/features/context-management.mdx
+++ b/docs/features/context-management.mdx
@@ -79,6 +79,8 @@ flowchart TB
 
 ## Quick Start
 
+<Steps>
+<Step title="Enable Context Management">
 <CodeGroup>
 ```python Basic
 from praisonaiagents import Agent
@@ -157,6 +159,8 @@ steps:
 <Tip>
 **For tool-heavy workflows**: Always enable `context: true` to prevent token overflow from large search results.
 </Tip>
+</Step>
+</Steps>
 
 ---
 

--- a/docs/features/context-overview.mdx
+++ b/docs/features/context-overview.mdx
@@ -318,6 +318,8 @@ agent = Agent(
 
 ## Quick Start Examples
 
+<Steps>
+<Step title="Enable or Customise">
 <CodeGroup>
 ```python Enable Context
 from praisonaiagents import Agent
@@ -360,6 +362,8 @@ context:
     tavily_extract: 5000
 ```
 </CodeGroup>
+</Step>
+</Steps>
 
 ## Process Flow Diagrams
 

--- a/docs/features/custom-actions.mdx
+++ b/docs/features/custom-actions.mdx
@@ -50,6 +50,8 @@ flowchart TD
 
 Self-contained in the workflow file — no external files needed. Define them in the top-level `actions:` block.
 
+<Steps>
+<Step title="Define and Run">
 ```yaml yaml-actions-demo.yaml
 type: job
 name: yaml-actions-demo
@@ -86,6 +88,8 @@ steps:
 ```bash
 praisonai workflow run yaml-actions-demo.yaml
 ```
+</Step>
+</Steps>
 
 ### YAML Action Types
 

--- a/docs/features/llm-as-judge.mdx
+++ b/docs/features/llm-as-judge.mdx
@@ -50,6 +50,8 @@ flowchart LR
 
 ## Quick Start
 
+<Steps>
+<Step title="Evaluate Output">
 <Tabs>
   <Tab title="Python">
 ```python
@@ -83,6 +85,8 @@ praisonai eval judge --input "Hello, how can I help?" --criteria "Response is he
 ```
   </Tab>
 </Tabs>
+</Step>
+</Steps>
 
 ## Evaluation Modes
 

--- a/docs/features/workflows.mdx
+++ b/docs/features/workflows.mdx
@@ -58,6 +58,8 @@ graph LR
 
 ## Quick Start
 
+<Steps>
+<Step title="Agentic or Pipeline">
 <CodeGroup>
 ```python Agentic Workflow
 from praisonaiagents import Agent, AgentFlow
@@ -132,6 +134,8 @@ workflow = AgentFlow(
 result = workflow.start("Explain quantum computing")
 ```
 </CodeGroup>
+</Step>
+</Steps>
 
 ## Workflow Class API
 


### PR DESCRIPTION
## Summary
- Close final 9 `docs/features/` pages missing `<Steps` or `<CardGroup` (config-file, conditional-branching, conditions, context-* , custom-actions, llm-as-judge, workflows)
- Add standard hero mermaid `classDef agent` + `classDef tool` palette to first 5 A2A pages (batch 1)
- Follow-up to #1134 / #1042; skips `docs/concepts/` and #648/#909/#928

## Test plan
- [x] Audit: Steps/CardGroup gaps = 0 in `docs/features/*.mdx`
- [x] Hero classDef batch 1 applied to a2a-client through a2a.mdx
- [ ] Mintlify preview renders Steps/CardGroup and mermaid diagrams