### PR TITLE
docs: hero classDef batches 2–6 (25 pages)

### DIFF
--- a/docs/features/a2ui.mdx
+++ b/docs/features/a2ui.mdx
@@ -14,13 +14,11 @@ graph LR
     P --> R[External Renderer]
     R --> U[User UI]
 
-    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef ui fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
     class A agent
-    class J,P process
-    class R,U ui
+    class J,P,R,U tool
 ```
 
 <Warning>

--- a/docs/features/activity-log.mdx
+++ b/docs/features/activity-log.mdx
@@ -17,13 +17,11 @@ graph LR
         Query --> Display[📊 Display]
     end
     
-    classDef action fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class Action,Agent action
-    class Log,Store process
-    class Query,Display result
+    class Agent agent
+    class Action,Log,Store,Query,Display tool
 ```
 
 ## Quick Start

--- a/docs/features/advanced-features.mdx
+++ b/docs/features/advanced-features.mdx
@@ -19,15 +19,11 @@ graph LR
         MCPFilter --> Tools[🔧 Allowed Tools]
     end
 
-    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef feature fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef safety fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
     class Agent agent
-    class AutoSumm,MsgQueue,SafeExec,MCPFilter feature
-    class CtxMgmt,Priority result
-    class Sandbox,Tools safety
+    class AutoSumm,MsgQueue,SafeExec,MCPFilter,CtxMgmt,Priority,Sandbox,Tools tool
 ```
 
 ## Quick Start

--- a/docs/features/advanced-memory.mdx
+++ b/docs/features/advanced-memory.mdx
@@ -46,13 +46,11 @@ graph TB
     SCORE --> SQL
     MEM0 --> GRAPH
     
-    classDef memory fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef quality fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef storage fill:#2E8B57,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class STM,LTM,ENT,USR memory
-    class SCORE,COMP,REL,CLR,ACC quality
-    class RAG,MEM0,SQL,GRAPH storage
+    class STM,LTM,ENT,USR agent
+    class SCORE,COMP,REL,CLR,ACC,RAG,MEM0,SQL,GRAPH tool
 ```
 
 ## Key Features

--- a/docs/features/agent-api-launch.mdx
+++ b/docs/features/agent-api-launch.mdx
@@ -18,17 +18,11 @@ graph LR
         MCPClient --> Response
     end
 
-    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef launch fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef protocol fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef client fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
     class Agent agent
-    class Launch launch
-    class HTTP,MCP protocol
-    class Client,MCPClient client
-    class Response result
+    class Launch,HTTP,MCP,Client,MCPClient,Response tool
 ```
 
 ## Quick Start

--- a/docs/features/agent-as-tool.mdx
+++ b/docs/features/agent-as-tool.mdx
@@ -30,9 +30,11 @@ flowchart LR
     R -->|"returns result"| P
     C -->|"returns result"| P
     
-    style P fill:#8B0000,color:#fff
-    style R fill:#189AB4,color:#fff
-    style C fill:#189AB4,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class P agent
+    class R,C tool
 ```
 
 ## Quick Start

--- a/docs/features/agent-cloning.mdx
+++ b/docs/features/agent-cloning.mdx
@@ -15,11 +15,11 @@ graph LR
         Base --> Clone3[📺 Slack Agent]
     end
     
-    classDef base fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef clone fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class Base base
-    class Clone1,Clone2,Clone3 clone
+    class Base agent
+    class Clone1,Clone2,Clone3 tool
 ```
 
 ## Quick Start

--- a/docs/features/agent-learn-skill.mdx
+++ b/docs/features/agent-learn-skill.mdx
@@ -16,13 +16,11 @@ graph LR
         W --> S[✅ Reusable skill]
     end
 
-    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
-    class R input
-    class G,D,W process
-    class S output
+    class R agent
+    class G,D,W,S tool
 ```
 
 ## Quick Start

--- a/docs/features/agent-max-budget.mdx
+++ b/docs/features/agent-max-budget.mdx
@@ -15,15 +15,11 @@ graph LR
     C -->|Yes| R[Continue]
     C -->|No| X[BudgetExceededError]
 
-    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef stop fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
-    class U input
-    class A,T process
-    class R ok
-    class C,X stop
+    class A agent
+    class U,T,C,R,X tool
 ```
 
 <Warning>

--- a/docs/features/agent-presets-and-modes.mdx
+++ b/docs/features/agent-presets-and-modes.mdx
@@ -19,13 +19,11 @@ graph LR
         PD --> Run
     end
 
-    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
-    class Cmd input
-    class Lookup,BP,UD,PD process
-    class Run output
+    class Run agent
+    class Cmd,Lookup,BP,UD,PD tool
 ```
 
 ## Quick Start

--- a/docs/features/agent-retry.mdx
+++ b/docs/features/agent-retry.mdx
@@ -16,15 +16,11 @@ graph LR
     Hook --> Try
     Try -->|Non-retryable / Max attempts| Fail[❌ Raise]
 
-    classDef call fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef fail fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
-    class Call call
-    class Try,Wait,Hook process
-    class Done success
-    class Fail fail
+    class Call agent
+    class Try,Wait,Hook,Done,Fail tool
 ```
 
 ## Quick Start

--- a/docs/features/agent-run-outcomes.mdx
+++ b/docs/features/agent-run-outcomes.mdx
@@ -18,15 +18,11 @@ graph LR
         B --> G[🚫 invalid_output]
     end
     
-    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef retryable fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef terminal fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class A input
-    class C success
-    class E,G retryable
-    class D,F terminal
+    class A agent
+    class B,C,D,E,F,G tool
 ```
 
 ## Quick Start

--- a/docs/features/agent-runtime-protocol.mdx
+++ b/docs/features/agent-runtime-protocol.mdx
@@ -9,18 +9,19 @@ One protocol, many runtimes — pick the engine that runs a single agent turn wi
 
 ```mermaid
 graph LR
-    A[👤 Agent + prompt]:::input --> R{Runtime Registry}:::config
-    R -->|resolve_runtime "praisonai"| B[🏠 Built-in PraisonAIRuntime]:::process
-    R -->|resolve_runtime "echo"| C[🧩 Custom Runtime]:::process
-    R -->|entry-point praisonai.runtimes| D[📦 Plugin Runtime]:::process
-    B --> O[✅ RuntimeResult / RuntimeDelta]:::result
+    A[Agent + prompt] --> R{Runtime Registry}
+    R -->|resolve_runtime "praisonai"| B[Built-in PraisonAIRuntime]
+    R -->|resolve_runtime "echo"| C[Custom Runtime]
+    R -->|entry-point praisonai.runtimes| D[Plugin Runtime]
+    B --> O[RuntimeResult / RuntimeDelta]
     C --> O
     D --> O
 
-    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class R,B,C,D,O tool
 ```
 
 <Note>

--- a/docs/features/aiui-backends.mdx
+++ b/docs/features/aiui-backends.mdx
@@ -17,13 +17,11 @@ graph LR
         B --> F[🎣 Hooks]
     end
     
-    classDef ui fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef api fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef service fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class A ui
-    class B api
-    class C,D,E,F service
+    class A agent
+    class B,C,D,E,F tool
 ```
 
 ## Quick Start

--- a/docs/features/allowed-tools.mdx
+++ b/docs/features/allowed-tools.mdx
@@ -19,17 +19,11 @@ graph LR
         E --> G
     end
     
-    classDef env fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef registry fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef filter fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class A env
-    class B,C registry
-    class D filter
-    class F,E result
     class G agent
+    class A,B,C,D,E,F tool
 ```
 
 ## Quick Start

--- a/docs/features/api-server-auth.mdx
+++ b/docs/features/api-server-auth.mdx
@@ -15,15 +15,11 @@ graph LR
         B -->|Invalid/Missing| D[❌ 401 Unauthorized]
     end
     
-    classDef request fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class A request
-    class B process
-    class C success
-    class D error
+    class A agent
+    class B,C,D tool
 ```
 
 ## Quick Start

--- a/docs/features/approval-protocol.mdx
+++ b/docs/features/approval-protocol.mdx
@@ -18,22 +18,19 @@ Approvals in shared chats are now actor-bound by default — only the requester 
 ```mermaid
 graph LR
     subgraph "Approval Protocol"
-        A[🔧 Tool Call] --> B{🔒 Required?}
+        Agent[Agent] --> A[🔧 Tool Call]
+        A --> B{🔒 Required?}
         B -->|No| D[✅ Execute]
         B -->|Yes| C[📋 Backend]
         C -->|Approved| D
         C -->|Denied| E[❌ Blocked]
     end
 
-    classDef tool fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef denied fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
-    class A tool
-    class B,C check
-    class D result
-    class E denied
+    class Agent agent
+    class A,B,C,D,E tool
 ```
 
 ## Quick Start

--- a/docs/features/approval.mdx
+++ b/docs/features/approval.mdx
@@ -37,15 +37,11 @@ graph LR
     Ask -->|❌ deny| Skip[⏹️ Skip]
     Tool -->|safe| Run
 
-    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef gate fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef bad fill:#EF4444,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
     class Agent agent
-    class Tool,Gate gate
-    class Run,Skip,Ask ok
-    class Deny bad
+    class Tool,Gate,Ask,Run,Skip,Deny tool
 ```
 
 ## Quick Start

--- a/docs/features/assign-agents.mdx
+++ b/docs/features/assign-agents.mdx
@@ -16,15 +16,11 @@ graph LR
         Work --> Report[📊 Agent Reports]
     end
     
-    classDef register fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef issue fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef work fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef report fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class Register register
-    class Create,Assign issue
-    class Work work
-    class Report report
+    class Register,Work,Report agent
+    class Create,Assign tool
 ```
 
 ## What is an Agent?

--- a/docs/features/async-agent-scheduler.mdx
+++ b/docs/features/async-agent-scheduler.mdx
@@ -22,19 +22,11 @@ graph LR
         E --> F
     end
     
-    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef scheduler fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef executor fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef failure fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef stats fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
     class A agent
-    class B scheduler
-    class C executor
-    class D success
-    class E failure
-    class F stats
+    class B,C,D,E,F tool
 ```
 
 ## Quick Start

--- a/docs/features/async-bridge.mdx
+++ b/docs/features/async-bridge.mdx
@@ -19,15 +19,11 @@ graph LR
         G --> H[✅ Result]
     end
     
-    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class A,F input
-    class B,C,G process
-    class E,H output
-    class D error
+    class A,F agent
+    class B,C,D,E,G,H tool
 ```
 
 ## Quick Start

--- a/docs/features/async-conversation-store.mdx
+++ b/docs/features/async-conversation-store.mdx
@@ -18,15 +18,11 @@ graph LR
         E --> F
     end
     
-    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef orchestrator fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef async fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef sync fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
     class A agent
-    class B orchestrator
-    class C,D async
-    class E sync
+    class B,C,D,E,F tool
 ```
 
 ## Quick Start

--- a/docs/features/async-crew-kickoff.mdx
+++ b/docs/features/async-crew-kickoff.mdx
@@ -17,17 +17,11 @@ graph LR
         E --> F[✅ Result]
     end
     
-    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef adapter fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef native fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class A input
-    class B,C process
-    class D adapter
-    class E native
-    class F output
+    class A agent
+    class B,C,D,E,F tool
 ```
 
 ## Quick Start

--- a/docs/features/async-db-hooks.mdx
+++ b/docs/features/async-db-hooks.mdx
@@ -31,13 +31,11 @@ graph LR
         F --> G
     end
     
-    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class A input
-    class B,C,E process
-    class D,F,G output
+    class A agent
+    class B,C,D,E,F,G tool
 ```
 
 ## Quick Start

--- a/docs/features/async-scheduler.mdx
+++ b/docs/features/async-scheduler.mdx
@@ -18,13 +18,11 @@ graph LR
         F --> D
     end
     
-    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
     class A agent
-    class B,C,D process
-    class E,F result
+    class B,C,D,E,F tool
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Standardise hero Mermaid `classDef agent` + `classDef tool` palette on 25 feature pages (batches 2–6)
- Fixes wrong colours or missing tool/agent classDefs in first 100 lines
- Skips `docs/concepts/` per scope

## Pages (a2ui → async-scheduler)
a2ui, activity-log, advanced-features, advanced-memory, agent-api-launch, agent-as-tool, agent-cloning, agent-learn-skill, agent-max-budget, agent-presets-and-modes, agent-retry, agent-run-outcomes, agent-runtime-protocol, aiui-backends, allowed-tools, api-server-auth, approval-protocol, approval, assign-agents, async-agent-scheduler, async-bridge, async-conversation-store, async-crew-kickoff, async-db-hooks, async-scheduler

## Palette
```
classDef agent fill:#8B0000,color:#fff
classDef tool fill:#189AB4,color:#fff
```

Refs #1042

## Test plan
- [x] All 25 pages contain both standard classDefs in hero diagram (first 100 lines)
- [ ] Mintlify preview renders diagrams correctly

Made with [Cursor](https://cursor.com)