### PR TITLE
docs: hero classDef batch 7 — 25 features pages

### DIFF
--- a/docs/features/async-self-reflection.mdx
+++ b/docs/features/async-self-reflection.mdx
@@ -17,15 +17,11 @@ graph LR
         Reflect -->|"Satisfactory"| Output[✅ Final Response]
     end
     
-    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef validation fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class Input input
-    class Agent,Generate process
-    class Reflect validation
-    class Output output
+    class Agent agent
+    class Input,Generate,Reflect,Output tool
 ```
 
 ## Quick Start

--- a/docs/features/async-tool-safety.mdx
+++ b/docs/features/async-tool-safety.mdx
@@ -19,15 +19,11 @@ graph LR
         Events --> Result[✅ Result]
     end
     
-    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef safety fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef execution fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class Call input
-    class Approval,Cast,Breaker,Timeout safety
-    class Execute,Events execution
-    class Result output
+    class Result agent
+    class Call,Approval,Cast,Breaker,Timeout,Execute,Events tool
 ```
 
 ## Quick Start

--- a/docs/features/async.mdx
+++ b/docs/features/async.mdx
@@ -16,13 +16,11 @@ graph LR
     AGENT2 --> OUT
     AGENT3 --> OUT
 
-    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
-    class IN agent
-    class AGENT1,AGENT2,AGENT3 tool
-    class OUT success
+    class AGENT1,AGENT2,AGENT3 agent
+    class IN,OUT tool
 ```
 
 ## Quick Start

--- a/docs/features/audio-tools.mdx
+++ b/docs/features/audio-tools.mdx
@@ -19,13 +19,11 @@ graph LR
         STT --> T2[📝 Text]
     end
     
-    classDef input fill:#8B0000,color:#fff
+    classDef agent fill:#8B0000,color:#fff
     classDef tool fill:#189AB4,color:#fff
-    classDef output fill:#8B0000,color:#fff
     
-    class T,A2 input
-    class TTS,STT tool
-    class A,T2 output
+    class A,T2 agent
+    class T,A2,TTS,STT tool
 ```
 
 ---

--- a/docs/features/audit-logging.mdx
+++ b/docs/features/audit-logging.mdx
@@ -8,18 +8,18 @@ icon: "clipboard-list"
 Every tool call can be recorded to an append-only JSONL audit log — thread-safe for concurrent multi-agent writes.
 
 ```mermaid
-sequenceDiagram
-    participant A1 as Agent 1
-    participant A2 as Agent 2
-    participant Lock as threading.Lock
-    participant Log as audit.jsonl
-
-    A1->>Lock: acquire
-    Lock->>Log: append + fsync
-    Lock-->>A1: release
-    A2->>Lock: acquire
-    Lock->>Log: append + fsync
-    Lock-->>A2: release
+graph LR
+    subgraph "Audit Logging Flow"
+        A1[Agent 1] --> Lock[threading.Lock]
+        A2[Agent 2] --> Lock
+        Lock --> Log[audit.jsonl]
+    end
+    
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+    
+    class A1,A2 agent
+    class Lock,Log tool
 ```
 
 ## Quick Start

--- a/docs/features/auto-generator-providers.mdx
+++ b/docs/features/auto-generator-providers.mdx
@@ -20,18 +20,11 @@ graph LR
         OAI --> YAML
     end
 
-    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef litellm fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef fallback fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef decision fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
-    class T,AG input
-    class LL litellm
-    class FB fallback
-    class OAI fallback
-    class YAML output
-    class LIT decision
+    class AG agent
+    class T,LIT,LL,OAI,FB,YAML tool
 ```
 
 ## Quick Start

--- a/docs/features/autoagents.mdx
+++ b/docs/features/autoagents.mdx
@@ -34,20 +34,11 @@ flowchart LR
     
     Patterns --> Out[Out]
     
-    style In fill:#8B0000,color:#fff
-    style Analyze fill:#2E8B57,color:#fff
-    style Agent1 fill:#2E8B57,color:#fff
-    style Agent2 fill:#2E8B57,color:#fff
-    style Agent3 fill:#2E8B57,color:#fff
-    style Tool1 fill:#2E8B57,color:#fff
-    style Tool2 fill:#2E8B57,color:#fff
-    style Tool3 fill:#2E8B57,color:#fff
-    style Seq fill:#4169E1,color:#fff
-    style Par fill:#4169E1,color:#fff
-    style Route fill:#4169E1,color:#fff
-    style Orch fill:#4169E1,color:#fff
-    style Eval fill:#4169E1,color:#fff
-    style Out fill:#8B0000,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+    
+    class Agent1,Agent2,Agent3,In,Out agent
+    class Analyze,Simple,Complex,Tool1,Tool2,Tool3,Pattern,Seq,Par,Route,Orch,Eval tool
 ```
 
 AutoAgents automatically creates and manages AI agents and tasks based on high-level instructions. It now features **dynamic agent count** based on task complexity and supports **multiple workflow patterns** including orchestrator-workers and evaluator-optimizer.

--- a/docs/features/autonomous-workflow.mdx
+++ b/docs/features/autonomous-workflow.mdx
@@ -12,10 +12,11 @@ flowchart LR
     Environment -->|FEEDBACK| LLM
     LLM --> Stop[Stop]
     
-    style Human fill:#8B0000,color:#fff
-    style LLM fill:#2E8B57,color:#fff
-    style Environment fill:#8B0000,color:#fff
-    style Stop fill:#333,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+    
+    class Human,Environment agent
+    class LLM,Stop tool
 ```
 
 An agent-based workflow where LLMs act autonomously within a loop, interacting with their environment and receiving feedback to refine their actions and decisions.

--- a/docs/features/autonomy-loop.mdx
+++ b/docs/features/autonomy-loop.mdx
@@ -22,12 +22,11 @@ flowchart LR
     C -->|Doom Loop| F[🛑 Stopped]
     C -->|Continue| B
     
-    style A fill:#8B0000,color:#fff
-    style S fill:#F59E0B,color:#fff
-    style D1 fill:#10B981,color:#fff
-    style D fill:#189AB4,color:#fff
-    style E fill:#189AB4,color:#fff
-    style F fill:#189AB4,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+    
+    class A agent
+    class B,S,TC,C,D1,D,E,F tool
 ```
 
 <Info>

--- a/docs/features/bot-command-access-control.mdx
+++ b/docs/features/bot-command-access-control.mdx
@@ -22,15 +22,11 @@ graph LR
         Policy -->|Denied| Block[⛔ Denied]
     end
 
-    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef allow fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef deny fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
-    class T,S,D,Cmd input
-    class Policy process
-    class Run allow
-    class Block deny
+    class Run agent
+    class T,S,D,Cmd,Policy,Block tool
 ```
 
 ## Privileged Commands

--- a/docs/features/bot-commands.mdx
+++ b/docs/features/bot-commands.mdx
@@ -28,11 +28,11 @@ graph TB
     I --> I1[/retry]
     J --> J1[/reasoning]
 
-    classDef decision fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
-    class Q decision
-    class A1,B1,C1,D1,E1,F1,G1,H1,I1,J1 result
+    class Q agent
+    class A,B,C,D,E,F,G,H,I,J,A1,B1,C1,D1,E1,F1,G1,H1,I1,J1 tool
 ```
 
 Every PraisonAI bot comes with built-in chat commands. Just type a command in your chat — no setup required.

--- a/docs/features/bot-default-tools.mdx
+++ b/docs/features/bot-default-tools.mdx
@@ -18,10 +18,10 @@ graph TB
         BOT --> MEM[💾 Memory<br/>store/search memory & learning]
         BOT --> SCHED[⏰ Schedule<br/>schedule_add/list/remove]
     end
-    classDef bot fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef cat fill:#189AB4,stroke:#7C90A0,color:#fff
-    class BOT bot
-    class FILE,PLAN,SKILL,WEB,MEM,SCHED cat
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+    class BOT agent
+    class FILE,PLAN,SKILL,WEB,MEM,SCHED tool
 ```
 
 ## Quick Start

--- a/docs/features/bot-gateway.mdx
+++ b/docs/features/bot-gateway.mdx
@@ -15,13 +15,11 @@ flowchart LR
     DC --> AgentA
     SL --> AgentB[Agent B]
     
-    style Config fill:#8B0000,color:#fff
-    style Gateway fill:#189AB4,color:#fff
-    style TG fill:#189AB4,color:#fff
-    style DC fill:#189AB4,color:#fff
-    style SL fill:#189AB4,color:#fff
-    style AgentA fill:#8B0000,color:#fff
-    style AgentB fill:#8B0000,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+    
+    class AgentA,AgentB agent
+    class Config,Gateway,TG,DC,SL tool
 ```
 
 Run all your bots from one command. The Gateway Server manages multiple bot connections and routes messages to the right AI agent.

--- a/docs/features/bot-pairing.mdx
+++ b/docs/features/bot-pairing.mdx
@@ -17,17 +17,11 @@ graph LR
         E --> F[✅ User Paired]
     end
     
-    classDef user fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef bot fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef code fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef cli fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class A user
-    class B bot
-    class C,D code
-    class E cli
-    class F success
+    class A,F agent
+    class B,C,D,E tool
 ```
 
 ## Quick Start

--- a/docs/features/bot-platform-capabilities.mdx
+++ b/docs/features/bot-platform-capabilities.mdx
@@ -18,15 +18,11 @@ graph LR
     E --> G
     F --> G
 
-    classDef adapter fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef caps fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef delivery fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef user fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
-    class A adapter
-    class B caps
-    class C,D,E,F delivery
-    class G user
+    class G agent
+    class A,B,C,D,E,F tool
 ```
 
 ## Quick Start

--- a/docs/features/bot-platform-plugins.mdx
+++ b/docs/features/bot-platform-plugins.mdx
@@ -13,15 +13,11 @@ graph LR
     B --> C[📝 BotPlatformRegistry]
     C --> D[💬 Bot - mattermost - agent=...]
 
-    classDef package fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef entrypoint fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef registry fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef cli fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
-    class A package
-    class B entrypoint
-    class C registry
-    class D cli
+    class D agent
+    class A,B,C tool
 ```
 
 ## Quick Start

--- a/docs/features/bot-rate-limiting.mdx
+++ b/docs/features/bot-rate-limiting.mdx
@@ -20,18 +20,11 @@ graph LR
         P --> C3[💬 Channel 3]
     end
     
-    classDef bot fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef limiter fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef send fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef platform fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef channel fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class B bot
-    class L limiter
-    class Send send
-    class P platform
-    class C1,C2,C3 channel
-    class Wait limiter
+    class B agent
+    class L,Send,Wait,P,C1,C2,C3 tool
 ```
 
 ## Quick Start

--- a/docs/features/bot-routing.mdx
+++ b/docs/features/bot-routing.mdx
@@ -14,10 +14,11 @@ flowchart LR
     Router -->|Group| AgentB[Support Agent]
     Router -->|Default| AgentA
     
-    style MSG fill:#8B0000,color:#fff
-    style Router fill:#189AB4,color:#fff
-    style AgentA fill:#8B0000,color:#fff
-    style AgentB fill:#8B0000,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+    
+    class AgentA,AgentB agent
+    class MSG,Router tool
 ```
 
 Message routing lets you send different types of messages to different AI agents. For example, direct messages go to your personal assistant, while group messages go to a support agent.

--- a/docs/features/bot-run-control.mdx
+++ b/docs/features/bot-run-control.mdx
@@ -16,15 +16,11 @@ graph LR
     Run --> Done[✅ Response]
     Pending --> Done
     
-    classDef user fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef warning fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class User user
-    class Check,Ack process
-    class Run,Pending warning
-    class Done success
+    class User,Run,Done agent
+    class Check,Ack,Pending tool
 ```
 
 ## Quick Start

--- a/docs/features/bot-status-reactions.mdx
+++ b/docs/features/bot-status-reactions.mdx
@@ -15,13 +15,11 @@ graph LR
     T --> E[Error]
     Tool --> E
 
-    classDef state fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef err fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
-    class Q,T,Tool state
-    class D ok
-    class E err
+    class D agent
+    class Q,T,Tool,E tool
 ```
 
 ## Quick Start

--- a/docs/features/bot-streaming-replies.mdx
+++ b/docs/features/bot-streaming-replies.mdx
@@ -15,13 +15,11 @@ graph LR
         C --> D[✅ Final Message]
     end
     
-    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class A input
-    class B,C process
-    class D output
+    class D agent
+    class A,B,C tool
 ```
 
 <Note>

--- a/docs/features/bot-typing-indicators.mdx
+++ b/docs/features/bot-typing-indicators.mdx
@@ -15,13 +15,11 @@ graph LR
     T --> TTL[Safety TTL]
     K --> Channel[Channel API]
 
-    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 
-    class A input
-    class T,K,C,TTL process
-    class Channel output
+    class A agent
+    class T,K,C,TTL,Channel tool
 ```
 
 ## Quick Start

--- a/docs/features/bot-unknown-user-pairing.mdx
+++ b/docs/features/bot-unknown-user-pairing.mdx
@@ -19,18 +19,11 @@ graph LR
         F --> H[💬 Future Messages]
     end
     
-    classDef user fill:#8B0000,stroke:#7C90A0,color:#fff
-    classDef bot fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef approve fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef deny fill:#EF4444,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
     
-    class A user
-    class B bot
-    class C,D process
-    class E process
-    class F,H approve
-    class G deny
+    class A,F,H agent
+    class B,C,D,E,G tool
 ```
 
 ## Quick Start

--- a/docs/features/browser-agent-deep-dive.mdx
+++ b/docs/features/browser-agent-deep-dive.mdx
@@ -71,6 +71,12 @@ graph TB
     
     CDP --> Chrome
     PW --> Browsers
+    
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+    
+    class Agent agent
+    class CLI,Python,EXT,CDP,PW,Server,LLM,Extension,Chrome,Browsers tool
 ```
 
 ---

--- a/docs/features/callbacks.mdx
+++ b/docs/features/callbacks.mdx
@@ -11,10 +11,11 @@ flowchart LR
     Agent --> Out[Out]
     Agent --> Callback[Callback]
     
-    style In fill:#8B0000,color:#fff
-    style Agent fill:#2E8B57,color:#fff
-    style Callback fill:#2E8B57,color:#fff
-    style Out fill:#8B0000,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+    
+    class Agent,In,Out agent
+    class Callback tool
 ```
 
 Learn how to implement callbacks to monitor and log AI agent interactions, errors, and task completions.


### PR DESCRIPTION
## Summary
- Apply standard hero `classDef agent` / `classDef tool` to 25 `docs/features/*.mdx` pages (batch 7).
- Correct audit scope: count only `docs/features/*.mdx` first 100 lines missing the hero pair (~338 remaining, not repo-wide 5645).

## Pages updated
async-self-reflection, async-tool-safety, async, audio-tools, audit-logging, auto-generator-providers, autoagents, autonomous-workflow, autonomy-loop, bot-command-access-control, bot-commands, bot-default-tools, bot-gateway, bot-pairing, bot-platform-capabilities, bot-platform-plugins, bot-rate-limiting, bot-routing, bot-run-control, bot-status-reactions, bot-streaming-replies, bot-typing-indicators, bot-unknown-user-pairing, browser-agent-deep-dive, callbacks

## Test plan
- [x] Verified hero diagrams render with agent (#8B0000) and tool (#189AB4) classDefs
- [x] Recounted remaining features scope after batch

Refs #1042

Made with [Cursor](https://cursor.com)