### PR TITLE
docs(features): hero classDef batch 18 (#1042)

### DIFF
--- a/docs/features/context-window-management.mdx
+++ b/docs/features/context-window-management.mdx
@@ -30,6 +30,9 @@ flowchart LR
     style Analyzer fill:#2E8B57,color:#fff
     style LLM fill:#4682B4,color:#fff
     style Optimized fill:#FFD700,color:#000
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 Context Window Management automatically handles token limits across different models, ensuring optimal use of available context while preserving important information.

--- a/docs/features/cross-platform-mirror.mdx
+++ b/docs/features/cross-platform-mirror.mdx
@@ -63,6 +63,9 @@ graph LR
     class T,D,S input
     class R process
     class U,H output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## How It Works

--- a/docs/features/cross-session-recall.mdx
+++ b/docs/features/cross-session-recall.mdx
@@ -26,6 +26,9 @@ graph LR
     class M mode
     class D,S,B shape
     class R result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/custom-actions.mdx
+++ b/docs/features/custom-actions.mdx
@@ -33,6 +33,9 @@ flowchart TD
     style E fill:#6366F1,color:#fff
     style G fill:#F59E0B,color:#fff
     style H fill:#EF4444,color:#fff
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 | Priority | Type | Where it lives |

--- a/docs/features/custom-agents-commands.mdx
+++ b/docs/features/custom-agents-commands.mdx
@@ -23,6 +23,9 @@ graph LR
     class U,P dir
     class D discover
     class A,C,R,RC run
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/custom-memory-adapters.mdx
+++ b/docs/features/custom-memory-adapters.mdx
@@ -25,6 +25,8 @@ graph LR
     class C registry
     class D adapter
     class E storage
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/custom-tool-safe-eval.mdx
+++ b/docs/features/custom-tool-safe-eval.mdx
@@ -28,6 +28,9 @@ graph LR
     class C check
     class F result
     class E error
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/daemon.mdx
+++ b/docs/features/daemon.mdx
@@ -37,6 +37,8 @@ graph LR
     class D2 warm
     class F2 cold
     class E1,E2 warm
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/database-persistence.mdx
+++ b/docs/features/database-persistence.mdx
@@ -36,6 +36,8 @@ graph LR
     class Agent agent
     class Hook process
     class Conv,State,Know storage
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/declarative-permissions.mdx
+++ b/docs/features/declarative-permissions.mdx
@@ -26,6 +26,9 @@ graph LR
     class YAML,CFG,CLI,PY input
     class PM process
     class Decision ok
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/delivery-config.mdx
+++ b/docs/features/delivery-config.mdx
@@ -33,6 +33,8 @@ graph LR
     class Build process
     class Journal,DLQ process
     class Store storage
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## What's on by default

--- a/docs/features/display-callbacks.mdx
+++ b/docs/features/display-callbacks.mdx
@@ -26,6 +26,8 @@ graph LR
     class Agent agent
     class Event,Tool,LLM,Err process
     class CB callback
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/display-system.mdx
+++ b/docs/features/display-system.mdx
@@ -26,6 +26,8 @@ graph LR
     class Run,Reg process
     class Output output
     class Rich,Custom dest
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/doctor-runtime-migration.mdx
+++ b/docs/features/doctor-runtime-migration.mdx
@@ -36,6 +36,9 @@ graph LR
     class D decision
     class E preview
     class F success
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/doom-loop-detection.mdx
+++ b/docs/features/doom-loop-detection.mdx
@@ -26,6 +26,9 @@ graph LR
     class Check check
     class W result
     class S critical
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/durable-approvals.mdx
+++ b/docs/features/durable-approvals.mdx
@@ -35,6 +35,8 @@ graph LR
     class A agent
     class B,C,D process
     class E,F result
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/durable-delivery.mdx
+++ b/docs/features/durable-delivery.mdx
@@ -33,6 +33,8 @@ graph LR
     class Queue storage
     class Sent success
     class Later pending
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/dynamic-context-discovery.mdx
+++ b/docs/features/dynamic-context-discovery.mdx
@@ -24,6 +24,9 @@ graph LR
     class M process
     class A store
     class R,Agent,G output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/dynamic-judge.mdx
+++ b/docs/features/dynamic-judge.mdx
@@ -31,6 +31,8 @@ graph LR
     class Agent,Criteria agent
     class Judge process
     class Score output
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/dynamic-tool-schemas.mdx
+++ b/docs/features/dynamic-tool-schemas.mdx
@@ -25,6 +25,9 @@ graph LR
     class B,C process
     class D override
     class E output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/dynamic-variables.mdx
+++ b/docs/features/dynamic-variables.mdx
@@ -35,6 +35,9 @@ graph LR
     class R process
     class V,C config
     class O,A output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/email-bot.mdx
+++ b/docs/features/email-bot.mdx
@@ -36,6 +36,8 @@ graph LR
     class IMAP imap
     class AM am
     class A agent
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/endpoint-provider-registry.mdx
+++ b/docs/features/endpoint-provider-registry.mdx
@@ -33,6 +33,9 @@ graph LR
     class B entrypoint
     class C registry
     class D serve
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/endpoints-code.mdx
+++ b/docs/features/endpoints-code.mdx
@@ -34,6 +34,8 @@ graph LR
     class SDK process
     class Server,Agent agent
     class Out output
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/error-handling.mdx
+++ b/docs/features/error-handling.mdx
@@ -37,6 +37,8 @@ graph LR
     class Tool tool
     class LLM,Net err
     class Val cfg
+
+    classDef agent fill:#8B0000,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/escalation-pipeline.mdx
+++ b/docs/features/escalation-pipeline.mdx
@@ -41,6 +41,9 @@ graph TB
     class Signals process
     class S0,S1,S2,S3 stage
     class Guard guard
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/evaluator-optimiser.mdx
+++ b/docs/features/evaluator-optimiser.mdx
@@ -43,6 +43,8 @@ graph LR
     class Gen,Eval agent
     class Eval process
     class Out output
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/event-bus.mdx
+++ b/docs/features/event-bus.mdx
@@ -36,6 +36,8 @@ graph LR
     class Agent,Tool agent
     class Bus process
     class Sub1,Sub2 output
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/execution-systems.mdx
+++ b/docs/features/execution-systems.mdx
@@ -34,6 +34,8 @@ graph LR
     class A agent
     class E1,E2,E3 exec
     class X1,X2,X3,X4 ext
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/external-agents-ui.mdx
+++ b/docs/features/external-agents-ui.mdx
@@ -35,6 +35,9 @@ graph LR
     class C agent
     class D subagent
     class E result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/external-cli-integrations.mdx
+++ b/docs/features/external-cli-integrations.mdx
@@ -33,6 +33,8 @@ graph LR
     class User,Agent input
     class Integration,CLI tool
     class Result output
+
+    classDef agent fill:#8B0000,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/fail-loud-defaults.mdx
+++ b/docs/features/fail-loud-defaults.mdx
@@ -31,6 +31,8 @@ graph LR
     class A1,A2 agent
     class B1 warn
     class B2 ok
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 <Warning>

--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -45,6 +45,8 @@ graph LR
     class P2 secondary
     class P3 tertiary
     class R result
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 <Note>

--- a/docs/features/fast-context.mdx
+++ b/docs/features/fast-context.mdx
@@ -24,6 +24,8 @@ graph LR
     class Parallel,Tools process
     class Cache config
     class Context result
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Key Features

--- a/docs/features/file-editing.mdx
+++ b/docs/features/file-editing.mdx
@@ -37,6 +37,8 @@ graph LR
     class D,DIAG diag
 
     classDef diag fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/file-snapshot.mdx
+++ b/docs/features/file-snapshot.mdx
@@ -24,6 +24,8 @@ graph LR
     class B process
     class C store
     class D result
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/first-run-onboarding.mdx
+++ b/docs/features/first-run-onboarding.mdx
@@ -31,6 +31,9 @@ graph LR
     class E error
     class D,F wizard
     class G wizard
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/framework-adapter-plugins.mdx
+++ b/docs/features/framework-adapter-plugins.mdx
@@ -24,6 +24,9 @@ graph LR
     class B entrypoint
     class C registry
     class D cli
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/framework-availability.mdx
+++ b/docs/features/framework-availability.mdx
@@ -32,6 +32,9 @@ graph LR
     class Check input
     class Cache,Probe,Store process
     class Result output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/framework-default-change.mdx
+++ b/docs/features/framework-default-change.mdx
@@ -34,6 +34,9 @@ graph LR
     class User input
     class CLI,YAML,Check,Default,UseSpecified middle
     class Run output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-agent-defaults.mdx
+++ b/docs/features/gateway-agent-defaults.mdx
@@ -35,6 +35,8 @@ graph LR
     class Gateway gateway
     class Agent agent
     class Reply reply
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-bind-aware-auth.mdx
+++ b/docs/features/gateway-bind-aware-auth.mdx
@@ -36,6 +36,9 @@ graph LR
     class Check decision
     class Local permissive
     class Token strict
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-channel-supervision.mdx
+++ b/docs/features/gateway-channel-supervision.mdx
@@ -43,6 +43,9 @@ graph LR
     class FAILED failed
     class PAUSED paused
     class STOPPED stopped
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-cli.mdx
+++ b/docs/features/gateway-cli.mdx
@@ -47,6 +47,8 @@ graph LR
     class User user
     class CLI,Daemon tool
     class Gateway,Health success
+
+    classDef agent fill:#8B0000,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-client.mdx
+++ b/docs/features/gateway-client.mdx
@@ -40,6 +40,8 @@ graph LR
     class Client process
     class GW output
     class Backoff agent
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-config-migration.mdx
+++ b/docs/features/gateway-config-migration.mdx
@@ -25,6 +25,9 @@ graph LR
     class A,B,C legacy
     class M schema
     class N result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-drain-trigger.mdx
+++ b/docs/features/gateway-drain-trigger.mdx
@@ -26,6 +26,9 @@ graph LR
     class WATCH process
     class POL policy
     class STOP,DONE result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-error-handling.mdx
+++ b/docs/features/gateway-error-handling.mdx
@@ -37,6 +37,9 @@ graph LR
     class Extract,Sanitize process
     class Reply output
     class Log log
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-flow-control.mdx
+++ b/docs/features/gateway-flow-control.mdx
@@ -39,6 +39,9 @@ graph LR
     class Inbox,Buffer decision
     class Queue,Send success
     class Reject,Drop,Close error
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-handshake-protocol.mdx
+++ b/docs/features/gateway-handshake-protocol.mdx
@@ -32,6 +32,8 @@ graph LR
     class C agent
     class G gateway
     class C ok
+
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Add standard hero Mermaid `classDef agent` (#8B0000) and `classDef tool` (#189AB4) to 50 features pages
- Range: `context-window-management` through `gateway-handshake-protocol`
- Refs #1042

## Test plan
- [x] Verified all 50 updated pages contain both classDefs in first 100 lines
- [x] Mintlify build (docs preview)