### PR TITLE
docs(features): hero classDef batch 19 (#1042)

### DIFF
--- a/docs/features/gateway-hooks.mdx
+++ b/docs/features/gateway-hooks.mdx
@@ -36,6 +36,9 @@ graph LR
     class P,A,D,T process
     class G agent
     class C,U result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-inbound-hooks.mdx
+++ b/docs/features/gateway-inbound-hooks.mdx
@@ -44,6 +44,9 @@ graph LR
     class AG agent
     class CB delivery
     class US user
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-operator-scopes.mdx
+++ b/docs/features/gateway-operator-scopes.mdx
@@ -27,6 +27,9 @@ graph LR
     class A admin
     class GW gateway
     class Agent agent
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-overview.mdx
+++ b/docs/features/gateway-overview.mdx
@@ -50,6 +50,9 @@ graph LR
     class U1,U2,U3 user
     class WS,CH1,CH2,CH3,RT gateway
     class A1,A2,A3 agent
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-route-bindings.mdx
+++ b/docs/features/gateway-route-bindings.mdx
@@ -25,6 +25,9 @@ graph LR
     class Msg input
     class Facts,Resolve process
     class VIP,Support,Ops,Default agent
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-scale-to-zero.mdx
+++ b/docs/features/gateway-scale-to-zero.mdx
@@ -29,6 +29,9 @@ graph LR
     class C gate
     class Q,H,Z sleep
     class W ok
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-session-continuity.mdx
+++ b/docs/features/gateway-session-continuity.mdx
@@ -25,6 +25,9 @@ graph LR
     class G gateway
     class C client
     class X drain
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-session-persistence.mdx
+++ b/docs/features/gateway-session-persistence.mdx
@@ -34,6 +34,9 @@ graph LR
     class B store
     class C store
     class D,E resume
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-telegram-multichannel.mdx
+++ b/docs/features/gateway-telegram-multichannel.mdx
@@ -67,6 +67,9 @@ graph TB
     class PORT,WS,CH1,CH2,CH3 gateway
     class SHARED,P1,P2,P3 knowledge
     class OAI,TAV external
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-tool-policy.mdx
+++ b/docs/features/gateway-tool-policy.mdx
@@ -35,6 +35,9 @@ graph LR
     class R,P gate
     class Deny warn
     class Full,A,Restore ok
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway-windows-deployment.mdx
+++ b/docs/features/gateway-windows-deployment.mdx
@@ -50,6 +50,9 @@ graph TB
     class PY,PKG,ENV setup
     class YML,ENVF,TOK config
     class GW,HEALTH,LOGS deploy
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/gateway.mdx
+++ b/docs/features/gateway.mdx
@@ -32,6 +32,9 @@ graph LR
     class C client
     class G gateway
     class A1,A2,A3 agent
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 <Tip>

--- a/docs/features/generate-reasoning.mdx
+++ b/docs/features/generate-reasoning.mdx
@@ -20,6 +20,9 @@ flowchart TD
     style COT fill:#2E8B57,color:#fff
     style Upload fill:#2E8B57,color:#fff
     style End fill:#8B0000,color:#fff
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## What is Chain-of-Thought Generation?

--- a/docs/features/generative-ui.mdx
+++ b/docs/features/generative-ui.mdx
@@ -29,6 +29,9 @@ graph TB
     class T decision
     class T0,T1,T2,T3 tier
     class R0,R1,R2,R3 result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/graph-memory.mdx
+++ b/docs/features/graph-memory.mdx
@@ -30,6 +30,9 @@ graph LR
     class Neo4j db
     class Nodes,Relations element
     class Results result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Overview

--- a/docs/features/guardrails.mdx
+++ b/docs/features/guardrails.mdx
@@ -24,6 +24,9 @@ graph LR
     class Output,Check tool
     class Result success
     class Retry warning
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/handoff-filters.mdx
+++ b/docs/features/handoff-filters.mdx
@@ -28,6 +28,9 @@ flowchart LR
     style C fill:#8B0000,color:#fff
     style F1 fill:#189AB4,color:#fff
     style F2 fill:#189AB4,color:#fff
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 <Info>

--- a/docs/features/handoffs.mdx
+++ b/docs/features/handoffs.mdx
@@ -27,6 +27,9 @@ graph LR
     class Triage triage
     class Billing,Refund,Support specialist
     class Response result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 <Note>

--- a/docs/features/heartbeat.mdx
+++ b/docs/features/heartbeat.mdx
@@ -22,6 +22,9 @@ graph LR
     class Timer timer
     class Agent agent
     class Callback,Retry result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/hermes-openclaw-skills-import.mdx
+++ b/docs/features/hermes-openclaw-skills-import.mdx
@@ -22,6 +22,9 @@ graph LR
     class A input
     class B,C process
     class D output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/hierarchical-config.mdx
+++ b/docs/features/hierarchical-config.mdx
@@ -21,6 +21,9 @@ graph TB
     class PROJ high
     class USER mid
     class GLOB low
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/hierarchical-summaries.mdx
+++ b/docs/features/hierarchical-summaries.mdx
@@ -26,6 +26,9 @@ graph LR
     class F,FS,PS process
     class Q input
     class R decision
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/history-injection.mdx
+++ b/docs/features/history-injection.mdx
@@ -36,6 +36,9 @@ flowchart LR
     style Session fill:#8B0000,color:#fff
     style Agent fill:#189AB4,color:#fff
     style LLM fill:#8B0000,color:#fff
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/hook-events.mdx
+++ b/docs/features/hook-events.mdx
@@ -37,6 +37,9 @@ graph TB
     class C,D,J agent
     class E,F,G,I tool
     class H result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/hooks.mdx
+++ b/docs/features/hooks.mdx
@@ -24,6 +24,9 @@ graph LR
     class INPUT,OUTPUT agent
     class TOOL tool
     class BEFORE,AFTER hook
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/host-integration.mdx
+++ b/docs/features/host-integration.mdx
@@ -26,6 +26,9 @@ graph LR
     class A app
     class B,C config
     class D output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/hosted-agent.mdx
+++ b/docs/features/hosted-agent.mdx
@@ -27,6 +27,9 @@ graph LR
     class C cloud
     class D tools
     class E output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/hybrid-workflows.mdx
+++ b/docs/features/hybrid-workflows.mdx
@@ -22,6 +22,9 @@ graph LR
     class H agent
     class J,W process
     class D,MA step
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/image-generation.mdx
+++ b/docs/features/image-generation.mdx
@@ -21,6 +21,9 @@ graph LR
     class A process
     class API process
     class Out result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/inbound-journal.mdx
+++ b/docs/features/inbound-journal.mdx
@@ -30,6 +30,9 @@ graph LR
     class Receive,Claim process
     class Agent,Complete success
     class Skip skip
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Default behavior (no config needed)

--- a/docs/features/incremental-indexing.mdx
+++ b/docs/features/incremental-indexing.mdx
@@ -23,6 +23,9 @@ graph LR
     class A input
     class B,C,D,E process
     class F result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/index.mdx
+++ b/docs/features/index.mdx
@@ -20,6 +20,9 @@ graph LR
     class Core agent
     class Intel,Flow,Data process
     class Deploy result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## 🚀 Core Agent Features

--- a/docs/features/industry-templates/agriculture.mdx
+++ b/docs/features/industry-templates/agriculture.mdx
@@ -24,6 +24,9 @@ graph LR
     class IN input
     class MA,DI,SR,YP agent
     class OUT output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/industry-templates/energy.mdx
+++ b/docs/features/industry-templates/energy.mdx
@@ -24,6 +24,9 @@ graph LR
     class IN input
     class SR,VA,PF,MS agent
     class OUT output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/industry-templates/healthcare.mdx
+++ b/docs/features/industry-templates/healthcare.mdx
@@ -24,6 +24,9 @@ graph LR
     class IN input
     class VS,EM,TR,RA agent
     class OUT output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/industry-templates/manufacturing.mdx
+++ b/docs/features/industry-templates/manufacturing.mdx
@@ -24,6 +24,9 @@ graph LR
     class IN input
     class PO,CI,OS,DD agent
     class OUT output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/industry-templates/overview.mdx
+++ b/docs/features/industry-templates/overview.mdx
@@ -22,6 +22,9 @@ graph LR
 
     class SRAO hub
     class MFG,ENG,HC,AG,TR industry
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/industry-templates/transportation.mdx
+++ b/docs/features/industry-templates/transportation.mdx
@@ -24,6 +24,9 @@ graph LR
     class IN input
     class LF,DC,HG,MP agent
     class OUT output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/injected-state.mdx
+++ b/docs/features/injected-state.mdx
@@ -23,6 +23,9 @@ graph LR
     class T tool
     class U user
     class R result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 The LLM sees only `query` in the schema. The agent automatically fills `state` before calling the tool.

--- a/docs/features/installation-extras.mdx
+++ b/docs/features/installation-extras.mdx
@@ -45,6 +45,9 @@ graph LR
     class CORE core
     class BOT,API,TOOLS,STORAGE,FLOW,ALL extra
     class F1,F2,F3,F4,F5,F6 feature
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/integration-patterns.mdx
+++ b/docs/features/integration-patterns.mdx
@@ -24,6 +24,9 @@ graph TD
     class C,E,G pattern
     class A,B,D,F decision
     class H cloud
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/integration-registry.mdx
+++ b/docs/features/integration-registry.mdx
@@ -22,6 +22,9 @@ graph LR
     class B entrypoint
     class C registry
     class D import
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/intelligent-conversation-compaction.mdx
+++ b/docs/features/intelligent-conversation-compaction.mdx
@@ -26,6 +26,9 @@ graph LR
     class B,E,F analyzer
     class C context
     class D output
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/interactive-approval.mdx
+++ b/docs/features/interactive-approval.mdx
@@ -25,6 +25,9 @@ graph LR
     class B tool
     class C,D check
     class E,F,G ok
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/interactive-bot-actions.mdx
+++ b/docs/features/interactive-bot-actions.mdx
@@ -30,6 +30,9 @@ graph LR
     class R registry
     class H handler
     class Reply reply
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/interactive-callback-authorization.mdx
+++ b/docs/features/interactive-callback-authorization.mdx
@@ -25,6 +25,9 @@ graph LR
     class R,AZ registry
     class H allow
     class X deny
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 <Warning>

--- a/docs/features/job-workflows.mdx
+++ b/docs/features/job-workflows.mdx
@@ -21,6 +21,9 @@ graph LR
     class Y agent
     class E process
     class S,A,J step
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/kanban-cli.mdx
+++ b/docs/features/kanban-cli.mdx
@@ -26,6 +26,9 @@ graph LR
     class CLI cli
     class Store,Protocol store
     class Impl impl
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/kanban.mdx
+++ b/docs/features/kanban.mdx
@@ -25,6 +25,9 @@ graph LR
     class Coordinator,Worker agent
     class Store store
     class Results result
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/knowledge-backends.mdx
+++ b/docs/features/knowledge-backends.mdx
@@ -23,6 +23,9 @@ graph LR
     class A agent
     class B process
     class C,D,E backend
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Add standard hero Mermaid `classDef agent` (#8B0000) and `classDef tool` (#189AB4) to 50 features pages
- Range: `gateway-hooks` through `knowledge-backends` (skipped `integrate-a2ui-frontend` — no hero Mermaid in first 100 lines)
- Refs #1042

## Test plan
- [x] Verified all 50 updated pages contain both classDefs in first 100 lines

Made with [Cursor](https://cursor.com)