### PR TITLE
docs(features): remove last concepts/ links for §9 sign-off

### DIFF
--- a/docs/features/agent-as-tool.mdx
+++ b/docs/features/agent-as-tool.mdx
@@ -283,4 +283,4 @@ Test each specialist agent independently before composing.
 
 - [Handoffs](/features/handoffs) - Transfer control between agents
 - [Multi-Agent Workflows](/features/workflows) - Coordinate multiple agents
-- [Tools](/concepts/tools) - Create custom tools
+- [Toolsets](/docs/features/toolsets) - Create custom tools

--- a/docs/features/index.mdx
+++ b/docs/features/index.mdx
@@ -28,16 +28,16 @@ graph LR
 ## 🚀 Core Agent Features
 
 <CardGroup cols={2}>
-  <Card title="Agents" icon="robot" href="../concepts/agents">
+  <Card title="Agents" icon="robot" href="./agent-profiles">
     Fundamental agent concepts and creation
   </Card>
-  <Card title="Tasks" icon="list-check" href="../concepts/tasks">
+  <Card title="Tasks" icon="list-check" href="./yaml-workflows">
     Task definition and management
   </Card>
-  <Card title="Tools" icon="wrench" href="../concepts/tools">
+  <Card title="Tools" icon="wrench" href="./toolsets">
     Agent tools and capabilities
   </Card>
-  <Card title="Memory" icon="brain" href="../concepts/memory">
+  <Card title="Memory" icon="brain" href="./advanced-memory">
     Basic memory systems
   </Card>
 </CardGroup>
@@ -62,10 +62,10 @@ graph LR
 ## 🔄 Workflow & Process
 
 <CardGroup cols={2}>
-  <Card title="Process Workflows" icon="diagram-project" href="../concepts/process">
+  <Card title="Process Workflows" icon="diagram-project" href="./workflows">
     Conditional execution with decision nodes
   </Card>
-  <Card title="Handoffs" icon="hand" href="../concepts/handoffs">
+  <Card title="Handoffs" icon="hand" href="./handoffs">
     Agent-to-agent task delegation
   </Card>
   <Card title="Approval System" icon="check-circle" href="./approval">
@@ -139,7 +139,7 @@ graph LR
   <Card title="Session Management" icon="users" href="./sessions">
     Stateful interactions with persistence
   </Card>
-  <Card title="Input Handling" icon="keyboard" href="../concepts/input-handling">
+  <Card title="Input Handling" icon="keyboard" href="./guardrails">
     Safe input processing and validation
   </Card>
 </CardGroup>
@@ -241,7 +241,7 @@ graph LR
 <Steps>
   <Step title="Choose Your Path">
     - **New to PraisonAI?** Start with the [Quickstart Guide](../quickstart)
-    - **Building Agents?** Check out [Agent Concepts](../concepts/agents)
+    - **Building Agents?** Check out [Agent Profiles](./agent-profiles)
     - **Advanced User?** Explore [Advanced Memory](./advanced-memory) or [Model Router](./model-router)
   </Step>
 

--- a/docs/features/langchain.mdx
+++ b/docs/features/langchain.mdx
@@ -246,7 +246,7 @@ Export provider keys in the shell or load them with `os.getenv` — LangChain to
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Memory Integration" icon="brain" href="../concepts/memory">
+  <Card title="Memory Integration" icon="brain" href="./advanced-memory">
     Learn how to combine LangChain tools with agent memory
   </Card>
   <Card title="Custom Tools" icon="wrench" href="./tools">


### PR DESCRIPTION
## Summary
- Replace final 3 files linking to `docs/concepts/` under `docs/features/`
- Hub cards in `index.mdx` now point at feature equivalents (`agent-profiles`, `toolsets`, `advanced-memory`, `workflows`, `handoffs`, `guardrails`, `yaml-workflows`)
- `agent-as-tool.mdx` → `/docs/features/toolsets`
- `langchain.mdx` → `./advanced-memory`

## Verification
```bash
grep -r 'concepts/' docs/features/ | wc -l  # 0
```

Refs #1042

## Test plan
- [x] `grep concepts/ docs/features/` returns 0 matches
- [ ] Mintlify preview links resolve


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several documentation links to point to the newer feature and topic pages.
  * Revised feature overview and onboarding routes to use local documentation paths.
  * Adjusted related links for agent tooling, input handling, agent profiles, and memory guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->