### PR TITLE
docs: §9 strict stragglers — features CardGroup + js hero colours (#648)

### DIFF
--- a/docs/features/context-overview.mdx
+++ b/docs/features/context-overview.mdx
@@ -23,7 +23,7 @@ flowchart LR
 
 ## What Makes PraisonAI Context Management Best-in-Class
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Smart Defaults" icon="wand-magic-sparkles">
     Auto-enables when agents have tools. Zero overhead when not needed.
   </Card>

--- a/docs/features/hook-events.mdx
+++ b/docs/features/hook-events.mdx
@@ -527,7 +527,7 @@ Wrap hook logic in try/except to prevent breaking agent execution.
 
 ## Related
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Hooks" icon="link" href="/docs/features/hooks">
     Hook system overview
   </Card>

--- a/docs/features/job-workflows.mdx
+++ b/docs/features/job-workflows.mdx
@@ -655,7 +655,7 @@ Use `continue_on_error: true` on optional cleanup steps so a failed lint does no
 
 ## Related
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Custom Actions" icon="puzzle-piece" href="/docs/features/custom-actions">
     YAML-defined, file-based, built-in actions
   </Card>

--- a/docs/features/kanban.mdx
+++ b/docs/features/kanban.mdx
@@ -342,7 +342,7 @@ Use separate boards for different projects or contexts. Default board works well
 
 ## Related
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
 <Card title="Async Jobs" icon="clock" href="/docs/features/async-jobs">
   Asynchronous job processing and queuing
 </Card>

--- a/docs/js/loops.mdx
+++ b/docs/js/loops.mdx
@@ -14,14 +14,12 @@ graph LR
         B --> C[📋 Items]
         C --> D[📊 Results]
     end
-    
-    classDef user fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef agent fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A user
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
     class B agent
-    class C,D output
+    class A,C,D tool
 ```
 
 ## Quick Start

--- a/docs/js/middleware.mdx
+++ b/docs/js/middleware.mdx
@@ -15,14 +15,12 @@ graph LR
         C --> D[🔧 Middleware]
         D --> E[📥 Output]
     end
-    
-    classDef io fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef middleware fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef agent fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A,E io
-    class B,D middleware
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
     class C agent
+    class A,B,D,E tool
 ```
 
 ## Quick Start

--- a/docs/js/ocr.mdx
+++ b/docs/js/ocr.mdx
@@ -14,14 +14,12 @@ graph LR
         B --> C[🖼️ Image]
         C --> D[📝 Text]
     end
-    
-    classDef user fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef agent fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A user
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
     class B agent
-    class C,D output
+    class A,C,D tool
 ```
 
 ## Quick Start

--- a/docs/js/optimizer.mdx
+++ b/docs/js/optimizer.mdx
@@ -14,14 +14,12 @@ graph LR
         B --> C[✏️ Adjust]
         C --> D[🎯 Improved]
     end
-    
-    classDef agent fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
-    
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
     class A agent
-    class B,C process
-    class D result
+    class B,C,D tool
 ```
 
 ## Quick Start

--- a/docs/js/output.mdx
+++ b/docs/js/output.mdx
@@ -14,14 +14,12 @@ graph LR
         B --> C[📋 Schema]
         C --> D[📊 Formatted]
     end
-    
-    classDef user fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef agent fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A user
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
     class B agent
-    class C,D output
+    class A,C,D tool
 ```
 
 ## Quick Start

--- a/docs/js/video.mdx
+++ b/docs/js/video.mdx
@@ -14,14 +14,12 @@ graph LR
         B --> C[🎬 Video]
         C --> D[📝 Analysis]
     end
-    
-    classDef user fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef agent fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A user
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
     class B agent
-    class C,D output
+    class A,C,D tool
 ```
 
 ## Quick Start

--- a/docs/js/vision.mdx
+++ b/docs/js/vision.mdx
@@ -14,14 +14,12 @@ graph LR
         B --> C[🖼️ Image]
         C --> D[📝 Analysis]
     end
-    
-    classDef user fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef agent fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A user
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
     class B agent
-    class C,D output
+    class A,C,D tool
 ```
 
 ## Quick Start

--- a/docs/js/web.mdx
+++ b/docs/js/web.mdx
@@ -14,14 +14,12 @@ graph LR
         B --> C[🌐 Web]
         C --> D[📝 Content]
     end
-    
-    classDef user fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef agent fill:#F59E0B,stroke:#7C90A0,color:#fff
-    classDef web fill:#10B981,stroke:#7C90A0,color:#fff
-    
-    class A user
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
     class B agent
-    class C,D web
+    class A,C,D tool
 ```
 
 ## Quick Start

--- a/docs/tools/gemini-internal-tools.mdx
+++ b/docs/tools/gemini-internal-tools.mdx
@@ -33,7 +33,7 @@ Google Gemini provides three powerful internal tools that are natively supported
 
 ## Available Internal Tools
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Google Search" icon="magnifying-glass">
     Real-time web search with automatic result grounding
     ```python

--- a/docs/tools/jira.mdx
+++ b/docs/tools/jira.mdx
@@ -12,6 +12,18 @@ icon: "list-check"
   - Jira Cloud API token ([generate here](https://id.atlassian.com/manage-profile/security/api-tokens))
 </Note>
 
+```mermaid
+graph LR
+    U[Input] --> A[Jira Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 ## Quick Start
 
 <Steps>

--- a/docs/tools/yaml-tools.mdx
+++ b/docs/tools/yaml-tools.mdx
@@ -32,9 +32,11 @@ flowchart LR
     T --> Resolution
     Resolution --> Agent
     
-    style YAML fill:#8B0000,color:#fff
-    style Agent fill:#8B0000,color:#fff
-    style Resolution fill:#189AB4,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class T,L,B,E tool
 ```
 
 ## Quick Start
@@ -73,7 +75,7 @@ flowchart LR
 
 ## Tool Sources
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Built-in Tools" icon="cube">
     70+ tools from `praisonaiagents.tools`
     


### PR DESCRIPTION
## Summary

Mechanical AGENTS.md section 9 fixes from the verification audit (refs #648):

- docs/features/ — cols={2} on Related/overview CardGroup in context-overview, hook-events, job-workflows, kanban.
- docs/js/ — canonical hero classDef agent / classDef tool on loops, middleware, ocr, optimizer, output, video, vision, web.
- docs/tools/ (strict stragglers) — hero + cols={2} on jira, yaml-tools, gemini-internal-tools.

No docs/concepts/ edits.

## Heuristic gap counts (files with gaps / total .mdx)

| Directory | Strict before → after | Section-conditional before → after |
|-----------|----------------------:|-----------------------------------:|
| docs/features | 6 → 5 | 25 → 22 |
| docs/js | 151 → 143 | 151 → 143 |
| docs/tools | 3 → 0 | 10 → 8 |
| docs/guides | 0 → 0 | 1 → 1 |

**Strict heuristic:** first 2500 chars — hero classDef agent fill:#8B0000, CardGroup cols={2}, Steps when Quick Start appears in window.

**Section-conditional:** Quick Start / Related / Best Practices sections + hero canonical pair in first 100 lines.

## Remaining gaps (not in scope for this PR)

- docs/js — 143 pages still lack canonical hero in the first 2500 chars (batch follow-up).
- docs/features — strict gaps are pages where Quick Start starts after char 2500 (autonomy-loop, history-injection, inbound-journal, workflow-hierarchical); section gaps include Related bullet lists and Best Practices without AccordionGroup.
- docs/tools — 8 section-conditional gaps are mostly Best Practices sections using CardGroup instead of AccordionGroup.
- docs/guides — documentation-style-guide.mdx flags CardGroup in prose/tables (false positive).

## Test plan

- [x] Local heuristic script re-run on changed branch
- [ ] Mintlify CI
