### PR TITLE
docs(tools): Best Practices AccordionGroup stragglers (#648)

### DIFF
--- a/docs/tools/calculator_tools.mdx
+++ b/docs/tools/calculator_tools.mdx
@@ -233,8 +233,8 @@ from praisonai_tools import calculate_financial
 
 ## Best Practices
 
-<CardGroup cols={2}>
-  <Card title="Precision Control" icon="ruler">
+<AccordionGroup>
+  <Accordion title="Precision Control">
     Control calculation precision:
     ```python
     evaluate(
@@ -242,14 +242,16 @@ from praisonai_tools import calculate_financial
         precision=5
     )
     ```
-  </Card>
-  <Card title="Safe Execution" icon="shield">
+  </Accordion>
+
+  <Accordion title="Safe Execution">
     Uses safe evaluation environment with:
     - Restricted builtins
     - Mathematical functions only
     - Variable validation
-  </Card>
-</CardGroup>
+  </Accordion>
+</AccordionGroup>
+
 
 ## Examples
 

--- a/docs/tools/chain-of-thought.mdx
+++ b/docs/tools/chain-of-thought.mdx
@@ -553,15 +553,45 @@ for q in qa_pairs.keys():
 
 ## Best Practices
 
-1. **Clear Problem Statements**: Always provide clear, unambiguous problem descriptions
-2. **Detailed Steps**: Include all intermediate steps, even seemingly obvious ones
-3. **Consistent Formatting**: Use consistent structure across all reasoning examples
-4. **Error Handling**: Include examples of common mistakes and their corrections
-5. **Diverse Examples**: Cover a wide range of problem types and difficulty levels
-6. **Verification Steps**: Always include a verification step to check the answer
-7. **Metadata**: Track model parameters and conditions for each example
-8. **Q&A Preparation**: Prepare comprehensive Q&A pairs before using GenerateCOT
-9. **Temperature Tuning**: Use lower temperature (0.3-0.5) for factual content, higher (0.7-0.9) for creative solutions
+<AccordionGroup>
+  <Accordion title="Clear Problem Statements">
+    Always provide clear, unambiguous problem descriptions
+  </Accordion>
+
+  <Accordion title="Detailed Steps">
+    Include all intermediate steps, even seemingly obvious ones
+  </Accordion>
+
+  <Accordion title="Consistent Formatting">
+    Use consistent structure across all reasoning examples
+  </Accordion>
+
+  <Accordion title="Error Handling">
+    Include examples of common mistakes and their corrections
+  </Accordion>
+
+  <Accordion title="Diverse Examples">
+    Cover a wide range of problem types and difficulty levels
+  </Accordion>
+
+  <Accordion title="Verification Steps">
+    Always include a verification step to check the answer
+  </Accordion>
+
+  <Accordion title="Metadata">
+    Track model parameters and conditions for each example
+  </Accordion>
+
+  <Accordion title="Q&A Preparation">
+    Prepare comprehensive Q&A pairs before using GenerateCOT
+  </Accordion>
+
+  <Accordion title="Temperature Tuning">
+    Use lower temperature (0.3-0.5) for factual content, higher (0.7-0.9) for creative solutions
+  </Accordion>
+
+</AccordionGroup>
+
 
 ## Common Use Cases
 

--- a/docs/tools/gemini-internal-tools.mdx
+++ b/docs/tools/gemini-internal-tools.mdx
@@ -342,32 +342,35 @@ tools=[
 
 ## Best Practices
 
-<Card title="Model Selection" icon="robot">
-  Use Gemini 2.0+ models for internal tools:
-  - `gemini/gemini-2.0-flash` (recommended)
-  - `gemini/gemini-2.0-flash-thinking-exp`
-  - Other Gemini 2.0+ models
-</Card>
+<AccordionGroup>
+  <Accordion title="Model Selection">
+    Use Gemini 2.0+ models for internal tools:
+    - `gemini/gemini-2.0-flash` (recommended)
+    - `gemini/gemini-2.0-flash-thinking-exp`
+    - Other Gemini 2.0+ models
+  </Accordion>
 
-<Card title="Error Handling" icon="triangle-exclamation">
-  Always handle potential errors:
-  ```python
-  try:
-      response = agent.start("Your query")
-  except Exception as e:
-      print(f"Error: {e}")
-  ```
-</Card>
+  <Accordion title="Error Handling">
+    Always handle potential errors:
+    ```python
+    try:
+        response = agent.start("Your query")
+    except Exception as e:
+        print(f"Error: {e}")
+    ```
+  </Accordion>
 
-<Card title="Debugging" icon="bug">
-  Enable reflection for better debugging:
-  ```python
-  agent = Agent(
-      # ... other config
-      reflection=True
-  )
-  ```
-</Card>
+  <Accordion title="Debugging">
+    Enable reflection for better debugging:
+    ```python
+    agent = Agent(
+        # ... other config
+        reflection=True
+    )
+    ```
+  </Accordion>
+</AccordionGroup>
+
 
 ## Troubleshooting
 

--- a/docs/tools/joy-trust-network.mdx
+++ b/docs/tools/joy-trust-network.mdx
@@ -172,10 +172,25 @@ Note: This is optional. Your agents are discoverable without verification.
 
 ## Best Practices
 
-1. **Always Verify Trust**: Check trust scores before any agent delegation
-2. **Set Appropriate Thresholds**: Use higher minimum scores for sensitive tasks
-3. **Build Reputation**: Complete tasks successfully to increase your agents' trust scores
-4. **Monitor Trust Changes**: Trust scores can change based on agent behavior
+<AccordionGroup>
+  <Accordion title="Always Verify Trust">
+    Check trust scores before any agent delegation
+  </Accordion>
+
+  <Accordion title="Set Appropriate Thresholds">
+    Use higher minimum scores for sensitive tasks
+  </Accordion>
+
+  <Accordion title="Build Reputation">
+    Complete tasks successfully to increase your agents' trust scores
+  </Accordion>
+
+  <Accordion title="Monitor Trust Changes">
+    Trust scores can change based on agent behavior
+  </Accordion>
+
+</AccordionGroup>
+
 
 ## Trust Score Guidelines
 

--- a/docs/tools/searxng.mdx
+++ b/docs/tools/searxng.mdx
@@ -409,11 +409,29 @@ for result in results:
 
 ## Best Practices
 
-1. **Local Instance**: Use a local SearxNG instance for better privacy and performance
-2. **Rate Limiting**: Be mindful of search frequency to avoid overwhelming your instance
-3. **Error Handling**: Always check for errors in the response
-4. **Custom URLs**: Use environment variables for different deployment environments
-5. **Result Validation**: Validate search results before using them in your application
+<AccordionGroup>
+  <Accordion title="Local Instance">
+    Use a local SearxNG instance for better privacy and performance
+  </Accordion>
+
+  <Accordion title="Rate Limiting">
+    Be mindful of search frequency to avoid overwhelming your instance
+  </Accordion>
+
+  <Accordion title="Error Handling">
+    Always check for errors in the response
+  </Accordion>
+
+  <Accordion title="Custom URLs">
+    Use environment variables for different deployment environments
+  </Accordion>
+
+  <Accordion title="Result Validation">
+    Validate search results before using them in your application
+  </Accordion>
+
+</AccordionGroup>
+
 
 ## Comparison with Other Search Tools
 

--- a/docs/tools/single-file-plugins.mdx
+++ b/docs/tools/single-file-plugins.mdx
@@ -352,20 +352,23 @@ for plugin in manager.list_single_file_plugins():
 
 ## Best Practices
 
-<CardGroup cols={2}>
-  <Card title="Keep It Simple" icon="leaf">
+<AccordionGroup>
+  <Accordion title="Keep It Simple">
     One plugin = one purpose. Don't cram unrelated tools into one file.
-  </Card>
-  <Card title="Document Tools" icon="book">
-    Use clear docstrings - they become the tool descriptions for the LLM.
-  </Card>
-  <Card title="Handle Errors" icon="shield">
+  </Accordion>
+
+  <Accordion title="Document Tools">
+    Use clear docstrings — they become the tool descriptions for the LLM.
+  </Accordion>
+
+  <Accordion title="Handle Errors">
     Return meaningful error messages instead of raising exceptions.
-  </Card>
-  <Card title="Type Hints" icon="code">
-    Always use type hints - they help generate accurate tool schemas.
-  </Card>
-</CardGroup>
+  </Accordion>
+
+  <Accordion title="Type Hints">
+    Always use type hints — they help generate accurate tool schemas.
+  </Accordion>
+</AccordionGroup>
 
 ### Good Plugin Example
 

--- a/docs/tools/tools.mdx
+++ b/docs/tools/tools.mdx
@@ -448,7 +448,7 @@ agent = Agent(
 )
 ```
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Tavily" icon="magnifying-glass" href="/docs/tools/tavily">
     AI-optimized search with web search, news, and content extraction
   </Card>
@@ -560,7 +560,7 @@ context = result.to_context_string() if result.files else None
 
 ## Tools Overview
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card
     title="Search Tools"
     icon="magnifying-glass"
@@ -638,7 +638,7 @@ def chain_tools(input_data: str) -> Dict:
 
 ### Tool Categories
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Data Collection Tools">
     - Web scraping
     - API integration
@@ -742,7 +742,7 @@ def advanced_tool(data: Dict) -> Dict:
 Following these best practices will help you create robust, efficient, and secure tools in PraisonAI.
 </Note>
 
-<CardGroup cols={1}>
+<CardGroup cols={2}>
   <Card title="Design Principles" icon="compass-drafting" iconType="solid">
     <AccordionGroup>
       <Accordion title="Single Responsibility">
@@ -799,7 +799,7 @@ Following these best practices will help you create robust, efficient, and secur
 
 <br />
 
-<CardGroup cols={1}>
+<CardGroup cols={2}>
   <Card title="Performance Optimization" icon="bolt" iconType="solid">
     <AccordionGroup>
       <Accordion title="Efficient Processing">
@@ -845,7 +845,7 @@ Following these best practices will help you create robust, efficient, and secur
 
 <br />
 
-<CardGroup cols={1}>
+<CardGroup cols={2}>
   <Card title="Security Best Practices" icon="shield-check" iconType="solid">
     <AccordionGroup>
       <Accordion title="Input Validation">

--- a/docs/tools/trafilatura.mdx
+++ b/docs/tools/trafilatura.mdx
@@ -414,13 +414,37 @@ def extract_unique_content(urls):
 
 ## Best Practices
 
-1. **Rate Limiting**: Always implement delays between requests to avoid overwhelming servers
-2. **Error Handling**: Wrap extraction calls in try-except blocks
-3. **Content Validation**: Verify extracted content meets minimum quality standards
-4. **Metadata Preservation**: Always extract metadata when available
-5. **Language Filtering**: Use language detection for multilingual sites
-6. **Caching**: Cache extracted content to avoid redundant requests
-7. **User Agent**: Set appropriate user agent strings
+<AccordionGroup>
+  <Accordion title="Rate Limiting">
+    Always implement delays between requests to avoid overwhelming servers
+  </Accordion>
+
+  <Accordion title="Error Handling">
+    Wrap extraction calls in try-except blocks
+  </Accordion>
+
+  <Accordion title="Content Validation">
+    Verify extracted content meets minimum quality standards
+  </Accordion>
+
+  <Accordion title="Metadata Preservation">
+    Always extract metadata when available
+  </Accordion>
+
+  <Accordion title="Language Filtering">
+    Use language detection for multilingual sites
+  </Accordion>
+
+  <Accordion title="Caching">
+    Cache extracted content to avoid redundant requests
+  </Accordion>
+
+  <Accordion title="User Agent">
+    Set appropriate user agent strings
+  </Accordion>
+
+</AccordionGroup>
+
 
 ## Performance Optimization
 


### PR DESCRIPTION
## Summary

Follow-up to #1158 — clears remaining **docs/tools/** section-conditional gaps (8 top-level `.mdx` files):

- **Best Practices** → `<AccordionGroup>` (replacing `CardGroup`, standalone `<Card>`, or numbered lists) on calculator_tools, chain-of-thought, gemini-internal-tools, joy-trust-network, searxng, single-file-plugins, trafilatura.
- **tools.mdx** — `CardGroup` `cols={1}` / `cols={3}` → `cols={2}` for §9 cardgroup heuristic.

Refs #648. No `docs/concepts/` edits.

## Heuristic gap counts (section-conditional, top-level `docs/tools/*.mdx`)

| Before | After |
|--------|------:|
| 8 / 51 | 0 / 51 |

**Section-conditional:** Quick Start / Related / Best Practices sections + hero canonical pair in first 100 lines; Best Practices requires `<AccordionGroup>`; all `<CardGroup>` require `cols={2}`.

## Test plan

- [x] Local `/tmp/agents_md_audit.py` section-conditional re-run on branch
- [ ] Mintlify CI

Made with [Cursor](https://cursor.com)