### PR TITLE
docs(whatsapp-bot): add Long Agent Turns section

### DIFF
--- a/docs/features/whatsapp-bot.mdx
+++ b/docs/features/whatsapp-bot.mdx
@@ -444,6 +444,53 @@ graph TB
 
 ---
 
+## Long Agent Turns
+
+A long agent turn on WhatsApp — deep research, big refactor, a slow model — stays `BUSY` for as long as it is making any progress, and is never restarted mid-stream.
+
+```mermaid
+sequenceDiagram
+    participant User as 📱 WhatsApp User
+    participant WA as WhatsApp Adapter
+    participant Agent as 🧠 Agent
+    participant Health as Channel Health
+
+    User->>WA: "Run a deep research"
+    WA->>Agent: start run (active_runs=1)
+    Agent-->>WA: streamed token
+    WA->>Health: note_run_progress()
+    Note over Health: last_run_progress refreshed
+    Agent-->>WA: tool call
+    WA->>Health: note_run_progress()
+    Health-->>WA: BUSY ✅ (within stuck_after)
+    Agent-->>WA: final answer
+    WA-->>User: reply
+
+    classDef user fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef adapter fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef health fill:#F59E0B,stroke:#7C90A0,color:#fff
+```
+
+The gateway watches each channel's health and only restarts it when it is genuinely stuck:
+
+- Progress comes from two sources: inbound transport activity (a message arrived) **and** in-run progress (the agent emitted a streamed token, called a tool, or fired an emitter event).
+- As long as either signal advanced within `stuck_after` (default 900 s), the channel stays `BUSY` and is never killed.
+- Only when **no** signal of any kind arrives for `stuck_after` seconds does the channel escalate to `STUCK` — a recoverable state that triggers a clean restart.
+
+| Scenario on WhatsApp | Health state | Outcome |
+|---|---|---|
+| Active inbound traffic + active run | `BUSY` | Channel kept alive |
+| Active run, no inbound, streaming tokens/tool calls within `stuck_after` | `BUSY` | Channel kept alive |
+| Active run, no signal of any kind for `> stuck_after` | `STUCK` | Channel restarted (genuine hang) |
+| No active runs, idle | `IDLE` | Channel kept alive |
+
+<Note>
+The same mechanism applies to every channel adapter, not just WhatsApp. For the full evaluator behaviour, configuration knobs (`stuck_after`, `busy_after`), and the `HealthResult.last_run_progress` field, see [Channel Supervision](/docs/features/gateway-channel-supervision).
+</Note>
+
+---
+
 ## Troubleshooting
 
 <AccordionGroup>
@@ -534,5 +581,8 @@ Custom command registration and handling
 </Card>
 <Card title="Approval Protocol" icon="shield-check" href="/docs/features/approval-protocol">
 Human-in-the-loop tool approval for bots
+</Card>
+<Card icon="heart-pulse" href="/docs/features/gateway-channel-supervision">
+How the gateway decides when to restart a channel — including long-agent-turn protection
 </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

Adds a `## Long Agent Turns` section to `docs/features/whatsapp-bot.mdx` between Architecture and Troubleshooting, documenting the in-run progress signal introduced in praisonaiagents 1.6.82.

**Changes:**
- New "Long Agent Turns" section with sequence diagram (AGENTS.md §3.1 colour palette)
- 4-row comparison table showing BUSY/STUCK/IDLE scenarios
- Cross-link `<Note>` pointing to `/docs/features/gateway-channel-supervision`
- Channel Supervision card added to Related `<CardGroup>`

**SDK ground truth verified:**
- `praisonai/bots/whatsapp.py:1137-1144` — `HealthResult(..., last_run_progress=self._resolve_run_progress(), ...)`
- `praisonaiagents/bots/protocols.py:514-593` — `evaluate_channel_health()` using `max(last_activity, last_run_progress)` for the busy branch

No changes to `docs/concepts/`, `docs/js/`, `docs/rust/`, or `docs.json`.

Fixes #1160

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Long Agent Turns” section for WhatsApp bot behavior during lengthy responses.
  * Clarified how agent status remains **BUSY** during active progress, and when it can move to **STUCK**.
  * Included a sequence diagram and a scenario table to illustrate expected outcomes.
  * Updated related links to surface channel supervision guidance and long-turn protection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->