### PR TITLE
docs: §9 reference-pages batch 2 (optional scopes)

### DIFF
--- a/docs/js/observability/scorecard-cli.mdx
+++ b/docs/js/observability/scorecard-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts observability test scorecard
 
 ## Related
 
-- [Scorecard Code Usage](/docs/js/observability/scorecard-code)
+<CardGroup cols={2}>
+  <Card title="Scorecard Code Usage" icon="book" href="/docs/js/observability/scorecard-code">
+    Scorecard Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/observability/scorecard-code.mdx
+++ b/docs/js/observability/scorecard-code.mdx
@@ -14,6 +14,8 @@ export SCORECARD_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent, setObservabilityAdapter } from 'praisonai';
 import { createObservabilityAdapter } from 'praisonai/observability';
@@ -30,7 +32,16 @@ const agent = new Agent({
 await agent.chat('Hello!');
 await obs.flush();
 ```
+</Step>
+<Step title="With Configuration">
+Adjust observability adapter options and agent settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Scorecard CLI Usage](/docs/js/observability/scorecard-cli)
+<CardGroup cols={2}>
+  <Card title="Scorecard CLI Usage" icon="terminal" href="/docs/js/observability/scorecard-cli">
+    Scorecard CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/observability/signoz-cli.mdx
+++ b/docs/js/observability/signoz-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts observability test signoz
 
 ## Related
 
-- [SigNoz Code Usage](/docs/js/observability/signoz-code)
+<CardGroup cols={2}>
+  <Card title="SigNoz Code Usage" icon="book" href="/docs/js/observability/signoz-code">
+    SigNoz Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/observability/signoz-code.mdx
+++ b/docs/js/observability/signoz-code.mdx
@@ -15,6 +15,8 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=https://ingest.signoz.io
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent, setObservabilityAdapter } from 'praisonai';
 import { createObservabilityAdapter } from 'praisonai/observability';
@@ -31,7 +33,16 @@ const agent = new Agent({
 await agent.chat('Hello!');
 await obs.flush();
 ```
+</Step>
+<Step title="With Configuration">
+Adjust observability adapter options and agent settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [SigNoz CLI Usage](/docs/js/observability/signoz-cli)
+<CardGroup cols={2}>
+  <Card title="SigNoz CLI Usage" icon="terminal" href="/docs/js/observability/signoz-cli">
+    SigNoz CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/observability/traceloop-cli.mdx
+++ b/docs/js/observability/traceloop-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts observability test traceloop
 
 ## Related
 
-- [Traceloop Code Usage](/docs/js/observability/traceloop-code)
+<CardGroup cols={2}>
+  <Card title="Traceloop Code Usage" icon="book" href="/docs/js/observability/traceloop-code">
+    Traceloop Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/observability/traceloop-code.mdx
+++ b/docs/js/observability/traceloop-code.mdx
@@ -14,6 +14,8 @@ export TRACELOOP_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent, setObservabilityAdapter } from 'praisonai';
 import { createObservabilityAdapter } from 'praisonai/observability';
@@ -30,7 +32,16 @@ const agent = new Agent({
 await agent.chat('Hello!');
 await obs.flush();
 ```
+</Step>
+<Step title="With Configuration">
+Adjust observability adapter options and agent settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Traceloop CLI Usage](/docs/js/observability/traceloop-cli)
+<CardGroup cols={2}>
+  <Card title="Traceloop CLI Usage" icon="terminal" href="/docs/js/observability/traceloop-cli">
+    Traceloop CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/observability/weave-cli.mdx
+++ b/docs/js/observability/weave-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts observability test weave
 
 ## Related
 
-- [Weave Code Usage](/docs/js/observability/weave-code)
+<CardGroup cols={2}>
+  <Card title="Weave Code Usage" icon="book" href="/docs/js/observability/weave-code">
+    Weave Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/observability/weave-code.mdx
+++ b/docs/js/observability/weave-code.mdx
@@ -14,6 +14,8 @@ export WANDB_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent, setObservabilityAdapter } from 'praisonai';
 import { createObservabilityAdapter } from 'praisonai/observability';
@@ -30,7 +32,16 @@ const agent = new Agent({
 await agent.chat('Hello!');
 await obs.flush();
 ```
+</Step>
+<Step title="With Configuration">
+Adjust observability adapter options and agent settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Weave CLI Usage](/docs/js/observability/weave-cli)
+<CardGroup cols={2}>
+  <Card title="Weave CLI Usage" icon="terminal" href="/docs/js/observability/weave-cli">
+    Weave CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/ai-gateway-cli.mdx
+++ b/docs/js/providers/ai-gateway-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor ai-gateway --json
 
 ## Related
 
-- [AI Gateway Code Usage](/docs/js/providers/ai-gateway-code)
+<CardGroup cols={2}>
+  <Card title="AI Gateway Code Usage" icon="book" href="/docs/js/providers/ai-gateway-code">
+    AI Gateway Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/ai-gateway-code.mdx
+++ b/docs/js/providers/ai-gateway-code.mdx
@@ -16,6 +16,8 @@ export AI_GATEWAY_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
   llm: 'ai-gateway/model'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [AI Gateway CLI Usage](/docs/js/providers/ai-gateway-cli)
+<CardGroup cols={2}>
+  <Card title="AI Gateway CLI Usage" icon="terminal" href="/docs/js/providers/ai-gateway-cli">
+    AI Gateway CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/aihubmix-cli.mdx
+++ b/docs/js/providers/aihubmix-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor aihubmix --json
 
 ## Related
 
-- [Aihubmix Code Usage](/docs/js/providers/aihubmix-code)
+<CardGroup cols={2}>
+  <Card title="Aihubmix Code Usage" icon="book" href="/docs/js/providers/aihubmix-code">
+    Aihubmix Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/aihubmix-code.mdx
+++ b/docs/js/providers/aihubmix-code.mdx
@@ -14,6 +14,8 @@ export AIHUBMIX_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Aihubmix CLI Usage](/docs/js/providers/aihubmix-cli)
+<CardGroup cols={2}>
+  <Card title="Aihubmix CLI Usage" icon="terminal" href="/docs/js/providers/aihubmix-cli">
+    Aihubmix CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/amazon-bedrock-cli.mdx
+++ b/docs/js/providers/amazon-bedrock-cli.mdx
@@ -31,4 +31,8 @@ praisonai-ts providers doctor aws
 
 ## Related
 
-- [Amazon Bedrock Code Usage](/docs/js/providers/amazon-bedrock-code)
+<CardGroup cols={2}>
+  <Card title="Amazon Bedrock Code Usage" icon="book" href="/docs/js/providers/amazon-bedrock-code">
+    Amazon Bedrock Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/amazon-bedrock-code.mdx
+++ b/docs/js/providers/amazon-bedrock-code.mdx
@@ -26,6 +26,8 @@ export AWS_REGION=us-east-1
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -37,7 +39,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Amazon Bedrock CLI](/docs/js/providers/amazon-bedrock-cli)
+<CardGroup cols={2}>
+  <Card title="Amazon Bedrock CLI" icon="terminal" href="/docs/js/providers/amazon-bedrock-cli">
+    Amazon Bedrock CLI
+  </Card>
+</CardGroup>

--- a/docs/js/providers/anthropic-cli.mdx
+++ b/docs/js/providers/anthropic-cli.mdx
@@ -165,5 +165,11 @@ Error: Rate limit exceeded
 
 ## Related
 
-- [Anthropic Code Usage](/docs/js/providers/anthropic-code)
-- [Providers CLI Overview](/docs/js/providers-cli)
+<CardGroup cols={2}>
+  <Card title="Anthropic Code Usage" icon="book" href="/docs/js/providers/anthropic-code">
+    Anthropic Code Usage
+  </Card>
+  <Card title="Providers CLI Overview" icon="terminal" href="/docs/js/providers-cli">
+    Providers CLI Overview
+  </Card>
+</CardGroup>

--- a/docs/js/providers/anthropic-code.mdx
+++ b/docs/js/providers/anthropic-code.mdx
@@ -31,6 +31,8 @@ export ANTHROPIC_API_KEY=sk-ant-...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -43,6 +45,11 @@ const agent = new Agent({
 const response = await agent.chat('Hello!');
 console.log(response);
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Available Models
 
@@ -187,5 +194,11 @@ Error: Model not found
 
 ## Related
 
-- [Anthropic CLI Usage](/docs/js/providers/anthropic-cli)
-- [Providers Overview](/docs/js/providers)
+<CardGroup cols={2}>
+  <Card title="Anthropic CLI Usage" icon="terminal" href="/docs/js/providers/anthropic-cli">
+    Anthropic CLI Usage
+  </Card>
+  <Card title="Providers Overview" icon="book" href="/docs/js/providers">
+    Providers Overview
+  </Card>
+</CardGroup>

--- a/docs/js/providers/assemblyai-cli.mdx
+++ b/docs/js/providers/assemblyai-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor assemblyai --json
 
 ## Related
 
-- [AssemblyAI Code Usage](/docs/js/providers/assemblyai-code)
+<CardGroup cols={2}>
+  <Card title="AssemblyAI Code Usage" icon="book" href="/docs/js/providers/assemblyai-code">
+    AssemblyAI Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/assemblyai-code.mdx
+++ b/docs/js/providers/assemblyai-code.mdx
@@ -16,6 +16,8 @@ export ASSEMBLYAI_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
   llm: 'assemblyai/best'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [AssemblyAI CLI Usage](/docs/js/providers/assemblyai-cli)
+<CardGroup cols={2}>
+  <Card title="AssemblyAI CLI Usage" icon="terminal" href="/docs/js/providers/assemblyai-cli">
+    AssemblyAI CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/azure-cli.mdx
+++ b/docs/js/providers/azure-cli.mdx
@@ -30,4 +30,8 @@ praisonai-ts providers doctor azure-openai
 
 ## Related
 
-- [Azure Code Usage](/docs/js/providers/azure-code)
+<CardGroup cols={2}>
+  <Card title="Azure Code Usage" icon="book" href="/docs/js/providers/azure-code">
+    Azure Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/azure-code.mdx
+++ b/docs/js/providers/azure-code.mdx
@@ -27,6 +27,8 @@ export AZURE_DEPLOYMENT_NAME=your-deployment
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -42,7 +44,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Azure CLI Usage](/docs/js/providers/azure-cli)
+<CardGroup cols={2}>
+  <Card title="Azure CLI Usage" icon="terminal" href="/docs/js/providers/azure-cli">
+    Azure CLI Usage
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

Follow-up to #1163 — mechanical AGENTS.md §9 (`<Steps>` on code pages, `<CardGroup>` on Related) for the next 20 optional-scope reference pages:

- Remaining `docs/js/observability/**`: scorecard, signoz, traceloop, weave (cli + code)
- Start of `docs/js/providers/**` (alphabetical): ai-gateway through azure (cli + code)

Refs #648.

## Verification

```bash
grep -rn "from praisonaiagents\.workflows" docs/features/
# (no output)

python3 -c "import json; json.load(open('docs.json'))" && echo "docs.json OK"
# docs.json OK

git diff --name-only main...HEAD -- docs/concepts/
# (no output)
```

## Gap tracker

- Baseline optional-scope gap: **154**
- Batch 2 files: **20**
- Remaining (154 − 40 cumulative after batch 1 + 2): **114**


Made with [Cursor](https://cursor.com)