### PR TITLE
docs: §9 reference-pages batch 3 (js providers baseten–deepseek)

### DIFF
--- a/docs/js/providers/baseten-cli.mdx
+++ b/docs/js/providers/baseten-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor baseten --json
 
 ## Related
 
-- [Baseten Code Usage](/docs/js/providers/baseten-code)
+<CardGroup cols={2}>
+  <Card title="Baseten Code Usage" icon="book" href="/docs/js/providers/baseten-code">
+    Baseten Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/baseten-code.mdx
+++ b/docs/js/providers/baseten-code.mdx
@@ -14,6 +14,8 @@ export BASETEN_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -23,7 +25,16 @@ const agent = new Agent({
   llm: 'baseten/model-id'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Baseten CLI Usage](/docs/js/providers/baseten-cli)
+<CardGroup cols={2}>
+  <Card title="Baseten CLI Usage" icon="terminal" href="/docs/js/providers/baseten-cli">
+    Baseten CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/black-forest-labs-cli.mdx
+++ b/docs/js/providers/black-forest-labs-cli.mdx
@@ -28,4 +28,8 @@ praisonai-ts providers doctor bfl
 
 ## Related
 
-- [Black Forest Labs Code Usage](/docs/js/providers/black-forest-labs-code)
+<CardGroup cols={2}>
+  <Card title="Black Forest Labs Code Usage" icon="book" href="/docs/js/providers/black-forest-labs-code">
+    Black Forest Labs Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/black-forest-labs-code.mdx
+++ b/docs/js/providers/black-forest-labs-code.mdx
@@ -16,6 +16,8 @@ export BFL_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
   llm: 'black-forest-labs/flux-pro'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Black Forest Labs CLI Usage](/docs/js/providers/black-forest-labs-cli)
+<CardGroup cols={2}>
+  <Card title="Black Forest Labs CLI Usage" icon="terminal" href="/docs/js/providers/black-forest-labs-cli">
+    Black Forest Labs CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/cerebras-cli.mdx
+++ b/docs/js/providers/cerebras-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts providers doctor cerebras --json
 
 ## Related
 
-- [Cerebras Code Usage](/docs/js/providers/cerebras-code)
+<CardGroup cols={2}>
+  <Card title="Cerebras Code Usage" icon="book" href="/docs/js/providers/cerebras-code">
+    Cerebras Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/cerebras-code.mdx
+++ b/docs/js/providers/cerebras-code.mdx
@@ -16,6 +16,8 @@ export CEREBRAS_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -27,7 +29,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Cerebras CLI Usage](/docs/js/providers/cerebras-cli)
+<CardGroup cols={2}>
+  <Card title="Cerebras CLI Usage" icon="terminal" href="/docs/js/providers/cerebras-cli">
+    Cerebras CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/clarifai-cli.mdx
+++ b/docs/js/providers/clarifai-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor clarifai --json
 
 ## Related
 
-- [Clarifai Code Usage](/docs/js/providers/clarifai-code)
+<CardGroup cols={2}>
+  <Card title="Clarifai Code Usage" icon="book" href="/docs/js/providers/clarifai-code">
+    Clarifai Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/clarifai-code.mdx
+++ b/docs/js/providers/clarifai-code.mdx
@@ -14,6 +14,8 @@ export CLARIFAI_PAT=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Clarifai CLI Usage](/docs/js/providers/clarifai-cli)
+<CardGroup cols={2}>
+  <Card title="Clarifai CLI Usage" icon="terminal" href="/docs/js/providers/clarifai-cli">
+    Clarifai CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/cloudflare-workers-ai-cli.mdx
+++ b/docs/js/providers/cloudflare-workers-ai-cli.mdx
@@ -29,4 +29,8 @@ praisonai-ts providers doctor cf-ai
 
 ## Related
 
-- [Cloudflare Workers AI Code Usage](/docs/js/providers/cloudflare-workers-ai-code)
+<CardGroup cols={2}>
+  <Card title="Cloudflare Workers AI Code Usage" icon="book" href="/docs/js/providers/cloudflare-workers-ai-code">
+    Cloudflare Workers AI Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/cloudflare-workers-ai-code.mdx
+++ b/docs/js/providers/cloudflare-workers-ai-code.mdx
@@ -15,6 +15,8 @@ export CLOUDFLARE_ACCOUNT_ID=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -24,7 +26,16 @@ const agent = new Agent({
   llm: 'cloudflare-workers-ai/@cf/meta/llama-2-7b-chat-int8'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Cloudflare Workers AI CLI Usage](/docs/js/providers/cloudflare-workers-ai-cli)
+<CardGroup cols={2}>
+  <Card title="Cloudflare Workers AI CLI Usage" icon="terminal" href="/docs/js/providers/cloudflare-workers-ai-cli">
+    Cloudflare Workers AI CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/cohere-cli.mdx
+++ b/docs/js/providers/cohere-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts providers doctor cohere --json
 
 ## Related
 
-- [Cohere Code Usage](/docs/js/providers/cohere-code)
+<CardGroup cols={2}>
+  <Card title="Cohere Code Usage" icon="book" href="/docs/js/providers/cohere-code">
+    Cohere Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/cohere-code.mdx
+++ b/docs/js/providers/cohere-code.mdx
@@ -24,6 +24,8 @@ export COHERE_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -35,7 +37,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Cohere CLI Usage](/docs/js/providers/cohere-cli)
+<CardGroup cols={2}>
+  <Card title="Cohere CLI Usage" icon="terminal" href="/docs/js/providers/cohere-cli">
+    Cohere CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/crosshatch-cli.mdx
+++ b/docs/js/providers/crosshatch-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor crosshatch --json
 
 ## Related
 
-- [Crosshatch Code Usage](/docs/js/providers/crosshatch-code)
+<CardGroup cols={2}>
+  <Card title="Crosshatch Code Usage" icon="book" href="/docs/js/providers/crosshatch-code">
+    Crosshatch Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/crosshatch-code.mdx
+++ b/docs/js/providers/crosshatch-code.mdx
@@ -14,6 +14,8 @@ export CROSSHATCH_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Crosshatch CLI Usage](/docs/js/providers/crosshatch-cli)
+<CardGroup cols={2}>
+  <Card title="Crosshatch CLI Usage" icon="terminal" href="/docs/js/providers/crosshatch-cli">
+    Crosshatch CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/deepgram-cli.mdx
+++ b/docs/js/providers/deepgram-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor deepgram --json
 
 ## Related
 
-- [Deepgram Code Usage](/docs/js/providers/deepgram-code)
+<CardGroup cols={2}>
+  <Card title="Deepgram Code Usage" icon="book" href="/docs/js/providers/deepgram-code">
+    Deepgram Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/deepgram-code.mdx
+++ b/docs/js/providers/deepgram-code.mdx
@@ -16,6 +16,8 @@ export DEEPGRAM_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
   llm: 'deepgram/nova-2'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Deepgram CLI Usage](/docs/js/providers/deepgram-cli)
+<CardGroup cols={2}>
+  <Card title="Deepgram CLI Usage" icon="terminal" href="/docs/js/providers/deepgram-cli">
+    Deepgram CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/deepinfra-cli.mdx
+++ b/docs/js/providers/deepinfra-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts providers doctor deepinfra --json
 
 ## Related
 
-- [DeepInfra Code Usage](/docs/js/providers/deepinfra-code)
+<CardGroup cols={2}>
+  <Card title="DeepInfra Code Usage" icon="book" href="/docs/js/providers/deepinfra-code">
+    DeepInfra Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/deepinfra-code.mdx
+++ b/docs/js/providers/deepinfra-code.mdx
@@ -16,6 +16,8 @@ export DEEPINFRA_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -27,7 +29,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [DeepInfra CLI Usage](/docs/js/providers/deepinfra-cli)
+<CardGroup cols={2}>
+  <Card title="DeepInfra CLI Usage" icon="terminal" href="/docs/js/providers/deepinfra-cli">
+    DeepInfra CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/deepseek-cli.mdx
+++ b/docs/js/providers/deepseek-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts providers doctor deepseek --json
 
 ## Related
 
-- [DeepSeek Code Usage](/docs/js/providers/deepseek-code)
+<CardGroup cols={2}>
+  <Card title="DeepSeek Code Usage" icon="book" href="/docs/js/providers/deepseek-code">
+    DeepSeek Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/deepseek-code.mdx
+++ b/docs/js/providers/deepseek-code.mdx
@@ -23,6 +23,8 @@ export DEEPSEEK_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -34,6 +36,11 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Available Models
 
@@ -44,4 +51,8 @@ const response = await agent.chat('Hello!');
 
 ## Related
 
-- [DeepSeek CLI Usage](/docs/js/providers/deepseek-cli)
+<CardGroup cols={2}>
+  <Card title="DeepSeek CLI Usage" icon="terminal" href="/docs/js/providers/deepseek-cli">
+    DeepSeek CLI Usage
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Mechanical §9 pass on 20 `docs/js/providers/**` pages (baseten through deepseek): `<Steps>` on code Quick Start, `<CardGroup>` on Related.
- Continues optional-scope work for refs #648 (no `docs/concepts/` changes).

## Test plan
- [x] 20 files updated, docs-only
- [ ] Mintlify build (CI)


Made with [Cursor](https://cursor.com)