### PR TITLE
docs(js/providers): reference-pages §9 batch 4 (dify–helicone)

### DIFF
--- a/docs/js/providers/dify-cli.mdx
+++ b/docs/js/providers/dify-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor dify --json
 
 ## Related
 
-- [Dify Code Usage](/docs/js/providers/dify-code)
+<CardGroup cols={2}>
+  <Card title="Dify Code Usage" icon="book" href="/docs/js/providers/dify-code">
+    Dify Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/dify-code.mdx
+++ b/docs/js/providers/dify-code.mdx
@@ -14,6 +14,8 @@ export DIFY_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Dify CLI Usage](/docs/js/providers/dify-cli)
+<CardGroup cols={2}>
+  <Card title="Dify CLI Usage" icon="terminal" href="/docs/js/providers/dify-cli">
+    Dify CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/elevenlabs-cli.mdx
+++ b/docs/js/providers/elevenlabs-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor elevenlabs --json
 
 ## Related
 
-- [ElevenLabs Code Usage](/docs/js/providers/elevenlabs-code)
+<CardGroup cols={2}>
+  <Card title="ElevenLabs Code Usage" icon="book" href="/docs/js/providers/elevenlabs-code">
+    ElevenLabs Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/elevenlabs-code.mdx
+++ b/docs/js/providers/elevenlabs-code.mdx
@@ -16,6 +16,8 @@ export ELEVENLABS_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
   llm: 'elevenlabs/eleven_multilingual_v2'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [ElevenLabs CLI Usage](/docs/js/providers/elevenlabs-cli)
+<CardGroup cols={2}>
+  <Card title="ElevenLabs CLI Usage" icon="terminal" href="/docs/js/providers/elevenlabs-cli">
+    ElevenLabs CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/fal-cli.mdx
+++ b/docs/js/providers/fal-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor fal --json
 
 ## Related
 
-- [Fal Code Usage](/docs/js/providers/fal-code)
+<CardGroup cols={2}>
+  <Card title="Fal Code Usage" icon="book" href="/docs/js/providers/fal-code">
+    Fal Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/fal-code.mdx
+++ b/docs/js/providers/fal-code.mdx
@@ -16,6 +16,8 @@ export FAL_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
   llm: 'fal/flux-pro'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Fal CLI Usage](/docs/js/providers/fal-cli)
+<CardGroup cols={2}>
+  <Card title="Fal CLI Usage" icon="terminal" href="/docs/js/providers/fal-cli">
+    Fal CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/fireworks-cli.mdx
+++ b/docs/js/providers/fireworks-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts providers doctor fireworks --json
 
 ## Related
 
-- [Fireworks Code Usage](/docs/js/providers/fireworks-code)
+<CardGroup cols={2}>
+  <Card title="Fireworks Code Usage" icon="book" href="/docs/js/providers/fireworks-code">
+    Fireworks Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/fireworks-code.mdx
+++ b/docs/js/providers/fireworks-code.mdx
@@ -24,6 +24,8 @@ export FIREWORKS_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -35,7 +37,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Fireworks CLI Usage](/docs/js/providers/fireworks-cli)
+<CardGroup cols={2}>
+  <Card title="Fireworks CLI Usage" icon="terminal" href="/docs/js/providers/fireworks-cli">
+    Fireworks CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/friendliai-cli.mdx
+++ b/docs/js/providers/friendliai-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor friendliai --json
 
 ## Related
 
-- [FriendliAI Code Usage](/docs/js/providers/friendliai-code)
+<CardGroup cols={2}>
+  <Card title="FriendliAI Code Usage" icon="book" href="/docs/js/providers/friendliai-code">
+    FriendliAI Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/friendliai-code.mdx
+++ b/docs/js/providers/friendliai-code.mdx
@@ -14,6 +14,8 @@ export FRIENDLI_TOKEN=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [FriendliAI CLI Usage](/docs/js/providers/friendliai-cli)
+<CardGroup cols={2}>
+  <Card title="FriendliAI CLI Usage" icon="terminal" href="/docs/js/providers/friendliai-cli">
+    FriendliAI CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/gladia-cli.mdx
+++ b/docs/js/providers/gladia-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor gladia --json
 
 ## Related
 
-- [Gladia Code Usage](/docs/js/providers/gladia-code)
+<CardGroup cols={2}>
+  <Card title="Gladia Code Usage" icon="book" href="/docs/js/providers/gladia-code">
+    Gladia Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/gladia-code.mdx
+++ b/docs/js/providers/gladia-code.mdx
@@ -16,6 +16,8 @@ export GLADIA_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
   llm: 'gladia/whisper-large-v3'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Gladia CLI Usage](/docs/js/providers/gladia-cli)
+<CardGroup cols={2}>
+  <Card title="Gladia CLI Usage" icon="terminal" href="/docs/js/providers/gladia-cli">
+    Gladia CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/google-cli.mdx
+++ b/docs/js/providers/google-cli.mdx
@@ -71,5 +71,11 @@ export GOOGLE_GENERATIVE_AI_API_KEY=AIza...
 
 ## Related
 
-- [Google Code Usage](/docs/js/providers/google-code)
-- [Providers CLI Overview](/docs/js/providers-cli)
+<CardGroup cols={2}>
+  <Card title="Google Code Usage" icon="book" href="/docs/js/providers/google-code">
+    Google Code Usage
+  </Card>
+  <Card title="Providers CLI Overview" icon="terminal" href="/docs/js/providers-cli">
+    Providers CLI Overview
+  </Card>
+</CardGroup>

--- a/docs/js/providers/google-code.mdx
+++ b/docs/js/providers/google-code.mdx
@@ -34,6 +34,8 @@ export GOOGLE_API_KEY=AIza...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -46,6 +48,11 @@ const agent = new Agent({
 const response = await agent.chat('Hello!');
 console.log(response);
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Available Models
 
@@ -156,6 +163,14 @@ Error: Resource exhausted
 
 ## Related
 
-- [Google CLI Usage](/docs/js/providers/google-cli)
-- [Google Vertex AI](/docs/js/providers/google-vertex-code)
-- [Providers Overview](/docs/js/providers)
+<CardGroup cols={2}>
+  <Card title="Google CLI Usage" icon="terminal" href="/docs/js/providers/google-cli">
+    Google CLI Usage
+  </Card>
+  <Card title="Google Vertex AI" icon="book" href="/docs/js/providers/google-vertex-code">
+    Google Vertex AI
+  </Card>
+  <Card title="Providers Overview" icon="book" href="/docs/js/providers">
+    Providers Overview
+  </Card>
+</CardGroup>

--- a/docs/js/providers/google-vertex-cli.mdx
+++ b/docs/js/providers/google-vertex-cli.mdx
@@ -29,4 +29,8 @@ praisonai-ts providers doctor vertex
 
 ## Related
 
-- [Google Vertex AI Code Usage](/docs/js/providers/google-vertex-code)
+<CardGroup cols={2}>
+  <Card title="Google Vertex AI Code Usage" icon="book" href="/docs/js/providers/google-vertex-code">
+    Google Vertex AI Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/google-vertex-code.mdx
+++ b/docs/js/providers/google-vertex-code.mdx
@@ -18,6 +18,8 @@ export GOOGLE_CLOUD_LOCATION=us-central1
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -29,7 +31,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Google Vertex AI CLI Usage](/docs/js/providers/google-vertex-cli)
+<CardGroup cols={2}>
+  <Card title="Google Vertex AI CLI Usage" icon="terminal" href="/docs/js/providers/google-vertex-cli">
+    Google Vertex AI CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/groq-cli.mdx
+++ b/docs/js/providers/groq-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts providers doctor groq --json
 
 ## Related
 
-- [Groq Code Usage](/docs/js/providers/groq-code)
+<CardGroup cols={2}>
+  <Card title="Groq Code Usage" icon="book" href="/docs/js/providers/groq-code">
+    Groq Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/groq-code.mdx
+++ b/docs/js/providers/groq-code.mdx
@@ -23,6 +23,8 @@ export GROQ_API_KEY=gsk_...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -34,6 +36,11 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Available Models
 
@@ -45,4 +52,8 @@ const response = await agent.chat('Hello!');
 
 ## Related
 
-- [Groq CLI Usage](/docs/js/providers/groq-cli)
+<CardGroup cols={2}>
+  <Card title="Groq CLI Usage" icon="terminal" href="/docs/js/providers/groq-cli">
+    Groq CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/helicone-cli.mdx
+++ b/docs/js/providers/helicone-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor helicone --json
 
 ## Related
 
-- [Helicone Code Usage](/docs/js/providers/helicone-code)
+<CardGroup cols={2}>
+  <Card title="Helicone Code Usage" icon="book" href="/docs/js/providers/helicone-code">
+    Helicone Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/helicone-code.mdx
+++ b/docs/js/providers/helicone-code.mdx
@@ -16,6 +16,8 @@ export HELICONE_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
   llm: 'helicone/openai/gpt-4o'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Helicone CLI Usage](/docs/js/providers/helicone-cli)
+<CardGroup cols={2}>
+  <Card title="Helicone CLI Usage" icon="terminal" href="/docs/js/providers/helicone-cli">
+    Helicone CLI Usage
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Mechanical AGENTS.md section 9 for docs/js/providers batch 4: dify through helicone (20 files).
- Quick Start on -code pages wrapped in Mintlify Steps (Simple Usage + With Configuration).
- Related sections use CardGroup / Card (including multi-link Google pages).
- Docs only; no docs/concepts/ changes.

Refs #648.

## Test plan

- [ ] Mintlify preview: spot-check dify-code, google-code, google-cli
- [ ] Confirm Related links resolve
