### PR TITLE
Reference pages §9: JS providers batch 5 (heroku–minimax)

### DIFF
--- a/docs/js/providers/heroku-cli.mdx
+++ b/docs/js/providers/heroku-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor heroku --json
 
 ## Related
 
-- [Heroku Code Usage](/docs/js/providers/heroku-code)
+<CardGroup cols={2}>
+  <Card title="Heroku Code Usage" icon="book" href="/docs/js/providers/heroku-code">
+    Heroku Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/heroku-code.mdx
+++ b/docs/js/providers/heroku-code.mdx
@@ -14,6 +14,8 @@ export HEROKU_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Heroku CLI Usage](/docs/js/providers/heroku-cli)
+<CardGroup cols={2}>
+  <Card title="Heroku CLI Usage" icon="terminal" href="/docs/js/providers/heroku-cli">
+    Heroku CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/huggingface-cli.mdx
+++ b/docs/js/providers/huggingface-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts providers doctor huggingface --json
 
 ## Related
 
-- [Hugging Face Code Usage](/docs/js/providers/huggingface-code)
+<CardGroup cols={2}>
+  <Card title="Hugging Face Code Usage" icon="book" href="/docs/js/providers/huggingface-code">
+    Hugging Face Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/huggingface-code.mdx
+++ b/docs/js/providers/huggingface-code.mdx
@@ -16,6 +16,8 @@ export HUGGINGFACE_API_KEY=hf_...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -27,7 +29,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Hugging Face CLI Usage](/docs/js/providers/huggingface-cli)
+<CardGroup cols={2}>
+  <Card title="Hugging Face CLI Usage" icon="terminal" href="/docs/js/providers/huggingface-cli">
+    Hugging Face CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/hume-cli.mdx
+++ b/docs/js/providers/hume-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor hume --json
 
 ## Related
 
-- [Hume Code Usage](/docs/js/providers/hume-code)
+<CardGroup cols={2}>
+  <Card title="Hume Code Usage" icon="book" href="/docs/js/providers/hume-code">
+    Hume Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/hume-code.mdx
+++ b/docs/js/providers/hume-code.mdx
@@ -16,6 +16,8 @@ export HUME_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
   llm: 'hume/evi'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Hume CLI Usage](/docs/js/providers/hume-cli)
+<CardGroup cols={2}>
+  <Card title="Hume CLI Usage" icon="terminal" href="/docs/js/providers/hume-cli">
+    Hume CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/langdb-cli.mdx
+++ b/docs/js/providers/langdb-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor langdb --json
 
 ## Related
 
-- [LangDB Code Usage](/docs/js/providers/langdb-code)
+<CardGroup cols={2}>
+  <Card title="LangDB Code Usage" icon="book" href="/docs/js/providers/langdb-code">
+    LangDB Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/langdb-code.mdx
+++ b/docs/js/providers/langdb-code.mdx
@@ -14,6 +14,8 @@ export LANGDB_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [LangDB CLI Usage](/docs/js/providers/langdb-cli)
+<CardGroup cols={2}>
+  <Card title="LangDB CLI Usage" icon="terminal" href="/docs/js/providers/langdb-cli">
+    LangDB CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/letta-cli.mdx
+++ b/docs/js/providers/letta-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor letta --json
 
 ## Related
 
-- [Letta Code Usage](/docs/js/providers/letta-code)
+<CardGroup cols={2}>
+  <Card title="Letta Code Usage" icon="book" href="/docs/js/providers/letta-code">
+    Letta Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/letta-code.mdx
+++ b/docs/js/providers/letta-code.mdx
@@ -14,6 +14,8 @@ export LETTA_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Letta CLI Usage](/docs/js/providers/letta-cli)
+<CardGroup cols={2}>
+  <Card title="Letta CLI Usage" icon="terminal" href="/docs/js/providers/letta-cli">
+    Letta CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/lm-studio-cli.mdx
+++ b/docs/js/providers/lm-studio-cli.mdx
@@ -27,4 +27,8 @@ praisonai-ts providers doctor lmstudio
 
 ## Related
 
-- [LM Studio Code Usage](/docs/js/providers/lm-studio-code)
+<CardGroup cols={2}>
+  <Card title="LM Studio Code Usage" icon="book" href="/docs/js/providers/lm-studio-code">
+    LM Studio Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/lm-studio-code.mdx
+++ b/docs/js/providers/lm-studio-code.mdx
@@ -16,6 +16,8 @@ export LM_STUDIO_BASE_URL=http://localhost:1234/v1
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -30,8 +32,17 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [LM Studio CLI Usage](/docs/js/providers/lm-studio-cli)
+<CardGroup cols={2}>
+  <Card title="LM Studio CLI Usage" icon="terminal" href="/docs/js/providers/lm-studio-cli">
+    LM Studio CLI Usage
+  </Card>
+</CardGroup>
 - [Local Providers](/docs/js/local-providers)

--- a/docs/js/providers/lmnt-cli.mdx
+++ b/docs/js/providers/lmnt-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor lmnt --json
 
 ## Related
 
-- [LMNT Code Usage](/docs/js/providers/lmnt-code)
+<CardGroup cols={2}>
+  <Card title="LMNT Code Usage" icon="book" href="/docs/js/providers/lmnt-code">
+    LMNT Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/lmnt-code.mdx
+++ b/docs/js/providers/lmnt-code.mdx
@@ -16,6 +16,8 @@ export LMNT_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
   llm: 'lmnt/aurora'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [LMNT CLI Usage](/docs/js/providers/lmnt-cli)
+<CardGroup cols={2}>
+  <Card title="LMNT CLI Usage" icon="terminal" href="/docs/js/providers/lmnt-cli">
+    LMNT CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/luma-cli.mdx
+++ b/docs/js/providers/luma-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor luma --json
 
 ## Related
 
-- [Luma Code Usage](/docs/js/providers/luma-code)
+<CardGroup cols={2}>
+  <Card title="Luma Code Usage" icon="book" href="/docs/js/providers/luma-code">
+    Luma Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/luma-code.mdx
+++ b/docs/js/providers/luma-code.mdx
@@ -16,6 +16,8 @@ export LUMA_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
   llm: 'luma/dream-machine'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Luma CLI Usage](/docs/js/providers/luma-cli)
+<CardGroup cols={2}>
+  <Card title="Luma CLI Usage" icon="terminal" href="/docs/js/providers/luma-cli">
+    Luma CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/mem0-cli.mdx
+++ b/docs/js/providers/mem0-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor mem0 --json
 
 ## Related
 
-- [Mem0 Code Usage](/docs/js/providers/mem0-code)
+<CardGroup cols={2}>
+  <Card title="Mem0 Code Usage" icon="book" href="/docs/js/providers/mem0-code">
+    Mem0 Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/mem0-code.mdx
+++ b/docs/js/providers/mem0-code.mdx
@@ -14,6 +14,8 @@ export MEM0_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Mem0 CLI Usage](/docs/js/providers/mem0-cli)
+<CardGroup cols={2}>
+  <Card title="Mem0 CLI Usage" icon="terminal" href="/docs/js/providers/mem0-cli">
+    Mem0 CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/minimax-cli.mdx
+++ b/docs/js/providers/minimax-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor minimax --json
 
 ## Related
 
-- [MiniMax Code Usage](/docs/js/providers/minimax-code)
+<CardGroup cols={2}>
+  <Card title="MiniMax Code Usage" icon="book" href="/docs/js/providers/minimax-code">
+    MiniMax Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/minimax-code.mdx
+++ b/docs/js/providers/minimax-code.mdx
@@ -14,6 +14,8 @@ export MINIMAX_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -23,7 +25,16 @@ const agent = new Agent({
   llm: 'minimax/abab6-chat'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [MiniMax CLI Usage](/docs/js/providers/minimax-cli)
+<CardGroup cols={2}>
+  <Card title="MiniMax CLI Usage" icon="terminal" href="/docs/js/providers/minimax-cli">
+    MiniMax CLI Usage
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Mechanical §9 layout for 20 `docs/js/providers/` pages from **heroku** through **minimax** (CLI + code pairs).
- **Quick Start**: `<Steps>` / `<Step>` on `-code` pages only.
- **Related**: Mintlify `<CardGroup>` / `<Card>` on all 20 pages (no `docs/concepts/` links).

Refs #648.

## Test plan
- [x] Diff matches prior batches (e.g. #1166 / helicone–groq pattern).
- [x] 20 files changed; no concepts paths added.
- [ ] Mintlify preview (optional).