### PR TITLE
Reference pages §9: JS providers batch 6 (mistral–qwen)

### DIFF
--- a/docs/js/providers/mistral-cli.mdx
+++ b/docs/js/providers/mistral-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts providers doctor mistral --json
 
 ## Related
 
-- [Mistral Code Usage](/docs/js/providers/mistral-code)
+<CardGroup cols={2}>
+  <Card title="Mistral Code Usage" icon="book" href="/docs/js/providers/mistral-code">
+    Mistral Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/mistral-code.mdx
+++ b/docs/js/providers/mistral-code.mdx
@@ -24,6 +24,8 @@ export MISTRAL_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -35,6 +37,11 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Available Models
 
@@ -47,4 +54,8 @@ const response = await agent.chat('Hello!');
 
 ## Related
 
-- [Mistral CLI Usage](/docs/js/providers/mistral-cli)
+<CardGroup cols={2}>
+  <Card title="Mistral CLI Usage" icon="terminal" href="/docs/js/providers/mistral-cli">
+    Mistral CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/mixedbread-cli.mdx
+++ b/docs/js/providers/mixedbread-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor mixedbread --json
 
 ## Related
 
-- [Mixedbread Code Usage](/docs/js/providers/mixedbread-code)
+<CardGroup cols={2}>
+  <Card title="Mixedbread Code Usage" icon="book" href="/docs/js/providers/mixedbread-code">
+    Mixedbread Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/mixedbread-code.mdx
+++ b/docs/js/providers/mixedbread-code.mdx
@@ -14,6 +14,8 @@ export MIXEDBREAD_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Mixedbread CLI Usage](/docs/js/providers/mixedbread-cli)
+<CardGroup cols={2}>
+  <Card title="Mixedbread CLI Usage" icon="terminal" href="/docs/js/providers/mixedbread-cli">
+    Mixedbread CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/nvidia-nim-cli.mdx
+++ b/docs/js/providers/nvidia-nim-cli.mdx
@@ -28,4 +28,8 @@ praisonai-ts providers doctor nvidia
 
 ## Related
 
-- [NVIDIA NIM Code Usage](/docs/js/providers/nvidia-nim-code)
+<CardGroup cols={2}>
+  <Card title="NVIDIA NIM Code Usage" icon="book" href="/docs/js/providers/nvidia-nim-code">
+    NVIDIA NIM Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/nvidia-nim-code.mdx
+++ b/docs/js/providers/nvidia-nim-code.mdx
@@ -14,6 +14,8 @@ export NVIDIA_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -23,7 +25,16 @@ const agent = new Agent({
   llm: 'nvidia-nim/meta/llama3-70b-instruct'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [NVIDIA NIM CLI Usage](/docs/js/providers/nvidia-nim-cli)
+<CardGroup cols={2}>
+  <Card title="NVIDIA NIM CLI Usage" icon="terminal" href="/docs/js/providers/nvidia-nim-cli">
+    NVIDIA NIM CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/ollama-cli.mdx
+++ b/docs/js/providers/ollama-cli.mdx
@@ -28,4 +28,8 @@ praisonai-ts providers doctor local
 
 ## Related
 
-- [Ollama Code Usage](/docs/js/providers/ollama-code)
+<CardGroup cols={2}>
+  <Card title="Ollama Code Usage" icon="book" href="/docs/js/providers/ollama-code">
+    Ollama Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/ollama-code.mdx
+++ b/docs/js/providers/ollama-code.mdx
@@ -29,6 +29,8 @@ export OLLAMA_BASE_URL=http://localhost:11434
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -40,6 +42,11 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Available Models
 
@@ -53,5 +60,11 @@ const response = await agent.chat('Hello!');
 
 ## Related
 
-- [Ollama CLI Usage](/docs/js/providers/ollama-cli)
-- [Local Providers](/docs/js/local-providers)
+<CardGroup cols={2}>
+  <Card title="Ollama CLI Usage" icon="terminal" href="/docs/js/providers/ollama-cli">
+    Ollama CLI Usage
+  </Card>
+  <Card title="Local Providers" icon="book" href="/docs/js/local-providers">
+    Local Providers
+  </Card>
+</CardGroup>

--- a/docs/js/providers/openai-cli.mdx
+++ b/docs/js/providers/openai-cli.mdx
@@ -178,5 +178,11 @@ Error: Model not found
 
 ## Related
 
-- [OpenAI Code Usage](/docs/js/providers/openai-code)
-- [Providers CLI Overview](/docs/js/providers-cli)
+<CardGroup cols={2}>
+  <Card title="OpenAI Code Usage" icon="book" href="/docs/js/providers/openai-code">
+    OpenAI Code Usage
+  </Card>
+  <Card title="Providers CLI Overview" icon="terminal" href="/docs/js/providers-cli">
+    Providers CLI Overview
+  </Card>
+</CardGroup>

--- a/docs/js/providers/openai-code.mdx
+++ b/docs/js/providers/openai-code.mdx
@@ -33,6 +33,8 @@ export OPENAI_API_KEY=sk-...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -45,6 +47,11 @@ const agent = new Agent({
 const response = await agent.chat('Hello!');
 console.log(response);
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Available Models
 
@@ -175,5 +182,11 @@ Error: Model not found
 
 ## Related
 
-- [OpenAI CLI Usage](/docs/js/providers/openai-cli)
-- [Providers Overview](/docs/js/providers)
+<CardGroup cols={2}>
+  <Card title="OpenAI CLI Usage" icon="terminal" href="/docs/js/providers/openai-cli">
+    OpenAI CLI Usage
+  </Card>
+  <Card title="Providers Overview" icon="book" href="/docs/js/providers">
+    Providers Overview
+  </Card>
+</CardGroup>

--- a/docs/js/providers/openai-compatible-cli.mdx
+++ b/docs/js/providers/openai-compatible-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts providers doctor openai-compatible --json
 
 ## Related
 
-- [OpenAI Compatible Code Usage](/docs/js/providers/openai-compatible-code)
+<CardGroup cols={2}>
+  <Card title="OpenAI Compatible Code Usage" icon="book" href="/docs/js/providers/openai-compatible-code">
+    OpenAI Compatible Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/openai-compatible-code.mdx
+++ b/docs/js/providers/openai-compatible-code.mdx
@@ -17,6 +17,8 @@ export OPENAI_COMPATIBLE_BASE_URL=https://api.example.com/v1
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -32,6 +34,11 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Compatible Services
 
@@ -43,4 +50,8 @@ const response = await agent.chat('Hello!');
 
 ## Related
 
-- [OpenAI Compatible CLI Usage](/docs/js/providers/openai-compatible-cli)
+<CardGroup cols={2}>
+  <Card title="OpenAI Compatible CLI Usage" icon="terminal" href="/docs/js/providers/openai-compatible-cli">
+    OpenAI Compatible CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/openrouter-cli.mdx
+++ b/docs/js/providers/openrouter-cli.mdx
@@ -22,4 +22,8 @@ praisonai-ts providers doctor openrouter --json
 
 ## Related
 
-- [OpenRouter Code Usage](/docs/js/providers/openrouter-code)
+<CardGroup cols={2}>
+  <Card title="OpenRouter Code Usage" icon="book" href="/docs/js/providers/openrouter-code">
+    OpenRouter Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/openrouter-code.mdx
+++ b/docs/js/providers/openrouter-code.mdx
@@ -16,6 +16,8 @@ export OPENROUTER_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -27,7 +29,16 @@ const agent = new Agent({
 
 const response = await agent.chat('Hello!');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [OpenRouter CLI Usage](/docs/js/providers/openrouter-cli)
+<CardGroup cols={2}>
+  <Card title="OpenRouter CLI Usage" icon="terminal" href="/docs/js/providers/openrouter-cli">
+    OpenRouter CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/perplexity-cli.mdx
+++ b/docs/js/providers/perplexity-cli.mdx
@@ -28,4 +28,8 @@ praisonai-ts providers doctor pplx
 
 ## Related
 
-- [Perplexity Code Usage](/docs/js/providers/perplexity-code)
+<CardGroup cols={2}>
+  <Card title="Perplexity Code Usage" icon="book" href="/docs/js/providers/perplexity-code">
+    Perplexity Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/perplexity-code.mdx
+++ b/docs/js/providers/perplexity-code.mdx
@@ -16,6 +16,8 @@ export PERPLEXITY_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -27,7 +29,16 @@ const agent = new Agent({
 
 const response = await agent.chat('What is the latest news?');
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Perplexity CLI Usage](/docs/js/providers/perplexity-cli)
+<CardGroup cols={2}>
+  <Card title="Perplexity CLI Usage" icon="terminal" href="/docs/js/providers/perplexity-cli">
+    Perplexity CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/portkey-cli.mdx
+++ b/docs/js/providers/portkey-cli.mdx
@@ -21,4 +21,8 @@ praisonai-ts providers doctor portkey --json
 
 ## Related
 
-- [Portkey Code Usage](/docs/js/providers/portkey-code)
+<CardGroup cols={2}>
+  <Card title="Portkey Code Usage" icon="book" href="/docs/js/providers/portkey-code">
+    Portkey Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/portkey-code.mdx
+++ b/docs/js/providers/portkey-code.mdx
@@ -16,6 +16,8 @@ export PORTKEY_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
   llm: 'portkey/openai/gpt-4o'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Portkey CLI Usage](/docs/js/providers/portkey-cli)
+<CardGroup cols={2}>
+  <Card title="Portkey CLI Usage" icon="terminal" href="/docs/js/providers/portkey-cli">
+    Portkey CLI Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/qwen-cli.mdx
+++ b/docs/js/providers/qwen-cli.mdx
@@ -28,4 +28,8 @@ praisonai-ts providers doctor dashscope
 
 ## Related
 
-- [Qwen Code Usage](/docs/js/providers/qwen-code)
+<CardGroup cols={2}>
+  <Card title="Qwen Code Usage" icon="book" href="/docs/js/providers/qwen-code">
+    Qwen Code Usage
+  </Card>
+</CardGroup>

--- a/docs/js/providers/qwen-code.mdx
+++ b/docs/js/providers/qwen-code.mdx
@@ -16,6 +16,8 @@ export DASHSCOPE_API_KEY=...
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```typescript
 import { Agent } from 'praisonai';
 
@@ -25,7 +27,16 @@ const agent = new Agent({
   llm: 'qwen/qwen-turbo'
 });
 ```
+</Step>
+<Step title="With Configuration">
+Adjust provider credentials and model settings for production — see the sections above.
+</Step>
+</Steps>
 
 ## Related
 
-- [Qwen CLI Usage](/docs/js/providers/qwen-cli)
+<CardGroup cols={2}>
+  <Card title="Qwen CLI Usage" icon="terminal" href="/docs/js/providers/qwen-cli">
+    Qwen CLI Usage
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Applies mechanical §9 reference layout to 20 JS provider pages (mistral through qwen): Steps on Quick Start for -code pages, CardGroup on Related sections.
- Part of #648 (AGENTS.md reference-pages rollout); no docs/concepts/ changes.

## Test plan
- [ ] Mintlify build passes
- [ ] Spot-check mistral-code.mdx and openai-cli.mdx (multi-card Related) render correctly

Refs #648