### PR TITLE
docs(tools/external): §9 batch 9 — hackernews through sqlite

### DIFF
--- a/docs/tools/external/hackernews.mdx
+++ b/docs/tools/external/hackernews.mdx
@@ -18,6 +18,8 @@ No API key required!
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import HackerNewsTool
 
@@ -28,6 +30,13 @@ hn = HackerNewsTool()
 stories = hn.get_top_stories(limit=5)
 print(stories)
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -129,6 +138,14 @@ else:
 
 ## Related Tools
 
-- [Reddit](/docs/tools/external/reddit) - Reddit discussions
-- [ArXiv](/docs/tools/external/arxiv) - Academic papers
-- [DuckDuckGo](/docs/tools/external/duckduckgo) - Web search
+<CardGroup cols={2}>
+  <Card title="Reddit" icon="book" href="/docs/tools/external/reddit">
+    Reddit discussions
+  </Card>
+  <Card title="ArXiv" icon="book" href="/docs/tools/external/arxiv">
+    Academic papers
+  </Card>
+  <Card title="DuckDuckGo" icon="book" href="/docs/tools/external/duckduckgo">
+    Web search
+  </Card>
+</CardGroup>

--- a/docs/tools/external/jina-code-interpreter.mdx
+++ b/docs/tools/external/jina-code-interpreter.mdx
@@ -24,3 +24,17 @@ coder_agent = Agent(instructions="""word = "strawberry"
 agents = AgentTeam(agents=[coder_agent])
 agents.start()
 ```
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+

--- a/docs/tools/external/jina-search.mdx
+++ b/docs/tools/external/jina-search.mdx
@@ -38,3 +38,17 @@ agents.start()
 ```
 
 Register on Jina Generate your JinaSearch API key from [Jina Platform](https://jina.ai/api-dashboard/key-manager)
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+

--- a/docs/tools/external/jina.mdx
+++ b/docs/tools/external/jina.mdx
@@ -24,6 +24,8 @@ Get your API key from [Jina AI](https://jina.ai/).
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import JinaTool
 
@@ -34,6 +36,13 @@ jina = JinaTool()
 content = jina.read("https://example.com")
 print(content)
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -137,6 +146,14 @@ else:
 
 ## Related Tools
 
-- [Firecrawl](/docs/tools/external/firecrawl) - Web scraping API
-- [Crawl4AI](/docs/tools/external/crawl4ai) - Open-source crawler
-- [Trafilatura](/docs/tools/external/trafilatura) - Content extraction
+<CardGroup cols={2}>
+  <Card title="Firecrawl" icon="book" href="/docs/tools/external/firecrawl">
+    Web scraping API
+  </Card>
+  <Card title="Crawl4AI" icon="book" href="/docs/tools/external/crawl4ai">
+    Open-source crawler
+  </Card>
+  <Card title="Trafilatura" icon="book" href="/docs/tools/external/trafilatura">
+    Content extraction
+  </Card>
+</CardGroup>

--- a/docs/tools/external/json.mdx
+++ b/docs/tools/external/json.mdx
@@ -16,6 +16,8 @@ pip install "praisonai[tools]"
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import JSONTool
 
@@ -26,6 +28,13 @@ json_tool = JSONTool()
 data = json_tool.read("config.json")
 print(data)
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -74,5 +83,11 @@ result = json_tool.query("data.json", ".users[0].name")
 
 ## Related Tools
 
-- [CSV](/docs/tools/external/csv) - CSV files
-- [File](/docs/tools/external/file) - General files
+<CardGroup cols={2}>
+  <Card title="CSV" icon="book" href="/docs/tools/external/csv">
+    CSV files
+  </Card>
+  <Card title="File" icon="book" href="/docs/tools/external/file">
+    General files
+  </Card>
+</CardGroup>

--- a/docs/tools/external/linear.mdx
+++ b/docs/tools/external/linear.mdx
@@ -7,6 +7,21 @@ icon: "list-check"
 
 Linear tools provide comprehensive issue management capabilities through Linear's GraphQL API, enabling agents to search, create, update, and comment on issues across teams.
 
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Set `LINEAR_OAUTH_TOKEN` or `LINEAR_API_KEY` (see **Authentication** below)
+2. Create an agent with Linear tool names (e.g. `linear_search_issues`)
+3. Run a prompt — see **Complete Linear Agent Example** below
+</Step>
+<Step title="With Configuration">
+Use OAuth or API key precedence from **Authentication**, and combine tools from **Issue Management** and **Team and Workflow**.
+</Step>
+</Steps>
+
+---
+
 ## Authentication
 
 Linear tools support both OAuth tokens and personal API keys with automatic precedence:
@@ -302,10 +317,7 @@ result = agent.start("Get issue INVALID-123")  # Will suggest search instead
 <Card title="GitHub Tools" icon="github" href="/docs/tools/external/github">
   Combine with GitHub for complete workflows
 </Card>
-<Card title="Tool Profiles" icon="wrench" href="/docs/concepts/tools">
-  Organize tools into reusable profiles
-</Card>
-<Card title="Agent Configuration" icon="gear" href="/docs/concepts/agents">
-  Agent setup and tool selection
+<Card title="Jira" icon="book" href="/docs/tools/external/jira">
+  Project management
 </Card>
 </CardGroup>

--- a/docs/tools/external/mongodb.mdx
+++ b/docs/tools/external/mongodb.mdx
@@ -23,6 +23,8 @@ export MONGODB_DATABASE=mydb
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import MongoDBTool
 
@@ -36,6 +38,13 @@ mongo = MongoDBTool(
 results = mongo.find("users", {"active": True})
 print(results)
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -118,6 +127,14 @@ docker run -d --name mongodb \
 
 ## Related Tools
 
-- [PostgreSQL](/docs/tools/external/postgres) - SQL database
-- [Redis](/docs/tools/external/redis) - Key-value store
-- [DynamoDB](/docs/tools/external/dynamodb) - AWS NoSQL
+<CardGroup cols={2}>
+  <Card title="PostgreSQL" icon="book" href="/docs/tools/external/postgres">
+    SQL database
+  </Card>
+  <Card title="Redis" icon="book" href="/docs/tools/external/redis">
+    Key-value store
+  </Card>
+  <Card title="DynamoDB" icon="book" href="/docs/tools/external/dynamodb">
+    AWS NoSQL
+  </Card>
+</CardGroup>

--- a/docs/tools/external/mysql.mdx
+++ b/docs/tools/external/mysql.mdx
@@ -26,6 +26,8 @@ export MYSQL_PASSWORD=your_password
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import MySQLTool
 
@@ -41,6 +43,13 @@ mysql = MySQLTool(
 results = mysql.query("SELECT * FROM users LIMIT 5")
 print(results)
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -114,6 +123,14 @@ docker run -d --name mysql \
 
 ## Related Tools
 
-- [PostgreSQL](/docs/tools/external/postgres) - PostgreSQL database
-- [SQLite](/docs/tools/external/sqlite) - SQLite database
-- [MongoDB](/docs/tools/external/mongodb) - NoSQL database
+<CardGroup cols={2}>
+  <Card title="PostgreSQL" icon="book" href="/docs/tools/external/postgres">
+    PostgreSQL database
+  </Card>
+  <Card title="SQLite" icon="book" href="/docs/tools/external/sqlite">
+    SQLite database
+  </Card>
+  <Card title="MongoDB" icon="book" href="/docs/tools/external/mongodb">
+    NoSQL database
+  </Card>
+</CardGroup>

--- a/docs/tools/external/notion.mdx
+++ b/docs/tools/external/notion.mdx
@@ -24,6 +24,8 @@ Get your token from [Notion Integrations](https://www.notion.so/my-integrations)
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import NotionTool
 
@@ -34,6 +36,13 @@ notion = NotionTool()
 results = notion.search("meeting notes")
 print(results)
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -94,6 +103,14 @@ page = notion.get_page("page_id")
 
 ## Related Tools
 
-- [Confluence](/docs/tools/external/confluence) - Atlassian wiki
-- [Google Docs](/docs/tools/external/google-drive) - Google Docs
-- [Trello](/docs/tools/external/trello) - Task management
+<CardGroup cols={2}>
+  <Card title="Confluence" icon="book" href="/docs/tools/external/confluence">
+    Atlassian wiki
+  </Card>
+  <Card title="Google Docs" icon="book" href="/docs/tools/external/google-drive">
+    Google Docs
+  </Card>
+  <Card title="Trello" icon="book" href="/docs/tools/external/trello">
+    Task management
+  </Card>
+</CardGroup>

--- a/docs/tools/external/postgres.mdx
+++ b/docs/tools/external/postgres.mdx
@@ -26,6 +26,8 @@ export POSTGRES_PASSWORD=your_password
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import PostgresTool
 
@@ -41,6 +43,13 @@ pg = PostgresTool(
 results = pg.query("SELECT * FROM users LIMIT 5")
 print(results)
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -170,6 +179,14 @@ else:
 
 ## Related Tools
 
-- [MySQL](/docs/tools/external/mysql) - MySQL database
-- [SQLite](/docs/tools/external/sqlite) - SQLite database
-- [MongoDB](/docs/tools/external/mongodb) - NoSQL database
+<CardGroup cols={2}>
+  <Card title="MySQL" icon="book" href="/docs/tools/external/mysql">
+    MySQL database
+  </Card>
+  <Card title="SQLite" icon="book" href="/docs/tools/external/sqlite">
+    SQLite database
+  </Card>
+  <Card title="MongoDB" icon="book" href="/docs/tools/external/mongodb">
+    NoSQL database
+  </Card>
+</CardGroup>

--- a/docs/tools/external/python.mdx
+++ b/docs/tools/external/python.mdx
@@ -16,6 +16,8 @@ pip install "praisonai[tools]"
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import PythonTool
 
@@ -26,6 +28,13 @@ python = PythonTool()
 result = python.execute("print(2 + 2)")
 print(result)
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -65,5 +74,11 @@ print(math.factorial(10))
 
 ## Related Tools
 
-- [Shell](/docs/tools/external/shell) - Shell commands
-- [Calculator](/docs/tools/external/calculator) - Math calculations
+<CardGroup cols={2}>
+  <Card title="Shell" icon="book" href="/docs/tools/external/shell">
+    Shell commands
+  </Card>
+  <Card title="Calculator" icon="book" href="/docs/tools/external/calculator">
+    Math calculations
+  </Card>
+</CardGroup>

--- a/docs/tools/external/qdrant.mdx
+++ b/docs/tools/external/qdrant.mdx
@@ -23,6 +23,8 @@ export QDRANT_API_KEY=your_api_key  # Optional for cloud
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import QdrantTool
 
@@ -33,6 +35,13 @@ qdrant = QdrantTool(url="http://localhost:6333")
 results = qdrant.search("products", query_vector=[0.1, 0.2, ...], limit=5)
 print(results)
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -101,6 +110,14 @@ docker run -d --name qdrant \
 
 ## Related Tools
 
-- [Pinecone](/docs/tools/external/pinecone) - Managed vector DB
-- [Chroma](/docs/tools/external/chroma) - Open-source vector DB
-- [Weaviate](/docs/tools/external/weaviate) - Vector search engine
+<CardGroup cols={2}>
+  <Card title="Pinecone" icon="book" href="/docs/tools/external/pinecone">
+    Managed vector DB
+  </Card>
+  <Card title="Chroma" icon="book" href="/docs/tools/external/chroma">
+    Open-source vector DB
+  </Card>
+  <Card title="Weaviate" icon="book" href="/docs/tools/external/weaviate">
+    Vector search engine
+  </Card>
+</CardGroup>

--- a/docs/tools/external/redis.mdx
+++ b/docs/tools/external/redis.mdx
@@ -24,6 +24,8 @@ export REDIS_PASSWORD=your_password  # Optional
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import RedisTool
 
@@ -35,6 +37,13 @@ redis.set("key", "value")
 value = redis.get("key")
 print(value)
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -118,6 +127,14 @@ docker run -d --name redis \
 
 ## Related Tools
 
-- [MongoDB](/docs/tools/external/mongodb) - NoSQL database
-- [PostgreSQL](/docs/tools/external/postgres) - SQL database
-- [Upstash](/docs/tools/external/upstash) - Serverless Redis
+<CardGroup cols={2}>
+  <Card title="MongoDB" icon="book" href="/docs/tools/external/mongodb">
+    NoSQL database
+  </Card>
+  <Card title="PostgreSQL" icon="book" href="/docs/tools/external/postgres">
+    SQL database
+  </Card>
+  <Card title="Upstash" icon="book" href="/docs/tools/external/upstash">
+    Serverless Redis
+  </Card>
+</CardGroup>

--- a/docs/tools/external/searchapi-search.mdx
+++ b/docs/tools/external/searchapi-search.mdx
@@ -22,3 +22,17 @@ editor_agent = Agent(instructions="Analyze the data and derive insights")
 agents = AgentTeam(agents=[data_agent, editor_agent])
 agents.start()
 ```
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+

--- a/docs/tools/external/serp-api.mdx
+++ b/docs/tools/external/serp-api.mdx
@@ -24,3 +24,17 @@ editor_agent = Agent(instructions="Write a blog article")
 agents = AgentTeam(agents=[data_agent, editor_agent])
 agents.start()
 ```
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+

--- a/docs/tools/external/serp-search.mdx
+++ b/docs/tools/external/serp-search.mdx
@@ -23,3 +23,17 @@ editor_agent = Agent(instructions="Write a blog article pointing out the jobs mo
 team = AgentTeam(agents=[data_agent, editor_agent])
 team.start()
 ```
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+

--- a/docs/tools/external/serper.mdx
+++ b/docs/tools/external/serper.mdx
@@ -24,6 +24,8 @@ Get your API key from [Serper](https://serper.dev/).
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import SerperTool
 
@@ -34,6 +36,13 @@ serper = SerperTool()
 results = serper.search("Python programming tutorials")
 print(results)
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -140,6 +149,14 @@ else:
 
 ## Related Tools
 
-- [Tavily](/docs/tools/external/tavily) - AI-powered search
-- [DuckDuckGo](/docs/tools/external/duckduckgo) - Privacy-focused search
-- [Exa](/docs/tools/external/exa) - Neural search
+<CardGroup cols={2}>
+  <Card title="Tavily" icon="book" href="/docs/tools/external/tavily">
+    AI-powered search
+  </Card>
+  <Card title="DuckDuckGo" icon="book" href="/docs/tools/external/duckduckgo">
+    Privacy-focused search
+  </Card>
+  <Card title="Exa" icon="book" href="/docs/tools/external/exa">
+    Neural search
+  </Card>
+</CardGroup>

--- a/docs/tools/external/shell.mdx
+++ b/docs/tools/external/shell.mdx
@@ -16,6 +16,8 @@ pip install "praisonai[tools]"
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import ShellTool
 
@@ -26,6 +28,13 @@ shell = ShellTool()
 result = shell.execute("ls -la")
 print(result)
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -72,5 +81,11 @@ result = shell.execute("echo 'Hello World'")
 
 ## Related Tools
 
-- [Python](/docs/tools/external/python) - Execute Python code
-- [Docker](/docs/tools/external/docker) - Container management
+<CardGroup cols={2}>
+  <Card title="Python" icon="book" href="/docs/tools/external/python">
+    Execute Python code
+  </Card>
+  <Card title="Docker" icon="book" href="/docs/tools/external/docker">
+    Container management
+  </Card>
+</CardGroup>

--- a/docs/tools/external/slack.mdx
+++ b/docs/tools/external/slack.mdx
@@ -23,6 +23,8 @@ export SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...  # Optional
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import SlackTool
 
@@ -32,6 +34,13 @@ slack = SlackTool()
 # Send message
 slack.send_message("#general", "Hello from PraisonAI!")
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -88,6 +97,14 @@ messages = slack.get_history("#general", limit=20)
 
 ## Related Tools
 
-- [Discord](/docs/tools/external/discord) - Discord messaging
-- [Telegram](/docs/tools/external/telegram) - Telegram bot
-- [Email](/docs/tools/external/email) - Email notifications
+<CardGroup cols={2}>
+  <Card title="Discord" icon="book" href="/docs/tools/external/discord">
+    Discord messaging
+  </Card>
+  <Card title="Telegram" icon="book" href="/docs/tools/external/telegram">
+    Telegram bot
+  </Card>
+  <Card title="Email" icon="book" href="/docs/tools/external/email">
+    Email notifications
+  </Card>
+</CardGroup>

--- a/docs/tools/external/sqlite.mdx
+++ b/docs/tools/external/sqlite.mdx
@@ -18,6 +18,8 @@ No additional dependencies required - SQLite is built into Python!
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import SQLiteTool
 
@@ -28,6 +30,13 @@ sqlite = SQLiteTool(path="mydata.db")
 results = sqlite.query("SELECT * FROM users LIMIT 5")
 print(results)
 ```
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+
+
 
 ## Usage with Agent
 
@@ -128,6 +137,14 @@ else:
 
 ## Related Tools
 
-- [PostgreSQL](/docs/tools/external/postgres) - PostgreSQL database
-- [MySQL](/docs/tools/external/mysql) - MySQL database
-- [DuckDB](/docs/tools/external/duckdb) - Analytics database
+<CardGroup cols={2}>
+  <Card title="PostgreSQL" icon="book" href="/docs/tools/external/postgres">
+    PostgreSQL database
+  </Card>
+  <Card title="MySQL" icon="book" href="/docs/tools/external/mysql">
+    MySQL database
+  </Card>
+  <Card title="DuckDB" icon="book" href="/docs/tools/external/duckdb">
+    Analytics database
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Mechanical §9 for 20 `docs/tools/external/*.mdx` files alphabetically after `google-trends.mdx` (hackernews → sqlite).
- `<Steps>` on **Quick Start** / **Getting Started**; **Related Tools** bullet lists → `<CardGroup>`.
- Removed `docs/concepts/` links from `linear.mdx` Related (no other `docs/concepts/` edits).

Refs #648

## Test plan
- [ ] Mintlify preview renders Steps and CardGroup on sample pages (hackernews, linear, serp-api)
- [ ] No links to `docs/concepts/` introduced in this batch


Made with [Cursor](https://cursor.com)