### PR TITLE
docs(tools/external): §9 batch 10 — final external sweep

### DIFF
--- a/docs/tools/external/agentql-toolkit.mdx
+++ b/docs/tools/external/agentql-toolkit.mdx
@@ -58,3 +58,17 @@ Use the same tool with an agent — see **Usage with Agent** below, or pass env 
 </Step>
 </Steps>
 
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Firecrawl" icon="book" href="/docs/tools/external/firecrawl">
+    Web scraping
+  </Card>
+  <Card title="Crawl4AI" icon="book" href="/docs/tools/external/crawl4ai">
+    AI web crawler
+  </Card>
+  <Card title="GitHub" icon="book" href="/docs/tools/external/github">
+    Repository automation
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/azure-code-interpreter.mdx
+++ b/docs/tools/external/azure-code-interpreter.mdx
@@ -26,3 +26,31 @@ coder_agent = Agent(instructions="""word = "strawberry"
 agents = AgentTeam(agents=[coder_agent])
 agents.start()
 ```
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Python" icon="book" href="/docs/tools/external/python">
+    Run Python code
+  </Card>
+  <Card title="Shell" icon="book" href="/docs/tools/external/shell">
+    Shell commands
+  </Card>
+  <Card title="Bearly Code Interpreter" icon="book" href="/docs/tools/external/bearly-code-interpreter">
+    Cloud code execution
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/bearly-code-interpreter.mdx
+++ b/docs/tools/external/bearly-code-interpreter.mdx
@@ -23,3 +23,31 @@ coder_agent = Agent(instructions="""for i in range(0,10):
 agents = AgentTeam(agents=[coder_agent])
 agents.start()
 ```
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Python" icon="book" href="/docs/tools/external/python">
+    Run Python code
+  </Card>
+  <Card title="Azure Code Interpreter" icon="book" href="/docs/tools/external/azure-code-interpreter">
+    Azure sessions runtime
+  </Card>
+  <Card title="Jina Code Interpreter" icon="book" href="/docs/tools/external/jina-code-interpreter">
+    Riza Python execution
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/brave-search.mdx
+++ b/docs/tools/external/brave-search.mdx
@@ -36,3 +36,31 @@ agents.start()
 ```
 
 Generate your BraveSearch API key from [BraveSearch](https://brave.com/search/api/)
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="DuckDuckGo" icon="book" href="/docs/tools/external/duckduckgo">
+    Privacy-focused search
+  </Card>
+  <Card title="Tavily" icon="book" href="/docs/tools/external/tavily">
+    AI-powered search
+  </Card>
+  <Card title="Serper" icon="book" href="/docs/tools/external/serper">
+    Google search API
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/duckduckgo-search.mdx
+++ b/docs/tools/external/duckduckgo-search.mdx
@@ -22,3 +22,31 @@ editor_agent = Agent(instructions="Write a scientifically researched outcome and
 agents = AgentTeam(agents=[data_agent, editor_agent])
 agents.start()
 ```
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Tavily" icon="book" href="/docs/tools/external/tavily">
+    AI-powered search
+  </Card>
+  <Card title="Brave Search" icon="book" href="/docs/tools/external/brave-search">
+    Brave Search API
+  </Card>
+  <Card title="Serper" icon="book" href="/docs/tools/external/serper">
+    Google search API
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/exa-search.mdx
+++ b/docs/tools/external/exa-search.mdx
@@ -33,3 +33,31 @@ editor_agent = Agent(instructions="Curate the available jobs at startups and the
 agents = AgentTeam(agents=[data_agent, editor_agent], process='hierarchical')
 agents.start()
 ```
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Exa" icon="book" href="/docs/tools/external/exa">
+    Neural search (praisonai-tools)
+  </Card>
+  <Card title="Tavily" icon="book" href="/docs/tools/external/tavily">
+    AI-powered search
+  </Card>
+  <Card title="Serper" icon="book" href="/docs/tools/external/serper">
+    Google search API
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/google-search.mdx
+++ b/docs/tools/external/google-search.mdx
@@ -30,3 +30,31 @@ agents.start()
 Generate your GoogleSearch API key from Google CloudConsole by clicking on [Create Credentials](https://console.cloud.google.com/apis/credentials)
 To get a CSE ID, Create a Google Programmable Search Engine [here](https://programmablesearchengine.google.com/)
 From the Overview of your newly created search engine copy the "Search engine ID"
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Serper" icon="book" href="/docs/tools/external/serper">
+    Google search API
+  </Card>
+  <Card title="Google Serper Search" icon="book" href="/docs/tools/external/google-serper-search">
+    LangChain Serper wrapper
+  </Card>
+  <Card title="Tavily" icon="book" href="/docs/tools/external/tavily">
+    AI-powered search
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/google-serper-search.mdx
+++ b/docs/tools/external/google-serper-search.mdx
@@ -31,3 +31,31 @@ editor_agent = Agent(instructions="List out the websites with their url and a sh
 agents = AgentTeam(agents=[data_agent, editor_agent])
 agents.start()
 ```
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Serper" icon="book" href="/docs/tools/external/serper">
+    Google search API
+  </Card>
+  <Card title="Google Search" icon="book" href="/docs/tools/external/google-search">
+    LangChain Google search
+  </Card>
+  <Card title="Serp Search" icon="book" href="/docs/tools/external/serp-search">
+    SerpAPI wrapper
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/google-trends.mdx
+++ b/docs/tools/external/google-trends.mdx
@@ -32,3 +32,31 @@ summarise_agent = Agent(
 agents = AgentTeam(agents=[research_agent, summarise_agent])
 agents.start()
 ```
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Serp Search" icon="book" href="/docs/tools/external/serp-search">
+    SerpAPI search
+  </Card>
+  <Card title="Google Search" icon="book" href="/docs/tools/external/google-search">
+    LangChain Google search
+  </Card>
+  <Card title="Tavily" icon="book" href="/docs/tools/external/tavily">
+    AI-powered search
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/jina-code-interpreter.mdx
+++ b/docs/tools/external/jina-code-interpreter.mdx
@@ -38,3 +38,17 @@ Use the same tool with an agent — see the **Overview** example, or pass env va
 </Step>
 </Steps>
 
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Python" icon="book" href="/docs/tools/external/python">
+    Run Python code
+  </Card>
+  <Card title="Bearly Code Interpreter" icon="book" href="/docs/tools/external/bearly-code-interpreter">
+    Cloud code execution
+  </Card>
+  <Card title="Azure Code Interpreter" icon="book" href="/docs/tools/external/azure-code-interpreter">
+    Azure sessions runtime
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/jina-search.mdx
+++ b/docs/tools/external/jina-search.mdx
@@ -52,3 +52,17 @@ Use the same tool with an agent — see the **Overview** example, or pass env va
 </Step>
 </Steps>
 
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Jina" icon="book" href="/docs/tools/external/jina">
+    Jina tools
+  </Card>
+  <Card title="Tavily" icon="book" href="/docs/tools/external/tavily">
+    AI-powered search
+  </Card>
+  <Card title="Exa" icon="book" href="/docs/tools/external/exa">
+    Neural search
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/searchapi-search.mdx
+++ b/docs/tools/external/searchapi-search.mdx
@@ -36,3 +36,17 @@ Use the same tool with an agent — see the **Overview** example, or pass env va
 </Step>
 </Steps>
 
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Serp Search" icon="book" href="/docs/tools/external/serp-search">
+    SerpAPI wrapper
+  </Card>
+  <Card title="Google Search" icon="book" href="/docs/tools/external/google-search">
+    LangChain Google search
+  </Card>
+  <Card title="Tavily" icon="book" href="/docs/tools/external/tavily">
+    AI-powered search
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/serp-api.mdx
+++ b/docs/tools/external/serp-api.mdx
@@ -38,3 +38,17 @@ Use the same tool with an agent — see the **Overview** example, or pass env va
 </Step>
 </Steps>
 
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Serp Search" icon="book" href="/docs/tools/external/serp-search">
+    SerpAPI wrapper
+  </Card>
+  <Card title="Google Search" icon="book" href="/docs/tools/external/google-search">
+    LangChain Google search
+  </Card>
+  <Card title="Serper" icon="book" href="/docs/tools/external/serper">
+    Google search API
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/serp-search.mdx
+++ b/docs/tools/external/serp-search.mdx
@@ -37,3 +37,17 @@ Use the same tool with an agent — see the **Overview** example, or pass env va
 </Step>
 </Steps>
 
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Serp API" icon="book" href="/docs/tools/external/serp-api">
+    SerpAPI tool page
+  </Card>
+  <Card title="Google Trends" icon="book" href="/docs/tools/external/google-trends">
+    Google Trends
+  </Card>
+  <Card title="Serper" icon="book" href="/docs/tools/external/serper">
+    Google search API
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/surrealdb.mdx
+++ b/docs/tools/external/surrealdb.mdx
@@ -472,11 +472,23 @@ LIVE SELECT * FROM users;
 
 ## Related Tools
 
-- [PostgreSQL](/docs/tools/external/postgres) - Relational database
-- [MongoDB](/docs/tools/external/mongodb) - Document database  
-- [Redis](/docs/tools/external/redis) - Key-value store
-- [MySQL](/docs/tools/external/mysql) - Relational database
-- [SQLite](/docs/tools/external/sqlite) - Embedded database
+<CardGroup cols={2}>
+  <Card title="PostgreSQL" icon="book" href="/docs/tools/external/postgres">
+    Relational database
+  </Card>
+  <Card title="MongoDB" icon="book" href="/docs/tools/external/mongodb">
+    Document database
+  </Card>
+  <Card title="Redis" icon="book" href="/docs/tools/external/redis">
+    Key-value store
+  </Card>
+  <Card title="MySQL" icon="book" href="/docs/tools/external/mysql">
+    Relational database
+  </Card>
+  <Card title="SQLite" icon="book" href="/docs/tools/external/sqlite">
+    Embedded database
+  </Card>
+</CardGroup>
 
 ## Best Practices
 

--- a/docs/tools/external/tavily-search.mdx
+++ b/docs/tools/external/tavily-search.mdx
@@ -33,3 +33,31 @@ editor_agent = Agent(instructions="Analyze the data and rank the tools based on 
 agents = AgentTeam(agents=[data_agent, editor_agent])
 agents.start()
 ```
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Tavily" icon="book" href="/docs/tools/external/tavily">
+    Tavily tool (praisonai-tools)
+  </Card>
+  <Card title="Exa Search" icon="book" href="/docs/tools/external/exa-search">
+    Exa LangChain integration
+  </Card>
+  <Card title="DuckDuckGo" icon="book" href="/docs/tools/external/duckduckgo">
+    Privacy-focused search
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/tavily.mdx
+++ b/docs/tools/external/tavily.mdx
@@ -24,6 +24,8 @@ Get your API key from [Tavily](https://tavily.com/).
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import TavilyTool
 
@@ -34,8 +36,12 @@ tavily = TavilyTool()
 results = tavily.search("What is quantum computing?")
 print(results)
 ```
-
-## Usage with Agent
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+ Usage with Agent
 
 ```python
 from praisonaiagents import Agent
@@ -145,6 +151,14 @@ else:
 
 ## Related Tools
 
-- [Exa Search](/docs/tools/external/exa) - Neural search engine
-- [DuckDuckGo](/docs/tools/external/duckduckgo) - Privacy-focused search
-- [Serper](/docs/tools/external/serper) - Google search API
+<CardGroup cols={2}>
+  <Card title="Exa Search" icon="book" href="/docs/tools/external/exa">
+    Neural search engine
+  </Card>
+  <Card title="DuckDuckGo" icon="book" href="/docs/tools/external/duckduckgo">
+    Privacy-focused search
+  </Card>
+  <Card title="Serper" icon="book" href="/docs/tools/external/serper">
+    Google search API
+  </Card>
+</CardGroup>

--- a/docs/tools/external/telegram.mdx
+++ b/docs/tools/external/telegram.mdx
@@ -25,6 +25,8 @@ Get your bot token from [@BotFather](https://t.me/botfather).
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import TelegramTool
 
@@ -34,8 +36,12 @@ telegram = TelegramTool()
 # Send message
 telegram.send_message("123456789", "Hello from PraisonAI!")
 ```
-
-## Usage with Agent
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+ Usage with Agent
 
 ```python
 from praisonaiagents import Agent
@@ -86,6 +92,14 @@ telegram.send_photo("123456789", "https://example.com/image.jpg", "Check this ou
 
 ## Related Tools
 
-- [Slack](/docs/tools/external/slack) - Slack messaging
-- [Discord](/docs/tools/external/discord) - Discord messaging
-- [WhatsApp](/docs/tools/external/whatsapp) - WhatsApp messaging
+<CardGroup cols={2}>
+  <Card title="Slack" icon="book" href="/docs/tools/external/slack">
+    Slack messaging
+  </Card>
+  <Card title="Discord" icon="book" href="/docs/tools/external/discord">
+    Discord messaging
+  </Card>
+  <Card title="WhatsApp" icon="book" href="/docs/tools/external/whatsapp">
+    WhatsApp messaging
+  </Card>
+</CardGroup>

--- a/docs/tools/external/weather.mdx
+++ b/docs/tools/external/weather.mdx
@@ -24,6 +24,8 @@ export WEATHERAPI_KEY=your_api_key
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import WeatherTool
 
@@ -34,8 +36,12 @@ weather = WeatherTool()
 result = weather.get_weather("London")
 print(result)
 ```
-
-## Usage with Agent
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+ Usage with Agent
 
 ```python
 from praisonaiagents import Agent
@@ -89,4 +95,8 @@ aqi = weather.get_air_quality("Beijing")
 
 ## Related Tools
 
-- [Google Maps](/docs/tools/external/google-maps) - Location services
+<CardGroup cols={2}>
+  <Card title="Google Maps" icon="book" href="/docs/tools/external/google-maps">
+    Location services
+  </Card>
+</CardGroup>

--- a/docs/tools/external/wikipedia-search.mdx
+++ b/docs/tools/external/wikipedia-search.mdx
@@ -22,3 +22,31 @@ summarise_agent = Agent(instructions="Summarize the data into a well structured 
 agents = AgentTeam(agents=[data_agent, summarise_agent])
 agents.start()
 ```
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Wikipedia" icon="book" href="/docs/tools/external/wikipedia">
+    Wikipedia tool
+  </Card>
+  <Card title="Tavily" icon="book" href="/docs/tools/external/tavily">
+    AI-powered search
+  </Card>
+  <Card title="ArXiv" icon="book" href="/docs/tools/external/arxiv">
+    Academic papers
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/wikipedia.mdx
+++ b/docs/tools/external/wikipedia.mdx
@@ -18,6 +18,8 @@ No API key required!
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import WikipediaTool
 
@@ -28,8 +30,12 @@ wiki = WikipediaTool()
 results = wiki.search("Python programming")
 print(results)
 ```
-
-## Usage with Agent
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+ Usage with Agent
 
 ```python
 from praisonaiagents import Agent
@@ -154,6 +160,14 @@ Use ISO language codes:
 
 ## Related Tools
 
-- [ArXiv](/docs/tools/external/arxiv) - Academic papers
-- [PubMed](/docs/tools/external/pubmed) - Medical research
-- [HackerNews](/docs/tools/external/hackernews) - Tech news
+<CardGroup cols={2}>
+  <Card title="ArXiv" icon="book" href="/docs/tools/external/arxiv">
+    Academic papers
+  </Card>
+  <Card title="PubMed" icon="book" href="/docs/tools/external/pubmed">
+    Medical research
+  </Card>
+  <Card title="HackerNews" icon="book" href="/docs/tools/external/hackernews">
+    Tech news
+  </Card>
+</CardGroup>

--- a/docs/tools/external/you-search.mdx
+++ b/docs/tools/external/you-search.mdx
@@ -23,3 +23,31 @@ editor_agent = Agent(instructions="Breifly describe the weather in Barcelona")
 agents = AgentTeam(agents=[data_agent, editor_agent])
 agents.start()
 ```
+
+## Getting Started
+
+<Steps>
+<Step title="Simple Usage">
+1. Install dependencies (see **Overview** above)
+2. Set required API keys in your environment
+3. Run the agent example in **Overview**
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see the **Overview** example, or pass env vars from the sections above.
+</Step>
+</Steps>
+
+## Related Tools
+
+<CardGroup cols={2}>
+  <Card title="Tavily" icon="book" href="/docs/tools/external/tavily">
+    AI-powered search
+  </Card>
+  <Card title="Exa" icon="book" href="/docs/tools/external/exa">
+    Neural search
+  </Card>
+  <Card title="Serper" icon="book" href="/docs/tools/external/serper">
+    Google search API
+  </Card>
+</CardGroup>
+

--- a/docs/tools/external/youtube.mdx
+++ b/docs/tools/external/youtube.mdx
@@ -22,6 +22,8 @@ export YOUTUBE_API_KEY=your_api_key  # Optional for basic features
 
 ## Quick Start
 
+<Steps>
+<Step title="Simple Usage">
 ```python
 from praisonai_tools import YouTubeTool
 
@@ -32,8 +34,12 @@ youtube = YouTubeTool()
 results = youtube.search("Python tutorials")
 print(results)
 ```
-
-## Usage with Agent
+</Step>
+<Step title="With Configuration">
+Use the same tool with an agent — see **Usage with Agent** below, or pass env vars and options from the sections above.
+</Step>
+</Steps>
+ Usage with Agent
 
 ```python
 from praisonaiagents import Agent
@@ -88,5 +94,11 @@ transcript = youtube.get_transcript("dQw4w9WgXcQ")
 
 ## Related Tools
 
-- [Spotify](/docs/tools/external/spotify) - Music search
-- [Wikipedia](/docs/tools/external/wikipedia) - Knowledge base
+<CardGroup cols={2}>
+  <Card title="Spotify" icon="book" href="/docs/tools/external/spotify">
+    Music search
+  </Card>
+  <Card title="Wikipedia" icon="book" href="/docs/tools/external/wikipedia">
+    Knowledge base
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Completes mechanical AGENTS.md §9 compliance for the remaining `docs/tools/external/*.mdx` pages (23 files): `<Steps>` on Quick Start / Getting Started and `<CardGroup>` on Related.
- Covers surrealdb→youtube plus stragglers (google-trends, duckduckgo-search, langchain search/interpreter stubs, agentql Related).
- No `docs/concepts/` links in Related cards; no concept page edits.

Refs #648

## Test plan
- [x] Heuristic scan: 0 §9 gaps across 50 external tool pages
- [x] No `/docs/concepts/` hrefs under Related in external corpus
- [ ] Mintlify preview (optional)