### PR TITLE
docs(tools/external): post-#1172 hero and Best Practices stragglers

### DIFF
--- a/docs/tools/external/email.mdx
+++ b/docs/tools/external/email.mdx
@@ -21,6 +21,8 @@ graph LR
     class Tools tools
     class Detect detect
     class AM,SMTP backend
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/tools/external/surrealdb.mdx
+++ b/docs/tools/external/surrealdb.mdx
@@ -31,6 +31,8 @@ graph LR
     class A agent
     class B tool
     class C,D,E,F data
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Installation
@@ -492,11 +494,27 @@ LIVE SELECT * FROM users;
 
 ## Best Practices
 
-1. **Multi-Model Design**: Leverage SurrealDB's multi-model capabilities for complex data
-2. **Namespace Organization**: Use namespaces to separate environments (dev/staging/prod)  
-3. **Security**: Always use authentication in production environments
-4. **Monitoring**: Set up monitoring for query performance and resource usage
-5. **Backup Strategy**: Implement regular backups for persistent storage setups
+<AccordionGroup>
+<Accordion title="Multi-Model Design">
+Leverage SurrealDB's multi-model capabilities for complex data — combine documents, graphs, and relations in one schema instead of forcing everything into a single model.
+</Accordion>
+
+<Accordion title="Namespace Organisation">
+Use namespaces to separate environments (dev, staging, prod) so agents and tools never cross wires between datasets.
+</Accordion>
+
+<Accordion title="Security">
+Always use authentication in production environments; avoid root credentials in agent-facing tools.
+</Accordion>
+
+<Accordion title="Monitoring">
+Set up monitoring for query performance and resource usage, especially when agents run ad hoc SurrealQL.
+</Accordion>
+
+<Accordion title="Backup Strategy">
+Implement regular backups for persistent storage setups before relying on agents for write-heavy workflows.
+</Accordion>
+</AccordionGroup>
 
 ## Community & Support
 

--- a/docs/tools/external/x.mdx
+++ b/docs/tools/external/x.mdx
@@ -22,6 +22,8 @@ graph LR
     class A input
     class B,C process
     class D output
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Adds canonical hero `classDef agent` / `classDef tool` pair (first 100 lines) on `email.mdx`, `x.mdx`, and `surrealdb.mdx`.
- Converts `surrealdb.mdx` **Best Practices** from a numbered list to `<AccordionGroup>`.
- No `docs/concepts/` edits.

Refs #648

## Verification
Mechanical heuristic on `docs/tools/external/` (mermaid hero classDef + Best Practices AccordionGroup):

```
gap count: 0
```

## Test plan
- [x] Heuristic scan: 0 gaps across external tool pages with hero mermaid
- [ ] Mintlify preview (optional)

Made with [Cursor](https://cursor.com)