### PR TITLE
docs(js): canonical hero classDef batch 1 (#648)

### DIFF
--- a/docs/js/advanced/a2a.mdx
+++ b/docs/js/advanced/a2a.mdx
@@ -23,6 +23,8 @@ graph LR
     class A,E agent
     class B,D message
     class C protocol
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/advanced/agui.mdx
+++ b/docs/js/advanced/agui.mdx
@@ -28,6 +28,8 @@ graph LR
     class C agui
     class D agent
     class E response
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/advanced/auto-rag.mdx
+++ b/docs/js/advanced/auto-rag.mdx
@@ -29,6 +29,8 @@ graph LR
     class C,D retrieve
     class E generate
     class F response
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/advanced/conditions.mdx
+++ b/docs/js/advanced/conditions.mdx
@@ -22,6 +22,8 @@ graph LR
     class A context
     class B condition
     class C,D action
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/advanced/config.mdx
+++ b/docs/js/advanced/config.mdx
@@ -24,6 +24,8 @@ graph LR
     class A config
     class B resolver
     class C,D,E,F feature
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/advanced/display.mdx
+++ b/docs/js/advanced/display.mdx
@@ -26,6 +26,8 @@ graph LR
     class B output
     class C callback
     class D,E,F target
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/advanced/embeddings.mdx
+++ b/docs/js/advanced/embeddings.mdx
@@ -25,6 +25,8 @@ graph LR
     class B embed
     class C vector
     class D,E use
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/advanced/gateway.mdx
+++ b/docs/js/advanced/gateway.mdx
@@ -27,6 +27,8 @@ graph LR
     class C bot
     class D agent
     class E response
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/advanced/guardrail-policies.mdx
+++ b/docs/js/advanced/guardrail-policies.mdx
@@ -27,6 +27,8 @@ graph LR
     class C allow
     class D block
     class E warn
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/advanced/plugins.mdx
+++ b/docs/js/advanced/plugins.mdx
@@ -24,6 +24,8 @@ graph LR
     class A plugin
     class B manager
     class C,D,E,F type
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/advanced/singletons.mdx
+++ b/docs/js/advanced/singletons.mdx
@@ -21,6 +21,8 @@ graph LR
     
     class A,B,C,D singleton
     class E state
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/advanced/trace.mdx
+++ b/docs/js/advanced/trace.mdx
@@ -26,6 +26,8 @@ graph LR
     class B events
     class C emitter
     class D,E,F sink
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/agent-cli.mdx
+++ b/docs/js/agent-cli.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Agent agent
     class CLI,User,Out tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/agent-flow.mdx
+++ b/docs/js/agent-flow.mdx
@@ -31,6 +31,8 @@ graph LR
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
     class Input,Output io
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/agent-team.mdx
+++ b/docs/js/agent-team.mdx
@@ -29,6 +29,8 @@ graph LR
     
     class A1,A2,A3 agent
     class Input,Output io
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/agent.mdx
+++ b/docs/js/agent.mdx
@@ -19,6 +19,8 @@ graph LR
     class Agent agent
     class Tools tool
     class User,Out tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/agentos.mdx
+++ b/docs/js/agentos.mdx
@@ -45,6 +45,8 @@ graph LR
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
     class API,Health,Agents endpoint
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/agents-cli.mdx
+++ b/docs/js/agents-cli.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Team agent
     class CLI,User,Out tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/agents.mdx
+++ b/docs/js/agents.mdx
@@ -24,6 +24,8 @@ graph LR
 
     class Team,A1,A2 agent
     class User,Out tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/ai-sdk-cli.mdx
+++ b/docs/js/ai-sdk-cli.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class LLM agent
     class CLI,User,Out tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary

Mechanical §9 hero fix for TypeScript docs: insert canonical `classDef agent` / `classDef tool` lines (no stroke) into the first hero Mermaid block when pages only had stroke-variant definitions.

- **20 files** in `docs/js/` (alphabetical hero-only stragglers from `advanced/a2a` through `ai-sdk-cli`)
- **docs/js section-conditional gaps:** 170 → **150** gap files (328 total MDX)

Refs #648

## Test plan

- [x] Section-conditional heuristic: 0 new gaps on touched files
- [x] No `docs/concepts/` edits
- [ ] Mintlify preview (optional)


Made with [Cursor](https://cursor.com)