### PR TITLE
docs(js): hero classDef batch 3 (citations–events)

### DIFF
--- a/docs/js/citations.mdx
+++ b/docs/js/citations.mdx
@@ -23,6 +23,9 @@ graph LR
     class A source
     class B agent
     class C,D output
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/cli.mdx
+++ b/docs/js/cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Agent agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/computer-use-cli.mdx
+++ b/docs/js/computer-use-cli.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Auto agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/computer-use.mdx
+++ b/docs/js/computer-use.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Agent agent
     class User,Screen tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 

--- a/docs/js/context-manager-cli.mdx
+++ b/docs/js/context-manager-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Ctx agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/context-manager.mdx
+++ b/docs/js/context-manager.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class CM agent
     class Agent,Window tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/criteria.mdx
+++ b/docs/js/criteria.mdx
@@ -24,6 +24,9 @@ graph LR
     class A,B agent
     class C check
     class D,E result
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/customtools.mdx
+++ b/docs/js/customtools.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Agent agent
     class User,Fn tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/database-cli.mdx
+++ b/docs/js/database-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class DB agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/database.mdx
+++ b/docs/js/database.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Agent agent
     class DB,Session tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/deep-research-cli.mdx
+++ b/docs/js/deep-research-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Research agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/deep-research.mdx
+++ b/docs/js/deep-research.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Agent agent
     class Query,Answer tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/development.mdx
+++ b/docs/js/development.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Repo agent
     class Dev,Build tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Development Setup

--- a/docs/js/embeddings-cli.mdx
+++ b/docs/js/embeddings-cli.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Svc agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/embeddings.mdx
+++ b/docs/js/embeddings.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Emb agent
     class Text,Vec tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/eval-results-cli.mdx
+++ b/docs/js/eval-results-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Svc agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/eval-results.mdx
+++ b/docs/js/eval-results.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Res agent
     class Eval,Out tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 Aggregate, analyze, and visualize Agent evaluation results. Track trends, compare runs, and generate reports.

--- a/docs/js/evaluation-cli.mdx
+++ b/docs/js/evaluation-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Svc agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/evaluation.mdx
+++ b/docs/js/evaluation.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Agent,Eval agent
     class Metrics tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 Evaluate your Agents before deploying to production. Test accuracy, measure performance, and verify tool usage. Catch regressions and ensure quality.

--- a/docs/js/events.mdx
+++ b/docs/js/events.mdx
@@ -20,6 +20,9 @@ graph LR
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
     class A agent
     class B,C,D,E tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Adds canonical `classDef agent` and `classDef tool` lines (+2) to the first hero Mermaid on 20 root `docs/js/*.mdx` pages (citations through events), matching #648 / batch 2 pattern.
- Root JS hero gap: **115 → 95** (pages still missing canonical lines in first diagram).

## Pages
citations, cli, computer-use (+ cli), context-manager (+ cli), criteria, customtools, database (+ cli), deep-research (+ cli), development, embeddings (+ cli), eval-results (+ cli), evaluation (+ cli), events.

## Test plan
- [x] Script verified 20 files updated; hero gap count 115 → 95 on `docs/js/*.mdx`
- [ ] Mintlify build (if CI runs)

Refs #648