### PR TITLE
docs(js): hero classDef batch 4 (execution–mcp-security-cli)

### DIFF
--- a/docs/js/execution.mdx
+++ b/docs/js/execution.mdx
@@ -20,6 +20,9 @@ graph LR
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
     class B agent
     class A,C,D,E tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/failover.mdx
+++ b/docs/js/failover.mdx
@@ -19,6 +19,9 @@ graph LR
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
     class B agent
     class A,C,D tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/files.mdx
+++ b/docs/js/files.mdx
@@ -20,6 +20,9 @@ graph LR
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
     class B agent
     class A,C,D,E tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/flow.mdx
+++ b/docs/js/flow.mdx
@@ -21,6 +21,9 @@ graph TB
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
     class B agent
     class A,C,D,E tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/graph-rag.mdx
+++ b/docs/js/graph-rag.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Graph agent
     class Query,Answer tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 

--- a/docs/js/guardrails-cli.mdx
+++ b/docs/js/guardrails-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Svc agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/guardrails.mdx
+++ b/docs/js/guardrails.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Agent,Guard agent
     class Safe tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 Guardrails protect your Agents by validating inputs and outputs. Block harmful content, enforce response formats, and ensure Agent behavior stays within bounds.

--- a/docs/js/handoffs.mdx
+++ b/docs/js/handoffs.mdx
@@ -19,6 +19,9 @@ graph LR
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
     class B agent
     class A,C,D tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/hierarchy-session-cli.mdx
+++ b/docs/js/hierarchy-session-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Svc agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/hierarchy-session.mdx
+++ b/docs/js/hierarchy-session.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Root,Child agent
     class Leaf tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 Create session hierarchies for complex multi-Agent workflows. Child sessions inherit context from parents, enabling scoped conversations and forking.

--- a/docs/js/hooks-manager.mdx
+++ b/docs/js/hooks-manager.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Agent,Hooks agent
     class Ops tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/image-agent-cli.mdx
+++ b/docs/js/image-agent-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Svc agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/image-agent.mdx
+++ b/docs/js/image-agent.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Agent agent
     class Vision tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/jobs.mdx
+++ b/docs/js/jobs.mdx
@@ -20,6 +20,9 @@ graph LR
     
     class C agent
     class A,B,D tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/js.mdx
+++ b/docs/js/js.mdx
@@ -47,6 +47,9 @@ graph LR
 
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     class AgentIcon1,AgentIcon2 agent
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 <Tabs>

--- a/docs/js/knowledge-base-cli.mdx
+++ b/docs/js/knowledge-base-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Svc agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/knowledge-base.mdx
+++ b/docs/js/knowledge-base.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Agent,KB agent
     class Answer tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/llm-guardrail-cli.mdx
+++ b/docs/js/llm-guardrail-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Svc agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/llm-guardrail.mdx
+++ b/docs/js/llm-guardrail.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Agent,Guard agent
     class Safe tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/mcp-security-cli.mdx
+++ b/docs/js/mcp-security-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Svc agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Add canonical `classDef agent` / `classDef tool` lines to the first hero mermaid on 20 root `docs/js/*.mdx` pages from `execution.mdx` through `mcp-security-cli.mdx` (alphabetical batch 4; `loops.mdx` already compliant).
- Matches #648 colour scheme; same +2-line pattern as batches 1–3.

## Test plan
- [x] Verified 20 files updated (+3 lines each including blank line before closing fence)
- [x] Root JS hero gap: **95 → 75** stragglers (76/151 pages with canonical first-hero classDef)
- [ ] Mintlify preview (optional)

Refs #648