### PR TITLE
docs(js): hero classDef batch 5 stragglers (mcp-security → performance-monitor-cli)

### DIFF
--- a/docs/js/mcp-security.mdx
+++ b/docs/js/mcp-security.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class MCP,Sec agent
     class Safe tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/mcp-tools-cli.mdx
+++ b/docs/js/mcp-tools-cli.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Svc agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/mcp-tools.mdx
+++ b/docs/js/mcp-tools.mdx
@@ -27,6 +27,9 @@ graph LR
     class B,D,E transport
     class C detect
     class F result
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/memory-cli.mdx
+++ b/docs/js/memory-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Svc agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/memory-hooks-cli.mdx
+++ b/docs/js/memory-hooks-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Svc agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/memory-hooks.mdx
+++ b/docs/js/memory-hooks.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Mem,Hooks agent
     class Ops tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/memory.mdx
+++ b/docs/js/memory.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Agent,Mem agent
     class Recall tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/multimodal-agent-cli.mdx
+++ b/docs/js/multimodal-agent-cli.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Svc agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/multimodal-agent.mdx
+++ b/docs/js/multimodal-agent.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Agent,MM agent
     class Out tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/nextjs.mdx
+++ b/docs/js/nextjs.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Agent agent
     class User,Next tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/nl-postgres-cli.mdx
+++ b/docs/js/nl-postgres-cli.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class DB agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ```mermaid

--- a/docs/js/nl-postgres.mdx
+++ b/docs/js/nl-postgres.mdx
@@ -16,6 +16,9 @@ graph LR
 
     class Agent agent
     class User,NL tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/nodejs.mdx
+++ b/docs/js/nodejs.mdx
@@ -46,6 +46,9 @@ graph LR
     class Agent1,Agent2 transparent
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 <Tabs>

--- a/docs/js/observability-cli.mdx
+++ b/docs/js/observability-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Obs agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start

--- a/docs/js/observability.mdx
+++ b/docs/js/observability.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Agent agent
     class Obs,Trace tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Supported Observability Tools (14+)

--- a/docs/js/performance-monitor-cli.mdx
+++ b/docs/js/performance-monitor-cli.mdx
@@ -17,6 +17,9 @@ graph LR
 
     class Mon agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Add canonical classDef agent and classDef tool lines to the first hero mermaid on 16 root docs/js pages (alphabetically after mcp-security-cli.mdx, through performance-monitor-cli.mdx).
- Four pages in the batch window already had canonical classDefs (middleware, ocr, optimizer, output).

## Hero gap
- Root docs/js first-mermaid canonical coverage: **75 → 59** (16 fixed this batch).

## Test plan
- [x] Verified only first mermaid block touched per file
- [x] No docs/concepts/ changes
- [x] Same pattern as batch 4 (#1178)

Refs #648
