### PR TITLE
docs(js): hero classDef batch 6 stragglers (performance-monitor → reranking)

### DIFF
--- a/docs/js/performance-monitor.mdx
+++ b/docs/js/performance-monitor.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Agent agent
     class Mon,Metrics tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/planning-cli.mdx
+++ b/docs/js/planning-cli.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Plan agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/planning.mdx
+++ b/docs/js/planning.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class Plan,Done tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/plugins.mdx
+++ b/docs/js/plugins.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class Plugin,Tools tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/postgres.mdx
+++ b/docs/js/postgres.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class PG,Store tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/prompt-expander-cli.mdx
+++ b/docs/js/prompt-expander-cli.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Exp agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/prompt-expander.mdx
+++ b/docs/js/prompt-expander.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class User,Out tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/provider-registry-cli.mdx
+++ b/docs/js/provider-registry-cli.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Reg agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/provider-registry.mdx
+++ b/docs/js/provider-registry.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Provider agent
     class Dev,Reg tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/providers-cli.mdx
+++ b/docs/js/providers-cli.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Prov agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/providers.mdx
+++ b/docs/js/providers.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Agent agent
     class LLM,Response tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Supported Providers (60+)

--- a/docs/js/pubsub.mdx
+++ b/docs/js/pubsub.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Agent agent
     class PubSub,Subscribers tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/query-rewriter-cli.mdx
+++ b/docs/js/query-rewriter-cli.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class CLI agent
     class User,Rewrite tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/query-rewriter.mdx
+++ b/docs/js/query-rewriter.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class Query,Result tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/rag-agent-cli.mdx
+++ b/docs/js/rag-agent-cli.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class User,KB tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/rag-agent.mdx
+++ b/docs/js/rag-agent.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Agent agent
     class User,KB,Response tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/realtime.mdx
+++ b/docs/js/realtime.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Agent agent
     class User,Stream tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/redis.mdx
+++ b/docs/js/redis.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class Redis,Cache tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/reflection.mdx
+++ b/docs/js/reflection.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Agent agent
     class Review,Output tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/reranking.mdx
+++ b/docs/js/reranking.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class Docs,Ranked tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 


### PR DESCRIPTION
## Summary
- Add canonical `classDef agent` / `classDef tool` lines to the first hero mermaid on 20 root `docs/js/*.mdx` pages alphabetically after `performance-monitor-cli.mdx`, through `reranking.mdx`.
- Same +2-line pattern as batches 1–5 (#1175–#1179); no `docs/concepts/` changes.

## Hero gap
- Root `docs/js` first-mermaid canonical coverage: **59 → 39** (20 fixed this batch).

## Test plan
- [x] Verified only first mermaid block touched per file (20 files, +2 lines each)
- [x] No `docs/concepts/` changes
- [x] Matches batch 5 pattern (#1179)

Refs #648