### PR TITLE
docs(js): hero classDef final sweep — 39 root stragglers (#648)

### DIFF
--- a/docs/js/resources.mdx
+++ b/docs/js/resources.mdx
@@ -18,6 +18,8 @@ graph LR
 
     class Agent agent
     class Resource,Output tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/retrieval.mdx
+++ b/docs/js/retrieval.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Agent agent
     class Query,Context tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/router-agent-cli.mdx
+++ b/docs/js/router-agent-cli.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Router agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/router-agent.mdx
+++ b/docs/js/router-agent.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Router agent
     class User,Specialist tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/routing.mdx
+++ b/docs/js/routing.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Router agent
     class User,Specialist tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/sandbox.mdx
+++ b/docs/js/sandbox.mdx
@@ -18,6 +18,8 @@ graph LR
 
     class Agent agent
     class Resource,Output tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/scheduler-cli.mdx
+++ b/docs/js/scheduler-cli.mdx
@@ -15,6 +15,8 @@ graph LR
 
     class Scheduler agent
     class User,CLI tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 # Scheduler CLI (TypeScript)

--- a/docs/js/scheduler.mdx
+++ b/docs/js/scheduler.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class Scheduler,Job tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/security.mdx
+++ b/docs/js/security.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Agent agent
     class Input,Safe tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/server-adapters-cli.mdx
+++ b/docs/js/server-adapters-cli.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Agent agent
     class CLI,HTTP tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/server-adapters.mdx
+++ b/docs/js/server-adapters.mdx
@@ -14,6 +14,8 @@ graph LR
 
     class Agent agent
     class HTTP,Client tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/sessions-cli.mdx
+++ b/docs/js/sessions-cli.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Session agent
     class CLI,User tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/sessions.mdx
+++ b/docs/js/sessions.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Agent agent
     class Session,User tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/skills-cli.mdx
+++ b/docs/js/skills-cli.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Skills agent
     class CLI,User tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/skills.mdx
+++ b/docs/js/skills.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class Skills tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/slackbot-agent-cli.mdx
+++ b/docs/js/slackbot-agent-cli.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Slack agent
     class CLI,User tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/slackbot-agent.mdx
+++ b/docs/js/slackbot-agent.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class Bot,Slack tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/streaming-cli.mdx
+++ b/docs/js/streaming-cli.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Stream agent
     class CLI,User tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 Control streaming behavior when running agents from the command line.

--- a/docs/js/streaming.mdx
+++ b/docs/js/streaming.mdx
@@ -24,6 +24,8 @@ graph LR
     class A agent
     class S stream
     class D output
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/structured-output-cli.mdx
+++ b/docs/js/structured-output-cli.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class JSON agent
     class CLI,User tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/structured-output.mdx
+++ b/docs/js/structured-output.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class Schema,JSON tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 

--- a/docs/js/tasks.mdx
+++ b/docs/js/tasks.mdx
@@ -27,6 +27,8 @@ graph LR
     class B task
     class C agent
     class D output
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/teams.mdx
+++ b/docs/js/teams.mdx
@@ -28,6 +28,8 @@ graph LR
 
     class C agent
     class A,B user
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/telemetry-cli.mdx
+++ b/docs/js/telemetry-cli.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Telemetry agent
     class CLI,User tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/telemetry.mdx
+++ b/docs/js/telemetry.mdx
@@ -15,6 +15,8 @@ graph LR
 
     class Agent agent
     class Telemetry,Analytics tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/template-catalog-cli.mdx
+++ b/docs/js/template-catalog-cli.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Catalog agent
     class CLI,User tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/template-catalog.mdx
+++ b/docs/js/template-catalog.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class Catalog,App tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/token-management.mdx
+++ b/docs/js/token-management.mdx
@@ -29,6 +29,8 @@ graph LR
 
     class Agent agent
     class Token tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/tools-cli.mdx
+++ b/docs/js/tools-cli.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Tools agent
     class CLI,User tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/tools.mdx
+++ b/docs/js/tools.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Agent agent
     class Tools,Action tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/typescript-async.mdx
+++ b/docs/js/typescript-async.mdx
@@ -17,6 +17,8 @@ graph LR
 
     class Agent agent
     class AgentTeam,User tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Installation

--- a/docs/js/typescript.mdx
+++ b/docs/js/typescript.mdx
@@ -46,6 +46,8 @@ graph LR
     class Agent1,Agent2 transparent
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 <Tabs>

--- a/docs/js/vector-store.mdx
+++ b/docs/js/vector-store.mdx
@@ -29,6 +29,8 @@ graph LR
     class R,A output
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/js/vector-stores.mdx
+++ b/docs/js/vector-stores.mdx
@@ -15,6 +15,8 @@ graph LR
 
     class Agent agent
     class User,Output tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 # Vector Stores for Agents

--- a/docs/js/voice-cli.mdx
+++ b/docs/js/voice-cli.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class User,Output tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 # Voice CLI Commands

--- a/docs/js/voice.mdx
+++ b/docs/js/voice.mdx
@@ -15,6 +15,8 @@ graph LR
 
     class Agent agent
     class User,Output tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 # Voice-Enabled Agents

--- a/docs/js/workflow-hooks.mdx
+++ b/docs/js/workflow-hooks.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class User,Output tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 # Workflow Hooks

--- a/docs/js/workflows-cli.mdx
+++ b/docs/js/workflows-cli.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class User,Output tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 # Workflows CLI Commands

--- a/docs/js/workflows.mdx
+++ b/docs/js/workflows.mdx
@@ -16,6 +16,8 @@ graph LR
 
     class Agent agent
     class User,Output tool
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 # Agent Workflows


### PR DESCRIPTION
## Summary
- Adds canonical `classDef agent` / `classDef tool` lines to the first hero mermaid on the remaining 39 root `docs/js/*.mdx` pages (resources → workflows).
- Closes the root hero straggler backlog from #648 batch 7; no `docs/concepts/` changes.

## Test plan
- [x] Root `docs/js/*.mdx` hero canonical pair count: 39 → 0
- [ ] Mintlify build / preview (if CI runs)

Refs #648