### PR TITLE
docs(js): CardGroup + AccordionGroup mechanical fixes (#648)

### DIFF
--- a/docs/js/multimodal-agent.mdx
+++ b/docs/js/multimodal-agent.mdx
@@ -196,11 +196,17 @@ console.log(result.url);
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Use appropriate models** - Not all models support vision
 2. **Optimize image size** - Resize large images to reduce tokens
 3. **Be specific** - Provide clear instructions for image analysis
 4. **Handle errors** - Some images may fail to process
 
+  </Accordion>
+</AccordionGroup>
 ## Environment Variables
 
 | Variable | Required | Description |

--- a/docs/js/nextjs.mdx
+++ b/docs/js/nextjs.mdx
@@ -266,12 +266,18 @@ export const POST = createRouteHandler({
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Use streaming** - Better UX for long responses
 2. **Handle errors** - Show user-friendly error messages
 3. **Add loading states** - Indicate when AI is thinking
 4. **Secure API routes** - Add authentication
 5. **Cache responses** - For repeated queries
 
+  </Accordion>
+</AccordionGroup>
 ## Related
 
 <CardGroup cols={2}>

--- a/docs/js/nl-postgres.mdx
+++ b/docs/js/nl-postgres.mdx
@@ -188,12 +188,18 @@ postgresql://user:password@host:port/database?sslmode=require
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Always use read-only mode** unless writes are necessary
 2. **Whitelist tables** to limit access
 3. **Set row limits** to prevent large result sets
 4. **Review generated SQL** before executing in production
 5. **Use connection pooling** for high-traffic applications
 
+  </Accordion>
+</AccordionGroup>
 ## Related
 
 <CardGroup cols={2}>

--- a/docs/js/plugins.mdx
+++ b/docs/js/plugins.mdx
@@ -318,6 +318,10 @@ console.log(JSON.stringify(schema, null, 2));
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Clear descriptions** - Write detailed descriptions for LLM understanding
 2. **Type safety** - Use TypeScript generics for input/output types
 3. **Error handling** - Use `safeRun()` or try/catch in `run()`
@@ -325,6 +329,8 @@ console.log(JSON.stringify(schema, null, 2));
 5. **Versioning** - Set `version` for tracking tool changes
 6. **Testing** - Write unit tests for your tools
 
+  </Accordion>
+</AccordionGroup>
 ## Example: Complete Plugin
 
 ```typescript

--- a/docs/js/slackbot-agent.mdx
+++ b/docs/js/slackbot-agent.mdx
@@ -228,11 +228,17 @@ bot.onMessage(async (message) => {
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Use threads** - Reply in threads to keep channels clean
 2. **Handle errors gracefully** - Return friendly error messages
 3. **Rate limit** - Respect Slack's rate limits
 4. **Log interactions** - Track usage for debugging
 
+  </Accordion>
+</AccordionGroup>
 ## Related
 
 <CardGroup cols={2}>

--- a/docs/js/structured-output-cli.mdx
+++ b/docs/js/structured-output-cli.mdx
@@ -287,12 +287,18 @@ export PRAISONAI_STRUCTURED_TEMP=0.1
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Use schema files** for complex schemas
 2. **Set low temperature** (0.1) for consistent output
 3. **Validate output** with `jq` or similar tools
 4. **Handle errors** in scripts
 5. **Use `--json`** flag for machine-readable output
 
+  </Accordion>
+</AccordionGroup>
 ## Related
 
 <CardGroup cols={2}>

--- a/docs/js/structured-output.mdx
+++ b/docs/js/structured-output.mdx
@@ -305,6 +305,10 @@ console.log(user.name); // TypeScript knows this is string
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Use specific schemas**: More specific schemas produce better results
 2. **Add descriptions**: Use `.describe()` to help the model understand fields
 3. **Lower temperature**: Use `temperature: 0.1` for consistent output
@@ -320,6 +324,8 @@ const DetailedSchema = z.object({
 });
 ```
 
+  </Accordion>
+</AccordionGroup>
 ## Multi-Agent Structured Output
 
 Use structured output in multi-agent workflows:

--- a/docs/js/tools/airweave.mdx
+++ b/docs/js/tools/airweave.mdx
@@ -109,11 +109,17 @@ interface AirweaveSearchResult {
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Connect sources first** - Set up data source connections in Airweave
 2. **Filter by source** - Narrow search to relevant sources
 3. **Use semantic queries** - Natural language works best
 4. **Set thresholds** - Adjust for precision vs recall
 
+  </Accordion>
+</AccordionGroup>
 ## Related Tools
 
 - [Exa](/docs/js/tools/exa) - Web search

--- a/docs/js/tools/bedrock-agentcore-cli.mdx
+++ b/docs/js/tools/bedrock-agentcore-cli.mdx
@@ -65,4 +65,9 @@ praisonai-ts tools run bedrock-browser-fill \
 
 ## Related
 
-- [Bedrock AgentCore](/docs/js/tools/bedrock-agentcore) - Code documentation
+
+<CardGroup cols={2}>
+  <Card title="Bedrock AgentCore" icon="book" href="/docs/js/tools/bedrock-agentcore">
+    Code documentation
+  </Card>
+</CardGroup>

--- a/docs/js/tools/bedrock-agentcore.mdx
+++ b/docs/js/tools/bedrock-agentcore.mdx
@@ -90,5 +90,12 @@ interface BrowserConfig {
 
 ## Related
 
-- [Code Execution](/docs/js/tools/code-execution) - General code execution
-- [Computer Use](/docs/js/computer-use) - Desktop automation
+
+<CardGroup cols={2}>
+  <Card title="Code Execution" icon="book" href="/docs/js/tools/code-execution">
+    General code execution
+  </Card>
+  <Card title="Computer Use" icon="book" href="/docs/js/computer-use">
+    Desktop automation
+  </Card>
+</CardGroup>

--- a/docs/js/tools/code-execution.mdx
+++ b/docs/js/tools/code-execution.mdx
@@ -114,11 +114,17 @@ interface CodeExecutionResult {
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Set timeouts** - Prevent infinite loops
 2. **Limit memory** - Avoid memory exhaustion
 3. **Validate output** - Check for errors
 4. **Use for computation** - Not for I/O operations
 
+  </Accordion>
+</AccordionGroup>
 ## Related Tools
 
 - [Code Mode](/docs/js/tools/code-mode) - Transform tools into code

--- a/docs/js/tools/code-mode-cli.mdx
+++ b/docs/js/tools/code-mode-cli.mdx
@@ -84,4 +84,9 @@ praisonai-ts tools run code-mode \
 
 ## Related
 
-- [Code Mode](/docs/js/tools/code-mode) - Code documentation
+
+<CardGroup cols={2}>
+  <Card title="Code Mode" icon="book" href="/docs/js/tools/code-mode">
+    Code documentation
+  </Card>
+</CardGroup>

--- a/docs/js/tools/code-mode.mdx
+++ b/docs/js/tools/code-mode.mdx
@@ -119,5 +119,12 @@ interface CodeModeResult {
 
 ## Related
 
-- [Code Execution](/docs/js/tools/code-execution) - Execute code
-- [Custom Tools](/docs/js/customtools) - Create custom tools
+
+<CardGroup cols={2}>
+  <Card title="Code Execution" icon="book" href="/docs/js/tools/code-execution">
+    Execute code
+  </Card>
+  <Card title="Custom Tools" icon="book" href="/docs/js/customtools">
+    Create custom tools
+  </Card>
+</CardGroup>

--- a/docs/js/tools/exa.mdx
+++ b/docs/js/tools/exa.mdx
@@ -170,12 +170,18 @@ interface ExaSearchResult {
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Use appropriate search type** - `auto` works well for most cases
 2. **Filter by category** - Narrow results for specific content types
 3. **Set date ranges** - Get recent or historical content as needed
 4. **Use livecrawl** - Get fresh content when needed
 5. **Limit results** - Start with fewer results and increase if needed
 
+  </Accordion>
+</AccordionGroup>
 ## Error Handling
 
 ```typescript

--- a/docs/js/tools/firecrawl.mdx
+++ b/docs/js/tools/firecrawl.mdx
@@ -257,12 +257,18 @@ try {
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Use appropriate tool** - Scrape for single pages, crawl for multiple
 2. **Set limits** - Always set crawl limits to avoid excessive API usage
 3. **Filter content** - Use includeTags/excludeTags to get relevant content
 4. **Handle async jobs** - Use pollTool for crawl and batch operations
 5. **Cache results** - Store scraped content to avoid repeated requests
 
+  </Accordion>
+</AccordionGroup>
 ## Related Tools
 
 - [Tavily](/docs/js/tools/tavily) - Web search and extraction

--- a/docs/js/tools/parallel.mdx
+++ b/docs/js/tools/parallel.mdx
@@ -143,11 +143,17 @@ interface ParallelSearchResult {
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Use semantic objectives** - Describe what you're looking for
 2. **Limit results** - Fewer results = faster responses
 3. **Combine with extract** - Search first, then extract full content
 4. **Trust compression** - Results are optimized for LLM consumption
 
+  </Accordion>
+</AccordionGroup>
 ## Related Tools
 
 - [Exa](/docs/js/tools/exa) - Semantic web search

--- a/docs/js/tools/perplexity.mdx
+++ b/docs/js/tools/perplexity.mdx
@@ -196,11 +196,17 @@ try {
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Use recency filters** - Get the most current information
 2. **Filter by domain** - Focus on authoritative sources
 3. **Set language** - Get results in the desired language
 4. **Limit results** - Start with fewer results for faster responses
 
+  </Accordion>
+</AccordionGroup>
 ## Related Tools
 
 - [Exa](/docs/js/tools/exa) - Semantic web search

--- a/docs/js/tools/registry.mdx
+++ b/docs/js/tools/registry.mdx
@@ -290,7 +290,18 @@ try {
 
 ## Related
 
-- [Tavily](/js/tools/tavily) - Web search tool
-- [Exa](/js/tools/exa) - Semantic search tool
-- [Custom Tools](/js/customtools) - Creating custom tools
-- [CLI Reference](/js/cli) - Command-line interface
+
+<CardGroup cols={2}>
+  <Card title="Tavily" icon="book" href="/js/tools/tavily">
+    Web search tool
+  </Card>
+  <Card title="Exa" icon="book" href="/js/tools/exa">
+    Semantic search tool
+  </Card>
+  <Card title="Custom Tools" icon="book" href="/js/customtools">
+    Creating custom tools
+  </Card>
+  <Card title="CLI Reference" icon="book" href="/js/cli">
+    Command-line interface
+  </Card>
+</CardGroup>

--- a/docs/js/tools/superagent.mdx
+++ b/docs/js/tools/superagent.mdx
@@ -185,11 +185,17 @@ interface VerifyResult {
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Layer security** - Use guard before processing user input
 2. **Redact early** - Remove PII before storing or processing
 3. **Verify claims** - Check factual statements against sources
 4. **Log securely** - Don't log redacted information
 
+  </Accordion>
+</AccordionGroup>
 ## Related Tools
 
 - [Tavily](/docs/js/tools/tavily) - Web search for verification

--- a/docs/js/tools/tavily-cli.mdx
+++ b/docs/js/tools/tavily-cli.mdx
@@ -262,6 +262,15 @@ Solution: Wait and retry, or upgrade your Tavily plan.
 
 ## Related
 
-- [Tavily Code Usage](/js/tools/tavily) - Programmatic usage guide
-- [Tools Registry](/js/tools/registry) - All available tools
-- [CLI Reference](/js/cli) - Full CLI documentation
+
+<CardGroup cols={2}>
+  <Card title="Tavily Code Usage" icon="book" href="/js/tools/tavily">
+    Programmatic usage guide
+  </Card>
+  <Card title="Tools Registry" icon="book" href="/js/tools/registry">
+    All available tools
+  </Card>
+  <Card title="CLI Reference" icon="book" href="/js/cli">
+    Full CLI documentation
+  </Card>
+</CardGroup>

--- a/docs/js/tools/tavily.mdx
+++ b/docs/js/tools/tavily.mdx
@@ -248,12 +248,18 @@ interface TavilyCrawlResult {
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Use appropriate search depth**: Use `basic` for quick searches, `advanced` for comprehensive research
 2. **Filter by domain**: Use `includeDomains` to focus on authoritative sources
 3. **Time-sensitive queries**: Use `timeRange` for news or recent information
 4. **Rate limiting**: Tavily has rate limits; implement appropriate delays for batch operations
 5. **Error handling**: Always handle potential API errors gracefully
 
+  </Accordion>
+</AccordionGroup>
 ## Pricing
 
 Tavily offers:
@@ -264,6 +270,15 @@ See [tavily.com/pricing](https://tavily.com/pricing) for details.
 
 ## Related
 
-- [Tavily CLI Usage](/js/tools/tavily-cli) - Command-line interface for Tavily
-- [Tools Registry](/js/tools/registry) - Overview of all available tools
-- [Exa Search](/js/tools/exa) - Alternative semantic search tool
+
+<CardGroup cols={2}>
+  <Card title="Tavily CLI Usage" icon="book" href="/js/tools/tavily-cli">
+    Command-line interface for Tavily
+  </Card>
+  <Card title="Tools Registry" icon="book" href="/js/tools/registry">
+    Overview of all available tools
+  </Card>
+  <Card title="Exa Search" icon="book" href="/js/tools/exa">
+    Alternative semantic search tool
+  </Card>
+</CardGroup>

--- a/docs/js/tools/valyu.mdx
+++ b/docs/js/tools/valyu.mdx
@@ -201,11 +201,17 @@ interface ValyuSearchResult {
 
 ## Best Practices
 
+
+<AccordionGroup>
+  <Accordion title="Guidelines">
+
 1. **Use specific tools** - Choose the right tool for your domain
 2. **Combine tools** - Use multiple tools for comprehensive analysis
 3. **Filter by source** - Narrow down to relevant data sources
 4. **Check dates** - Financial data is time-sensitive
 
+  </Accordion>
+</AccordionGroup>
 ## Related Tools
 
 - [Exa](/docs/js/tools/exa) - General web search


### PR DESCRIPTION
## Summary
- Fixes remaining 7 CardGroup and 16 AccordionGroup section-conditional gaps under `docs/js/` (22 files touched; tavily overlaps both).
- Brings full `docs/js` section-conditional audit to 0/328.

## Test plan
- [x] Section-conditional gap scan: 0 files

Refs #648