### PR TITLE
docs(js): nested hero diagrams batch 2 — observability + providers (#648)

### DIFF
--- a/docs/js/observability/scorecard-cli.mdx
+++ b/docs/js/observability/scorecard-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Scorecard observability"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Scorecard CLI Commands
 
 ## Environment Setup

--- a/docs/js/observability/scorecard-code.mdx
+++ b/docs/js/observability/scorecard-code.mdx
@@ -4,6 +4,19 @@ description: "Use Scorecard AI testing with PraisonAI TypeScript"
 icon: "chart-line"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Scorecard Observability
 
 ## Environment Variables

--- a/docs/js/observability/signoz-cli.mdx
+++ b/docs/js/observability/signoz-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for SigNoz observability"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # SigNoz CLI Commands
 
 ## Environment Setup

--- a/docs/js/observability/signoz-code.mdx
+++ b/docs/js/observability/signoz-code.mdx
@@ -4,6 +4,19 @@ description: "Use SigNoz OpenTelemetry with PraisonAI TypeScript"
 icon: "chart-line"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # SigNoz Observability
 
 ## Environment Variables

--- a/docs/js/observability/traceloop-cli.mdx
+++ b/docs/js/observability/traceloop-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Traceloop observability"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Traceloop CLI Commands
 
 ## Environment Setup

--- a/docs/js/observability/traceloop-code.mdx
+++ b/docs/js/observability/traceloop-code.mdx
@@ -4,6 +4,19 @@ description: "Use Traceloop OpenLLMetry with PraisonAI TypeScript"
 icon: "chart-line"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Traceloop Observability
 
 ## Environment Variables

--- a/docs/js/observability/weave-cli.mdx
+++ b/docs/js/observability/weave-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Weave observability"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Weave CLI Commands
 
 ## Environment Setup

--- a/docs/js/observability/weave-code.mdx
+++ b/docs/js/observability/weave-code.mdx
@@ -4,6 +4,19 @@ description: "Use Weights & Biases Weave with PraisonAI TypeScript"
 icon: "chart-line"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Weave Observability
 
 ## Environment Variables

--- a/docs/js/providers/ai-gateway-cli.mdx
+++ b/docs/js/providers/ai-gateway-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for AI Gateway provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # AI Gateway CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/ai-gateway-code.mdx
+++ b/docs/js/providers/ai-gateway-code.mdx
@@ -4,6 +4,19 @@ description: "Use AI Gateway with PraisonAI TypeScript"
 icon: "route"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # AI Gateway Provider
 
 Unified AI gateway access.

--- a/docs/js/providers/aihubmix-cli.mdx
+++ b/docs/js/providers/aihubmix-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Aihubmix provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Aihubmix CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/aihubmix-code.mdx
+++ b/docs/js/providers/aihubmix-code.mdx
@@ -4,6 +4,19 @@ description: "Use Aihubmix with PraisonAI TypeScript"
 icon: "brain"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Aihubmix Provider
 
 ## Environment Variables

--- a/docs/js/providers/amazon-bedrock-cli.mdx
+++ b/docs/js/providers/amazon-bedrock-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Amazon Bedrock provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Amazon Bedrock CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/amazon-bedrock-code.mdx
+++ b/docs/js/providers/amazon-bedrock-code.mdx
@@ -4,6 +4,19 @@ description: "Use Amazon Bedrock with PraisonAI TypeScript"
 icon: "aws"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Amazon Bedrock Provider
 
 Use AWS Bedrock for managed AI models.

--- a/docs/js/providers/anthropic-cli.mdx
+++ b/docs/js/providers/anthropic-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Anthropic provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Anthropic CLI Commands
 
 Manage and test Anthropic Claude provider via the command line.

--- a/docs/js/providers/anthropic-code.mdx
+++ b/docs/js/providers/anthropic-code.mdx
@@ -4,6 +4,19 @@ description: "Use Anthropic Claude models with PraisonAI TypeScript"
 icon: "message"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Anthropic Provider
 
 Use Anthropic's Claude models including Claude 4, Claude 3.5 Sonnet, and Claude 3 Opus.

--- a/docs/js/providers/assemblyai-cli.mdx
+++ b/docs/js/providers/assemblyai-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for AssemblyAI provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # AssemblyAI CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/assemblyai-code.mdx
+++ b/docs/js/providers/assemblyai-code.mdx
@@ -4,6 +4,19 @@ description: "Use AssemblyAI transcription with PraisonAI TypeScript"
 icon: "microphone"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # AssemblyAI Provider
 
 Speech-to-text with AssemblyAI.

--- a/docs/js/providers/azure-cli.mdx
+++ b/docs/js/providers/azure-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Azure OpenAI provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Azure OpenAI CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/azure-code.mdx
+++ b/docs/js/providers/azure-code.mdx
@@ -4,6 +4,19 @@ description: "Use Azure OpenAI Service with PraisonAI TypeScript"
 icon: "microsoft"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Azure OpenAI Provider
 
 Use Azure-hosted OpenAI models with enterprise features.


### PR DESCRIPTION
## Summary
- Completes remaining 8 docs/js/observability pages missing a canonical hero Mermaid block (scorecard, signoz, traceloop, weave — CLI + code).
- Adds the same minimal hero to 12 docs/js/providers pages alphabetically from the start (ai-gateway through azure — CLI + code).
- Strict nested hero gap under docs/js: 145 → 125 (refs #648).

## Test plan
- [x] Verified each edited file has mermaid + canonical classDef pair within first 100 lines
- [x] No changes under docs/concepts/
- [ ] Mintlify preview (optional)
