### PR TITLE
docs(js): nested hero diagrams batch 3 — providers (#648)

### DIFF
--- a/docs/js/providers/baseten-cli.mdx
+++ b/docs/js/providers/baseten-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Baseten provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Baseten CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/baseten-code.mdx
+++ b/docs/js/providers/baseten-code.mdx
@@ -4,6 +4,19 @@ description: "Use Baseten with PraisonAI TypeScript"
 icon: "server"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Baseten Provider
 
 ## Environment Variables

--- a/docs/js/providers/black-forest-labs-cli.mdx
+++ b/docs/js/providers/black-forest-labs-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Black Forest Labs provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Black Forest Labs CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/black-forest-labs-code.mdx
+++ b/docs/js/providers/black-forest-labs-code.mdx
@@ -4,6 +4,19 @@ description: "Use FLUX image generation with PraisonAI TypeScript"
 icon: "image"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Black Forest Labs Provider
 
 FLUX image generation models.

--- a/docs/js/providers/cerebras-cli.mdx
+++ b/docs/js/providers/cerebras-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Cerebras provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Cerebras CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/cerebras-code.mdx
+++ b/docs/js/providers/cerebras-code.mdx
@@ -4,6 +4,19 @@ description: "Use Cerebras with PraisonAI TypeScript"
 icon: "microchip"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Cerebras Provider
 
 Ultra-fast inference with Cerebras.

--- a/docs/js/providers/clarifai-cli.mdx
+++ b/docs/js/providers/clarifai-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Clarifai provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Clarifai CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/clarifai-code.mdx
+++ b/docs/js/providers/clarifai-code.mdx
@@ -4,6 +4,19 @@ description: "Use Clarifai with PraisonAI TypeScript"
 icon: "eye"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Clarifai Provider
 
 ## Environment Variables

--- a/docs/js/providers/cloudflare-workers-ai-cli.mdx
+++ b/docs/js/providers/cloudflare-workers-ai-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Cloudflare Workers AI provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Cloudflare Workers AI CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/cloudflare-workers-ai-code.mdx
+++ b/docs/js/providers/cloudflare-workers-ai-code.mdx
@@ -4,6 +4,19 @@ description: "Use Cloudflare Workers AI with PraisonAI TypeScript"
 icon: "cloud"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Cloudflare Workers AI Provider
 
 ## Environment Variables

--- a/docs/js/providers/cohere-cli.mdx
+++ b/docs/js/providers/cohere-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Cohere provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Cohere CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/cohere-code.mdx
+++ b/docs/js/providers/cohere-code.mdx
@@ -4,6 +4,19 @@ description: "Use Cohere models with PraisonAI TypeScript"
 icon: "c"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Cohere Provider
 
 Use Cohere's Command models and embeddings.

--- a/docs/js/providers/crosshatch-cli.mdx
+++ b/docs/js/providers/crosshatch-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Crosshatch provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Crosshatch CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/crosshatch-code.mdx
+++ b/docs/js/providers/crosshatch-code.mdx
@@ -4,6 +4,19 @@ description: "Use Crosshatch with PraisonAI TypeScript"
 icon: "brain"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Crosshatch Provider
 
 ## Environment Variables

--- a/docs/js/providers/deepgram-cli.mdx
+++ b/docs/js/providers/deepgram-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Deepgram provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Deepgram CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/deepgram-code.mdx
+++ b/docs/js/providers/deepgram-code.mdx
@@ -4,6 +4,19 @@ description: "Use Deepgram speech with PraisonAI TypeScript"
 icon: "microphone"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Deepgram Provider
 
 Speech recognition with Deepgram.

--- a/docs/js/providers/deepinfra-cli.mdx
+++ b/docs/js/providers/deepinfra-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for DeepInfra provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # DeepInfra CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/deepinfra-code.mdx
+++ b/docs/js/providers/deepinfra-code.mdx
@@ -4,6 +4,19 @@ description: "Use DeepInfra with PraisonAI TypeScript"
 icon: "server"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # DeepInfra Provider
 
 Fast inference with DeepInfra.

--- a/docs/js/providers/deepseek-cli.mdx
+++ b/docs/js/providers/deepseek-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for DeepSeek provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # DeepSeek CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/deepseek-code.mdx
+++ b/docs/js/providers/deepseek-code.mdx
@@ -4,6 +4,19 @@ description: "Use DeepSeek models with PraisonAI TypeScript"
 icon: "magnifying-glass"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # DeepSeek Provider
 
 Use DeepSeek's models including DeepSeek Chat and DeepSeek Reasoner.


### PR DESCRIPTION
## Summary
- Adds minimal hero Mermaid diagrams with canonical `classDef` pair (first 100 lines) to twenty `docs/js/providers/` pages: baseten through deepseek (cli + code pairs).
- No `docs/concepts/` changes.

## Metrics
- Strict nested hero gap: **125 → 105**
- Providers remaining: **82** (was 102)
- Tools remaining: **23** (unchanged)

Refs #648

## Test plan
- [x] Verified canonical `classDef agent` / `classDef tool` in first 100 lines for all 20 files
- [x] Gap count script on `docs/js` (excluding concepts)


Made with [Cursor](https://cursor.com)