### PR TITLE
docs(js): nested hero batch 5 — providers Heroku→Minimax

### DIFF
--- a/docs/js/providers/heroku-cli.mdx
+++ b/docs/js/providers/heroku-cli.mdx
@@ -4,6 +4,21 @@ description: "CLI commands for Heroku provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # Heroku CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/heroku-code.mdx
+++ b/docs/js/providers/heroku-code.mdx
@@ -4,6 +4,21 @@ description: "Use Heroku with PraisonAI TypeScript"
 icon: "cloud"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # Heroku Provider
 
 ## Environment Variables

--- a/docs/js/providers/huggingface-cli.mdx
+++ b/docs/js/providers/huggingface-cli.mdx
@@ -4,6 +4,21 @@ description: "CLI commands for Hugging Face provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # Hugging Face CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/huggingface-code.mdx
+++ b/docs/js/providers/huggingface-code.mdx
@@ -4,6 +4,21 @@ description: "Use Hugging Face Inference with PraisonAI TypeScript"
 icon: "face-smile"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # Hugging Face Provider
 
 Access Hugging Face models via Inference API.

--- a/docs/js/providers/hume-cli.mdx
+++ b/docs/js/providers/hume-cli.mdx
@@ -4,6 +4,21 @@ description: "CLI commands for Hume provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # Hume CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/hume-code.mdx
+++ b/docs/js/providers/hume-code.mdx
@@ -4,6 +4,21 @@ description: "Use Hume AI emotion with PraisonAI TypeScript"
 icon: "face-smile"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # Hume Provider
 
 Emotion AI with Hume.

--- a/docs/js/providers/langdb-cli.mdx
+++ b/docs/js/providers/langdb-cli.mdx
@@ -4,6 +4,21 @@ description: "CLI commands for LangDB provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # LangDB CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/langdb-code.mdx
+++ b/docs/js/providers/langdb-code.mdx
@@ -4,6 +4,21 @@ description: "Use LangDB with PraisonAI TypeScript"
 icon: "database"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # LangDB Provider
 
 ## Environment Variables

--- a/docs/js/providers/letta-cli.mdx
+++ b/docs/js/providers/letta-cli.mdx
@@ -4,6 +4,21 @@ description: "CLI commands for Letta provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # Letta CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/letta-code.mdx
+++ b/docs/js/providers/letta-code.mdx
@@ -4,6 +4,21 @@ description: "Use Letta with PraisonAI TypeScript"
 icon: "brain"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # Letta Provider
 
 ## Environment Variables

--- a/docs/js/providers/lm-studio-cli.mdx
+++ b/docs/js/providers/lm-studio-cli.mdx
@@ -4,6 +4,21 @@ description: "CLI commands for LM Studio provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # LM Studio CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/lm-studio-code.mdx
+++ b/docs/js/providers/lm-studio-code.mdx
@@ -4,6 +4,21 @@ description: "Use LM Studio local models with PraisonAI TypeScript"
 icon: "desktop"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # LM Studio Provider
 
 Run models locally with LM Studio.

--- a/docs/js/providers/lmnt-cli.mdx
+++ b/docs/js/providers/lmnt-cli.mdx
@@ -4,6 +4,21 @@ description: "CLI commands for LMNT provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # LMNT CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/lmnt-code.mdx
+++ b/docs/js/providers/lmnt-code.mdx
@@ -4,6 +4,21 @@ description: "Use LMNT TTS with PraisonAI TypeScript"
 icon: "volume-high"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # LMNT Provider
 
 Text-to-speech with LMNT.

--- a/docs/js/providers/luma-cli.mdx
+++ b/docs/js/providers/luma-cli.mdx
@@ -4,6 +4,21 @@ description: "CLI commands for Luma provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # Luma CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/luma-code.mdx
+++ b/docs/js/providers/luma-code.mdx
@@ -4,6 +4,21 @@ description: "Use Luma AI video generation with PraisonAI TypeScript"
 icon: "video"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # Luma Provider
 
 Video generation with Luma AI.

--- a/docs/js/providers/mem0-cli.mdx
+++ b/docs/js/providers/mem0-cli.mdx
@@ -4,6 +4,21 @@ description: "CLI commands for Mem0 provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # Mem0 CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/mem0-code.mdx
+++ b/docs/js/providers/mem0-code.mdx
@@ -4,6 +4,21 @@ description: "Use Mem0 with PraisonAI TypeScript"
 icon: "brain"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # Mem0 Provider
 
 ## Environment Variables

--- a/docs/js/providers/minimax-cli.mdx
+++ b/docs/js/providers/minimax-cli.mdx
@@ -4,6 +4,21 @@ description: "CLI commands for MiniMax provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # MiniMax CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/minimax-code.mdx
+++ b/docs/js/providers/minimax-code.mdx
@@ -4,6 +4,21 @@ description: "Use MiniMax with PraisonAI TypeScript"
 icon: "brain"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
+
 # MiniMax Provider
 
 ## Environment Variables


### PR DESCRIPTION
## Summary

- Adds minimal canonical hero Mermaid (`classDef agent` / `classDef tool`) to **20** `docs/js/providers/` pages from **Heroku** through **Minimax** (CLI + code pairs).
- Continues nested hero rollout for PraisonAI TypeScript docs (refs #648).
- No changes under `docs/concepts/`.

## Coverage

| Area | Before | After |
|------|--------|-------|
| `docs/js` pages with hero | 243/328 | 263/328 |
| Gap (missing hero) | 85 | **65** |
| `docs/js/providers` | 52/114 | **72/114** |
| `docs/js/tools` | 0/23 | 0/23 (unchanged) |

## Test plan

- [x] 20 files only, alphabetically Heroku → Minimax
- [x] Canonical palette via `classDef` (no raw `style`)
- [ ] Mintlify preview / CI green


Made with [Cursor](https://cursor.com)