### PR TITLE
docs(js): nested hero batch 7 — final providers + tools (#648)

### DIFF
--- a/docs/js/providers/mistral-cli.mdx
+++ b/docs/js/providers/mistral-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Mistral provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Mistral CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/mistral-code.mdx
+++ b/docs/js/providers/mistral-code.mdx
@@ -4,6 +4,19 @@ description: "Use Mistral AI models with PraisonAI TypeScript"
 icon: "wind"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Mistral Provider
 
 Use Mistral AI's models including Mistral Large and Codestral.

--- a/docs/js/providers/requesty-cli.mdx
+++ b/docs/js/providers/requesty-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Requesty provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Requesty CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/requesty-code.mdx
+++ b/docs/js/providers/requesty-code.mdx
@@ -4,6 +4,19 @@ description: "Use Requesty with PraisonAI TypeScript"
 icon: "brain"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Requesty Provider
 
 ## Environment Variables

--- a/docs/js/providers/revai-cli.mdx
+++ b/docs/js/providers/revai-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Rev.ai provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Rev.ai CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/revai-code.mdx
+++ b/docs/js/providers/revai-code.mdx
@@ -4,6 +4,19 @@ description: "Use Rev.ai transcription with PraisonAI TypeScript"
 icon: "microphone"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Rev.ai Provider
 
 Speech transcription with Rev.ai.

--- a/docs/js/providers/runpod-cli.mdx
+++ b/docs/js/providers/runpod-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for RunPod provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # RunPod CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/runpod-code.mdx
+++ b/docs/js/providers/runpod-code.mdx
@@ -4,6 +4,19 @@ description: "Use RunPod with PraisonAI TypeScript"
 icon: "server"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # RunPod Provider
 
 ## Environment Variables

--- a/docs/js/providers/sambanova-cli.mdx
+++ b/docs/js/providers/sambanova-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for SambaNova provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # SambaNova CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/sambanova-code.mdx
+++ b/docs/js/providers/sambanova-code.mdx
@@ -4,6 +4,19 @@ description: "Use SambaNova with PraisonAI TypeScript"
 icon: "microchip"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # SambaNova Provider
 
 ## Environment Variables

--- a/docs/js/providers/sarvam-cli.mdx
+++ b/docs/js/providers/sarvam-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Sarvam provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Sarvam CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/sarvam-code.mdx
+++ b/docs/js/providers/sarvam-code.mdx
@@ -4,6 +4,19 @@ description: "Use Sarvam with PraisonAI TypeScript"
 icon: "brain"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Sarvam Provider
 
 ## Environment Variables

--- a/docs/js/providers/spark-cli.mdx
+++ b/docs/js/providers/spark-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Spark provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Spark CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/spark-code.mdx
+++ b/docs/js/providers/spark-code.mdx
@@ -4,6 +4,19 @@ description: "Use Spark with PraisonAI TypeScript"
 icon: "bolt"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Spark Provider
 
 ## Environment Variables

--- a/docs/js/providers/togetherai-cli.mdx
+++ b/docs/js/providers/togetherai-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Together.ai provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Together.ai CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/togetherai-code.mdx
+++ b/docs/js/providers/togetherai-code.mdx
@@ -4,6 +4,19 @@ description: "Use Together.ai with PraisonAI TypeScript"
 icon: "users"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Together.ai Provider
 
 Access open-source models via Together.ai.

--- a/docs/js/providers/vercel-cli.mdx
+++ b/docs/js/providers/vercel-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Vercel provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Vercel CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/vercel-code.mdx
+++ b/docs/js/providers/vercel-code.mdx
@@ -4,6 +4,19 @@ description: "Use Vercel AI with PraisonAI TypeScript"
 icon: "triangle"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Vercel Provider
 
 ## Environment Variables

--- a/docs/js/providers/xai-cli.mdx
+++ b/docs/js/providers/xai-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for xAI Grok provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # xAI CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/xai-code.mdx
+++ b/docs/js/providers/xai-code.mdx
@@ -4,6 +4,19 @@ description: "Use xAI Grok models with PraisonAI TypeScript"
 icon: "bolt"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # xAI Provider
 
 Use xAI's Grok models including Grok-4 and Grok-3.

--- a/docs/js/providers/zhipu-ai-cli.mdx
+++ b/docs/js/providers/zhipu-ai-cli.mdx
@@ -4,6 +4,19 @@ description: "CLI commands for Zhipu AI provider"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Zhipu AI CLI Commands
 
 ## Environment Setup

--- a/docs/js/providers/zhipu-ai-code.mdx
+++ b/docs/js/providers/zhipu-ai-code.mdx
@@ -4,6 +4,19 @@ description: "Use Zhipu AI (GLM) with PraisonAI TypeScript"
 icon: "brain"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Zhipu AI Provider
 
 ## Environment Variables

--- a/docs/js/tools/airweave-cli.mdx
+++ b/docs/js/tools/airweave-cli.mdx
@@ -4,6 +4,19 @@ description: "Command-line interface for Airweave unified search"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Airweave CLI
 
 Search across connected data sources from the command line.

--- a/docs/js/tools/airweave.mdx
+++ b/docs/js/tools/airweave.mdx
@@ -4,6 +4,21 @@ description: "Unified search across 35+ data sources with semantic search"
 icon: "database"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> T[Tool]
+    T --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+    class T tool
+```
+
 # Airweave Search Tool
 
 Airweave is an open-source platform that makes any app searchable for your agent. Sync and search across 35+ data sources (Notion, Slack, Google Drive, databases, and more) with semantic search.

--- a/docs/js/tools/bedrock-agentcore-cli.mdx
+++ b/docs/js/tools/bedrock-agentcore-cli.mdx
@@ -4,6 +4,19 @@ description: "Command-line interface for AWS Bedrock AgentCore tools"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Bedrock AgentCore CLI
 
 Use AWS Bedrock AgentCore tools from the command line.

--- a/docs/js/tools/bedrock-agentcore.mdx
+++ b/docs/js/tools/bedrock-agentcore.mdx
@@ -4,6 +4,21 @@ description: "AWS Bedrock AgentCore tools for code interpretation and browser au
 icon: "aws"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> T[Tool]
+    T --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+    class T tool
+```
+
 # Bedrock AgentCore
 
 AWS Bedrock AgentCore provides code interpretation and browser automation capabilities.

--- a/docs/js/tools/code-execution-cli.mdx
+++ b/docs/js/tools/code-execution-cli.mdx
@@ -4,6 +4,19 @@ description: "Command-line interface for code execution"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Code Execution CLI
 
 Execute Python code from the command line.

--- a/docs/js/tools/code-execution.mdx
+++ b/docs/js/tools/code-execution.mdx
@@ -4,6 +4,21 @@ description: "Execute Python code in a sandboxed environment using Vercel Sandbo
 icon: "code"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> T[Tool]
+    T --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+    class T tool
+```
+
 # Code Execution Tool
 
 Execute Python code safely in a sandboxed environment using Vercel Sandbox. Run calculations, data processing, and computational tasks in isolation.

--- a/docs/js/tools/code-mode-cli.mdx
+++ b/docs/js/tools/code-mode-cli.mdx
@@ -4,6 +4,19 @@ description: "Command-line interface for Code Mode tool"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Code Mode CLI
 
 Use Code Mode from the command line for code generation and editing.

--- a/docs/js/tools/code-mode.mdx
+++ b/docs/js/tools/code-mode.mdx
@@ -4,6 +4,21 @@ description: "AI-powered code generation and editing tool"
 icon: "code"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> T[Tool]
+    T --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+    class T tool
+```
+
 # Code Mode
 
 Code Mode provides AI-powered code generation and editing capabilities for agents.

--- a/docs/js/tools/exa-cli.mdx
+++ b/docs/js/tools/exa-cli.mdx
@@ -4,6 +4,19 @@ description: "Command-line interface for Exa web search"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Exa Web Search CLI
 
 Use Exa semantic web search from the command line.

--- a/docs/js/tools/exa.mdx
+++ b/docs/js/tools/exa.mdx
@@ -4,6 +4,21 @@ description: "Semantic web search with Exa AI for intelligent information retrie
 icon: "magnifying-glass"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> T[Tool]
+    T --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+    class T tool
+```
+
 # Exa Web Search Tool
 
 Exa is a powerful semantic web search API that provides intelligent search capabilities for AI agents. It supports neural search, content filtering, and real-time web crawling.

--- a/docs/js/tools/firecrawl-cli.mdx
+++ b/docs/js/tools/firecrawl-cli.mdx
@@ -4,6 +4,19 @@ description: "Command-line interface for Firecrawl web scraping and crawling"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Firecrawl CLI
 
 Use Firecrawl web scraping and crawling from the command line.

--- a/docs/js/tools/firecrawl.mdx
+++ b/docs/js/tools/firecrawl.mdx
@@ -4,6 +4,21 @@ description: "Web scraping, crawling, and data extraction for AI applications"
 icon: "fire"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> T[Tool]
+    T --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+    class T tool
+```
+
 # Firecrawl Tools
 
 Firecrawl provides powerful web scraping, search, crawling, and data extraction capabilities for AI applications.

--- a/docs/js/tools/parallel-cli.mdx
+++ b/docs/js/tools/parallel-cli.mdx
@@ -4,6 +4,19 @@ description: "Command-line interface for Parallel web search"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Parallel Web CLI
 
 Use Parallel token-efficient web search from the command line.

--- a/docs/js/tools/parallel.mdx
+++ b/docs/js/tools/parallel.mdx
@@ -4,6 +4,21 @@ description: "Token-efficient web search and extraction for AI agents"
 icon: "bolt"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> T[Tool]
+    T --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+    class T tool
+```
+
 # Parallel Web Tools
 
 Parallel provides best-in-class tools to search and extract context from the web. Results are compressed for optimal token efficiency at inference time.

--- a/docs/js/tools/perplexity-cli.mdx
+++ b/docs/js/tools/perplexity-cli.mdx
@@ -4,6 +4,19 @@ description: "Command-line interface for Perplexity web search"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Perplexity Search CLI
 
 Use Perplexity real-time web search from the command line.

--- a/docs/js/tools/perplexity.mdx
+++ b/docs/js/tools/perplexity.mdx
@@ -4,6 +4,21 @@ description: "Real-time web search with advanced filtering powered by Perplexity
 icon: "brain"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> T[Tool]
+    T --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+    class T tool
+```
+
 # Perplexity Search Tool
 
 Perplexity Search provides real-time web search with advanced filtering including domain, language, date range, and recency filters.

--- a/docs/js/tools/registry.mdx
+++ b/docs/js/tools/registry.mdx
@@ -4,6 +4,21 @@ description: "AI SDK Tools Registry - Built-in tools for PraisonAI agents"
 icon: "toolbox"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> T[Tool]
+    T --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+    class T tool
+```
+
 # AI SDK Tools Registry
 
 PraisonAI provides a unified registry of AI SDK tools that can be used with agents. All tools are lazy-loaded and have optional dependencies.

--- a/docs/js/tools/superagent-cli.mdx
+++ b/docs/js/tools/superagent-cli.mdx
@@ -4,6 +4,19 @@ description: "Command-line interface for Superagent security tools"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Superagent Security CLI
 
 Use Superagent security tools from the command line.

--- a/docs/js/tools/superagent.mdx
+++ b/docs/js/tools/superagent.mdx
@@ -4,6 +4,21 @@ description: "AI security guardrails for prompt injection, PII redaction, and cl
 icon: "shield"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> T[Tool]
+    T --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+    class T tool
+```
+
 # Superagent Security Tools
 
 Superagent provides AI security guardrails including prompt injection detection, PII/PHI redaction, and claim verification against source materials.

--- a/docs/js/tools/tavily-cli.mdx
+++ b/docs/js/tools/tavily-cli.mdx
@@ -4,6 +4,19 @@ description: "Command-line interface for Tavily search, extract, and crawl opera
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Tavily CLI Usage
 
 Use Tavily search capabilities directly from the command line.

--- a/docs/js/tools/tavily.mdx
+++ b/docs/js/tools/tavily.mdx
@@ -4,6 +4,21 @@ description: "Web search, content extraction, and crawling with Tavily AI SDK"
 icon: "magnifying-glass"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> T[Tool]
+    T --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+    class T tool
+```
+
 # Tavily Search Tool
 
 Tavily provides AI-optimized web search, content extraction, and website crawling capabilities for your agents.

--- a/docs/js/tools/valyu-cli.mdx
+++ b/docs/js/tools/valyu-cli.mdx
@@ -4,6 +4,19 @@ description: "Command-line interface for Valyu domain-specific search"
 icon: "terminal"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 # Valyu Search CLI
 
 Use Valyu domain-specific search tools from the command line.

--- a/docs/js/tools/valyu.mdx
+++ b/docs/js/tools/valyu.mdx
@@ -4,6 +4,21 @@ description: "Domain-specific search tools for finance, research, patents, and m
 icon: "chart-line"
 ---
 
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> T[Tool]
+    T --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+    class T tool
+```
+
 # Valyu Search Tools
 
 Valyu provides powerful domain-specific search tools including web search, finance, academic papers, biomedical, patents, SEC filings, economics data, and company research.


### PR DESCRIPTION
## Summary
- Adds minimal hero Mermaid diagrams with canonical `classDef` (agent `#8B0000`, tool `#189AB4`) within the first 100 lines for the remaining **45** `docs/js` pages.
- **22** provider pages (Mistral stragglers + Requesty through Zhipu AI, CLI + code).
- **23** tool pages under `docs/js/tools/` (Agent→Tool hero on code pages; minimal Input→Agent→Output on CLI pages).
- Closes the nested-hero gap for `docs/js` (excludes `docs/concepts/`): **45 → 0** missing; **328/328** strict hero compliance.

Refs #648

## Test plan
- [x] Audited all `docs/js/**/*.mdx` excluding `concepts/` for canonical classDef pair + mermaid in first 100 lines
- [x] Verified gap count 0 and strict hero count 328/328 locally

Made with [Cursor](https://cursor.com)