### PR TITLE
docs: document PR #2411 framework adapter extensibility

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -756,6 +756,7 @@
                   "docs/features/plugins",
                   "docs/features/framework-adapter-plugins",
                   "docs/features/framework-availability",
+                  "docs/features/workflow-yaml-framework-field",
                   "docs/features/bot-platform-capabilities",
                   "docs/features/bot-platform-plugins",
                   "docs/features/registry-dependency-injection",

--- a/docs/features/framework-adapter-plugins.mdx
+++ b/docs/features/framework-adapter-plugins.mdx
@@ -29,6 +29,10 @@ graph LR
     classDef tool fill:#189AB4,color:#fff
 ```
 
+<Warning>
+**Deprecated:** Direct imports of concrete built-in adapter classes from `praisonai.framework_adapters` (`CrewAIAdapter`, `AutoGenAdapter`, `AutoGenV4Adapter`, `AG2Adapter`) now emit `DeprecationWarning`. Use the registry (`get_default_registry().create("crewai")`) or register via the entry-point group instead.
+</Warning>
+
 ## Quick Start
 
 <Steps>
@@ -38,10 +42,10 @@ Register a framework adapter directly in your code:
 
 ```python
 from typing import Any, Callable, Dict, List, Optional
+from praisonaiagents import BaseFrameworkAdapter
 from praisonai.framework_adapters.registry import get_default_registry
-from praisonai.framework_adapters.base import FrameworkAdapter
 
-class MyFrameworkAdapter:
+class MyFrameworkAdapter(BaseFrameworkAdapter):
     name = "myframework"
 
     def is_available(self) -> bool:
@@ -62,11 +66,7 @@ class MyFrameworkAdapter:
         task_callback: Optional[Callable] = None,
         cli_config: Optional[Dict[str, Any]] = None,
     ) -> str:
-        # Framework execution logic
         return "Framework execution result"
-
-    def cleanup(self) -> None:
-        pass
 
 # Register the adapter (preferred for app code)
 registry = get_default_registry()
@@ -75,25 +75,60 @@ registry.register("myframework", MyFrameworkAdapter)
 
 </Step>
 
-<Step title="Entry Point Plugin">
+<Step title="Entry-Point Plugin (installable)">
 
-Create a pip-installable plugin using `pyproject.toml`:
+Create a pip-installable plugin — no manual `registry.register()` call needed:
+
+```python
+# my_framework_adapter.py
+from praisonaiagents import BaseFrameworkAdapter
+
+class MyFrameworkAdapter(BaseFrameworkAdapter):
+    name = "my_framework"
+    install_hint = "pip install my-framework-bridge"
+    requires_tools_extra = False
+
+    def is_available(self) -> bool:
+        return True
+
+    def run(
+        self,
+        config,
+        llm_config,
+        topic,
+        *,
+        tools_dict=None,
+        agent_callback=None,
+        task_callback=None,
+        cli_config=None,
+    ) -> str:
+        return f"my_framework ran: {topic}"
+```
 
 ```toml
 # pyproject.toml
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
-name = "myframework-praisonai"
-version = "1.0.0"
+name = "my-framework-bridge"
+version = "0.0.1"
+dependencies = ["praisonaiagents"]
+
+[tool.setuptools]
+py-modules = ["my_framework_adapter"]
 
 [project.entry-points."praisonai.framework_adapters"]
-myframework = "myframework_praisonai.adapter:MyFrameworkAdapter"
+my_framework = "my_framework_adapter:MyFrameworkAdapter"
 ```
 
 ```bash
-# Use the framework after installation
-pip install myframework-praisonai
-praisonai --framework myframework agents.yaml
+pip install -e ./examples/python/frameworks/custom_adapter
+praisonai --framework my_framework agents.yaml
 ```
+
+After `pip install`, the adapter appears in `praisonai --framework` choices and `praisonai doctor` automatically — no manual `registry.register()` call needed.
 
 </Step>
 </Steps>
@@ -196,7 +231,7 @@ A family adapter routes to a concrete sibling adapter based on environment or co
 import os
 import logging
 from typing import Dict, Any, Optional
-from praisonai.framework_adapters.base import BaseFrameworkAdapter
+from praisonaiagents import BaseFrameworkAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -288,6 +323,8 @@ def resolve(self, *, config: Optional[Dict[str, Any]] = None) -> "FrameworkAdapt
 **Worked example — `AutoGenAdapter.resolve`:** the orchestrator passes YAML config; the adapter instantiates siblings directly:
 
 ```python
+from praisonaiagents import BaseFrameworkAdapter
+
 def resolve(self, *, config: Optional[Dict[str, Any]] = None) -> "BaseFrameworkAdapter":
     version = "auto"
     if config and config.get("autogen_version"):
@@ -351,10 +388,10 @@ sequenceDiagram
 
 ```python
 from typing import Any, Callable, Dict, List, Optional
+from praisonaiagents import BaseFrameworkAdapter
 from praisonai.framework_adapters.registry import get_default_registry
-from praisonai.framework_adapters.base import FrameworkAdapter
 
-class CustomCrewAIAdapter:
+class CustomCrewAIAdapter(BaseFrameworkAdapter):
     name = "crewai"
 
     def is_available(self) -> bool:
@@ -391,7 +428,7 @@ registry.register("crewai", CustomCrewAIAdapter)
 ```python
 import subprocess
 from typing import Any, Callable, Dict, List, Optional
-from praisonai.framework_adapters.base import BaseFrameworkAdapter
+from praisonaiagents import BaseFrameworkAdapter
 
 class NonPythonAdapter(BaseFrameworkAdapter):
     name = "external_framework"
@@ -426,7 +463,7 @@ class NonPythonAdapter(BaseFrameworkAdapter):
 ```python
 import logging
 from typing import Any, Callable, Dict, List, Optional
-from praisonai.framework_adapters.base import BaseFrameworkAdapter
+from praisonaiagents import BaseFrameworkAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -525,7 +562,7 @@ Log framework events for debugging:
 
 ```python
 import logging
-from praisonai.framework_adapters.base import BaseFrameworkAdapter
+from praisonaiagents import BaseFrameworkAdapter
 
 class LoggingAdapter(BaseFrameworkAdapter):
     def __init__(self):
@@ -599,11 +636,42 @@ def is_available(self) -> bool:
     return check_availability("myframework")  # cached, uses importlib.util.find_spec
 ```
 
-The `is_available()` method is called on every CLI startup and framework probe. Full imports here cause multi-second delays. The centralized availability check uses cached `importlib.util.find_spec` for fast, repeated checks.
-
 </Accordion>
 
 </AccordionGroup>
+
+---
+
+## Registry Helpers
+
+Registry-level helpers for building CLIs and plugins:
+
+```python
+from praisonai.framework_adapters.registry import (
+    list_framework_choices,
+    list_available_frameworks,
+    get_install_hint,
+)
+```
+
+| Helper | Returns | Use case |
+|---|---|---|
+| `list_framework_choices(*, include_unavailable=False)` | `list[str]` | Build the CLI `--framework` choice list (registered adapters; pass `include_unavailable=True` for the full list) |
+| `list_available_frameworks()` | `list[str]` | Filter to just those whose `is_available()` returns `True` |
+| `get_install_hint(name)` | `str` | Adapter-aware install hint string (e.g. `pip install 'praisonai[autogen]'`) |
+| `framework_option_help()` | `str` | Auto-generated `--help` text for the `--framework` flag |
+
+```python
+from praisonai.framework_adapters.registry import list_framework_choices, get_install_hint
+
+# See which frameworks appear in --framework choices
+choices = list_framework_choices()
+print(choices)  # ['crewai', 'praisonai', 'autogen', 'my_framework']
+
+# Get install instructions for a missing framework
+hint = get_install_hint("crewai")
+print(hint)  # pip install 'praisonai[crewai]'
+```
 
 ---
 
@@ -752,5 +820,8 @@ If `praisonai --list-frameworks` (or `registry.list_names()`) no longer shows yo
 </Card>
 <Card title="CrewAI Integration" icon="users" href="/docs/framework/crewai">
   See how built-in framework adapters are implemented
+</Card>
+<Card title="Workflow YAML Framework Field" icon="diagram-project" href="/docs/features/workflow-yaml-framework-field">
+  How framework: works in workflow YAML vs agents.yaml
 </Card>
 </CardGroup>

--- a/docs/features/framework-availability.mdx
+++ b/docs/features/framework-availability.mdx
@@ -104,6 +104,10 @@ Vector store backends use the same centralized probe registry — `praisonai.ada
 `autogen_v2` is an **adapter name** registered in `FrameworkAdapterRegistry`, not a probe name in `_framework_availability`. The probe name remains `autogen` (it imports the `autogen` v0.2 package). Use the adapter's `.is_available()` method to test whether a specific adapter will dispatch successfully — it folds in the `implemented` marker.
 </Note>
 
+<Note>
+`autogen_v4` and `ag2` are **not in the built-in adapter registry** by default. `praisonai doctor` and `praisonai --framework` only list them when registered via an entry-point plugin. Raw package installation alone (e.g. `pip install autogen-agentchat`) does not cause them to appear.
+</Note>
+
 ---
 
 ## Adapter Availability vs Framework Availability
@@ -114,11 +118,17 @@ Two distinct concepts affect whether an AutoGen-family adapter will actually wor
 |---|---|
 | "Is the underlying package importable?" | `is_available("autogen")` from `_framework_availability` |
 | "Will calling `adapter.run(...)` actually work?" | `AutoGenV4Adapter().is_available()` (folds `implemented` flag) |
+| "Is the adapter registered AND available?" | `registry.is_available("autogen_v4")` |
 
 For AutoGen v0.4 and AG2 today: the package may import successfully, but the adapter still reports `False` because `implemented = False`. This is the safety-by-default behaviour added in PR #2086.
 
+`praisonai doctor` and `--framework` choices now use `registry.is_available(name)` — not raw package probes — for `autogen_v4` and `ag2`. This means installing `autogen-agentchat` alone will **not** flip them to available unless the adapter is also registered. Since `autogen_v4` and `ag2` adapters are unregistered stubs by default (excluded from `_BUILTIN_ADAPTERS`), they only appear in `doctor` and `--framework` when registered via an entry-point plugin.
+
 ```python
 from praisonai._framework_availability import is_available
+from praisonai.framework_adapters.registry import get_default_registry
+
+registry = get_default_registry()
 
 # Package-level check: is the v0.4 package installed?
 pkg_available = is_available("autogen_v4")  # True if autogen-agentchat is installed
@@ -127,8 +137,11 @@ pkg_available = is_available("autogen_v4")  # True if autogen-agentchat is insta
 from praisonai.framework_adapters.autogen_adapter import AutoGenV4Adapter
 adapter_available = AutoGenV4Adapter().is_available()  # False — implemented = False
 
-# pkg_available may be True while adapter_available is False
-# Always use adapter.is_available() to test dispatch-readiness
+# Registry-level check: what doctor and --framework choices use
+registry_available = registry.is_available("autogen_v4")  # False — not in builtin registry
+
+# pkg_available may be True while adapter_available and registry_available are False
+# Always use registry.is_available() to test whether --framework will list an adapter
 ```
 
 ---

--- a/docs/features/workflow-yaml-framework-field.mdx
+++ b/docs/features/workflow-yaml-framework-field.mdx
@@ -1,0 +1,207 @@
+---
+title: "Workflow YAML Framework Field"
+sidebarTitle: "Workflow `framework:`"
+description: "How the framework: key in YAML chooses an execution backend"
+icon: "diagram-project"
+---
+
+The `framework:` key in YAML picks which execution backend runs your agents — but the rules differ between **agents.yaml** and **workflow YAML**.
+
+```python
+from praisonaiagents import Agent, PraisonAIAgents
+
+agent = Agent(name="Writer", instructions="Write helpful posts")
+PraisonAIAgents(agents=[agent]).start("Write about caching")
+```
+
+```mermaid
+graph TB
+    subgraph "Choosing framework:"
+        YAML[📄 YAML File] --> Type{Workflow YAML?}
+        Type -->|"steps:/type:job"| WF[🛠️ Workflow Engine]
+        Type -->|otherwise| AG[🧑🤝🧑 AgentsGenerator]
+        WF --> WFCheck{framework: praisonai?}
+        WFCheck -->|yes| Ok1[✅ Run]
+        WFCheck -->|other| Err[❌ ValueError]
+        AG --> Reg[📚 Registry]
+        Reg --> Run[✅ Resolve adapter and run]
+    end
+    classDef yaml fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef err fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef proc fill:#189AB4,stroke:#7C90A0,color:#fff
+    class YAML yaml
+    class Ok1,Run ok
+    class Err err
+    class WF,AG,Reg,Type,WFCheck proc
+```
+
+## Quick Start
+
+<Steps>
+<Step title="agents.yaml — any registered framework">
+
+```yaml
+framework: crewai
+topic: Write a blog post
+roles:
+  writer:
+    role: Writer
+    goal: Write engaging posts
+    backstory: Senior editor
+    tasks:
+      draft:
+        description: Write a post about {topic}
+        expected_output: A 500-word post
+```
+
+```bash
+praisonai agents.yaml
+```
+
+</Step>
+
+<Step title="workflow YAML — praisonai only">
+
+```yaml
+framework: praisonai
+type: job
+steps:
+  - id: research
+    agent: researcher
+  - id: write
+    agent: writer
+    depends_on: [research]
+```
+
+```bash
+praisonai workflow.yaml
+```
+
+</Step>
+</Steps>
+
+---
+
+## Which file uses which?
+
+| YAML shape | Engine | `framework:` choices |
+|---|---|---|
+| `roles:` / `topic:` (agents.yaml) | `AgentsGenerator` + registry | Any registered adapter (`crewai`, `praisonai`, `autogen`, plus entry-point plugins) |
+| `steps:` + `workflow:` (workflow YAML) | Native Workflow engine | `praisonai` only |
+| `type: job` / `type: hybrid` (workflow YAML) | Native Workflow engine | `praisonai` only |
+
+If `framework:` is omitted, agents.yaml defaults via `FrameworkAdapterRegistry.pick_default()` and workflow YAML defaults to `praisonai`.
+
+---
+
+## Error you will see
+
+```
+ValueError: framework='crewai' in workflow YAML is not supported for workflow execution.
+Native PraisonAI Workflow engine only supports framework='praisonai'.
+Use a non-workflow agents.yaml with a supported registered framework, or set framework: praisonai.
+```
+
+---
+
+## What to do
+
+```mermaid
+graph LR
+    Need[I need a non-praisonai framework] --> Q{What YAML do I want?}
+    Q -->|Linear roles/tasks| AY[Use agents.yaml]
+    Q -->|Workflow steps/job/hybrid| WY[Stay on framework: praisonai]
+    AY --> CL[praisonai --framework crewai agents.yaml]
+    WY --> NX[Build a CrewAI-side workflow externally]
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef ask fill:#F59E0B,stroke:#7C90A0,color:#fff
+    class Need start
+    class Q ask
+    class AY,WY,CL,NX ok
+```
+
+---
+
+## Programmatic check
+
+```python
+from praisonai.framework_adapters.workflow_framework import (
+    validate_workflow_framework,
+    framework_from_config,
+)
+
+cfg = {"framework": "praisonai", "steps": []}
+fw = framework_from_config(cfg)         # "praisonai"
+validate_workflow_framework(fw)         # no-op when valid; raises ValueError otherwise
+```
+
+`framework_from_config({})` returns `"praisonai"` (safe default). `framework_from_config({"framework": "CrewAI"})` returns `"crewai"` (lowercased before validation).
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant AgentsGenerator
+    participant WorkflowEngine
+
+    User->>CLI: praisonai workflow.yaml
+    CLI->>AgentsGenerator: load YAML
+    AgentsGenerator->>AgentsGenerator: detect steps:/type:job
+    AgentsGenerator->>WorkflowEngine: route to workflow runner
+    WorkflowEngine->>WorkflowEngine: validate_workflow_framework(fw)
+    alt framework: praisonai
+        WorkflowEngine-->>User: ✅ execute
+    else framework: crewai (or other)
+        WorkflowEngine-->>User: ❌ ValueError
+    end
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Use agents.yaml for multi-framework work">
+If you need CrewAI, AutoGen, or a custom framework, write your config as `roles:`/`topic:` agents.yaml. The `framework:` key there accepts any registered adapter.
+</Accordion>
+
+<Accordion title="Omit framework: in workflow YAML">
+The default is `praisonai`, so you can omit the `framework:` key entirely in workflow YAML. This avoids accidentally setting an unsupported value.
+</Accordion>
+
+<Accordion title="Validate early in custom code">
+Call `validate_workflow_framework(fw)` immediately after parsing config if you're building tooling around workflow YAML. It raises `ValueError` with an actionable message before any execution starts.
+</Accordion>
+
+<Accordion title="Check registry choices before building CLI menus">
+Use `list_framework_choices()` from `praisonai.framework_adapters.registry` to populate dropdowns or CLI help text — it includes entry-point plugins automatically.
+
+```python
+from praisonai.framework_adapters.registry import list_framework_choices
+
+choices = list_framework_choices()
+print(choices)  # ['crewai', 'praisonai', 'autogen', 'my_plugin']
+```
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card icon="puzzle-piece" href="/docs/features/framework-adapter-plugins">
+  Add new execution backends via Python entry points
+</Card>
+<Card icon="file-code" href="/docs/features/yaml-workflows">
+  Full workflow YAML reference
+</Card>
+</CardGroup>

--- a/docs/features/yaml-workflows.mdx
+++ b/docs/features/yaml-workflows.mdx
@@ -233,13 +233,25 @@ This means calling `AgentsGenerator(agent_file="release.yaml").generate_crew_and
 **Async parity:** `agenerate_crew_and_kickoff()` now initializes observability and adapter setup the same way `generate_crew_and_kickoff()` does — Langfuse / AgentOps traces are wired on both paths.
 </Note>
 
+<Warning>
+**Workflow YAML `framework:` is validated.** Native PraisonAI Workflow engine only supports `framework: praisonai`. Declaring anything else (e.g. `framework: crewai`) raises `ValueError`:
+
+```
+ValueError: framework='crewai' in workflow YAML is not supported for workflow execution.
+Native PraisonAI Workflow engine only supports framework='praisonai'.
+Use a non-workflow agents.yaml with a supported registered framework, or set framework: praisonai.
+```
+
+For non-`praisonai` execution, use an agents.yaml-style file via `AgentsGenerator`. See [Workflow YAML Framework Field](/docs/features/workflow-yaml-framework-field) for details.
+</Warning>
+
 ## Complete workflow.yaml Reference
 
 ```yaml
 # workflow.yaml - Full feature reference
 name: Complete Workflow
 description: Demonstrates all workflow.yaml features
-framework: praisonai  # praisonai, crewai, autogen
+framework: praisonai  # workflow YAML only supports praisonai
 process: workflow     # sequential, hierarchical, workflow
 input: "Your input data here"  # Data passed into workflow (accessed via {{input}})
 

--- a/docs/framework/autogen.mdx
+++ b/docs/framework/autogen.mdx
@@ -272,6 +272,12 @@ NotImplementedError: AG2 adapter is not yet implemented. Use framework='autogen'
 
 Switch to `framework: autogen` or `framework: autogen_v2`. Both adapters are stubs pending [issue #1590](https://github.com/MervinPraison/PraisonAI/issues/1590).
 
+### Pinning AutoGen versions
+
+Setting `AUTOGEN_VERSION=v0.4` or `AUTOGEN_VERSION=ag2` (or YAML `autogen_version: v0.4`) now raises `ImportError` if the requested variant is not registered, instead of silently falling back to v0.2. Workflow-level `autogen_version` in config/YAML takes precedence over the env var. Use `AUTOGEN_VERSION=auto` (or omit it) to allow fallback.
+
+Since `autogen_v4` and `ag2` adapters are unregistered stubs by default, `--framework autogen` resolves to v0.2 unless you install an entry-point plugin that registers `autogen_v4` or `ag2`.
+
 ### AUTOGEN_VERSION=v0.4 warns but continues
 
 When `AUTOGEN_VERSION=v0.4` is set but v0.4 is not installed (or is a stub), the router logs a warning and returns `"autogen_v4"` — the caller then hits `NotImplementedError` when `.run()` is invoked. This is expected behaviour; switch to `v0.2`.

--- a/docs/sdk/praisonai/cli.mdx
+++ b/docs/sdk/praisonai/cli.mdx
@@ -46,7 +46,7 @@ PraisonAI(
 | `tools` | list | `None` | List of tools to make available |
 
 <Note>
-If neither `--framework` CLI flag nor YAML `framework:` key is set, PraisonAI defaults to the `praisonai` adapter.
+If neither `--framework` CLI flag nor YAML `framework:` key is set, PraisonAI calls `FrameworkAdapterRegistry.pick_default()` which walks `("crewai", "praisonai", "autogen", "ag2")` and returns the first available built-in, then falls back to any entry-point plugin. `--framework` choices are populated dynamically from the registry — third-party plugins installed via the `praisonai.framework_adapters` entry point appear automatically.
 </Note>
 
 ### Methods


### PR DESCRIPTION
## Summary

Implements documentation for [PR #2411](https://github.com/MervinPraison/PraisonAI/pull/2411) (framework adapter extensibility), fixing #1190.

### Changes

- **`docs/features/framework-adapter-plugins.mdx`** (significant update):
  - Replace all `from praisonai.framework_adapters.base import FrameworkAdapter` with `from praisonaiagents import BaseFrameworkAdapter`
  - Add installable entry-point plugin section with `pyproject.toml` template
  - Add Registry Helpers table (`list_framework_choices`, `list_available_frameworks`, `get_install_hint`, `framework_option_help`)
  - Add `DeprecationWarning` callout for direct concrete adapter imports (`CrewAIAdapter`, `AutoGenAdapter`, etc.)
  - Add link to new `workflow-yaml-framework-field` page in Related

- **`docs/features/framework-availability.mdx`** (small update):
  - Expand adapter vs framework vs registry availability table with registry-level check
  - Add note that `autogen_v4`/`ag2` are not in built-in registry; doctor/`--framework` only list them when registered via entry-point

- **`docs/features/yaml-workflows.mdx`** (small update):
  - Add `<Warning>` callout that workflow YAML `framework:` only supports `praisonai`; other values raise `ValueError` with actionable message

- **`docs/sdk/praisonai/cli.mdx`** (small update):
  - Expand default-framework note to mention `pick_default()` and registry-driven `--framework` choices including entry-point plugins

- **`docs/framework/autogen.mdx`** (small update):
  - Add "Pinning AutoGen versions" subsection noting that `AUTOGEN_VERSION=v0.4`/`ag2` now raises `ImportError` instead of silent fallback

- **`docs/features/workflow-yaml-framework-field.mdx`** (new page):
  - Focused page on YAML `framework:` field differences between agents.yaml and workflow YAML
  - Includes Mermaid diagrams, Quick Start steps, error message, programmatic check, best practices

- **`docs.json`**: Add new page under Features group (NOT Concepts)

### Quality Checklist
- [x] All code samples import via `from praisonaiagents import BaseFrameworkAdapter`
- [x] No code sample imports `FrameworkAdapter` from `praisonai.framework_adapters.base` for new content
- [x] Hero Mermaid diagram on new page uses standard palette
- [x] No edits in `docs/concepts/`
- [x] No entries added under `docs.json` "Concepts" group
- [x] `docs.json` remains valid JSON
- [x] New page placed in `docs/features/`
- [x] Workflow YAML restriction reflected in `yaml-workflows.mdx` and new page
- [x] Deprecation `<Warning>` added on `framework-adapter-plugins.mdx`
- [x] Registry helpers documented with table in `framework-adapter-plugins.mdx`

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for a YAML `framework:` setting that selects the execution backend, with examples and validation guidance.
  * Expanded framework adapter docs with plugin registration, registry helpers, and dynamic framework selection in the CLI.

* **Bug Fixes**
  * Clarified that only the supported workflow framework is accepted in workflow YAML, with a clear error shown for invalid values.
  * Updated framework availability guidance so installed plugins and registry status are reflected accurately in CLI tools and diagnostics.

* **Documentation**
  * Added troubleshooting notes for AutoGen version pinning and updated multiple framework-related examples and references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->