### PR TITLE
docs: reflect dynamic framework discovery + install hints from PR #2415

### DIFF
--- a/docs/cli/auto.mdx
+++ b/docs/cli/auto.mdx
@@ -70,7 +70,7 @@ praisonai --auto "<task description>" [options]
 |--------|-------------|
 | `--auto` | Enable auto mode with task description |
 | `--merge` | Merge with existing agents.yaml instead of overwriting |
-| `--framework` | Framework to use (crewai, autogen, praisonai) |
+| `--framework` | Framework adapter to use. Discovered dynamically from the adapter registry — built-in (`ag2`, `autogen`, `autogen_v4`, `crewai`, `praisonai`) and any installed third-party adapter (entry-point group `praisonai.framework_adapters`). |
 
 ## Intelligent Tool Discovery
 

--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -308,7 +308,7 @@ praisonai memory show               # known subcommand → routed normally
 
 | Flag | Type | Description |
 |------|------|-------------|
-| `--framework` | choice | Framework: crewai/autogen/praisonai |
+| `--framework` | choice | Framework adapter to use. Choices are discovered from the adapter registry, so built-in adapters (`ag2`, `autogen`, `autogen_v4`, `crewai`, `praisonai`) and any third-party adapter installed via the `praisonai.framework_adapters` entry-point group are all valid. See [Framework Adapter Plugins](/docs/features/framework-adapter-plugins#auto-discovery-in-the-cli). |
 | `--ui` | choice | UI: chainlit/gradio |
 | `--auto` | remainder | Auto-generate agents |
 | `--init` | remainder | Initialize `agents.yaml` from a task description. Prints provider-setup guidance and exits if no LLM provider is configured (see [`praisonai setup`](/docs/cli/setup)). |

--- a/docs/features/framework-adapter-plugins.mdx
+++ b/docs/features/framework-adapter-plugins.mdx
@@ -132,6 +132,58 @@ The framework adapter registry provides a central point for managing framework i
 
 ---
 
+## Auto-Discovery in the CLI
+
+Once your adapter is registered (in-process via `register()` or via the `praisonai.framework_adapters` entry-point group), it appears automatically wherever framework names are listed or validated — no further wiring needed:
+
+| Surface | What it shows / validates against |
+|---------|-----------------------------------|
+| `praisonai --framework <name>` argparse `choices` | `list_framework_choices(include_unavailable=True)` |
+| `praisonai doctor` `agents.yaml` `framework:` field check | `list_framework_choices(include_unavailable=True)` |
+| Missing-framework error → install hint | adapter's own `install_hint` (falls back to `pip install 'praisonai[<name>]'`) |
+
+The single source of truth is `praisonai.framework_adapters.list_framework_choices()`. When `include_unavailable=False` (the default) only adapters whose `is_available()` returns `True` are returned; the CLI uses `include_unavailable=True` so users see every registered framework and get a friendly error if its dependencies are missing.
+
+### Declaring an install hint
+
+Surface a tailored install command for your adapter so users don't see the generic fallback:
+
+```python
+class MyFrameworkAdapter:
+    name = "myframework"
+    install_hint = 'pip install "myframework-praisonai[gpu]"'
+
+    def is_available(self) -> bool: ...
+    def run(self, config, llm_config, topic, *, tools_dict=None,
+            agent_callback=None, task_callback=None, cli_config=None): ...
+    def cleanup(self) -> None: ...
+```
+
+When `myframework` is selected but not installed, the CLI now raises:
+
+```
+ImportError: 'myframework' was requested but is not installed.
+Install with: pip install "myframework-praisonai[gpu]"
+```
+
+If you omit `install_hint`, the wrapper falls back to `pip install 'praisonai[myframework]'`.
+
+### Missing optional dependencies no longer leak
+
+`FrameworkAdapterRegistry.is_available()` now catches `ImportError` raised when an adapter's constructor touches a missing optional dependency, alongside the existing `ValueError`/`TypeError`. A plugin with unmet deps reports as unavailable rather than crashing the CLI list, the doctor check, or `pick_default()`.
+
+## Helpers exposed at the package root
+
+```python
+from praisonai.framework_adapters import (
+    list_framework_choices,   # canonical name list (sorted, optionally filtered to available)
+    get_install_hint,         # adapter-declared hint, or fallback
+    get_default_registry,
+)
+```
+
+---
+
 ## Configuration
 
 <Card title="Framework Adapter Registry API" icon="code" href="/docs/sdk/reference/praisonai/modules/adapters">
@@ -661,6 +713,8 @@ default = registry.pick_default()  # returns your plugin adapter name
 
 <Note>
 The `praisonaiagents → praisonai` rename is reflected in `DEFAULT_PRIORITY` — the tuple uses `"praisonai"`, not `"praisonaiagents"`. Any YAML or code that relied on the old probe tuple `("crewai", "praisonaiagents", "autogen", "ag2")` now uses `pick_default()` instead.
+
+The static fallback list used by the CLI only when the adapter layer itself cannot be imported is `["ag2", "autogen", "crewai", "praisonai"]` (alphabetical) — `ag2` is a first-class member of this canonical list.
 </Note>
 
 ---
@@ -737,7 +791,7 @@ Your code can still ignore the values — the signature just needs to accept the
 
 <Accordion title="My adapter disappeared from the available frameworks list">
 
-If `praisonai --list-frameworks` (or `registry.list_names()`) no longer shows your adapter, run `registry.is_available("<your-adapter-name>")`. Since PR #2083, `is_available()` catches `TypeError` from the new protocol validator and returns `False` rather than raising — so a malformed plugin is silently filtered out of the available list. Check the application logs for the `TypeError` message above and fix the `run()` signature.
+If `praisonai --list-frameworks` (or `registry.list_names()`) no longer shows your adapter, run `registry.is_available("<your-adapter-name>")`. Since PR #2083, `is_available()` catches `TypeError` from the new protocol validator and returns `False` rather than raising — so a malformed plugin is silently filtered out of the available list. Since PR #2415, `is_available()` also catches `ImportError` raised during adapter construction (e.g., when the adapter's `__init__` touches an optional dependency). Check the application logs for the error message above and fix the `run()` signature or ensure your dependencies are properly guarded.
 
 </Accordion>
 </AccordionGroup>

--- a/docs/features/framework-adapter-plugins.mdx
+++ b/docs/features/framework-adapter-plugins.mdx
@@ -172,6 +172,8 @@ If you omit `install_hint`, the wrapper falls back to `pip install 'praisonai[my
 
 `FrameworkAdapterRegistry.is_available()` now catches `ImportError` raised when an adapter's constructor touches a missing optional dependency, alongside the existing `ValueError`/`TypeError`. A plugin with unmet deps reports as unavailable rather than crashing the CLI list, the doctor check, or `pick_default()`.
 
+---
+
 ## Helpers exposed at the package root
 
 ```python

--- a/docs/features/framework-default-change.mdx
+++ b/docs/features/framework-default-change.mdx
@@ -89,6 +89,8 @@ PraisonAI resolves the framework in this order:
 | 2 | YAML key | `framework: crewai` |
 | 3 | Default | `praisonai` |
 
+The set of valid framework names is discovered dynamically from the adapter registry — see [Framework Adapter Plugins](/docs/features/framework-adapter-plugins#auto-discovery-in-the-cli).
+
 ---
 
 ## How to Keep CrewAI as Default


### PR DESCRIPTION
## Summary

Reflects the changes from PraisonAI PR #2415 (dynamic adapter registry as single source of truth for framework names) across the documentation.

### Changes

- **`docs/features/framework-adapter-plugins.mdx`** — Added new "Auto-Discovery in the CLI" section (after "How It Works") covering:
  - Table of surfaces now driven by `list_framework_choices()` (argparse choices, doctor validation, install hints)
  - `install_hint` class attribute example with tailored error message
  - Note that `is_available()` now also catches `ImportError` (PR #2415), not just `ValueError`/`TypeError`
  - "Helpers exposed at the package root" code block (`list_framework_choices`, `get_install_hint`, `get_default_registry`)
  - Updated static fallback list note: `["ag2", "autogen", "crewai", "praisonai"]` — `ag2` is first-class
  - Updated Troubleshooting accordion to mention `ImportError` catch (PR #2415)

- **`docs/cli/cli-reference.mdx`** — Updated `--framework` row to describe dynamic discovery from adapter registry with link to new section

- **`docs/cli/auto.mdx`** — Updated `--framework` option row to describe dynamic discovery

- **`docs/features/framework-default-change.mdx`** — Added one-line cross-link after the precedence table

Fixes #1208

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that framework options are now discovered dynamically from the adapter registry.
  * Updated the list of available built-in frameworks and added guidance for third-party adapter support.
  * Expanded framework adapter plugin docs with auto-discovery behavior, install hints, and troubleshooting notes.
  * Refined framework precedence docs to reflect the new discovery-based selection flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->