### PR TITLE
docs: update for workflow fail-fast, dynamic framework discovery, tool-resolver+async DB init

### DIFF
--- a/docs/cli/doctor.mdx
+++ b/docs/cli/doctor.mdx
@@ -365,7 +365,7 @@ graph LR
 - Binary availability (git, docker, npx)
 
 ### Configuration (`config`)
-- agents.yaml existence and syntax
+- agents.yaml existence and syntax — the `framework:` field is validated against the adapter registry, so any installed adapter (built-in or third-party entry-point plugin) passes the check
 - workflow.yaml validation
 - .praison config directory
 - .env file detection

--- a/docs/cli/workflow.mdx
+++ b/docs/cli/workflow.mdx
@@ -130,6 +130,39 @@ Workflows use global flags (same as other commands):
 | `--verbose` | Enable verbose output |
 | `--save` | Save output to file |
 
+## Workflow YAML Schema
+
+### `framework:` key
+
+YAML workflow files accept a top-level `framework:` key. Only `praisonai` (case-insensitive) is supported by the native execution engine.
+
+| Value | Behaviour |
+|-------|-----------|
+| Omitted or empty | Defaults to `praisonai` — no change |
+| `praisonai` (any case) | Runs normally |
+| Any other value (`crewai`, `autogen`, …) | Raises `ValueError` at `Workflow.run()` time |
+
+```yaml
+# my_workflow.yaml
+framework: praisonai   # ✅ OK — or simply omit this key
+roles:
+  researcher:
+    backstory: "You are a researcher"
+    goal: "Research the topic"
+```
+
+If you set a different framework name, PraisonAI raises immediately rather than silently running the native engine:
+
+```text
+ValueError: Workflow YAML framework='crewai' is not supported by the native
+PraisonAI execution engine. Only 'praisonai' is supported. Either remove the
+'framework:' key or set it to 'praisonai'.
+```
+
+<Note>
+The `framework:` validation only applies to the native YAML workflow executor (`Workflow.run()`). To run CrewAI or AutoGen, use the [framework adapters](/docs/features/framework-adapter-plugins) path via `praisonai --framework crewai agents.yaml` — see [Framework Availability](/docs/features/framework-availability) for adapter details.
+</Note>
+
 ## Workflow File Format
 
 Workflows are stored in `.praison/workflows/` as **Markdown files** with YAML frontmatter:

--- a/docs/features/auto-generator-providers.mdx
+++ b/docs/features/auto-generator-providers.mdx
@@ -120,6 +120,28 @@ asyncio.run(main())
 ```
 
 </Step>
+
+<Step title="Calling from an existing event loop (FastAPI, Jupyter)">
+
+`AutoGenerator.generate()` can now be called from inside a running event loop — it offloads to a worker thread automatically instead of raising `RuntimeError: This event loop is already running`.
+
+```python
+from fastapi import FastAPI
+from praisonai import AutoGenerator
+
+app = FastAPI()
+
+@app.get("/generate")
+async def generate(topic: str):
+    generator = AutoGenerator(topic=topic)
+    # Safe to call .generate() here — no RuntimeError
+    agents_yaml = generator.generate()
+    return {"yaml": agents_yaml}
+```
+
+Prefer `await generator.agenerate()` when you are already in an async context — it avoids the thread-offload overhead. The sync `.generate()` form is provided as a safe fallback.
+
+</Step>
 </Steps>
 
 ---

--- a/docs/features/database-persistence.mdx
+++ b/docs/features/database-persistence.mdx
@@ -199,6 +199,8 @@ praisonai persistence import --file backup.jsonl
 
 The `DatabaseAdapter`'s async callbacks (`on_agent_start`, `on_user_message`, `on_agent_message`, `on_tool_call`, `on_agent_end`) never block the event loop. Store construction runs off-loop via `asyncio.to_thread`, so FastAPI handlers, Jupyter notebooks, and async test suites all work without stalls on cold startup.
 
+---
+
 ## Transient Failure Handling
 
 When a database is temporarily unavailable (bad config, network blip, cloud auth glitch), the adapter records the failure and waits before re-attempting. This prevents hammering a down backend on every agent callback while still recovering automatically once the backend is back.

--- a/docs/features/database-persistence.mdx
+++ b/docs/features/database-persistence.mdx
@@ -195,6 +195,31 @@ praisonai persistence import --file backup.jsonl
 
 ---
 
+## Async-Safe Initialisation
+
+The `DatabaseAdapter`'s async callbacks (`on_agent_start`, `on_user_message`, `on_agent_message`, `on_tool_call`, `on_agent_end`) never block the event loop. Store construction runs off-loop via `asyncio.to_thread`, so FastAPI handlers, Jupyter notebooks, and async test suites all work without stalls on cold startup.
+
+## Transient Failure Handling
+
+When a database is temporarily unavailable (bad config, network blip, cloud auth glitch), the adapter records the failure and waits before re-attempting. This prevents hammering a down backend on every agent callback while still recovering automatically once the backend is back.
+
+The cool-down period is configurable via `init_retry_cooldown` (default **30 seconds**):
+
+```python
+from praisonai.db.adapter import DatabaseAdapter
+
+adapter = DatabaseAdapter(
+    database_url="postgresql://localhost/praisonai",
+    init_retry_cooldown=10.0,  # try again 10s after a failed init
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `init_retry_cooldown` | `float` | `30.0` | Seconds to wait before retrying a failed store init |
+
+After a soft init failure (raised during `_ainit_stores()`), the adapter pauses for `init_retry_cooldown` seconds before re-running store construction on the next callback. Persistence resumes automatically once the backend becomes reachable — no process restart needed.
+
 ## Best Practices
 
 <AccordionGroup>

--- a/docs/features/framework-adapter-plugins.mdx
+++ b/docs/features/framework-adapter-plugins.mdx
@@ -100,6 +100,27 @@ praisonai --framework myframework agents.yaml
 
 ---
 
+## What the Registry Controls
+
+Registering through the `praisonai.framework_adapters` entry-point group gives your adapter automatic visibility across three surfaces — no extra wiring required:
+
+| Surface | Effect |
+|---------|--------|
+| `praisonai --framework <name>` | Your adapter name appears in the argparse `choices=` list |
+| `praisonai doctor config` | `agents.yaml framework: <name>` passes validation |
+| Install-hint messages | Your adapter's `install_hint` attribute is shown when the framework module is missing |
+
+```bash
+# Example: after pip install praisonai-langgraph
+$ praisonai --framework langgraph agents.yaml   # accepted
+$ praisonai doctor
+✓ agents.yaml framework='langgraph' is a registered adapter
+```
+
+See [Framework Availability — Dynamic Discovery](/docs/features/framework-availability#dynamic-framework-discovery) for more details on how the registry feeds these surfaces.
+
+---
+
 ## How It Works
 
 ```mermaid

--- a/docs/features/framework-availability.mdx
+++ b/docs/features/framework-availability.mdx
@@ -15,6 +15,52 @@ praison = PraisonAI(agent_file="agents.yaml")
 praison.run()
 ```
 
+## Dynamic Framework Discovery
+
+`praisonai --framework` choices and `praisonai doctor` framework validation are both driven by the adapter registry — not a hardcoded list. Any pip-installed third-party adapter registered under the `praisonai.framework_adapters` entry-point group appears automatically in `--help` and passes the doctor check.
+
+```bash
+# After pip install praisonai-langgraph, langgraph appears automatically:
+$ praisonai --framework langgraph agents.yaml
+
+# praisonai doctor also accepts it:
+$ praisonai doctor
+✓ agents.yaml framework='langgraph' is a registered adapter
+```
+
+Two registration paths feed the registry:
+
+1. **Built-ins** — `praisonai`, `crewai`, `autogen`, `ag2` are registered at import time.
+2. **Third-party entry points** — packages that declare `praisonai.framework_adapters` entries are discovered automatically. See [Framework Adapter Plugins](/docs/features/framework-adapter-plugins) for how to author and register a plugin.
+
+```mermaid
+graph LR
+    subgraph "Adapter discovery"
+        Reg[Adapter Registry]
+        EP[Entry-point group<br/>praisonai.framework_adapters]
+        Built[Built-ins<br/>praisonai / crewai / autogen]
+        CLI[praisonai --framework choices]
+        Doc[praisonai doctor validation]
+        Hint[Install-hint messages]
+    end
+
+    Built --> Reg
+    EP --> Reg
+    Reg --> CLI
+    Reg --> Doc
+    Reg --> Hint
+
+    classDef reg fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef src fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef out fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Reg reg
+    class Built,EP src
+    class CLI,Doc,Hint out
+```
+
+Install-hint messages for missing frameworks also come from each adapter's own `install_hint` attribute via `get_install_hint()`, so third-party adapters can ship accurate instructions (e.g. `pip install praisonai-langgraph`).
+
 ```mermaid
 graph LR
     subgraph "Framework Availability"

--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -477,6 +477,33 @@ agent.start("What is 21 * 2?")
 
 ---
 
+## Local Tool Override Warning
+
+When a class-based tool in your local `tools/` directory shares a name with a tool already resolved from the resolution chain (wrapper registry, `praisonaiagents.tools`, etc.), `resolve_all_from_yaml()` logs a warning:
+
+```text
+WARNING praisonai.tool_resolver: Local tool 'serper' overrides a tool already
+resolved from the resolution chain
+```
+
+This warns you when a local definition silently wins over a built-in or registered tool of the same name. To resolve it, either rename your local tool or remove the conflicting source from the chain.
+
+## Hot-Reload: `invalidate_local_tools_dir()`
+
+In long-running processes (file watchers, dev servers), the `tools/` directory class scan is cached per-resolver. After editing `tools/*.py`, trigger a re-scan:
+
+```python
+from praisonai.tool_resolver import ToolResolver
+
+resolver = ToolResolver()
+
+# ... user edits tools/my_tool.py ...
+resolver.invalidate_local_tools_dir()
+# next resolve_all_from_yaml() re-scans the directory
+```
+
+`clear_cache()` also clears the directory cache alongside the resolve cache.
+
 ## Security
 
 Security enforcement is handled by `_safe_loader.load_user_module`:

--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -488,6 +488,8 @@ resolved from the resolution chain
 
 This warns you when a local definition silently wins over a built-in or registered tool of the same name. To resolve it, either rename your local tool or remove the conflicting source from the chain.
 
+---
+
 ## Hot-Reload: `invalidate_local_tools_dir()`
 
 In long-running processes (file watchers, dev servers), the `tools/` directory class scan is cached per-resolver. After editing `tools/*.py`, trigger a re-scan:
@@ -503,6 +505,8 @@ resolver.invalidate_local_tools_dir()
 ```
 
 `clear_cache()` also clears the directory cache alongside the resolve cache.
+
+---
 
 ## Security
 


### PR DESCRIPTION
## Summary

- **PR #2414 (fail-fast workflow YAML framework):** `docs/cli/workflow.mdx` gets a new `framework:` key schema section documenting the supported values, exact `ValueError` message, and cross-link to adapter docs for users who actually want CrewAI/AutoGen
- **PR #2415 (dynamic framework discovery):** `docs/features/framework-availability.mdx` gains a "Dynamic Framework Discovery" section with Mermaid diagram; `docs/cli/doctor.mdx` notes the registry-driven framework check; `docs/features/framework-adapter-plugins.mdx` adds "What the Registry Controls" section documenting CLI choices, doctor validation, and install-hint surfaces
- **PR #2418 (sync/async, DB init, tool-resolver):** `docs/features/database-persistence.mdx` adds async-safe initialisation and `init_retry_cooldown` (default 30s) sections; `docs/features/tool-resolver.mdx` adds local tool override WARNING callout and `invalidate_local_tools_dir()` hot-reload section; `docs/features/auto-generator-providers.mdx` adds a FastAPI/Jupyter event-loop safe Quick Start step

All edits are in `docs/features/` and `docs/cli/` — no `docs/concepts/` files were touched.

Fixes #1210

Generated with [Claude Code](https://claude.ai/code)