### PR TITLE
docs: surface persisted capabilities + protocol_version on GatewaySession

### DIFF
--- a/docs/features/gateway-handshake-protocol.mdx
+++ b/docs/features/gateway-handshake-protocol.mdx
@@ -239,6 +239,29 @@ Events are advertised only if the client requested the matching capability.
 
 ---
 
+## Server-side state after handshake
+
+After `hello_ok` is sent, the gateway records the negotiated protocol version and the client's advertised capabilities on the session itself. Both are read-only and survive resume.
+
+```python
+session = gateway.get_session(session_id)
+session.protocol_version    # → 1   (negotiated min(client_max, GATEWAY_PROTOCOL_VERSION))
+session.capabilities        # → ["streaming", "presence", "ack"]   (defensive copy)
+```
+
+| Property | Type | Notes |
+|---|---|---|
+| `session.protocol_version` | `int` | Read-only. Set by the `hello` handler from the negotiated value. |
+| `session.capabilities` | `List[str]` | Read-only. Returns a copy — mutating the returned list does not change session state. Empty list when the client advertised no capabilities. |
+
+Both properties are populated on the `hello` path **and** the legacy `join` path, so server code can branch on `session.capabilities` without checking which handshake the client used.
+
+<Tip>
+Use this to tailor delivery — e.g. only enqueue `token_stream` events when `"streaming" in session.capabilities` — without re-parsing the original `hello` frame.
+</Tip>
+
+---
+
 ## Policy Limits
 
 | Key | Default | Description |

--- a/docs/features/gateway-handshake-protocol.mdx
+++ b/docs/features/gateway-handshake-protocol.mdx
@@ -250,7 +250,7 @@ session.capabilities        # → ["streaming", "presence", "ack"]   (defensive 
 ```
 
 | Property | Type | Notes |
-|---|---|---|
+|----------|------|-------|
 | `session.protocol_version` | `int` | Read-only. Set by the `hello` handler from the negotiated value. |
 | `session.capabilities` | `List[str]` | Read-only. Returns a copy — mutating the returned list does not change session state. Empty list when the client advertised no capabilities. |
 

--- a/docs/features/gateway-session-continuity.mdx
+++ b/docs/features/gateway-session-continuity.mdx
@@ -30,6 +30,10 @@ graph LR
     classDef tool fill:#189AB4,color:#fff
 ```
 
+<Tip>
+Resumed sessions also restore the handshake's negotiated `protocol_version` and the client's advertised `capabilities` — see [Server-side state after handshake](/docs/features/gateway-handshake-protocol#server-side-state-after-handshake).
+</Tip>
+
 ## Quick Start
 
 <Steps>

--- a/docs/features/gateway-session-persistence.mdx
+++ b/docs/features/gateway-session-persistence.mdx
@@ -104,6 +104,25 @@ gateway:
 
 </Steps>
 
+## What gets persisted
+
+The on-disk record under `persist_path` is the JSON returned by `GatewaySession.to_dict()`. Key fields:
+
+| Key | Type | Purpose |
+|---|---|---|
+| `session_id` | `str` | Stable identifier; used on resume |
+| `event_cursor` | `int` | Position in the event log for replay |
+| `sequence` | `int` | Monotonic outbound sequence (gap detection) |
+| `protocol_version` | `int` | Protocol version negotiated at the last handshake |
+| `capabilities` | `List[str]` | Capability tokens advertised by the client (`streaming`, `presence`, `ack`, …) |
+| `events` | `List[GatewayEvent]` | Last 100 events (for replay) |
+| `pending_inbox` | `List[...]` | In-flight inbound queue snapshot |
+| `is_executing` | `bool` | Mid-turn flag for [Session Continuity](/docs/features/gateway-session-continuity) |
+
+<Note>
+`capabilities` and `protocol_version` are restored on resume so server-side code that branches on either keeps working without re-handshake. A persisted record from before the upgrade (no `capabilities` key) restores cleanly to `[]` — no migration required.
+</Note>
+
 ## How it works
 
 ```mermaid

--- a/docs/features/gateway-session-persistence.mdx
+++ b/docs/features/gateway-session-persistence.mdx
@@ -109,7 +109,7 @@ gateway:
 The on-disk record under `persist_path` is the JSON returned by `GatewaySession.to_dict()`. Key fields:
 
 | Key | Type | Purpose |
-|---|---|---|
+|-----|------|---------|
 | `session_id` | `str` | Stable identifier; used on resume |
 | `event_cursor` | `int` | Position in the event log for replay |
 | `sequence` | `int` | Monotonic outbound sequence (gap detection) |


### PR DESCRIPTION
## Summary

- **`gateway-handshake-protocol.mdx`**: Added new "Server-side state after handshake" section documenting the `session.protocol_version` and `session.capabilities` read-only properties, including the defensive-copy note and a Tip on using capabilities to tailor delivery.
- **`gateway-session-persistence.mdx`**: Added new "What gets persisted" section enumerating the full `GatewaySession.to_dict()` JSON shape, including the new `capabilities` field, with a backward-compatibility note for older persisted records.
- **`gateway-session-continuity.mdx`**: Added a one-line `<Tip>` cross-linking to the new handshake-page section so readers on the continuity page learn that resumed sessions also restore `capabilities` and `protocol_version`.

No new pages created. No `docs/concepts/` edits. No `docs.json` changes needed.

Fixes #1216

Generated with [Claude Code](https://claude.ai/code)