### PR TITLE
docs: align AGENTS.md, fix Vector Store parity, update vector-store.mdx

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,11 @@ cd praisonai-package
 python3 src/praisonai/scripts/generate_docs_parity.py --copy-docs
 ```
 
+**Full command for agents (run from repo root):**
+```bash
+python3 praisonai-package/src/praisonai/scripts/generate_docs_parity.py --copy-docs
+```
+
 This command:
 1. Scans SDK features and docs for all three SDKs
 2. Generates `DOCS_PARITY.md` reports

--- a/docs/features/DOCS_PARITY.md
+++ b/docs/features/DOCS_PARITY.md
@@ -1,6 +1,6 @@
 # Documentation Parity Tracker (Python)
 
-> **Categories:** 66 | **Documented:** 65 | **Parity:** 98.5%
+> **Categories:** 66 | **Documented:** 66 | **Parity:** 100%
 
 This report compares **Python SDK feature categories** against **Python documentation** (docs/concepts, docs/features, etc.).
 
@@ -9,9 +9,9 @@ This report compares **Python SDK feature categories** against **Python document
 | Metric | Count |
 |--------|-------|
 | Feature Categories | 66 |
-| **Documented Categories** | **65** |
-| **Undocumented Categories** | **1** |
-| **Parity** | **98.5%** |
+| **Documented Categories** | **66** |
+| **Undocumented Categories** | **0** |
+| **Parity** | **100%** |
 
 ## Documented Categories
 
@@ -79,15 +79,14 @@ This report compares **Python SDK feature categories** against **Python document
 | ✅ Tools | 12 | 118 | 28063 |
 | ✅ Tracing | 3 | 2 | 139 |
 | ✅ Video | 2 | 6 | 510 |
+| ✅ Vector Store | 1 | 1 | 364 |
 | ✅ Vision | 2 | 1 | 283 |
 | ✅ Web | 3 | 8 | 1849 |
 | ✅ Workflows | 4 | 14 | 6183 |
 
 ## Undocumented Categories (Need Documentation)
 
-| Category | Features |
-|----------|----------|
-| ❌ Vector Store | 1 |
+*All categories are now documented.*
 
 ## Documentation Without Features
 

--- a/docs/features/vector-store.mdx
+++ b/docs/features/vector-store.mdx
@@ -82,6 +82,8 @@ agent.start("How do I configure authentication?")
 <Step title="Direct Registry Usage">
 Access the in-memory store directly to add and query vectors.
 
+<Note>`get_vector_store_registry` is not re-exported from the top-level package — use the full module path below.</Note>
+
 ```python
 from praisonaiagents.knowledge.vector_store import get_vector_store_registry
 


### PR DESCRIPTION
## Summary

- **AGENTS.md §1.8**: Added relative-path "Full command for agents" block (`python3 praisonai-package/src/praisonai/scripts/generate_docs_parity.py --copy-docs`) — avoids the machine-specific absolute `/Users/praison/...` path from the provided version. All other existing §1.4 callouts, §1.5 path notes, and sequential §1.6–§1.10 numbering are preserved as-is.

- **`docs/features/DOCS_PARITY.md`**: Corrected the tracker — `vector-store.mdx` (364 lines) was already fully documented but mis-classified as undocumented. Updated: 65→66 documented categories, 98.5%→100% parity, removed `❌ Vector Store` row, added `✅ Vector Store` to the documented table.

- **`docs/features/vector-store.mdx`**: Added a `<Note>` in Step 3 explaining why `get_vector_store_registry` requires a deep import (`praisonaiagents.knowledge.vector_store`) — it is not re-exported from the top-level `praisonaiagents` package. The page already has a sequence diagram (§3.4 compliant) and correct structure, so no further changes were needed.

## What was NOT changed (intentional)

- Kept the section renumbering callout at the top of AGENTS.md
- Kept the `docs/concepts/` CAUTION/IMPORTANT callouts in §1.4
- Kept the `> Path note:` in §1.5 and the `(synced copy; upstream: ...)` / `(submodule only)` / `(human-only)` suffixes
- Did NOT introduce a duplicate `1.5` heading
- Did NOT apply the absolute `/Users/praison/...` path

Fixes #1214

Generated with [Claude Code](https://claude.ai/code)