### PR TITLE
docs: document graceful skill degradation (fallback_for_tools / fallback_for_servers)

### DIFF
--- a/docs/features/hermes-openclaw-skills-import.mdx
+++ b/docs/features/hermes-openclaw-skills-import.mdx
@@ -477,12 +477,20 @@ graph LR
         C[requires_env] --> F[SkillRequirements.env_vars]
         G[openclaw] --> H[SkillRequirements.openclaw_hints]
     end
+
+    subgraph "PraisonAI-only Extensions"
+        I[fallback_for_tools] --> J[SkillRequirements.fallback_for_tools]
+        K[fallback_for_servers] --> L[SkillRequirements.fallback_for_servers]
+    end
     
     classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
     classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef praisonai fill:#8B0000,stroke:#7C90A0,color:#fff
     
     class A,B,C,G input
     class D,E,F,H output
+    class I,K praisonai
+    class J,L output
 ```
 
 | Hermes/OpenClaw Key | PraisonAI Field | Validation Result |
@@ -491,6 +499,10 @@ graph LR
 | `requires_servers` | `SkillRequirements.servers` | Missing servers → DEGRADED/UNAVAILABLE |
 | `requires_env` | `SkillRequirements.env_vars` | Missing env vars → DEGRADED |
 | `openclaw` | `SkillRequirements.openclaw_hints` | Passthrough metadata |
+| `fallback_for_tools` ¹ | `SkillRequirements.fallback_for_tools` | Skill hidden when listed tool is present |
+| `fallback_for_servers` ¹ | `SkillRequirements.fallback_for_servers` | Skill hidden when listed server is present |
+
+¹ **PraisonAI-specific extension** — no Hermes/OpenClaw equivalent. Skills with these declarations are auto-hidden when the named capability is available. See [Graceful Fallback Skills](/features/skill-capability-gates#graceful-fallback-skills) for the full behaviour spec.
 
 ### Updated Linting
 
@@ -521,7 +533,9 @@ def lint_frontmatter(skill_path: str) -> list:
             'requires_tools', 'requires-tools',
             'requires_servers', 'requires-servers', 
             'requires_env', 'requires-env',
-            'openclaw'
+            'openclaw',
+            'fallback_for_tools', 'fallback-for-tools',
+            'fallback_for_servers', 'fallback-for-servers',
         ]
         
         return [f"Missing required key: {key}" for key in missing]

--- a/docs/features/hermes-openclaw-skills-import.mdx
+++ b/docs/features/hermes-openclaw-skills-import.mdx
@@ -502,13 +502,16 @@ graph LR
 | `fallback_for_tools` ¹ | `SkillRequirements.fallback_for_tools` | Skill hidden when listed tool is present |
 | `fallback_for_servers` ¹ | `SkillRequirements.fallback_for_servers` | Skill hidden when listed server is present |
 
-¹ **PraisonAI-specific extension** — no Hermes/OpenClaw equivalent. Skills with these declarations are auto-hidden when the named capability is available. See [Graceful Fallback Skills](/features/skill-capability-gates#graceful-fallback-skills) for the full behaviour spec.
+¹ **PraisonAI-specific extension** — no Hermes/OpenClaw equivalent. Skills with these declarations are auto-hidden when the named capability is available. See [Graceful Fallback Skills](/docs/features/skill-capability-gates#graceful-fallback-skills) for the full behaviour spec.
 
 ### Updated Linting
 
 Update your frontmatter linting to accept these new capability requirement keys:
 
 ```python
+import yaml
+from pathlib import Path
+
 def lint_frontmatter(skill_path: str) -> list:
     """Lint SKILL.md frontmatter for compatibility."""
     skill_md = Path(skill_path) / "SKILL.md"
@@ -543,7 +546,7 @@ def lint_frontmatter(skill_path: str) -> list:
         return [f"Invalid YAML: {e}"]
 ```
 
-For complete capability gates documentation, see [Skill Capability Gates](/features/skill-capability-gates).
+For complete capability gates documentation, see [Skill Capability Gates](/docs/features/skill-capability-gates).
 
 ---
 

--- a/docs/features/skill-capability-gates.mdx
+++ b/docs/features/skill-capability-gates.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Skill Capability Gates"
 sidebarTitle: "Capability Gates"
-description: "Declare and enforce tool, server, and env requirements for Agent Skills"
+description: "Declare what skills require — or graceful fallback for — and enforce it at runtime"
 icon: "shield-check"
 ---
 
@@ -118,8 +118,104 @@ All frontmatter keys are **optional** and **backward-compatible**. Existing skil
 | `requires_env` | `requires-env` | `list[str]` or string | `SkillRequirements.env_vars` |
 | `allowed-tools` | — | `list[str]` or string | **Also** appended to `tools` (backward compat) |
 | `openclaw` | — | `dict` | `SkillRequirements.openclaw_hints` (passthrough) |
+| `fallback_for_tools` | `fallback-for-tools` | `list[str]` or string | `SkillRequirements.fallback_for_tools` |
+| `fallback_for_servers` | `fallback-for-servers` | `list[str]` or string | `SkillRequirements.fallback_for_servers` |
 
-**String forms are normalized** — both `requires_tools: "pdf_read, ocr_extract"` and `requires_tools: "pdf_read ocr_extract"` work.
+**String forms are normalized** — both `requires_tools: "pdf_read, ocr_extract"` and `requires_tools: "pdf_read ocr_extract"` work. The same normalization applies to `fallback_for_tools` and `fallback_for_servers`.
+
+---
+
+## Graceful Fallback Skills
+
+`fallback_for_tools` / `fallback_for_servers` let a skill stay hidden until the agent is missing the capability it covers.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Researcher",
+    instructions="Answer questions, citing sources",
+    skills=["./skills/web-via-terminal"],  # auto-hidden if web_search tool is present
+)
+
+agent.start("Find today's BTC closing price")
+```
+
+The matching `SKILL.md` frontmatter:
+
+```yaml
+---
+name: web-via-terminal
+description: Fetch the web via terminal when no web tool is available.
+requires_tools: [terminal]       # this fallback still needs a shell to run
+fallback_for_tools: [web_search] # only offered when web_search is absent
+---
+
+# Web via terminal
+When asked to fetch a URL, use curl/wget through the terminal tool.
+```
+
+### Behaviour
+
+| `web_search` present | `terminal` present | `web-via-terminal` offered? |
+|:--:|:--:|:--:|
+| ✅ | ✅ | ❌ (hidden — capable agent doesn't need fallback) |
+| ❌ | ✅ | ✅ (fallback fires) |
+| ❌ | ❌ | ❌ (own `requires_tools: [terminal]` unmet) |
+| ✅ | ❌ | ❌ (capability already present) |
+
+<Note>
+A fallback skill's own `requires_*` gates are always enforced, regardless of the enforcement level. An unusable fallback is never injected into the agent's context.
+</Note>
+
+### When to Use fallback vs. requires
+
+```mermaid
+graph TB
+    Q{Should the skill always be available?} -->|Yes| R[Use requires_tools / requires_servers]
+    Q -->|"No — only when something is missing"| F[Use fallback_for_tools / fallback_for_servers]
+    F --> N{Does the fallback itself need a tool?}
+    N -->|Yes| C[Add requires_tools alongside fallback_for_tools]
+    N -->|No| D[Just declare fallback_for_*]
+
+    classDef question fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef both fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class Q,N question
+    class R,D result
+    class C,F both
+```
+
+### Skill Discovery Sequence
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant SkillManager
+    participant CapabilityValidator
+    participant ToolRegistry
+
+    Note over Agent,ToolRegistry: Capability PRESENT — fallback hidden
+    Agent->>SkillManager: discover skills
+    SkillManager->>CapabilityValidator: evaluate web-via-terminal
+    CapabilityValidator->>ToolRegistry: is web_search available?
+    ToolRegistry-->>CapabilityValidator: YES
+    CapabilityValidator-->>SkillManager: HIDDEN (fallback not needed)
+    SkillManager-->>Agent: skill excluded from index
+
+    Note over Agent,ToolRegistry: Capability ABSENT — fallback offered
+    Agent->>SkillManager: discover skills
+    SkillManager->>CapabilityValidator: evaluate web-via-terminal
+    CapabilityValidator->>ToolRegistry: is web_search available?
+    ToolRegistry-->>CapabilityValidator: NO
+    CapabilityValidator->>ToolRegistry: is terminal available? (requires_tools)
+    ToolRegistry-->>CapabilityValidator: YES
+    CapabilityValidator-->>SkillManager: ACTIVE (fallback fires)
+    SkillManager-->>Agent: skill included in index
+```
+
+The validator evaluates both `available_tools` / `available_servers` for the keep-or-hide decision and the fallback skill's own `requires_*` gates before injecting it.
 
 ---
 
@@ -292,6 +388,34 @@ praisonai doctor skills --requirements   # Show detailed per-skill diagnostics
 
 ## Common Patterns
 
+### Terminal-based Web Fallback
+
+```yaml
+---
+name: web-via-terminal
+description: Fetch the web via terminal when no web tool is available.
+requires_tools: [terminal]
+fallback_for_tools: [web_search]
+---
+
+# Web via terminal
+When asked to fetch a URL, use curl/wget through the terminal tool.
+```
+
+### Local-file Fallback for Absent MCP Server
+
+```yaml
+---
+name: local-notes
+description: Search ~/notes when the Notion MCP server is unavailable.
+requires_tools: [filesystem_read]
+fallback_for_servers: [mcp:notion]
+---
+
+# Local notes search
+Search ~/notes/ for relevant files when Notion is unavailable.
+```
+
 ### Soft-warn in Dev, Strict in Prod
 
 ```python
@@ -371,6 +495,10 @@ SKILL_CAPABILITY_ENFORCEMENT=warn
 # Production
 SKILL_CAPABILITY_ENFORCEMENT=strict
 ```
+</Accordion>
+
+<Accordion title="Use fallback_for_* for graceful degradation, not as a feature switch">
+Fallback skills disappear automatically when the real capability is present; they are not a runtime toggle. If you need a user-controlled switch, gate the skill with `requires_env` on a feature-flag env var instead.
 </Accordion>
 
 <Accordion title="Cache validation results (validator already caches; document clear_cache())">


### PR DESCRIPTION
## Summary

Documents the graceful skill degradation feature introduced in PraisonAI PR #2434, as requested in issue #1215.

### Changes

**`docs/features/skill-capability-gates.mdx`** (main work):
- Updated `description` frontmatter to cover both requirements and fallback declarations
- Added **Graceful Fallback Skills** section after the Frontmatter Reference with:
  - Agent-centric Quick Start Python example first (per AGENTS.md §1.1 #9)
  - Matching `SKILL.md` frontmatter showing `fallback_for_tools` alongside `requires_tools`
  - Behaviour table covering all 4 scenarios (capability present/absent × own requires met/unmet)
  - Decision diagram (`graph TB`) for choosing `requires_*` vs. `fallback_for_*`
  - Sequence diagram showing skill discovery with two flows: capability present → hidden, capability absent → offered
  - Note about fallback skills' own `requires_*` gates always being enforced
- Extended Frontmatter Reference table with `fallback_for_tools` and `fallback_for_servers` rows including hyphenated aliases
- Added two new Common Patterns: terminal-based web fallback and local-file MCP server fallback
- Added "Use fallback_for_* for graceful degradation, not as a feature switch" Best Practices accordion

**`docs/features/hermes-openclaw-skills-import.mdx`** (cross-link update):
- Added `fallback_for_tools` and `fallback_for_servers` nodes to the Mermaid mapping diagram (styled in `#8B0000` dark red to distinguish as PraisonAI-only)
- Added two new rows to the capability keys table with footnote marking them as PraisonAI-specific extensions with no Hermes/OpenClaw equivalent
- Added cross-link to the new Graceful Fallback Skills section
- Updated the `lint_frontmatter` helper to accept the new frontmatter keys

**`docs/concepts/skills.mdx`** — **not modified** (human-approved only, per AGENTS.md §1.9)

**`docs.json`** — not modified (no new pages added)

## Acceptance Checklist

- [x] `Graceful Fallback Skills` section added after Frontmatter Reference
- [x] Section opens with agent-centric Python `Agent(...)` example before any `SKILL.md` frontmatter
- [x] Imports use `from praisonaiagents import Agent`
- [x] All four behaviour cases listed in a single comparison table
- [x] Frontmatter Reference table includes both `fallback_for_tools` and `fallback_for_servers` rows with hyphenated aliases
- [x] Decision diagram and sequence diagram added with AGENTS.md §3.1 color scheme
- [x] Two new Common Patterns examples added
- [x] New Best Practices accordion added
- [x] `hermes-openclaw-skills-import.mdx` mapping table + Mermaid block updated with PraisonAI-only note and cross-link
- [x] `docs/concepts/skills.mdx` is **unchanged**
- [x] `docs.json` is **unchanged**
- [x] No forbidden phrases used

Fixes #1215

Generated with [Claude Code](https://claude.ai/code)