### PR TITLE
docs: cover skill fallbacks, Retry-After, async max_budget, gateway capabilities (#1218)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -870,6 +870,7 @@
                   "docs/features/callbacks",
                   "docs/features/skills",
                   "docs/features/skill-capability-gates",
+                  "docs/features/skill-fallbacks",
                   "docs/features/skills-vs-tools",
                   "docs/features/workspace",
                   "docs/features/zep-memory",

--- a/docs/features/agent-max-budget.mdx
+++ b/docs/features/agent-max-budget.mdx
@@ -47,6 +47,32 @@ When spend reaches $0.50, the run stops with `BudgetExceededError` including age
 
 </Step>
 
+<Step title="Async run with budget cap">
+
+```python
+import asyncio
+from praisonaiagents import Agent, ExecutionConfig
+
+agent = Agent(
+    name="AsyncResearcher",
+    instructions="Research topics asynchronously",
+    execution=ExecutionConfig(max_budget=0.50),
+)
+
+async def main():
+    try:
+        await agent.astart("Research the history of AI")
+    except Exception as e:
+        if "BudgetExceeded" in type(e).__name__:
+            print(f"Budget exceeded: {e}")
+
+asyncio.run(main())
+```
+
+`astart()` raises `BudgetExceededError` the same way `start()` does — the async path now has identical pre-call guards and post-call cost accounting.
+
+</Step>
+
 <Step title="Warn instead of stopping">
 
 ```python
@@ -68,6 +94,10 @@ With `on_budget_exceeded="warn"`, the agent logs a warning but continues. `warn`
 
 </Step>
 </Steps>
+
+<Note>
+`max_budget` is enforced on both sync (`start()`) and async (`astart()`) paths as of **1.6.88+**. Gateway bots that call `astart()` internally now honour the budget cap and raise `BudgetExceededError` identically to sync runs.
+</Note>
 
 ## How It Works
 

--- a/docs/features/bot-rate-limiting.mdx
+++ b/docs/features/bot-rate-limiting.mdx
@@ -185,6 +185,45 @@ await asyncio.sleep(delay)  # Multiple channels sleep concurrently
 
 ---
 
+## Server-provided Retry-After
+
+When a messaging platform explicitly tells the bot how long to wait, that hint takes precedence over the policy backoff.
+
+```mermaid
+graph TB
+    E[Rate-limit error received] --> P{Server hint present?}
+    P -->|Yes| H[Wait server-mandated seconds]
+    P -->|No| B[Policy exponential backoff]
+    H --> R[Retry send]
+    B --> R
+
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef action fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef retry fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class P decision
+    class H,B action
+    class R retry
+    class E error
+```
+
+**Precedence order (highest first):**
+
+1. **Server-mandated wait** — extracted from the platform error:
+   - **Telegram**: `parameters.retry_after` field (or `.retry_after` attr on `RetryAfter` exception)
+   - **HTTP channels** (Slack / Discord / WhatsApp): `Retry-After` header — integer seconds *or* HTTP-date
+   - **Text fallback**: `retry after ` / `retry_after: ` in the error message body
+2. **Policy exponential backoff** — only used when the server provides no hint
+
+The resilience layer (`_resilience.deliver_with_retry` and `_delivery.deliver_with_retry`) reads the server hint via `server_retry_after(err)` and sleeps for exactly that duration before the next attempt. The `OutboundQueue` also stores the hint and gates the next drain cycle accordingly.
+
+<Note>
+The hint is available across all delivery paths — both the immediate retry helper and the durable outbound queue — so no send bypasses a server-mandated backoff.
+</Note>
+
+---
+
 ## Best Practices
 
 <AccordionGroup>

--- a/docs/features/bot-rate-limiting.mdx
+++ b/docs/features/bot-rate-limiting.mdx
@@ -224,6 +224,31 @@ The hint is available across all delivery paths — both the immediate retry hel
 
 ---
 
+## Penalised Lanes
+
+After a 429 from a messaging platform, `RateLimiter.penalise(channel_id, seconds)` widens the wait window for that channel — and the global window — so the next sends don't immediately re-trip the limit.
+
+```python
+from praisonai.bots._rate_limit import RateLimiter
+
+limiter = RateLimiter.for_platform("telegram")
+
+# When a 429 arrives, the delivery layer calls:
+# limiter.penalise(channel_id="telegram-chat-123", seconds=30)
+# — the channel's per_channel_delay grows for 30 s,
+#   and the global bucket also absorbs the penalty.
+```
+
+`penalise` is called automatically by `_delivery.deliver_with_retry` via its optional `rate_limiter=` argument when a server-mandated `Retry-After` hint is detected. You can also call it manually if you observe 429s through other means.
+
+| What penalise does | Effect |
+|---|---|
+| Widens per-channel wait window by `seconds` | That channel's sends space out |
+| Adds a global bucket penalty | Other channels slow slightly too |
+| Resets automatically after the penalty duration | Normal rate resumes without intervention |
+
+---
+
 ## Best Practices
 
 <AccordionGroup>

--- a/docs/features/gateway-handshake-protocol.mdx
+++ b/docs/features/gateway-handshake-protocol.mdx
@@ -252,6 +252,53 @@ Clients should self-configure from the `policy` object in `hello_ok`. See [Gatew
 
 ---
 
+## Persisted Session State
+
+After `hello_ok`, the gateway records both the negotiated protocol version and the client-advertised capabilities on the `GatewaySession`. These values survive disconnect and resume.
+
+```python
+import asyncio
+from praisonai.gateway import GatewayClient
+
+async def main():
+    client = GatewayClient(
+        url="ws://localhost:8765",
+        agent_id="assistant",
+        capabilities=["streaming", "ack"],
+    )
+    await client.connect()
+    # After hello_ok, the server-side session exposes:
+    # session.protocol_version  → "1"  (negotiated version string)
+    # session.capabilities      → ["streaming", "ack"]  (client-advertised)
+
+asyncio.run(main())
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `session.protocol_version` | `str` | The negotiated protocol version agreed during `hello`. |
+| `session.capabilities` | `list[str]` | The capabilities the client advertised in the `hello` message. |
+
+Both properties are written into `session.to_dict()` and restored by `from_dict()`, so they survive server restarts and session persistence backends.
+
+**Server-side hooks** and **custom routing code** can read these off any live session:
+
+```python
+def on_message(session, payload):
+    if "streaming" in session.capabilities:
+        # send token_stream events
+        ...
+    else:
+        # send complete message at once
+        ...
+```
+
+<Note>
+If `to_dict()` / `from_dict()` encounters a non-list value for capabilities (e.g. from an older snapshot), it is safely restored as `[]` to avoid errors.
+</Note>
+
+---
+
 ## Best Practices
 
 <AccordionGroup>

--- a/docs/features/rate-limiter.mdx
+++ b/docs/features/rate-limiter.mdx
@@ -120,38 +120,6 @@ The limiter applies to both the initial LLM call and the follow-up after tool ex
 
 ---
 
-## Penalised Lanes
-
-After a 429 from a messaging platform, `RateLimiter.penalise(channel_id, seconds)` widens the wait window for that channel — and the global window — so the next sends don't immediately re-trip the limit.
-
-```python
-from praisonaiagents import Agent
-from praisonai.bots._rate_limit import RateLimiter
-
-# Shared limiter for a Telegram bot
-limiter = RateLimiter.for_platform("telegram")
-
-agent = Agent(
-    name="TelegramBot",
-    instructions="Reply helpfully",
-)
-
-# When a 429 arrives, the delivery layer calls:
-# limiter.penalise(channel_id="telegram-chat-123", seconds=30)
-# — the channel's per_channel_delay grows for 30 s,
-#   and the global bucket also absorbs the penalty.
-```
-
-`penalise` is called automatically by `_delivery.deliver_with_retry` via its optional `rate_limiter=` argument when a server-mandated `Retry-After` hint is detected. You can also call it manually if you observe 429s through other means.
-
-| What penalise does | Effect |
-|---|---|
-| Widens per-channel wait window by `seconds` | That channel's sends space out |
-| Adds a global bucket penalty | Other channels slow slightly too |
-| Resets automatically after the penalty duration | Normal rate resumes without intervention |
-
----
-
 ## Best Practices
 
 <AccordionGroup>

--- a/docs/features/rate-limiter.mdx
+++ b/docs/features/rate-limiter.mdx
@@ -120,6 +120,38 @@ The limiter applies to both the initial LLM call and the follow-up after tool ex
 
 ---
 
+## Penalised Lanes
+
+After a 429 from a messaging platform, `RateLimiter.penalise(channel_id, seconds)` widens the wait window for that channel — and the global window — so the next sends don't immediately re-trip the limit.
+
+```python
+from praisonaiagents import Agent
+from praisonai.bots._rate_limit import RateLimiter
+
+# Shared limiter for a Telegram bot
+limiter = RateLimiter.for_platform("telegram")
+
+agent = Agent(
+    name="TelegramBot",
+    instructions="Reply helpfully",
+)
+
+# When a 429 arrives, the delivery layer calls:
+# limiter.penalise(channel_id="telegram-chat-123", seconds=30)
+# — the channel's per_channel_delay grows for 30 s,
+#   and the global bucket also absorbs the penalty.
+```
+
+`penalise` is called automatically by `_delivery.deliver_with_retry` via its optional `rate_limiter=` argument when a server-mandated `Retry-After` hint is detected. You can also call it manually if you observe 429s through other means.
+
+| What penalise does | Effect |
+|---|---|
+| Widens per-channel wait window by `seconds` | That channel's sends space out |
+| Adds a global bucket penalty | Other channels slow slightly too |
+| Resets automatically after the penalty duration | Normal rate resumes without intervention |
+
+---
+
 ## Best Practices
 
 <AccordionGroup>

--- a/docs/features/skill-fallbacks.mdx
+++ b/docs/features/skill-fallbacks.mdx
@@ -1,0 +1,222 @@
+---
+title: "Skill Fallbacks"
+sidebarTitle: "Skill Fallbacks"
+description: "Offer a skill only when a capability is missing — graceful degradation for skills"
+icon: "puzzle-piece"
+---
+
+Fallback skills are offered only when a needed tool or MCP server is absent.
+
+```mermaid
+graph LR
+    subgraph "Skill Fallback Logic"
+        T{Primary Tool Present?}
+        T -->|Yes| H[Fallback Hidden]
+        T -->|No| R{Fallback Requirements Met?}
+        R -->|Yes| S[Fallback Shown]
+        R -->|No| H2[Fallback Hidden]
+    end
+
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef shown fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef hidden fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class T,R decision
+    class S shown
+    class H,H2 hidden
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Declare a fallback in SKILL.md">
+
+Add `fallback_for_tools` or `fallback_for_servers` to the SKILL.md frontmatter:
+
+```yaml
+---
+name: web-via-terminal
+description: Fetch web content using terminal when no web tool is available
+requires_tools: [terminal]
+fallback_for_tools: [web]
+---
+
+# Web via Terminal
+When the web tool is absent, use terminal commands like curl to fetch content.
+```
+
+The skill appears **only when** the `web` tool is not present, and **only when** `terminal` is available.
+
+</Step>
+
+<Step title="Wire it into an Agent">
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Researcher",
+    instructions="Find information for the user",
+    skills=["./skills/web-via-terminal", "./skills/web-fetch"],
+)
+agent.start("Look up the latest Python release")
+```
+
+- If `web-fetch` provides a `web` tool → `web-via-terminal` is hidden.
+- If only `terminal` is available → `web-via-terminal` is offered.
+
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant SkillManager
+    participant Skill as web-via-terminal
+
+    Agent->>SkillManager: get_available_skills()
+    SkillManager->>Skill: check fallback_for_tools = [web]
+    alt web tool present
+        SkillManager-->>Agent: skill excluded (primary present)
+    else web tool absent
+        SkillManager->>Skill: check requires_tools = [terminal]
+        alt terminal present
+            SkillManager-->>Agent: skill included
+        else terminal absent
+            SkillManager-->>Agent: skill excluded (requires_tools not met)
+        end
+    end
+```
+
+| Primary tool state | Fallback `requires_*` met? | Skill offered? |
+|---|---|---|
+| **Present** | Any | No — primary handles it |
+| **Absent** | Yes | Yes — fallback steps in |
+| **Absent** | No | No — fallback can't run either |
+
+<Note>
+The skill's own `requires_tools` / `requires_servers` / `requires_env` gates still apply on top of fallback eligibility. A fallback skill that can't satisfy its own requirements is still excluded.
+</Note>
+
+---
+
+## Configuration Options
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `fallback_for_tools` | `list[str]` | `[]` | Skill is offered only when none of these tool names are present. |
+| `fallback_for_servers` | `list[str]` | `[]` | Skill is offered only when none of these MCP server names are present. |
+| `fallback-for-tools` | `list[str]` | `[]` | Hyphenated alias of `fallback_for_tools`. |
+| `fallback-for-servers` | `list[str]` | `[]` | Hyphenated alias of `fallback_for_servers`. |
+
+Both underscore and hyphen forms are accepted. If both are set, the union is used.
+
+---
+
+## Common Patterns
+
+### Web fallback via terminal
+
+When a native `web` tool is absent, let agents use `curl` through the `terminal` tool instead:
+
+```yaml
+---
+name: web-via-terminal
+requires_tools: [terminal]
+fallback_for_tools: [web]
+---
+```
+
+### Local search fallback when no MCP search server is configured
+
+```yaml
+---
+name: local-grep-search
+description: Search local files using grep when no MCP search server is available
+requires_tools: [terminal]
+fallback_for_servers: [mcp-search-server]
+---
+```
+
+### Multiple primary tools — fallback hidden unless all are absent
+
+```yaml
+---
+name: lightweight-pdf-reader
+requires_tools: [terminal]
+fallback_for_tools: [pdf_read, ocr_extract]
+---
+```
+
+The fallback is hidden if **any** of `pdf_read` or `ocr_extract` is present.
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Pair fallback_for_* with requires_*">
+A fallback skill that cannot run is still excluded. Always declare the tools the fallback actually needs via `requires_tools` so the skill manager can gate it properly.
+
+```yaml
+---
+name: web-via-terminal
+requires_tools: [terminal]        # needs terminal to run
+fallback_for_tools: [web]         # only offered when web is absent
+---
+```
+</Accordion>
+
+<Accordion title="Keep fallback skill outputs self-explanatory">
+Fallback skills run in place of a primary capability — their output should be as close as possible to what the primary would produce. Add notes in the skill body describing any known differences.
+</Accordion>
+
+<Accordion title="Don't chain fallbacks">
+Avoid making a fallback skill declare its own `fallback_for_*` pointing to another fallback skill. The filter logic is applied once during skill discovery and chaining is not resolved automatically.
+</Accordion>
+
+<Accordion title="Test with the primary absent and present">
+Verify both paths: that the fallback appears when the primary is absent, and that it disappears when the primary is present.
+
+```python
+# Without primary tool
+agent_no_web = Agent(
+    name="Test",
+    instructions="Research topics",
+    skills=["./skills/web-via-terminal"],  # web tool not loaded
+)
+
+# With primary tool loaded — fallback should be hidden
+agent_with_web = Agent(
+    name="Test",
+    instructions="Research topics",
+    skills=["./skills/web-via-terminal", "./skills/web-fetch"],
+)
+```
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Skill Capability Gates" icon="shield-check" href="/docs/features/skill-capability-gates">
+  Declare tool, server, and env requirements — the forward gates that fallbacks complement
+</Card>
+<Card title="Agent Skills" icon="puzzle-piece" href="/docs/features/skills">
+  Overview of the skills system and how to write skills
+</Card>
+<Card title="Skill Invocation" icon="play" href="/docs/features/skills-invocation">
+  How skills are invoked at runtime
+</Card>
+<Card title="Skill Lifecycle" icon="rotate" href="/docs/features/skill-lifecycle">
+  Discover, validate, and activate skills
+</Card>
+</CardGroup>

--- a/docs/features/token-budgeting.mdx
+++ b/docs/features/token-budgeting.mdx
@@ -38,6 +38,10 @@ graph LR
     classDef tool fill:#189AB4,color:#fff
 ```
 
+<Note>
+**Async enforcement (1.6.88+):** `ExecutionConfig(max_budget=...)` is now enforced on async agent runs (`astart()`) as well as sync runs. `BudgetExceededError` is raised on both paths when the cap is exceeded. Gateway bots also honour the budget.
+</Note>
+
 ## Quick Start
 
 <Steps>


### PR DESCRIPTION
## Summary

Covers 4 merged PraisonAI PRs that had no documentation:

### PR #2434 — Skill Fallbacks
- **New page** `docs/features/skill-fallbacks.mdx`
- Documents `fallback_for_tools` / `fallback_for_servers` SKILL.md frontmatter keys
- Includes hero Mermaid diagram, Quick Start, How It Works sequence diagram, configuration table, common patterns, best practices (AccordionGroup), related links (CardGroup)
- `docs.json` updated: `features/skill-fallbacks` added to Features group

### PR #2431 — Server-provided Retry-After
- **Updated** `docs/features/bot-rate-limiting.mdx`
  - New "Server-provided Retry-After" section with decision diagram
  - Precedence: Telegram `parameters.retry_after` → HTTP `Retry-After` header → text fallback → policy backoff
- **Updated** `docs/features/rate-limiter.mdx`
  - New "Penalised Lanes" section documenting `RateLimiter.penalise(channel_id, seconds)`

### PR #2425 — Async max_budget enforcement
- **Updated** `docs/features/agent-max-budget.mdx`
  - Note callout: `max_budget` now enforced on `astart()` as of 1.6.88+
  - New async Quick Start step with `astart()` example
- **Updated** `docs/features/token-budgeting.mdx`
  - Note callout: async enforcement parity

### PR #2429 — Gateway hello capabilities persisted
- **Updated** `docs/features/gateway-handshake-protocol.mdx`
  - New "Persisted Session State" section: `session.protocol_version`, `session.capabilities`, `to_dict`/`from_dict` round-trip, server hook example

## Checklist
- [x] `docs/features/skill-fallbacks.mdx` created, follows AGENTS.md template
- [x] `docs/features/bot-rate-limiting.mdx` updated with Retry-After section
- [x] `docs/features/rate-limiter.mdx` updated with penalised lanes section
- [x] `docs/features/agent-max-budget.mdx` updated with async enforcement note
- [x] `docs/features/token-budgeting.mdx` updated with async enforcement note
- [x] `docs/features/gateway-handshake-protocol.mdx` updated with persisted session state
- [x] `docs.json` updated for new page; JSON validates
- [x] No `docs/concepts/` files touched

Fixes #1218

Generated with [Claude Code](https://claude.ai/code)