### PR TITLE
docs: confirm ExecutionConfig(max_budget) covers async/bots/gateway

### DIFF
--- a/docs/features/agent-max-budget.mdx
+++ b/docs/features/agent-max-budget.mdx
@@ -102,6 +102,10 @@ Budget tracking adds zero overhead when `max_budget` is `None` (the default). In
 
 Before each LLM call in `stop` mode, the agent estimates the minimum call cost: input tokens ≈ total characters ÷ 4, plus the configured `max_tokens` output reservation. If the running total plus this estimate meets or exceeds `max_budget`, the call is blocked before dispatch — the LLM is never billed and `$0` is recorded for that turn.
 
+## Async, Streaming, Bots & Gateway
+
+Budget enforcement covers every dispatch path — sync `agent.start()`, async `agent.astart()`, streaming, and the bot / gateway flow. The same pre-call guard (`stop` mode) and post-call accounting (`warn` / callable) run on both `_chat_completion` and `_execute_unified_achat_completion`, so a bot deployed with `execution=ExecutionConfig(max_budget=0.50)` will refuse the over-budget call rather than silently overrunning.
+
 ## Configuration Options
 
 | Option | Type | Default | Description |

--- a/docs/features/cli-budget-handling.mdx
+++ b/docs/features/cli-budget-handling.mdx
@@ -104,6 +104,8 @@ The `praisonai` CLI wraps every `agent.start(...)` / `agent.chat(...)` call in a
 1. Prints a single-line, red, rich-formatted message including the actionable hint.
 2. Exits with code `1` so shell scripts and CI can detect the failure.
 
+- The same handler covers async (`agent.astart()`) and streaming paths — bots and gateway deployments route through here and respect `max_budget` identically.
+
 This works across **every** CLI display mode: `silent` (`-qq`), `quiet` (`-q`), `verbose` (`-v`), `debug` (`-vv`), `--output jsonl`, `--output json`, `--output flow`, `--output editor`, and default.
 
 ---


### PR DESCRIPTION
## Summary

- Adds a new Async, Streaming, Bots & Gateway subsection to docs/features/agent-max-budget.mdx confirming budget enforcement applies to all dispatch paths.
- Appends a clarifying bullet to docs/features/cli-budget-handling.mdx noting the same handler covers agent.astart() and streaming paths.
- No new files created; docs/concepts/ untouched; docs.json unchanged.

Fixes #1221

Generated with Claude Code https://claude.ai/code