### PR TITLE
docs: add Skill Bundles page (fixes #1222)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -869,6 +869,7 @@
                   "docs/features/variable-substitution",
                   "docs/features/callbacks",
                   "docs/features/skills",
+                  "docs/features/skill-bundles",
                   "docs/features/skill-capability-gates",
                   "docs/features/skills-vs-tools",
                   "docs/features/workspace",

--- a/docs/features/skill-bundles.mdx
+++ b/docs/features/skill-bundles.mdx
@@ -1,0 +1,281 @@
+---
+title: "Skill Bundles"
+sidebarTitle: "Skill Bundles"
+description: "Select a named, reusable set of skills with a single @bundle marker"
+icon: "boxes-stacked"
+---
+
+Skill bundles let one `@name` reference pull in a whole set of skills at once.
+
+```mermaid
+graph LR
+    subgraph "Skill Bundles"
+        S["@backend-dev"] --> R[🧠 Resolve]
+        R --> A[📋 code-review]
+        R --> B[📋 tdd]
+        R --> C[📋 pr-workflow]
+        A & B & C --> P[✅ Agent prompt]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class S input
+    class R process
+    class A,B,C agent
+    class P output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Define a bundle (YAML)">
+Create a manifest file in your skills directory:
+
+```yaml
+# ./.praisonai/skills/bundles/backend-dev.yaml
+name: backend-dev
+description: Backend feature work.
+skills: [code-review, tdd, pr-workflow]
+instruction: Prefer small, reviewable commits.
+```
+</Step>
+
+<Step title="Select the bundle from an Agent">
+Pass the `@bundle-name` selector in `skills`:
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Backend Helper",
+    instructions="Help me ship backend features.",
+    skills=["@backend-dev"],
+)
+
+agent.start("Add a /health endpoint")
+```
+</Step>
+
+<Step title="Or use YAML / CLI">
+```yaml
+# agents.yaml
+agents:
+  helper:
+    role: Helper
+    goal: Ship features
+    backstory: You are helpful.
+    skills:
+      - "@backend-dev"
+```
+
+```bash
+praisonai skills bundle list
+praisonai skills bundle show backend-dev
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant SkillManager
+    participant Bundle as Bundle store
+    participant Skills as Skill store
+
+    User->>Agent: Agent(skills=["@backend-dev"])
+    Agent->>SkillManager: discover_bundles()
+    Agent->>SkillManager: resolve(["@backend-dev"])
+    SkillManager->>Bundle: lookup "backend-dev"
+    Bundle-->>SkillManager: ["code-review", "tdd", "pr-workflow"]
+    loop each member
+        SkillManager->>Skills: add_skill_by_name(member)
+    end
+    SkillManager-->>Agent: ready, prompt includes bundle_instructions
+```
+
+| Entry | What the Agent does |
+|-------|---------------------|
+| `"./skills/code-review"` | Loads the skill at that path (unchanged behaviour). |
+| `"@backend-dev"` | Resolves the bundle, loads each member skill by name. |
+| `"@unknown"` | Logs a WARNING and continues. The Agent does not crash. |
+
+---
+
+## Manifest Format
+
+Two layouts are supported — choose the one that fits your structure.
+
+**Layout A — bundles/ folder (recommended for shared sets):**
+
+```yaml
+# ./.praisonai/skills/bundles/backend-dev.yaml
+name: backend-dev
+description: Backend feature work.
+skills: [code-review, tdd, pr-workflow]
+instruction: Prefer small, reviewable commits.
+```
+
+**Layout B — BUNDLE.yaml inside a skill directory:**
+
+```yaml
+# ./.praisonai/skills/frontend/BUNDLE.yaml
+name: frontend
+skills:
+  - ui-review
+  - storybook
+```
+
+### Manifest Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | required | Bundle name (kebab-case). Empty or missing raises `ValueError`. |
+| `description` | `str` | `""` | Free-text description of the bundle's purpose. |
+| `skills` | `List[str]` | `[]` | Member skill names or nested `@bundle` selectors. |
+| `instruction` | `str \| None` | `None` | Bundle-level guidance injected above the member skills. |
+| `path` | `Path \| None` | `None` | Path to the manifest file (set on discovery; not user-supplied). |
+
+<Note>
+`BundleManifest.from_dict()` accepts both `skills:` (preferred) and `members:` keys, and handles both string (`"a, b c"`) and list forms.
+</Note>
+
+---
+
+## Discovery Locations
+
+`discover_bundles()` scans each skill root for:
+
+1. `bundles/*.yaml` and `bundles/*.yml` (sorted; first-registration-wins on collision)
+2. Per-skill-dir: `BUNDLE.yaml`, `BUNDLE.yml`, `bundle.yaml`, `bundle.yml`
+
+Default roots follow the same precedence as skill discovery:
+
+<Steps>
+  <Step title="Project">`./.praisonai/skills/` or `./.claude/skills/`</Step>
+  <Step title="Ancestors">Every `.praisonai/skills` or `.claude/skills` in a parent directory</Step>
+  <Step title="User">`~/.praisonai/skills/`</Step>
+  <Step title="System">`/etc/praison/skills/`</Step>
+</Steps>
+
+---
+
+## Nested Bundles
+
+Bundles can reference other bundles with `@` selectors:
+
+```yaml
+# bundles/common.yaml
+name: common
+skills: [log, cfg]
+
+# bundles/backend.yaml
+name: backend
+skills:
+  - "@common"
+  - api
+```
+
+```python
+from praisonaiagents.skills import SkillManager
+
+mgr = SkillManager()
+mgr.resolve(["@backend"])  # → ["log", "cfg", "api"]
+```
+
+Cycle protection is built in — a bundle that directly or indirectly references itself is logged and skipped, so there is no infinite recursion.
+
+---
+
+## Bundle Instructions
+
+When a bundle has an `instruction:` field, it is surfaced to the LLM in a `<bundle_instructions>` block above the regular `<available_skills>` block:
+
+```xml
+<bundle_instructions>
+Prefer small, reviewable commits.
+</bundle_instructions>
+
+<available_skills>
+...
+</available_skills>
+```
+
+Nested bundles contribute their instructions too, in selection order. See `SkillManager.to_prompt()` for the full XML shape.
+
+---
+
+## CLI Reference
+
+```bash
+praisonai skills bundle list
+
+praisonai skills bundle list --dirs ./.praisonai/skills
+
+praisonai skills bundle show backend-dev
+praisonai skills bundle show @backend-dev
+```
+
+Exit code `1` if `show` cannot find the named bundle.
+
+---
+
+## Choosing Between Options
+
+```mermaid
+flowchart TD
+    Q{Pick one or many skills?}
+    Q -->|one specific skill| P[Use a path: skills=['./skills/x']]
+    Q -->|a fixed, named set used in many agents| B[Use a bundle: skills=['@team-defaults']]
+    Q -->|skills selected dynamically by an LLM| A[Use auto-discovery + LLM activation]
+
+    classDef opt fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef pick fill:#F59E0B,stroke:#7C90A0,color:#fff
+    class Q pick
+    class P,B,A opt
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Name bundles by intent, not by team">
+    Use names like `backend-dev`, `pr-author`, not `team-A`. Bundles represent a capability set, not an org chart — other teams can adopt the same bundle without renaming.
+  </Accordion>
+  <Accordion title="Keep bundles small (3–7 skills)">
+    Large bundles consume more of the agent's context budget. When a bundle grows beyond 7 skills, split it into composable sub-bundles and reference them with `@` selectors.
+  </Accordion>
+  <Accordion title="Use instruction: for cross-cutting guidance">
+    Anything that applies to all member skills — like "Prefer small commits" — belongs at bundle level. Avoid duplicating the same instruction across every `SKILL.md`.
+  </Accordion>
+  <Accordion title="Bundles are forgiving by design">
+    A typo in `@bundle` or a missing member skill logs a warning and continues — the agent does not crash. Watch logs in CI; do not rely on a crash to catch typos.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Agent Skills" icon="puzzle-piece" href="/docs/features/skills">
+    Author SKILL.md files and configure skills on agents
+  </Card>
+  <Card title="Skill Invocation" icon="slash" href="/docs/features/skills-invocation">
+    How skills are invoked via slash commands, auto-trigger, and programmatic API
+  </Card>
+  <Card title="Skills Config" icon="gear" href="/docs/configuration/skills-config">
+    `SkillsConfig` discovery options
+  </Card>
+  <Card title="Skills CLI" icon="terminal" href="/docs/cli/skills">
+    `praisonai skills` CLI overview
+  </Card>
+</CardGroup>

--- a/docs/features/skills-invocation.mdx
+++ b/docs/features/skills-invocation.mdx
@@ -277,6 +277,9 @@ Save `SKILL.md` as UTF-8. Run `praisonai skills validate --path ./my-skill` to c
 <Card title="Agent Skills" icon="puzzle-piece" href="/docs/features/skills">
   Author SKILL.md files and configure skills on agents
 </Card>
+<Card title="Skill Bundles" icon="boxes-stacked" href="/docs/features/skill-bundles">
+  Select a named, reusable set of skills with a single @bundle marker
+</Card>
 <Card title="Skill Manage" icon="wand-magic-sparkles" href="/docs/features/skill-manage">
   Create, edit, and approve agent-proposed skills
 </Card>

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -23,6 +23,10 @@ agent.start("Extract the main findings from report.pdf")
 </Note>
 
 <Tip>
+**Want to group several skills under one name?** See [Skill Bundles](/docs/features/skill-bundles) — a single `@bundle` selector expands to a full set of skills.
+</Tip>
+
+<Tip>
 **Want to generate a skill from your own repo or docs?** See [Learn a Skill from Sources](/docs/features/learn-skill) — one command turns code/docs/PDFs into a grounded `SKILL.md`.
 </Tip>
 


### PR DESCRIPTION
## Summary

- Creates `docs/features/skill-bundles.mdx` — new page for the Skill Bundles feature shipped in [MervinPraison/PraisonAI#2435](https://github.com/MervinPraison/PraisonAI/pull/2435)
- Registers the page in `docs.json` under the Features group (sibling of `docs/features/skills`)
- Adds a cross-link Tip in `docs/features/skills.mdx` pointing to the new page
- Adds a Skill Bundles card to the Related section of `docs/features/skills-invocation.mdx`

## What the new page covers

- Hero Mermaid diagram (standard AGENTS.md colour palette)
- Quick Start with `<Steps>`: define bundle YAML → Python agent → YAML/CLI
- How It Works sequence diagram + entry-behaviour table
- Manifest format (both layouts: `bundles/*.yaml` and `BUNDLE.yaml`)
- All `BundleManifest` fields with types and defaults (exact SDK match)
- Discovery locations (same precedence as skill discovery)
- Nested bundles + cycle protection
- Bundle instructions (`<bundle_instructions>` prompt injection)
- CLI reference: `praisonai skills bundle list` / `show`
- Decision flowchart: path vs bundle vs auto-discovery
- Best Practices accordion group
- Related `<CardGroup>`

Fixes #1222

Generated with [Claude Code](https://claude.ai/code)