### PR TITLE
docs: update stale praisonai[...] install hints to praisonai-frameworks[...]

### DIFF
--- a/docs/api-reference/index.mdx
+++ b/docs/api-reference/index.mdx
@@ -25,7 +25,7 @@ This section provides detailed information about the PraisonAI API and its frame
 ### CrewAI Integration
 Requires installation with:
 ```bash
-pip install "praisonai[crewai]"
+pip install "praisonai-frameworks[crewai]"
 ```
 
 Features:
@@ -37,7 +37,7 @@ Features:
 ### AG2 (Formerly AutoGen) Integration
 Requires installation with:
 ```bash
-pip install "praisonai[autogen]"
+pip install "praisonai-frameworks[autogen]"
 ```
 
 Features:

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -22,8 +22,8 @@ from praisonai.auto import AutoGenerator
 
 ### praisonai.agents_generator
 Framework-specific agent generation and orchestration:
-- CrewAI support (requires `praisonai[crewai]`)
-- AG2 (Formerly AutoGen) support (requires `praisonai[autogen]`)
+- CrewAI support (requires `praisonai-frameworks[crewai]`)
+- AG2 (Formerly AutoGen) support (requires `praisonai-frameworks[autogen]`)
 
 ```python
 from praisonai.agents_generator import AgentsGenerator
@@ -68,9 +68,9 @@ print(__version__)   # "X.Y.Z"
 pip install praisonai
 
 # Framework-specific installations
-pip install "praisonai[crewai]"    # Install with CrewAI support
-pip install "praisonai[autogen]"   # Install with AG2 support
-pip install "praisonai[crewai,autogen]"  # Install both frameworks
+pip install "praisonai-frameworks[crewai]"    # Install with CrewAI support
+pip install "praisonai-frameworks[autogen]"   # Install with AG2 support
+pip install "praisonai-frameworks[crewai,autogen]"  # Install both frameworks
 
 # Additional features
 pip install "praisonai[ui]"        # Install UI support
@@ -83,14 +83,14 @@ pip install "praisonai[call]"      # Install Call feature
 ## Framework-specific Features
 
 ### CrewAI
-When installing with `pip install "praisonai[crewai]"`, you get:
+When installing with `pip install "praisonai-frameworks[crewai]"`, you get:
 - CrewAI framework support
 - PraisonAI tools integration
 - Task delegation capabilities
 - Sequential and parallel task execution
 
 ### AG2 (Formerly AutoGen)
-When installing with `pip install "praisonai[autogen]"`, you get:
+When installing with `pip install "praisonai-frameworks[autogen]"`, you get:
 - AG2 framework support
 - PraisonAI tools integration
 - Multi-agent conversation capabilities

--- a/docs/features/auto-generator-providers.mdx
+++ b/docs/features/auto-generator-providers.mdx
@@ -35,7 +35,7 @@ graph LR
 Install PraisonAI and set your OpenAI key:
 
 ```bash
-pip install "praisonai[crewai]"
+pip install "praisonai-frameworks[crewai]"
 ```
 
 ```bash

--- a/docs/features/framework-adapter-plugins.mdx
+++ b/docs/features/framework-adapter-plugins.mdx
@@ -242,9 +242,9 @@ class AutoGenFamilyAdapter(BaseFrameworkAdapter):
 
         raise ImportError(
             "No AutoGen variant is available. Install with:\n"
-            "  pip install 'praisonai[autogen]' for v0.2\n"
-            "  pip install 'praisonai[autogen-v4]' for v0.4\n"
-            "  pip install 'praisonai[ag2]' for AG2"
+            "  pip install 'praisonai-frameworks[autogen]' for v0.2\n"
+            "  pip install 'praisonai-frameworks[autogen-v4]' for v0.4\n"
+            "  pip install 'praisonai-frameworks[ag2]' for AG2"
         )
 
     def resolve(self, *, config: Optional[Dict[str, Any]] = None) -> "BaseFrameworkAdapter":

--- a/docs/framework/autogen.mdx
+++ b/docs/framework/autogen.mdx
@@ -43,9 +43,9 @@ Only AutoGen v0.2 is working today. Both v0.4 and AG2 adapters are stubs that ra
 ```mermaid
 graph TB
     Start[Which AutoGen framework name?] --> Q1{Do you need to pin<br/>exactly v0.2?}
-    Q1 -->|Yes| A1["framework: autogen_v2<br/>pip install praisonai[autogen]"]
+    Q1 -->|Yes| A1["framework: autogen_v2<br/>pip install praisonai-frameworks[autogen]"]
     Q1 -->|No| Q2{Let the router pick<br/>based on AUTOGEN_VERSION?}
-    Q2 -->|Yes| A2["framework: autogen<br/>pip install praisonai[autogen]"]
+    Q2 -->|Yes| A2["framework: autogen<br/>pip install praisonai-frameworks[autogen]"]
     Q2 -->|Future v0.4| A3["framework: autogen_v4 🚧<br/>raises NotImplementedError today"]
 
     classDef question fill:#6366F1,stroke:#7C90A0,color:#fff
@@ -59,10 +59,10 @@ graph TB
 
 | Framework | Install | Best For | Status |
 |-----------|---------|----------|--------|
-| `framework: autogen` | `pip install "praisonai[autogen]"` | Family router — picks variant via `AUTOGEN_VERSION` | ✅ Working (v0.2 only) |
-| `framework: autogen_v2` | `pip install "praisonai[autogen]"` | Pin v0.2 directly, skip the router | ✅ Working |
-| `framework: autogen_v4` | `pip install "praisonai[autogen-v4]"` | Future AutoGen v0.4 support | 🚧 Stub — raises `NotImplementedError` |
-| `framework: ag2` | `pip install "praisonai[ag2]"` | Future AG2 support | 🚧 Stub — raises `NotImplementedError` |
+| `framework: autogen` | `pip install "praisonai-frameworks[autogen]"` | Family router — picks variant via `AUTOGEN_VERSION` | ✅ Working (v0.2 only) |
+| `framework: autogen_v2` | `pip install "praisonai-frameworks[autogen]"` | Pin v0.2 directly, skip the router | ✅ Working |
+| `framework: autogen_v4` | `pip install "praisonai-frameworks[autogen-v4]"` | Future AutoGen v0.4 support | 🚧 Stub — raises `NotImplementedError` |
+| `framework: ag2` | `pip install "praisonai-frameworks[ag2]"` | Future AG2 support | 🚧 Stub — raises `NotImplementedError` |
 
 ---
 
@@ -110,9 +110,9 @@ If no AutoGen variant is installed, the family router raises:
 ```python
 # No AutoGen variant installed → ImportError:
 #   No AutoGen variant is available. Install with:
-#     pip install 'praisonai[autogen]' for v0.2
-#     pip install 'praisonai[autogen-v4]' for v0.4
-#     pip install 'praisonai[ag2]' for AG2
+#     pip install 'praisonai-frameworks[autogen]' for v0.2
+#     pip install 'praisonai-frameworks[autogen-v4]' for v0.4
+#     pip install 'praisonai-frameworks[ag2]' for AG2
 ```
 
 ---
@@ -125,7 +125,7 @@ Original AutoGen v0.2 support — the only fully-working AutoGen adapter today.
 
 <Step title="Install">
 ```bash
-pip install "praisonai[autogen]"
+pip install "praisonai-frameworks[autogen]"
 ```
 </Step>
 
@@ -256,12 +256,12 @@ When no AutoGen variant is installed and `framework: autogen` is used:
 
 ```
 ImportError: No AutoGen variant is available. Install with:
-  pip install 'praisonai[autogen]' for v0.2
-  pip install 'praisonai[autogen-v4]' for v0.4
-  pip install 'praisonai[ag2]' for AG2
+  pip install 'praisonai-frameworks[autogen]' for v0.2
+  pip install 'praisonai-frameworks[autogen-v4]' for v0.4
+  pip install 'praisonai-frameworks[ag2]' for AG2
 ```
 
-Fix: `pip install "praisonai[autogen]"` for v0.2 (the only working option today).
+Fix: `pip install "praisonai-frameworks[autogen]"` for v0.2 (the only working option today).
 
 ### NotImplementedError on v0.4 or AG2
 

--- a/docs/framework/crewai.mdx
+++ b/docs/framework/crewai.mdx
@@ -34,7 +34,7 @@ graph LR
 
 <Step title="Install">
 ```bash
-pip install "praisonai[crewai]"
+pip install "praisonai-frameworks[crewai]"
 ```
 </Step>
 
@@ -315,13 +315,13 @@ praisonai --framework crewai --auto "Create a Movie Script About Cat in Mars"
 ```
 Framework 'crewai' was requested but is not installed.
 Install it with:
-    pip install 'praisonai[crewai]'   # or: pip install crewai
+    pip install 'praisonai-frameworks[crewai]'   # or: pip install crewai
 ```
 The error appears **immediately**, before YAML parsing — so a typo in `--framework` is caught before any expensive setup runs.
 
 ### Installation Errors
 
-- **Missing CrewAI**: `pip install "praisonai[crewai]"`
+- **Missing CrewAI**: `pip install "praisonai-frameworks[crewai]"`
 - **Tool resolution issues**: Ensure tool names in `tools: []` exist in the global `tools_dict`
 
 ---

--- a/docs/nocode/installation.mdx
+++ b/docs/nocode/installation.mdx
@@ -26,13 +26,13 @@ Version: 2.x.x
 
 ```bash
 # CrewAI framework
-pip install "praisonai[crewai]"
+pip install "praisonai-frameworks[crewai]"
 
 # AG2 (AutoGen) framework
-pip install "praisonai[autogen]"
+pip install "praisonai-frameworks[autogen]"
 
 # Both frameworks
-pip install "praisonai[crewai,autogen]"
+pip install "praisonai-frameworks[crewai,autogen]"
 ```
 
 ## Optional: Additional Features

--- a/docs/nocode/tldr.mdx
+++ b/docs/nocode/tldr.mdx
@@ -38,12 +38,12 @@ praisonai agents.yaml
 
 ```bash
 # CrewAI
-pip install "praisonai[crewai]"
+pip install "praisonai-frameworks[crewai]"
 python -m praisonai --framework crewai --init "create a report"
 python -m praisonai --framework crewai
 
 # AG2 (AutoGen)
-pip install "praisonai[autogen]"
+pip install "praisonai-frameworks[autogen]"
 python -m praisonai --framework autogen --init "create a report"
 python -m praisonai --framework autogen
 ```

--- a/docs/sdk/praisonai/index.mdx
+++ b/docs/sdk/praisonai/index.mdx
@@ -80,13 +80,13 @@ pip install praisonai
 ### CrewAI Integration
 
 ```bash
-pip install "praisonai[crewai]"
+pip install "praisonai-frameworks[crewai]"
 ```
 
 ### AutoGen Integration
 
 ```bash
-pip install "praisonai[autogen]"
+pip install "praisonai-frameworks[autogen]"
 ```
 
 ## Related

--- a/docs/tools/tools.mdx
+++ b/docs/tools/tools.mdx
@@ -967,9 +967,9 @@ pip install praisonaiagents praisonai-tools
 <Tab title="Wrapper with Tools">
 ```bash
 # Via wrapper (includes praisonai-tools automatically)
-pip install "praisonai[crewai]"
+pip install "praisonai-frameworks[crewai]"
 # or
-pip install "praisonai[autogen]"
+pip install "praisonai-frameworks[autogen]"
 ```
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

Updates 10 `.mdx` documentation files to replace stale `praisonai[crewai]`, `praisonai[autogen]`, `praisonai[autogen-v4]`, and `praisonai[ag2]` install hints with the new `praisonai-frameworks[...]` package extras, following the package split in MervinPraison/PraisonAI#2464.

**Files updated:**
- `docs/api.mdx`
- `docs/api-reference/index.mdx`
- `docs/framework/autogen.mdx`
- `docs/framework/crewai.mdx`
- `docs/features/auto-generator-providers.mdx`
- `docs/features/framework-adapter-plugins.mdx`
- `docs/sdk/praisonai/index.mdx`
- `docs/tools/tools.mdx`
- `docs/nocode/installation.mdx`
- `docs/nocode/tldr.mdx`

**Not touched:** `praisonai[ui]`, `praisonai[chat]`, `praisonai[code]`, `praisonai[realtime]`, `praisonai[call]` — those extras still live on the `praisonai` package.

Fixes #1244

Generated with [Claude Code](https://claude.ai/code)