### PR TITLE
docs: DOCS_PARITY.md audit notes — parity script false negatives (fixes #1242)

### DIFF
--- a/docs/features/DOCS_PARITY.md
+++ b/docs/features/DOCS_PARITY.md
@@ -89,11 +89,15 @@ This report compares **Python SDK feature categories** against **Python document
 |----------|----------|
 | ❌ Vector Store | 1 |
 
+> **⚠️ Audit note (2026-06-30):** `docs/features/vector-store.mdx` (364 lines) already exists and covers `praisonaiagents/knowledge/vector_store.py`. The parity script is mis-categorising this page under **Knowledge** because `vector_store.py` lives inside `praisonaiagents/knowledge/`. This is a false negative in the generator, **not** a missing doc page. Do not create a duplicate page. File an upstream bug against `praisonai._dev.parity.docs_generator` in `MervinPraison/PraisonAI` to fix the bucket mapping. See issue [#1242](https://github.com/MervinPraison/PraisonAIDocs/issues/1242) for details.
+
 ## Documentation Without Features
 
 These docs exist but don't match any implemented feature category:
 
 - ℹ️ Documents (1 docs, 775 lines)
+
+> **ℹ️ Audit note (2026-06-30):** The "Documents" orphan is likely `docs/examples/agent-recipes/documents/` or a recipe-only collection. Investigate which file/folder the parity script counts and either (a) rename it to match an existing SDK category, or (b) accept it as a non-feature recipe (informational only). See issue [#1242](https://github.com/MervinPraison/PraisonAIDocs/issues/1242) for details.
 
 ---
 

--- a/docs/js/DOCS_PARITY.md
+++ b/docs/js/DOCS_PARITY.md
@@ -98,11 +98,27 @@ This report compares **TypeScript/JavaScript SDK feature categories** against **
 | ❌ Token Management | 1 |
 | ❌ Vector Store | 6 |
 
+> **⚠️ Audit note (2026-06-30):** The following doc pages already exist in `docs/js/` but the parity generator is not matching them to the SDK categories listed above. This is a false negative in the generator — **do not create duplicate pages**. Re-run the generator or file an upstream bug against `praisonai._dev.parity.docs_generator` in `MervinPraison/PraisonAI` to fix the bucket mapping. See issue [#1242](https://github.com/MervinPraison/PraisonAIDocs/issues/1242) for details.
+>
+> | Category (flagged ❌) | Existing doc file |
+> |-----------------------|-------------------|
+> | AI SDK | `docs/js/ai-sdk.mdx`, `docs/js/ai-sdk-cli.mdx` |
+> | Jobs | `docs/js/jobs.mdx` |
+> | Middleware | `docs/js/middleware.mdx` |
+> | Scheduler | `docs/js/scheduler.mdx`, `docs/js/scheduler-cli.mdx` |
+> | Streaming | `docs/js/streaming.mdx`, `docs/js/streaming-cli.mdx` |
+> | Token Management | `docs/js/token-management.mdx` |
+> | Vector Store | `docs/js/vector-store.mdx`, `docs/js/vector-stores.mdx` |
+>
+> Per AGENTS.md §1.8 these pages are **auto-generated only** — do not hand-author new pages in `docs/js/`.
+
 ## Documentation Without Features
 
 These docs exist but don't match any implemented feature category:
 
 - ℹ️ Deep Research (2 docs, 292 lines)
+
+> **ℹ️ Audit note (2026-06-30):** The "Deep Research" orphan is likely `docs/js/deep-research.mdx` and `docs/js/deep-research-cli.mdx`. Investigate whether these map to an upstream TypeScript SDK category and update the generator's bucket list if so. See issue [#1242](https://github.com/MervinPraison/PraisonAIDocs/issues/1242) for details.
 
 ---
 

--- a/docs/rust/DOCS_PARITY.md
+++ b/docs/rust/DOCS_PARITY.md
@@ -91,11 +91,25 @@ This report compares **Rust SDK feature categories** against **Rust documentatio
 | ❌ Token Management | 2 |
 | ❌ Vector Store | 2 |
 
+> **⚠️ Audit note (2026-06-30):** The following doc pages already exist in `docs/rust/` but the parity generator is not matching them to the SDK categories listed above. This is a false negative in the generator — **do not create duplicate pages**. Re-run the generator or file an upstream bug against `praisonai._dev.parity.docs_generator` in `MervinPraison/PraisonAI` to fix the bucket mapping. See issue [#1242](https://github.com/MervinPraison/PraisonAIDocs/issues/1242) for details.
+>
+> | Category (flagged ❌) | Existing doc file |
+> |-----------------------|-------------------|
+> | Callbacks | `docs/rust/callbacks.mdx` |
+> | Process | `docs/rust/process.mdx` |
+> | Streaming | `docs/rust/streaming.mdx` |
+> | Token Management | `docs/rust/token-management.mdx` |
+> | Vector Store | `docs/rust/vector-store.mdx` |
+>
+> Per AGENTS.md §1.8 these pages are **auto-generated only** — do not hand-author new pages in `docs/rust/`.
+
 ## Documentation Without Features
 
 These docs exist but don't match any implemented feature category:
 
 - ℹ️ CLI (1 docs, 123 lines)
+
+> **ℹ️ Audit note (2026-06-30):** The "CLI" orphan is likely `docs/rust/cli.mdx`. Investigate whether this maps to an upstream Rust SDK category and update the generator's bucket list if so, or accept it as an informational page (CLI usage for the Rust SDK). See issue [#1242](https://github.com/MervinPraison/PraisonAIDocs/issues/1242) for details.
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses the 2026-06-30 AGENTS.md compliance audit from #1242 (Pass 1 — parity tracker annotation).

- **`docs/features/DOCS_PARITY.md`**: Added audit note explaining that the `❌ Vector Store` entry is a false negative. `docs/features/vector-store.mdx` (364 lines) already exists and covers `praisonaiagents/knowledge/vector_store.py`. The parity script mis-categorises the page under "Knowledge" because `vector_store.py` lives inside `praisonaiagents/knowledge/`. No duplicate page should be created.

- **`docs/js/DOCS_PARITY.md`**: Added audit note with a mapping table showing that all 7 "undocumented" JS categories already have existing pages (`ai-sdk.mdx`, `jobs.mdx`, `middleware.mdx`, `scheduler.mdx`, `streaming.mdx`, `token-management.mdx`, `vector-store.mdx`). The generator is not matching them to their SDK categories.

- **`docs/rust/DOCS_PARITY.md`**: Added audit note with a mapping table showing that all 5 "undocumented" Rust categories already have existing pages (`callbacks.mdx`, `process.mdx`, `streaming.mdx`, `token-management.mdx`, `vector-store.mdx`). Same generator bucket-mapping issue.

## What was NOT done (and why)

- **No new pages created**: The audit found the Python feature corpus is complete (Vector Store page exists). Creating new JS/Rust pages would violate AGENTS.md §1.8 (auto-generated only).
- **No `docs/concepts/` edits**: All concept-page fixes require human approval (AGENTS.md §1.9). Sibling issue created: #1257.
- **Friendly-import fix deferred**: `docs/concepts/agentflow.mdx:109` fix needs human approval — tracked in #1257.
- **Upstream parity generator not fixed**: The generator is in `MervinPraison/PraisonAI` (separate repo). The false-negative reports should be filed there as bugs.

## Test plan

- [x] `docs/features/DOCS_PARITY.md` is valid Markdown with audit note explaining Vector Store discrepancy
- [x] `docs/js/DOCS_PARITY.md` is valid Markdown with mapping table of existing pages
- [x] `docs/rust/DOCS_PARITY.md` is valid Markdown with mapping table of existing pages
- [x] No `docs/concepts/` files were touched
- [x] No new `.mdx` pages created
- [x] `docs.json` unchanged (verified no navigation changes needed)

Generated with [Claude Code](https://claude.ai/code)