### PR TITLE
docs(telemetry): fix fictitious signatures and update enable/disable behavior

### DIFF
--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -103,6 +103,15 @@ graph LR
         export DO_NOT_TRACK=true
         ```
     </Step>
+
+    <Step title="Enable Telemetry Explicitly (Optional)">
+        To enable telemetry via environment variable (required since telemetry is off by default):
+        ```bash
+        export PRAISONAI_TELEMETRY_ENABLED=true
+        # or
+        export PRAISONAI_PERFORMANCE_ENABLED=true
+        ```
+    </Step>
 </Steps>
 
 ## What is Tracked
@@ -134,29 +143,41 @@ Telemetry can be disabled in multiple ways:
 
 ### Environment Variables (Recommended)
 
+**Opt-out (any of these disables telemetry):**
 ```bash
-# Set any of these before running your code
 export PRAISONAI_TELEMETRY_DISABLED=true
 export PRAISONAI_DISABLE_TELEMETRY=true
+export PRAISONAI_PERFORMANCE_DISABLED=true
 export DO_NOT_TRACK=true  # Universal standard
 export OTEL_SDK_DISABLED=true  # OpenTelemetry standard
+```
+
+**Opt-in (required since telemetry is off by default):**
+```bash
+export PRAISONAI_TELEMETRY_ENABLED=true
+# or
+export PRAISONAI_PERFORMANCE_ENABLED=true
 ```
 
 <Note>
 **CLI Integration:** As of PR #1552, PraisonAI respects pre-existing `OTEL_SDK_DISABLED` environment variables instead of overwriting them. Telemetry initialization now runs from `cli.PraisonAI.__init__` (explicit call to `_ensure_telemetry_defaults()`), not from the lazy `__getattr__` hook in `praisonai/__init__.py`. This means importing `praisonai` no longer touches the filesystem or `os.environ`; only constructing `PraisonAI(...)` does. Initialization is also thread-safe (uses `threading.Lock`).
 </Note>
 
-### Programmatically
+### Enabling / Disabling Telemetry Programmatically
 
 ```python
-from praisonaiagents import disable_telemetry, get_telemetry
+from praisonaiagents import enable_telemetry, disable_telemetry
 
+# Turn telemetry on (no-op if an env opt-out is set)
+enable_telemetry()
+
+# Turn telemetry off — instrumentation hooks stop installing
 disable_telemetry()
-
-# Option 2: Disable at runtime
-telemetry = get_telemetry()
-telemetry.enabled = False
 ```
+
+<Note>
+**Precedence:** Explicit environment opt-out always wins. Setting `DO_NOT_TRACK=true` (or any of the `*_DISABLED` flags above) makes `enable_telemetry()` a no-op. Otherwise, the most recent programmatic call decides the state. With neither set, telemetry is off by default until `enable_telemetry()` is called or `PRAISONAI_TELEMETRY_ENABLED=true` / `PRAISONAI_PERFORMANCE_ENABLED=true` is exported.
+</Note>
 
 ### Langfuse + opt-out coexistence
 
@@ -329,6 +350,7 @@ collector.stop()
     - Verify telemetry.enabled is True
     - Check debug logs with LOGLEVEL=DEBUG
     - Ensure you're using the latest version
+    - If you call `enable_telemetry()` but hooks still don't fire, check whether an opt-out env var (`DO_NOT_TRACK`, `PRAISONAI_TELEMETRY_DISABLED`, `PRAISONAI_DISABLE_TELEMETRY`, `PRAISONAI_PERFORMANCE_DISABLED`) is set — those always win
   </Card>
 
   <Card title="Privacy Concerns" icon="shield">

--- a/docs/sdk/praisonaiagents/telemetry.mdx
+++ b/docs/sdk/praisonaiagents/telemetry.mdx
@@ -42,82 +42,58 @@ Telemetry features require installation with the telemetry extra: `pip install p
 Retrieves the current telemetry instance.
 
 ```python
-def get_telemetry() -> Optional[TelemetryCollector]
+def get_telemetry() -> MinimalTelemetry
 ```
 
 **Returns:**
-- `Optional[TelemetryCollector]`: The current telemetry collector instance, or None if telemetry is disabled
+- `MinimalTelemetry`: The global telemetry instance. Always returns an instance (never `None`). Check `.enabled` to see if telemetry is active.
 
 **Example:**
 ```python
 telemetry = get_telemetry()
-if telemetry:
-    print(f"Telemetry enabled: {telemetry.enabled}")
-    print(f"Collection level: {telemetry.level}")
+print(f"Telemetry enabled: {telemetry.enabled}")
 ```
 
 ### enable_telemetry
 
-Enables telemetry collection with specified configuration.
+Programmatically enables telemetry. If an environment opt-out variable is set, this call is a no-op.
 
 ```python
-def enable_telemetry(
-    level: str = "minimal",
-    custom_collector: Optional[TelemetryCollector] = None,
-    export_endpoint: Optional[str] = None,
-    export_interval: int = 60,
-    include_prompts: bool = False,
-    include_results: bool = False
-) -> TelemetryCollector
+def enable_telemetry() -> None
 ```
 
-**Parameters:**
-- `level` (str, optional): Telemetry level ("minimal", "basic", "detailed"). Defaults to "minimal"
-- `custom_collector` (TelemetryCollector, optional): Custom telemetry collector instance
-- `export_endpoint` (str, optional): Endpoint for exporting telemetry data
-- `export_interval` (int, optional): Export interval in seconds. Defaults to 60
-- `include_prompts` (bool, optional): Include prompt content in telemetry. Defaults to False
-- `include_results` (bool, optional): Include result content in telemetry. Defaults to False
+**Returns:** `None`
 
-**Returns:**
-- `TelemetryCollector`: The enabled telemetry collector instance
-
-**Telemetry Levels:**
-- `"minimal"`: Basic metrics only (counts, timings)
-- `"basic"`: Includes error information and performance metrics
-- `"detailed"`: Full telemetry including traces and detailed metrics
+<Note>
+**Precedence:** Explicit environment opt-out always wins over programmatic calls. Setting `DO_NOT_TRACK=true` (or any `*_DISABLED` flag) makes `enable_telemetry()` a no-op. Otherwise, telemetry is off by default until `enable_telemetry()` is called or an opt-in env var is exported.
+</Note>
 
 **Example:**
 ```python
-# Enable minimal telemetry
-telemetry = enable_telemetry(level="minimal")
+from praisonaiagents import enable_telemetry, get_telemetry
 
-# Enable detailed telemetry with custom endpoint
-telemetry = enable_telemetry(
-    level="detailed",
-    export_endpoint="http://localhost:4317",
-    export_interval=30,
-    include_prompts=False,
-    include_results=False
-)
+# Turn telemetry on (no-op if an env opt-out is set)
+enable_telemetry()
+assert get_telemetry().enabled is True
 ```
 
 ### disable_telemetry
 
-Disables telemetry collection completely.
+Programmatically disables telemetry. Instrumentation hooks stop installing after this call.
 
 ```python
 def disable_telemetry() -> None
 ```
 
+**Returns:** `None`
+
 **Example:**
 ```python
+from praisonaiagents import disable_telemetry, get_telemetry
+
 # Disable all telemetry
 disable_telemetry()
-
-# Verify telemetry is disabled
-telemetry = get_telemetry()
-assert telemetry is None or not telemetry.enabled
+assert get_telemetry().enabled is False
 ```
 
 ## Classes
@@ -319,14 +295,19 @@ collector.shutdown()
 
 ## Environment Variables
 
-Telemetry behavior can be configured via environment variables:
+Telemetry behavior is controlled by these environment variables:
 
-- `PRAISONAI_TELEMETRY_ENABLED`: Enable/disable telemetry ("true"/"false")
-- `PRAISONAI_TELEMETRY_LEVEL`: Set telemetry level ("minimal"/"basic"/"detailed")
-- `PRAISONAI_TELEMETRY_ENDPOINT`: Set export endpoint
-- `PRAISONAI_TELEMETRY_EXPORT_INTERVAL`: Set export interval in seconds
-- `PRAISONAI_TELEMETRY_INCLUDE_PROMPTS`: Include prompts in telemetry ("true"/"false")
-- `PRAISONAI_TELEMETRY_INCLUDE_RESULTS`: Include results in telemetry ("true"/"false")
+**Opt-in (enables telemetry when set to `true`):**
+- `PRAISONAI_TELEMETRY_ENABLED=true`
+- `PRAISONAI_PERFORMANCE_ENABLED=true`
+
+**Opt-out (disables telemetry; always wins over programmatic calls):**
+- `PRAISONAI_TELEMETRY_DISABLED=true`
+- `PRAISONAI_DISABLE_TELEMETRY=true`
+- `PRAISONAI_PERFORMANCE_DISABLED=true`
+- `DO_NOT_TRACK=true`
+
+**Precedence:** `env opt-out > programmatic override > cached env-default`
 
 ## Privacy and Security
 
@@ -344,14 +325,9 @@ from praisonaiagents import (
     get_telemetry,
     disable_telemetry
 )
-import os
 
-# Configure via environment
-os.environ["PRAISONAI_TELEMETRY_LEVEL"] = "detailed"
-os.environ["PRAISONAI_TELEMETRY_ENDPOINT"] = "http://localhost:4317"
-
-# Enable telemetry
-telemetry = enable_telemetry()
+# Enable telemetry programmatically (no-op if env opt-out is set)
+enable_telemetry()
 
 # Create agents - telemetry is automatically integrated
 agent = Agent(
@@ -360,52 +336,26 @@ agent = Agent(
 )
 
 # Run agent - metrics are automatically collected
-result = agent.run("Analyze the sales data")
+result = agent.start("Analyze the sales data")
 
 # Access telemetry data
-if telemetry:
-    # Custom metric
-    telemetry.record_metric(
-        "custom_analysis_score",
-        value=0.95,
-        labels={"category": "sales"}
-    )
-    
-    # Custom event
-    telemetry.record_event(
-        "analysis_completed",
-        attributes={
-            "agent": "AnalysisAgent",
-            "data_points": 1000
-        }
-    )
+telemetry = get_telemetry()
+if telemetry.enabled:
+    # Manually track events (usually automatic)
+    telemetry.track_agent_execution("AnalysisAgent", success=True)
+    telemetry.track_task_completion("AnalyzeData", success=True)
+    telemetry.track_tool_usage("web_search", success=True)
+    telemetry.track_error("ValueError")
+    telemetry.track_feature_usage("custom_feature")
 
 # Disable telemetry when done
 disable_telemetry()
+assert get_telemetry().enabled is False
 ```
 
 ## Integration with Observability Platforms
 
-PraisonAI telemetry is compatible with OpenTelemetry and can export to:
-
-- **Prometheus**: Metrics collection and alerting
-- **Jaeger**: Distributed tracing
-- **Grafana**: Visualization and dashboards
-- **Datadog**: Full-stack monitoring
-- **New Relic**: Application performance monitoring
-- **CloudWatch**: AWS monitoring service
-
-### Example: Prometheus Integration
-
-```python
-# Enable telemetry with Prometheus endpoint
-telemetry = enable_telemetry(
-    level="detailed",
-    export_endpoint="http://localhost:9090/metrics"
-)
-
-# Metrics will be automatically exported in Prometheus format
-```
+For OpenTelemetry, Langfuse, and Prometheus integrations, see the [Observability documentation](/docs/observability/).
 
 ## Best Practices
 

--- a/docs/sdk/reference/praisonaiagents/functions/disable_telemetry.mdx
+++ b/docs/sdk/reference/praisonaiagents/functions/disable_telemetry.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Disable Telemetry • AI Agent SDK"
 sidebarTitle: "Disable Telemetry"
-description: "disable_telemetry: Disable telemetry."
+description: "disable_telemetry: Programmatically disable telemetry."
 icon: "function"
 ---
 
@@ -13,18 +13,18 @@ icon: "function"
 
 > This function is defined in the [**telemetry**](../modules/telemetry) module.
 
-Disable telemetry.
+Programmatically disable telemetry.
 
 ## Signature
 
 ```python
-def disable_telemetry() -> Any
+def disable_telemetry() -> None
 ```
 
 ### Returns
 
-<ResponseField name="Returns" type="Any">
-  The result of the operation.
+<ResponseField name="Returns" type="None">
+  No return value. After this call, `get_telemetry().enabled` is `False`.
 </ResponseField>
 
 

--- a/docs/sdk/reference/praisonaiagents/functions/enable_telemetry.mdx
+++ b/docs/sdk/reference/praisonaiagents/functions/enable_telemetry.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Enable Telemetry • AI Agent SDK"
 sidebarTitle: "Enable Telemetry"
-description: "enable_telemetry: Enable telemetry (if not disabled by environment)."
+description: "enable_telemetry: Programmatically enable telemetry (if not disabled by environment)."
 icon: "function"
 ---
 
@@ -13,18 +13,18 @@ icon: "function"
 
 > This function is defined in the [**telemetry**](../modules/telemetry) module.
 
-Enable telemetry (if not disabled by environment).
+Programmatically enable telemetry (if not disabled by environment).
 
 ## Signature
 
 ```python
-def enable_telemetry() -> Any
+def enable_telemetry() -> None
 ```
 
 ### Returns
 
-<ResponseField name="Returns" type="Any">
-  The result of the operation.
+<ResponseField name="Returns" type="None">
+  No return value. This is a no-op if any environment opt-out variable is set (`DO_NOT_TRACK`, `PRAISONAI_TELEMETRY_DISABLED`, `PRAISONAI_DISABLE_TELEMETRY`, `PRAISONAI_PERFORMANCE_DISABLED`).
 </ResponseField>
 
 


### PR DESCRIPTION
## Summary

- Replaces fake `enable_telemetry(level=..., export_endpoint=...)` signature with the real parameterless `enable_telemetry() -> None`
- Removes fictitious "Telemetry Levels" section (minimal/basic/detailed don't exist in SDK)
- Removes fictitious env vars (`PRAISONAI_TELEMETRY_LEVEL`, `_ENDPOINT`, `_EXPORT_INTERVAL`, `_INCLUDE_PROMPTS`, `_INCLUDE_RESULTS`)
- Adds real env vars: `PRAISONAI_PERFORMANCE_DISABLED` (opt-out), `PRAISONAI_TELEMETRY_ENABLED`, `PRAISONAI_PERFORMANCE_ENABLED` (opt-in)
- Adds precedence ladder documentation: `env opt-out > programmatic override > cached env-default`
- Adds symmetric `enable_telemetry()` example alongside `disable_telemetry()` in features doc
- Adds `<Note>` callout explaining precedence rules
- Fixes `disable_telemetry()` example: `get_telemetry()` returns a `MinimalTelemetry` instance (never `None`), so check `.enabled` not `is None`
- Updates stub reference files: correct return type `-> None` (not `-> Any`) with proper description

Fixes #1245

Generated with [Claude Code](https://claude.ai/code)