### PR TITLE
docs: fix friendly-import violations in workflow examples (fixes #1257)

### DIFF
--- a/examples/conditional_branching_example.py
+++ b/examples/conditional_branching_example.py
@@ -12,8 +12,7 @@ The if: pattern enables dynamic workflow paths based on
 runtime conditions and variable values.
 """
 
-from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-from praisonaiagents.workflows import if_, loop
+from praisonaiagents import AgentFlow, WorkflowContext, StepResult, if_, loop
 
 
 # =============================================================================

--- a/examples/nested_workflows_example.py
+++ b/examples/nested_workflows_example.py
@@ -11,8 +11,7 @@ These patterns enable complex data processing pipelines
 while maintaining clean, readable workflow definitions.
 """
 
-from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-from praisonaiagents.workflows import loop, parallel, route
+from praisonaiagents import AgentFlow, WorkflowContext, StepResult, loop, parallel, route
 
 
 # =============================================================================

--- a/examples/workflows/workflow_loop_csv.py
+++ b/examples/workflows/workflow_loop_csv.py
@@ -4,8 +4,7 @@ Agentic Loop with CSV Workflow Example
 Demonstrates iterating over a CSV file with an agent processing each row.
 """
 
-from praisonaiagents import Agent, Workflow
-from praisonaiagents.workflows import loop
+from praisonaiagents import Agent, Workflow, loop
 import tempfile
 import os
 

--- a/examples/workflows/workflow_loop_csv_non_agentic.py
+++ b/examples/workflows/workflow_loop_csv_non_agentic.py
@@ -4,8 +4,7 @@ Workflow Loop with CSV Example
 Demonstrates iterating over a CSV file, processing each row.
 """
 
-from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-from praisonaiagents.workflows import loop
+from praisonaiagents import AgentFlow, WorkflowContext, StepResult, loop
 import tempfile
 import os
 

--- a/examples/workflows/workflow_loop_list.py
+++ b/examples/workflows/workflow_loop_list.py
@@ -4,8 +4,7 @@ Workflow Loop with List Example
 Demonstrates iterating over a list of items, processing each one.
 """
 
-from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-from praisonaiagents.workflows import loop
+from praisonaiagents import AgentFlow, WorkflowContext, StepResult, loop
 
 # Sample data
 fruits = ["apple", "banana", "cherry", "date", "elderberry"]

--- a/examples/workflows/workflow_parallel.py
+++ b/examples/workflows/workflow_parallel.py
@@ -5,8 +5,7 @@ Demonstrates running multiple agents concurrently and
 combining their results with an aggregator agent.
 """
 
-from praisonaiagents import Agent, AgentFlow
-from praisonaiagents.workflows import parallel
+from praisonaiagents import Agent, AgentFlow, parallel
 
 # Create parallel research agents
 market_researcher = Agent(

--- a/examples/workflows/workflow_parallel_non_agentic.py
+++ b/examples/workflows/workflow_parallel_non_agentic.py
@@ -5,8 +5,7 @@ Demonstrates running multiple steps concurrently and
 combining their results.
 """
 
-from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-from praisonaiagents.workflows import parallel
+from praisonaiagents import AgentFlow, WorkflowContext, StepResult, parallel
 import time
 
 # Parallel workers - each does independent work

--- a/examples/workflows/workflow_repeat.py
+++ b/examples/workflows/workflow_repeat.py
@@ -5,8 +5,7 @@ Demonstrates the evaluator-optimizer pattern where an agent
 generates content and another evaluates it, repeating until approved.
 """
 
-from praisonaiagents import Agent, Workflow
-from praisonaiagents.workflows import repeat
+from praisonaiagents import Agent, Workflow, repeat
 
 # Create generator agent
 generator = Agent(

--- a/examples/workflows/workflow_repeat_non_agentic.py
+++ b/examples/workflows/workflow_repeat_non_agentic.py
@@ -5,8 +5,7 @@ Demonstrates repeating a step until a condition is met.
 This is useful for iterative improvement patterns.
 """
 
-from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-from praisonaiagents.workflows import repeat
+from praisonaiagents import AgentFlow, WorkflowContext, StepResult, repeat
 
 # Simulated content generator that improves each iteration
 class ContentGenerator:

--- a/examples/workflows/workflow_routing.py
+++ b/examples/workflows/workflow_routing.py
@@ -5,8 +5,7 @@ Demonstrates decision-based routing where an agent classifier
 routes to specialized handler agents based on the request type.
 """
 
-from praisonaiagents import Agent, AgentFlow
-from praisonaiagents.workflows import route
+from praisonaiagents import Agent, AgentFlow, route
 
 # Create classifier agent
 classifier = Agent(

--- a/examples/workflows/workflow_routing_non_agentic.py
+++ b/examples/workflows/workflow_routing_non_agentic.py
@@ -5,8 +5,7 @@ Demonstrates decision-based routing where the workflow
 takes different paths based on the output of a decision step.
 """
 
-from praisonaiagents import AgentFlow, WorkflowContext, StepResult
-from praisonaiagents.workflows import route
+from praisonaiagents import AgentFlow, WorkflowContext, StepResult, route
 
 # Decision maker - determines which route to take
 def classify_request(ctx: WorkflowContext) -> StepResult:


### PR DESCRIPTION
## Summary

Fixes the friendly-import violations identified in issue #1257 that exist in the `examples/` directory (not `docs/concepts/` which requires human approval per AGENTS.md §1.9).

### Changes Made

Replaced `from praisonaiagents.workflows import X` with `from praisonaiagents import X` in 11 example files:

| File | Symbols fixed |
|------|--------------|
| `examples/conditional_branching_example.py` | `if_`, `loop` |
| `examples/nested_workflows_example.py` | `loop`, `parallel`, `route` |
| `examples/workflows/workflow_loop_csv.py` | `loop` |
| `examples/workflows/workflow_loop_csv_non_agentic.py` | `loop` |
| `examples/workflows/workflow_loop_list.py` | `loop` |
| `examples/workflows/workflow_parallel.py` | `parallel` |
| `examples/workflows/workflow_parallel_non_agentic.py` | `parallel` |
| `examples/workflows/workflow_repeat.py` | `repeat` |
| `examples/workflows/workflow_repeat_non_agentic.py` | `repeat` |
| `examples/workflows/workflow_routing.py` | `route` |
| `examples/workflows/workflow_routing_non_agentic.py` | `route` |

### Rationale

Per AGENTS.md §6.1, the preferred user-friendly import style is `from praisonaiagents import loop` (and similar). All these symbols are available at the top level via lazy `__getattr__` in `praisonaiagents/__init__.py`.

### What Was NOT Changed (Requires Human Approval)

The following `docs/concepts/` files require explicit human approval per AGENTS.md §1.9 before AI edits are allowed:
- `docs/concepts/agentflow.mdx` line 109 — `from praisonaiagents.workflows import loop` violation
- 11 concept pages missing `<Steps>` component
- `docs/concepts/claw.mdx` missing hero Mermaid diagram

A maintainer must approve those edits separately before an agent can apply them.

Fixes #1257

Generated with [Claude Code](https://claude.ai/code)