### PR TITLE
docs: document BEFORE_TOOL_DEFINITIONS hook event

### DIFF
--- a/docs/features/hook-events.mdx
+++ b/docs/features/hook-events.mdx
@@ -18,12 +18,13 @@ graph TB
         B --> C[💬 USER_PROMPT_SUBMIT]
         C --> D[🤖 BEFORE_AGENT]
         D --> E[🧠 BEFORE_LLM]
-        E --> F[📤 AFTER_LLM]
-        F --> G[🔧 BEFORE_TOOL]
-        G --> H[⚙️ Tool Execution]
-        H --> I[📦 AFTER_TOOL]
-        I --> J[✅ AFTER_AGENT]
-        J --> K[📴 SESSION_END]
+        E --> F[📋 BEFORE_TOOL_DEFINITIONS]
+        F --> G[📤 AFTER_LLM]
+        G --> H[🔧 BEFORE_TOOL]
+        H --> I[⚙️ Tool Execution]
+        I --> J[📦 AFTER_TOOL]
+        J --> K[✅ AFTER_AGENT]
+        K --> L[📴 SESSION_END]
     end
     
     classDef setup fill:#6366F1,stroke:#7C90A0,color:#fff
@@ -33,10 +34,10 @@ graph TB
     classDef result fill:#10B981,stroke:#7C90A0,color:#fff
     
     class A setup
-    class B,K session
-    class C,D,J agent
-    class E,F,G,I tool
-    class H result
+    class B,L session
+    class C,D,K agent
+    class E,F,G,H,J tool
+    class I result
 
     classDef agent fill:#8B0000,color:#fff
     classDef tool fill:#189AB4,color:#fff
@@ -98,6 +99,64 @@ def before_tool(event_data):
 @registry.on(HookEvent.AFTER_TOOL)
 def after_tool(event_data):
     print(f"Result: {event_data.result}")
+    return HookResult.allow()
+```
+
+### Tool Definition Events
+
+| Event | Trigger | Input Type | Use Case |
+|-------|---------|------------|----------|
+| `BEFORE_TOOL_DEFINITIONS` | After advertised tool list is assembled, before sent to LLM | `BeforeToolDefinitionsInput` | Redact tools per request, append usage notes, constrain schema per model |
+
+`BEFORE_TOOL_DEFINITIONS` lets you shape the tool list the LLM actually sees — without changing the agent's permanent tool registration. Mutate `tool_definitions` **in place**; the runtime only adopts in-place mutations.
+
+<Warning>
+Mutate in place using `event_data.tool_definitions[:] = [...]`. Reassigning the local name (`event_data.tool_definitions = [...]`) is silently ignored by the runtime.
+</Warning>
+
+#### BeforeToolDefinitionsInput Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `tool_definitions` | `List[Dict[str, Any]]` | `[]` | The fully-assembled OpenAI-style tool definition list about to be sent to the LLM. Mutate **in place** to filter or rewrite. |
+| `model` | `str` | `""` | Model id the call will be sent to (e.g. `"gpt-4o"`). Use for per-model filtering. |
+| `session_id`, `cwd`, `event_name`, `timestamp`, `agent_name` | — | — | Standard `HookInput` fields. |
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.hooks import HookRegistry, HookEvent, HookResult
+
+registry = HookRegistry()
+
+@registry.on(HookEvent.BEFORE_TOOL_DEFINITIONS)
+def sandbox_tools(event_data):
+    # Drop dangerous tools for this request
+    event_data.tool_definitions[:] = [
+        t for t in event_data.tool_definitions
+        if t["function"]["name"] != "delete_file"
+    ]
+    # Annotate remaining tools
+    for t in event_data.tool_definitions:
+        if t["function"]["name"] == "read_file":
+            t["function"]["description"] += " (sandboxed: /workspace only)"
+    return HookResult.allow()
+
+agent = Agent(
+    name="SafeAgent",
+    instructions="Help the user with file operations.",
+    hooks=registry,
+)
+
+agent.start("List my files")
+```
+
+**Per-model filtering** using the `model` field:
+
+```python
+@registry.on(HookEvent.BEFORE_TOOL_DEFINITIONS)
+def small_model_subset(event_data):
+    if event_data.model.startswith("gpt-3.5"):
+        event_data.tool_definitions[:] = event_data.tool_definitions[:5]
     return HookResult.allow()
 ```
 
@@ -459,6 +518,7 @@ def handle_blocked(event_data):
 |-------|----------|-------------|
 | `BEFORE_TOOL` | Tool | Before tool execution |
 | `AFTER_TOOL` | Tool | After tool execution |
+| `BEFORE_TOOL_DEFINITIONS` | Tool | Before tool definitions are sent to LLM |
 | `BEFORE_AGENT` | Agent | Before agent runs |
 | `AFTER_AGENT` | Agent | After agent completes |
 | `BEFORE_LLM` | LLM | Before LLM API call |

--- a/docs/features/hooks.mdx
+++ b/docs/features/hooks.mdx
@@ -10,7 +10,9 @@ Hooks intercept agent actions at lifecycle points so you can log, modify, or blo
 ```mermaid
 graph LR
     subgraph "Agent Lifecycle"
-        INPUT["📥 Input"] --> BEFORE["🪝 BEFORE_TOOL\nhook"]
+        INPUT["📥 Input"] --> BTD["🪝 BEFORE_TOOL_DEFINITIONS\nhook"]
+        BTD --> LLM["🧠 LLM Call"]
+        LLM --> BEFORE["🪝 BEFORE_TOOL\nhook"]
         BEFORE --> TOOL["⚙️ Tool\nExecution"]
         TOOL --> AFTER["🪝 AFTER_TOOL\nhook"]
         AFTER --> OUTPUT["📤 Output"]
@@ -22,8 +24,8 @@ graph LR
     classDef success fill:#10B981,stroke:#7C90A0,color:#fff
 
     class INPUT,OUTPUT agent
-    class TOOL tool
-    class BEFORE,AFTER hook
+    class TOOL,LLM tool
+    class BTD,BEFORE,AFTER hook
 
     classDef agent fill:#8B0000,color:#fff
     classDef tool fill:#189AB4,color:#fff
@@ -120,6 +122,7 @@ sequenceDiagram
 |-------|--------------|
 | `before_tool` | Before any tool executes |
 | `after_tool` | After a tool returns a result |
+| `before_tool_definitions` | After tool list assembled, before sent to LLM — shape what the model sees |
 | `before_agent` | Before the agent starts a turn |
 | `after_agent` | After the agent completes a turn |
 | `before_llm` | Before an LLM API call |

--- a/docs/features/plugins.mdx
+++ b/docs/features/plugins.mdx
@@ -107,11 +107,12 @@ Place plugins in `~/.praisonai/plugins/` (user-wide) or `./.praisonai/plugins/` 
 ```mermaid
 flowchart TB
     INPUT["📥 User Input"] --> BA["🪝 before_agent"]
-    BA --> BT["🪝 before_tool"]
+    BA --> BTD["🪝 before_tool_definitions"]
+    BTD --> LLM["🧠 LLM"]
+    LLM --> BT["🪝 before_tool"]
     BT --> TOOL["🔧 Tool"]
     TOOL --> AT["🪝 after_tool"]
-    AT --> LLM["🧠 LLM"]
-    LLM --> AA["🪝 after_agent"]
+    AT --> AA["🪝 after_agent"]
     AA --> OUTPUT["📤 Response"]
 
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
@@ -119,14 +120,14 @@ flowchart TB
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
 
     class INPUT,OUTPUT agent
-    class BA,BT,AT,AA hook
+    class BA,BTD,BT,AT,AA hook
     class TOOL,LLM tool
 ```
 
 | Plugin type | What it adds |
 |-------------|--------------|
 | **Tool** | Functions registered via `@tool` |
-| **Hook** | Lifecycle callbacks (`before_tool`, `after_llm`, …) |
+| **Hook** | Lifecycle callbacks (`before_tool`, `before_tool_definitions`, `after_llm`, …) |
 | **Guardrail** | Output validation on `after_agent` |
 
 ---
@@ -161,6 +162,28 @@ def log_before(data):
 @add_hook("after_tool")
 def log_after(data):
     print(f"Done: {data.tool_name}")
+```
+
+Create `~/.praisonai/plugins/tool_sandbox.py` to filter advertised tools:
+
+```python
+"""
+Plugin Name: Tool Sandbox
+Description: Filters tool definitions sent to the LLM
+Version: 1.0.0
+Hooks: before_tool_definitions
+"""
+
+from praisonaiagents.hooks import add_hook
+
+BLOCKED = {"delete_file", "shell_exec"}
+
+@add_hook("before_tool_definitions")
+def sandbox_tools(data):
+    data.tool_definitions[:] = [
+        t for t in data.tool_definitions
+        if t["function"]["name"] not in BLOCKED
+    ]
 ```
 
 ```python


### PR DESCRIPTION
## Summary

Documents the new `BEFORE_TOOL_DEFINITIONS` hook event shipped in PraisonAI PR #2469 / commit `7fe7163`.

### Changes

- **`docs/features/hook-events.mdx`**:
  - Updated hero lifecycle Mermaid diagram to include `BEFORE_TOOL_DEFINITIONS` node between `BEFORE_LLM` and `AFTER_LLM` (teal color, matches existing tool event scheme)
  - Added new **"Tool Definition Events"** subsection with:
    - Event table with trigger, input type, and use case
    - `BeforeToolDefinitionsInput` field reference table (`tool_definitions`, `model`, inherited fields)
    - Security sandbox example (drop dangerous tools + annotate descriptions)
    - Per-model filtering example using the `model` field
    - `<Warning>` callout about the "mutate in place vs reassign" footgun
  - Added `BEFORE_TOOL_DEFINITIONS` row to the Complete Event Reference table

- **`docs/features/hooks.mdx`**:
  - Updated hero Mermaid diagram to show `BEFORE_TOOL_DEFINITIONS` between input assembly and tool execution
  - Added `before_tool_definitions` row to Available Hook Events table

- **`docs/features/plugins.mdx`**:
  - Updated plugin lifecycle flowchart to include `before_tool_definitions` hook node
  - Added `before_tool_definitions` to the hook lifecycle description
  - Added `tool_sandbox.py` plugin example demonstrating per-request tool filtering

### Not changed
- `docs/concepts/` — not touched (human-approved only per AGENTS.md §1.9)
- `docs.json` — no new pages created, existing pages already registered

Fixes #1287

Generated with [Claude Code](https://claude.ai/code)