### PR TITLE
docs: add Dead Target Registry page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -356,7 +356,7 @@
                       "docs/features/inbound-dlq",
                       "docs/features/inbound-journal",
                       "docs/features/long-running-bots",
-                      "docs/features/durable-delivery",
+                      "docs/features/durable-delivery", "docs/features/dead-target-registry",
                       "docs/features/bot-routing",
                       "docs/features/gateway-route-bindings",
                       "docs/features/gateway-tool-policy",

--- a/docs/features/dead-target-registry.mdx
+++ b/docs/features/dead-target-registry.mdx
@@ -1,0 +1,325 @@
+---
+title: "Dead Target Registry"
+sidebarTitle: "Dead Target Registry"
+description: "Self-healing suppression of permanently-unreachable channels — bot kicked, chat deleted, account deactivated"
+icon: "shield-x"
+---
+
+Dead Target Registry stops a long-running gateway from re-attempting channels that have become permanently unreachable, and self-heals the moment any send succeeds again.
+
+```mermaid
+graph LR
+    subgraph "Dead Target Registry"
+        Send[📤 deliver] --> Check{🔍 is_dead?}
+        Check -->|No| API[📱 Platform API]
+        Check -->|Yes — suppressed| Skip[⏭ short-circuit]
+        Check -->|Yes — reprobe due| API
+        API -->|✅ success| Clear[🧹 clear → self-heal]
+        API -->|❌ permanent| Mark[🚫 mark_dead]
+    end
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef dead fill:#8B0000,stroke:#7C90A0,color:#fff
+    class Send input
+    class Check check
+    class API,Clear result
+    class Skip,Mark dead
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Default OFF — no changes needed">
+`DeliveryRouter` without a registry works exactly as before — no suppression, no changes to existing behaviour.
+
+```python
+from praisonai.bots import DeliveryRouter
+
+router = DeliveryRouter(botos)
+```
+</Step>
+
+<Step title="Opt in for a long-running gateway">
+Attach a `DeadTargetRegistry` to suppress permanently-dead channels and self-heal on recovery.
+
+```python
+from praisonai.bots import DeliveryRouter, DeadTargetRegistry
+
+registry = DeadTargetRegistry()
+router   = DeliveryRouter(botos, dead_targets=registry)
+
+ok = await router.deliver("telegram", "Daily standup ready")
+```
+
+If the bot was kicked from this chat earlier, the call short-circuits — no API hit, no log spam. After ~1 h it re-probes once; if the user re-added the bot, that probe succeeds and the suppression clears automatically.
+</Step>
+
+<Step title="Inspect and clear">
+Query suppressed channels or un-suppress one manually.
+
+```python
+print(registry.size())
+
+for t in registry.list_dead():
+    print(t.platform, t.channel_id, t.reason, t.ts)
+
+registry.clear("telegram", "-1001234")
+```
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Router as DeliveryRouter
+    participant Reg as DeadTargetRegistry
+    participant Plat as Platform
+
+    Router->>Reg: is_dead(platform, channel_id)?
+    alt suppressed and not yet re-probeable
+        Reg-->>Router: True
+        Router-->>Router: short-circuit (target_unreachable_suppressed)
+    else not suppressed (or re-probe due)
+        Reg-->>Router: False (or reprobe=True)
+        Router->>Plat: send_message
+        alt success
+            Plat-->>Router: ok
+            Router->>Reg: clear(platform, channel_id) — self-heal
+        else permanent failure (403 / 404 / 410 / text pattern)
+            Plat-->>Router: error
+            Router->>Reg: mark_dead(platform, channel_id, reason)
+        else transient (5xx / 429 / timeout) or message-scoped 404
+            Plat-->>Router: error
+            Note over Router: no mark — stays on retry path
+        end
+    end
+```
+
+**Self-heal timeline:**
+
+```mermaid
+graph LR
+    A[T=0: mark_dead] --> B[T < 1h: all sends suppressed]
+    B --> C[T ≈ 1h: one reprobe send allowed]
+    C -->|success| D[cleared — fully back in service]
+    C -->|still permanent| E[re-marked dead — clock resets]
+    classDef start fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef quiet fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef probe fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef good fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef bad fill:#8B0000,stroke:#7C90A0,color:#fff
+    class A start
+    class B quiet
+    class C probe
+    class D good
+    class E bad
+```
+
+| Phase | Behaviour |
+|-------|-----------|
+| **mark_dead** | Target recorded with timestamp. Persisted atomically to JSON. |
+| **suppressed** | Every `deliver()` call returns `False` immediately — no API hit. |
+| **reprobe** | After `reprobe_seconds`, one send is allowed through to test recovery. |
+| **self-heal** | Success clears the registry entry. Next send goes through normally. |
+| **re-marked** | Permanent failure on reprobe resets the clock for another cycle. |
+
+---
+
+## Configuration Options
+
+### `DeadTargetRegistry` constructor
+
+```python
+from praisonai.bots import DeadTargetRegistry
+
+registry = DeadTargetRegistry(
+    persist_path="~/.praisonai/state/dead_targets.json",
+    max_size=10_000,
+    ttl_seconds=2_592_000,
+    reprobe_seconds=3600,
+)
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `persist_path` | `Path \| None` | `~/.praisonai/state/dead_targets.json` | JSON file for durability. Parent directories are created automatically. Pass a tmp path for ephemeral / test instances. |
+| `max_size` | `int` | `10_000` | Maximum dead entries kept. Oldest (by `ts`) are evicted when exceeded. `<= 0` disables the bound. |
+| `ttl_seconds` | `int` | `2_592_000` (30 days) | Entries older than this are dropped lazily on the next access, so a long-dead target is eventually re-probed even if no send ever cleared it. `<= 0` disables TTL. |
+| `reprobe_seconds` | `int` | `3600` (1 hour) | Once this elapses since `mark_dead`, **one** send is allowed through to test recovery. Success self-heals; repeated permanent failure resets the clock. `<= 0` disables re-probing. |
+
+### Public methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `is_dead(platform, channel_id)` | `bool` | `True` if currently suppressed. Expired entries are removed lazily and `False` is returned. |
+| `should_reprobe(platform, channel_id)` | `bool` | `True` if a dead target is due for a single self-healing re-probe (`reprobe_seconds` elapsed since last `mark_dead`). |
+| `mark_dead(platform, channel_id, reason)` | `None` | Record a confirmed-permanent failure. Idempotent — re-marking refreshes the timestamp and resets the re-probe clock. Persisted atomically. |
+| `clear(platform, channel_id)` | `None` | Un-suppress a target. Called automatically on every successful send. No-op if the target is not in the registry. Persisted atomically. |
+| `list_dead()` | `list[DeadTarget]` | Snapshot of currently-suppressed targets (TTL-expired ones pruned first), sorted oldest-first by `ts`. |
+| `size()` | `int` | Number of currently-suppressed targets (TTL-expired ones pruned first). |
+
+`DeadTarget` is a frozen dataclass: `platform: str`, `channel_id: str`, `reason: str`, `ts: float` (Unix epoch).
+
+---
+
+## What Counts as Permanent
+
+`is_permanent_target_failure(err, platform)` classifies an exception before `DeliveryRouter` calls `mark_dead`.
+
+### Permanent — target marked dead
+
+| Signal | Details |
+|--------|---------|
+| HTTP `403` Forbidden | Via `err.status`, `err.status_code`, or `err.error_code` |
+| HTTP `404` Not Found | Same attribute probe — **only** if not a message-scoped 404 (see exclusions below) |
+| HTTP `410` Gone | Same attribute probe |
+| `forbidden` | Text pattern (case-insensitive) on the exception message |
+| `bot was kicked` | |
+| `bot was blocked` | |
+| `user is deactivated` | |
+| `chat not found` | |
+| `channel not found` | |
+| `group chat was deleted` | |
+| `the group chat was deleted` | |
+| `bot is not a member` | |
+| `not enough rights` | |
+| `have no rights to send` | |
+| `need administrator rights` | |
+| `peer_id_invalid` | |
+| `account_not_found` | |
+| `channel_archived` | |
+| `is_archived` | |
+| `blocked by the user` | |
+
+### Not permanent — stays on the retry path
+
+| Signal | Why excluded |
+|--------|-------------|
+| Any transient / recoverable error | 5xx, 429, timeouts, connection resets — checked **first**, transient wins |
+| `message to edit not found` | Message-scoped 404 — does NOT condemn the whole channel |
+| `message not found` | Same |
+| `message to delete not found` | Same |
+| `message_id_invalid` | Same |
+| `thread not found` | Same |
+| `unknown message` | Same |
+| `reply not found` | Same |
+| `message can't be edited` | Same |
+| **HTTP `401` Unauthorized** | **Deliberately excluded.** 401 signals an account-/token-level auth problem (revoked or wrong credentials), not the death of one specific channel. Marking channels dead on a 401 would suppress every target the moment a token expires, and the 30-day TTL would keep them suppressed long after the token is fixed. Auth failures stay off the dead-target path. |
+
+<Note>
+**Platform names are stored lower-cased.** `mark_dead("Telegram", ...)` and `is_dead("TELEGRAM", ...)` refer to the same entry. Users coming from YAML keys like `Telegram:` don't need to worry about casing.
+</Note>
+
+---
+
+## Common Patterns
+
+### Long-running broadcast gateway
+
+A gateway pushing periodic updates to many channels suppresses dead ones so they don't burn rate-limit budget on every cycle.
+
+```python
+import asyncio
+from praisonai.bots import BotOS, DeliveryRouter, DeadTargetRegistry
+
+registry = DeadTargetRegistry()
+botos    = BotOS(...)
+router   = DeliveryRouter(botos, dead_targets=registry)
+
+async def broadcast(channels, message):
+    for platform, channel_id in channels:
+        await router.deliver(f"{platform}:{channel_id}", message)
+```
+
+Dead channels are skipped silently; recovered channels re-enter service within one reprobe cycle (~1 h by default).
+
+### Operator dashboard via `list_dead()`
+
+Expose suppressed channels in a health or admin endpoint so operators can see what has been suppressed and why.
+
+```python
+from praisonai.bots import DeadTargetRegistry
+
+registry = DeadTargetRegistry()
+
+@app.get("/admin/dead-targets")
+async def dead_targets():
+    return [
+        {"platform": t.platform, "channel_id": t.channel_id,
+         "reason": t.reason, "since": t.ts}
+        for t in registry.list_dead()
+    ]
+```
+
+### Custom suppression for one chat
+
+Un-suppress a channel manually after confirming the bot has been re-added.
+
+```python
+registry.clear("telegram", "-1001234567890")
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Default-OFF on purpose">
+Attach a registry only on long-running gateways with periodic, broadcast, or scheduled sends. Single-request CLIs and request-response bots don't need it — adding suppression to short-lived processes just adds complexity with no benefit.
+</Accordion>
+
+<Accordion title="401 is intentionally NOT permanent">
+Never treat HTTP 401 Unauthorized as a dead-target signal. Token expiry would suppress every channel simultaneously, and the 30-day TTL would hide the fix for a month. Auth failures stay on the normal error path so the operator sees and fixes them quickly.
+</Accordion>
+
+<Accordion title="Keep persist_path on a real filesystem">
+Store the registry on a persistent local path — not `/tmp` and not a container tmpfs. The default `~/.praisonai/state/dead_targets.json` is the right location; use it as a template.
+
+```python
+registry = DeadTargetRegistry(
+    persist_path="/data/praisonai/state/dead_targets.json"
+)
+```
+</Accordion>
+
+<Accordion title="Tune reprobe_seconds to your fan-out cadence">
+The default 1-hour reprobe window suits most periodic-update gateways. Raise it if kicked-bot scenarios are rare and you'd rather not probe recovered channels frequently. Lower it if recovery latency matters (e.g. high-priority alert channels).
+
+```python
+registry = DeadTargetRegistry(reprobe_seconds=300)
+```
+</Accordion>
+
+<Accordion title="list_dead() is your operator dashboard">
+Expose `list_dead()` in your gateway's admin or health endpoint so operators can see suppressed channels at a glance. Pair it with `registry.size()` for a quick health metric.
+
+```python
+print(f"Suppressed channels: {registry.size()}")
+for t in registry.list_dead():
+    print(f"  {t.platform}:{t.channel_id} — {t.reason}")
+```
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Durable Delivery" icon="shield-check" href="/docs/features/durable-delivery">
+  Persistent outbox + retry for transient failures — composes with the dead-target registry
+</Card>
+<Card title="Channel Supervision" icon="heart-pulse" href="/docs/features/gateway-channel-supervision">
+  Self-healing gateway channels with operator pause/resume/reconnect controls
+</Card>
+<Card title="Proactive Delivery" icon="send" href="/docs/features/proactive-delivery">
+  Scheduled and broadcast outbound message delivery
+</Card>
+<Card title="Delivery Config" icon="settings" href="/docs/features/delivery-config">
+  Delivery surface configuration reference
+</Card>
+</CardGroup>

--- a/docs/features/durable-delivery.mdx
+++ b/docs/features/durable-delivery.mdx
@@ -5,7 +5,7 @@ description: "Persist outbound bot messages with retry, idempotency, and crash-s
 icon: "shield-check"
 ---
 
-Durable Delivery persists every outbound bot message to a SQLite outbox so retries, restarts, and platform outages never drop a reply.
+Durable Delivery persists every outbound bot message to a SQLite outbox so retries, restarts, and platform outages never drop a reply. For **permanently** dead targets — bot kicked, chat deleted — see [Dead Target Registry](/docs/features/dead-target-registry), which suppresses doomed sends instead of queuing them.
 
 <Note>
 This page covers **outbound** durability (`DurableDelivery` / `OutboundQueue`). For **inbound** durability — which is now on by default for all gateway/bot runs — see [Inbound Journal](/docs/features/inbound-journal) and [Inbound DLQ](/docs/features/inbound-dlq).
@@ -481,6 +481,9 @@ asyncio.create_task(delivery.drain_pending())
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Dead Target Registry" icon="shield-x" href="/docs/features/dead-target-registry">
+  Suppress permanently-dead channels — the permanent-failure complement to durable retry
+</Card>
 <Card title="Inbound Journal" icon="book" href="/docs/features/inbound-journal">
   Inbound counterpart — deduplicate webhook redeliveries and recover in-flight messages
 </Card>

--- a/docs/features/gateway-channel-supervision.mdx
+++ b/docs/features/gateway-channel-supervision.mdx
@@ -497,6 +497,9 @@ When the upstream API is rate-limited, restart storms make the problem worse. Lo
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Dead Target Registry" icon="shield-x" href="/docs/features/dead-target-registry">
+  Suppress permanently-dead channels — bot kicked, chat deleted, account deactivated
+</Card>
 <Card title="Gateway CLI" icon="tower-broadcast" href="/docs/features/gateway-cli">
   Complete CLI reference for gateway management
 </Card>


### PR DESCRIPTION
## Summary

- New page `docs/features/dead-target-registry.mdx` documenting the self-healing `DeadTargetRegistry` component from PraisonAI PR #2489
- `docs.json` updated — `dead-target-registry` added under Communication & Messaging subgroup, next to `durable-delivery`
- Cross-links added in `durable-delivery.mdx` (intro note + Related card) and `gateway-channel-supervision.mdx` (Related card)

## What the page covers (per quality checklist)

- **Quick Start** (3 Steps): default-OFF → opt-in → inspect/clear
- **Hero Mermaid diagram** + lifecycle sequence + self-heal timeline diagrams (standard colour scheme)
- **Configuration Options**: all 4 constructor parameters with exact SDK defaults (`max_size=10_000`, `ttl_seconds=2_592_000`, `reprobe_seconds=3600`, `persist_path=~/.praisonai/state/dead_targets.json`)
- **All 6 public methods** documented (`is_dead`, `should_reprobe`, `mark_dead`, `clear`, `list_dead`, `size`)
- **What counts as permanent**: 3 HTTP codes (403/404/410), 17 text patterns, transient exclusions, message-scoped 404 exclusions, and **401 explicitly called out** as deliberately excluded with explanation
- **Platform name case-insensitivity** noted
- **Common Patterns**: broadcast gateway, operator dashboard via `list_dead()`, manual clear
- **Best Practices** (AccordionGroup, 5 accordions)
- **Related** CardGroup pointing to durable-delivery, gateway-channel-supervision, proactive-delivery, delivery-config
- No PR/commit/Greptile history in the doc body
- Top-level imports only (`from praisonai.bots import DeadTargetRegistry, DeliveryRouter`)

Fixes #1286

Generated with [Claude Code](https://claude.ai/code)