### PR TITLE
docs(cli/tools): document new "registered" source surfaced by tools list/info (PR #2476)

### DIFF
--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -463,6 +463,7 @@ praisonai memory add "Important context"
 
 # Tool management
 praisonai tools list
+praisonai tools list --source registered
 
 # Workflow management
 praisonai workflow list

--- a/docs/cli/tools.mdx
+++ b/docs/cli/tools.mdx
@@ -31,8 +31,19 @@ praisonai tools info internet_search
 
 ### List Tools
 
+Each tool is attributed to one of four source categories — `builtin`, `local`, `external`, or `registered` — reflecting the exact source that `resolve()` would use at run time.
+
 ```bash
 praisonai tools list
+```
+
+Filter by source using `--source` (or `-s`):
+
+```bash
+praisonai tools list --source registered
+praisonai tools list -s local
+praisonai tools list -s builtin
+praisonai tools list -s external
 ```
 
 **Expected Output:**
@@ -40,38 +51,24 @@ praisonai tools list
 🔧 Available Tools:
 --------------------------------------------------
 
-  Search:
-    • internet_search: Available
-    • wikipedia_search: Search Wikipedia
-    • arxiv_search: Search arXiv papers
-    • tavily_search: Available
-
-  File:
-    • read_file: Available
-    • write_file: Available
-    • list_files: Available
-    • csv_read: Read CSV files
-    • json_read: Read JSON files
-    • yaml_read: Read YAML files
-
-  Code:
-    • execute_code: Available
-    • shell_command: Execute shell commands
-    • calculator: Perform mathematical calculations
-
-  Data:
-    • pandas_query: Query data with Pandas
-    • duckdb_query: SQL queries with DuckDB
-    • yfinance: Financial market data
-
-  Web:
-    • crawl4ai: Web crawling
-    • trafilatura: Web content extraction
-    • duckduckgo: DuckDuckGo search
+  internet_search     [builtin]   Perform internet searches using DuckDuckGo
+  wikipedia_search    [builtin]   Search Wikipedia
+  my_custom_tool      [local]     Tool from local tools.py
+  my_plugin_tool      [registered] Entry-point plugin tool
 
 --------------------------------------------------
-Total: 18 tools available
+Total: <count> tools
+Built-in: <X> | Local: <Y> | External: <Z> | Registered: <W>
 ```
+
+**Source categories:**
+
+| Source | What it means |
+|--------|---------------|
+| `builtin` | Shipped with `praisonaiagents.tools` — no extra install needed |
+| `local` | Loaded from your local `tools.py` file |
+| `external` | From the optional `praisonai-tools` package |
+| `registered` | Registered via `ToolRegistry` (`register_function`) or a core SDK entry-point plugin |
 
 ### Get Tool Info
 
@@ -91,6 +88,8 @@ praisonai tools info internet_search
 │ Status              │ ✅ Available                               │
 │ Dependencies        │ duckduckgo-search                          │
 └─────────────────────┴────────────────────────────────────────────┘
+
+Source: praisonaiagents.tools (built-in)
 
 Description:
   Perform internet searches using DuckDuckGo. Returns a list of
@@ -114,6 +113,15 @@ Example Usage:
 Returns:
   List of dictionaries with keys: title, url, snippet
 ```
+
+**Source labels in `tools info`:**
+
+| Source value | Label shown |
+|---|---|
+| `builtin` | `Source: praisonaiagents.tools (built-in)` |
+| `local` | `Source: Local tools.py` |
+| `external` | `Source: praisonai-tools package` |
+| `registered` | `Source: Registered/entry-point tool (registry)` |
 
 ### Search Tools
 
@@ -144,6 +152,16 @@ Found 4 matching tools:
      Description: AI-powered web search with Tavily
 ```
 
+### Validate Tools
+
+Check that a tool is discoverable and will resolve correctly:
+
+```bash
+praisonai tools validate internet_search
+```
+
+Validation uses the same discovery path as `list` and `info`, so a tool that passes validation will also be visible in `tools list` and resolvable at agent run time.
+
 ### Help
 
 ```bash
@@ -157,6 +175,7 @@ Tools Commands:
   praisonai tools list              - List all available tools
   praisonai tools info <name>       - Get detailed info about a tool
   praisonai tools search <query>    - Search for tools by name/description
+  praisonai tools validate <name>   - Validate a tool is discoverable
   praisonai tools help              - Show this help
 
 Using Tools with Agents:

--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -117,6 +117,14 @@ CLI, YAML, recipes, templates, and Python all share this resolution chain. See [
 **One resolution chain for every surface.** Whether you load tools via the CLI `--tools` flag, a YAML `tools:` list in `agents.yaml`, a recipe's `tools:` list, or `Agent(tools=[...])` in Python, PraisonAI walks the same five-source chain: local `tools.py` → wrapper `ToolRegistry` → `praisonaiagents.tools` → `praisonai-tools` → core SDK plugins. Tools registered through any of these become visible everywhere — no more "works in Python but not in the recipe."
 </Note>
 
+<Note>
+**Discovery matches resolution.** As of [PR #2476](https://github.com/MervinPraison/PraisonAI/pull/2476), `praisonai tools list` and `tools info` enumerate every source in this chain — including tools registered through the wrapper `ToolRegistry` (`register_function`) and core SDK registry (entry-point plugins). Each tool surfaces with its authoritative source via `ToolResolver.list_available_sources()`, so attribution matches the callable `resolve()` would actually return — no more "resolves at run time but invisible to the CLI."
+
+Tools appear under one of four source labels: `builtin` (`praisonaiagents.tools`), `local` (your `tools.py`), `external` (`praisonai-tools` package), or `registered` (wrapper `ToolRegistry` or core SDK entry-point plugin). See [CLI tools reference](/docs/cli/tools) for the full label table and `--source` filter usage.
+
+**Custom-sources subtlety:** a resolver built with an explicit `sources=` list does **not** enumerate the default built-in / external / core-registry sources in discovery (it would misrepresent what `resolve()` can return). The wrapper `ToolRegistry` is always enumerated when present, regardless of custom sources.
+</Note>
+
 ---
 
 ## Registering Tools at Runtime
@@ -381,6 +389,7 @@ sequenceDiagram
 | `load_functions_from_module(path)` | `Dict[str, Callable]` | Load plain Python functions from a single `.py` file. |
 | `load_classes_from_module(path)` | `Dict[str, Callable]` | Load and instantiate `BaseTool` subclasses and `langchain_community.tools.*` classes from a single `.py` file. |
 | `load_functions_from_package(path)` | `Dict[str, Callable]` | Iterate `*.py` in a directory (skipping `__*.py`) and union the functions. |
+| `list_available_sources()` | `Dict[str, str]` | Returns `{name: source}` where source is one of `"local"`, `"builtin"`, `"external"`, `"registered"`. Reflects the chain `resolve()` would actually use — used by `praisonai tools list` / `tools info` for authoritative source attribution. |
 
 <Warning>
 **Migration from `AgentsGenerator` (PR #2017).** `AgentsGenerator.load_tools_from_module`, `load_tools_from_module_class`, and `load_tools_from_package` have been removed. Use the equivalent `ToolResolver` methods above. The new versions enforce the `PRAISONAI_ALLOW_LOCAL_TOOLS` security gate uniformly.


### PR DESCRIPTION
## Summary

Documents the new `registered` source category introduced in [PraisonAI PR #2476](https://github.com/MervinPraison/PraisonAI/pull/2476), which makes CLI tool discovery match the resolver's actual resolution chain.

### Changes

- **`docs/cli/tools.mdx`** (primary):
  - Introduces the four source categories (`builtin`, `local`, `external`, `registered`) under `### List Tools`
  - Adds `--source` / `-s` filter examples
  - Refreshes the "Expected Output" snippet to show per-tool source column and `Registered: <W>` count in the footer
  - Adds a source-labels table under `### Get Tool Info` showing the label printed for each source value
  - Adds new `### Validate Tools` section (previously undocumented)
  - Adds `praisonai tools validate <name>` to the Help expected output

- **`docs/features/tool-resolver.mdx`** (light update):
  - Adds "Discovery matches resolution" note explaining that `praisonai tools list`/`tools info` now enumerate all 5 sources via `ToolResolver.list_available_sources()`
  - Adds `list_available_sources()` row to the method table

- **`docs/cli/cli-reference.mdx`** (one-liner):
  - Adds `praisonai tools list --source registered` example under tool management

Fixes #1291

Cross-references: PraisonAI #2476, PraisonAI #2474

Generated with [Claude Code](https://claude.ai/code)