### PR TITLE
docs: update CLI tool flags to reflect ToolResolver chain (fixes #1303)

### DIFF
--- a/docs/cli/deep-research.mdx
+++ b/docs/cli/deep-research.mdx
@@ -64,6 +64,10 @@ praisonai research --query-rewrite --rewrite-tools "internet_search" "AI trends"
 
 ### With Custom Tools
 
+<Note>
+Tool names passed to `--tools` resolve through the canonical `ToolResolver` chain: local `tools.py` → wrapper registry → `praisonaiagents.tools` → `praisonai-tools` package → core SDK plugins. Non-SDK-builtin names (e.g. `praisonai-tools` package tools, wrapper-registry tools, plugin tools) now resolve here too — previously these silently warned "Unknown tool". See [Tool Resolver](/docs/features/tool-resolver).
+</Note>
+
 ```bash
 # Use custom tools from file (gathers context before deep research)
 praisonai research --tools tools.py "Your research query"
@@ -72,6 +76,9 @@ praisonai research -t my_tools.py "Your research query"
 # Use built-in tools by name (comma-separated)
 praisonai research --tools "internet_search,wiki_search" "Your query"
 praisonai research -t "yfinance,calculator_tools" "Stock analysis query"
+
+# Tool from praisonai-tools package or wrapper registry
+praisonai research --tools "tavily_search" "Your research query"
 ```
 
 ### Save Output

--- a/docs/cli/prompt-expansion.mdx
+++ b/docs/cli/prompt-expansion.mdx
@@ -50,8 +50,19 @@ praisonai "blog about AI" --expand-prompt -v
 
 ### With Tools for Context
 
+<Note>
+Tool names passed to `--expand-tools` resolve through the canonical `ToolResolver` chain: local `tools.py` → wrapper registry → `praisonaiagents.tools` → `praisonai-tools` package → core SDK plugins. Class-style tools are auto-instantiated. See [Tool Resolver](/docs/features/tool-resolver).
+</Note>
+
 ```bash
+# File-path form (unchanged)
 praisonai "latest AI trends" --expand-prompt --expand-tools tools.py
+
+# Comma-separated names (SDK builtins, praisonai-tools, wrapper-registry, or local tools.py)
+praisonai "latest AI trends" --expand-prompt --expand-tools "internet_search,wiki_search"
+
+# Tool from praisonai-tools package
+praisonai "latest AI trends" --expand-prompt --expand-tools "tavily_search"
 ```
 
 ### Combine with Query Rewrite

--- a/docs/cli/query-rewrite.mdx
+++ b/docs/cli/query-rewrite.mdx
@@ -39,9 +39,22 @@ praisonai "AI trends" --query-rewrite
 
 ### With Search Tools
 
+<Note>
+Tool names passed to `--rewrite-tools` resolve through the canonical `ToolResolver` chain: local `tools.py` → wrapper registry → `praisonaiagents.tools` → `praisonai-tools` package → core SDK plugins. Class-style tools are auto-instantiated. See [Tool Resolver](/docs/features/tool-resolver).
+</Note>
+
 ```bash
-# Rewrite with search tools (agent decides when to search)
+# Single SDK builtin
 praisonai "latest developments" --query-rewrite --rewrite-tools "internet_search"
+
+# Comma-separated names (SDK builtins, praisonai-tools, wrapper-registry, or local tools.py)
+praisonai "latest developments" --query-rewrite --rewrite-tools "internet_search,wiki_search"
+
+# Tool from praisonai-tools package
+praisonai "latest news" --query-rewrite --rewrite-tools "tavily_search"
+
+# Custom tool registered in local tools.py (file-path form — unchanged)
+praisonai "latest developments" --query-rewrite --rewrite-tools tools.py
 
 # Works with any prompt
 praisonai "explain quantum computing" --query-rewrite -v

--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -185,9 +185,9 @@ The wrapper now invokes `resolve()` once per YAML-referenced tool name, with res
 
 Directory mode iterates each `.py` file and unions the results using the same security gates and extraction logic.
 
-### CLI and recipes use the same resolver (PR #1857, PR #2059)
+### CLI and recipes use the same resolver (PR #1857, PR #2059, PR #2499)
 
-`praisonai --tools tavily_search,my_tool "..."` goes through `ToolResolver.resolve(name, instantiate=True)`, identical to the YAML path. Recipe and template tool loading via `resolve_tools()` also delegates to `ToolResolver` (PR #2059), so wrapper `ToolRegistry` registrations, `praisonai-tools` package tools, and core SDK plugin tools are reachable from recipes and templates — not just the agent build path.
+`praisonai --tools tavily_search,my_tool "..."` goes through `ToolResolver.resolve(name, instantiate=True)`, identical to the YAML path. Recipe and template tool loading via `resolve_tools()` also delegates to `ToolResolver` (PR #2059), so wrapper `ToolRegistry` registrations, `praisonai-tools` package tools, and core SDK plugin tools are reachable from recipes and templates — not just the agent build path. As of PR #2499 the same chain also handles `--rewrite-tools` (query-rewrite), `--expand-tools` (prompt-expansion), and `research --tools`.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates CLI documentation to reflect the new `ToolResolver` chain behavior introduced in PraisonAI PR #2499, where `--rewrite-tools`, `--expand-tools`, and `research --tools` now resolve tool names through the full 5-step canonical chain instead of only `TOOL_MAPPINGS`.

## Changes

- **`docs/cli/query-rewrite.mdx`**: Added comma-separated name examples, `praisonai-tools` package example, file-path form alongside name form, and a `<Note>` callout explaining the ToolResolver chain for `--rewrite-tools`.
- **`docs/cli/prompt-expansion.mdx`**: Added name-form examples alongside existing file-path form, and a `<Note>` callout for `--expand-tools` resolver chain (including class-tool auto-instantiation note).
- **`docs/cli/deep-research.mdx`**: Added `<Note>` clarifying non-SDK-builtin names now resolve via the full chain for `research --tools`; added `tavily_search` example.
- **`docs/features/tool-resolver.mdx`**: Extended the CLI-and-recipes paragraph to include `--rewrite-tools`, `--expand-tools`, and `research --tools` as resolver-backed surfaces (PR #2499 scope).

Fixes #1303

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how CLI tool names are resolved across research, prompt expansion, and query rewrite commands.
  * Added examples for using built-in tools, comma-separated tool lists, custom local tools, and tools from the `praisonai-tools` package.
  * Expanded guidance to show that CLI and recipe-based tool loading follow the same resolution path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->