### PR TITLE
docs: Pydantic AI framework integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1165,6 +1165,7 @@
               "docs/framework/autogen",
               "docs/framework/agno",
               "docs/framework/google-adk",
+              "docs/framework/pydantic-ai",
               "docs/framework/praisonaiagents",
               "docs/api",
               "docs/api/index",

--- a/docs/framework/agno.mdx
+++ b/docs/framework/agno.mdx
@@ -7,7 +7,7 @@ icon: "robot"
 Use `framework: agno` in agents YAML to execute roles and tasks through the [Agno](https://github.com/agno-agi/agno) adapter in `praisonai-frameworks`.
 
 <Note>
-Requires `praisonai-frameworks` **0.1.7+**. Install with `pip install "praisonai[agno]"` or `pip install "praisonai-frameworks[agno]"`.
+Requires `praisonai-frameworks` **0.1.8+**. Install with `pip install "praisonai[agno]"` or `pip install "praisonai-frameworks[agno]"`.
 </Note>
 
 ## Quick Start
@@ -51,12 +51,35 @@ praisonai agents.yaml --framework agno
 |-------|---------|--------|
 | 1 | Single role, single task | Supported |
 | 2 | Sequential tasks with `context:` | Supported |
-| 3 | `handoff.to` | Not wired — warning logged |
+| 3 | `handoff.to` (single task → Team route) | Supported |
+
+## Handoffs
+
+Use `handoff.to` with a single router task; specialists are routed via Agno `Team(mode=route)`:
+
+```yaml
+framework: agno
+topic: language help
+roles:
+  triage:
+    role: Triage Agent
+    handoff:
+      to:
+        - English Agent
+    tasks:
+      route:
+        description: Help with {topic}
+  english:
+    role: English Agent
+    goal: Reply in English only
+    backstory: English specialist.
+```
+
+Multi-task configs with `handoff.to` fall back to sequential execution.
 
 ## Limitations
 
 - Sync `run()` only
 - Workflow YAML does not support `framework: agno` — use agents YAML
-- `handoff.to` is not implemented yet
 
 See also: [Framework Adapter Plugins](/docs/features/framework-adapter-plugins)

--- a/docs/framework/agno.mdx
+++ b/docs/framework/agno.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Agno with PraisonAI"
+sidebarTitle: "Agno"
 description: "Run PraisonAI agents YAML with the Agno framework via praisonai-frameworks"
 icon: "robot"
 ---

--- a/docs/framework/google-adk.mdx
+++ b/docs/framework/google-adk.mdx
@@ -7,7 +7,7 @@ icon: "google"
 Use `framework: google_adk` to run agents YAML through [Google ADK](https://github.com/google/adk-python) (`InMemoryRunner`).
 
 <Note>
-Requires `praisonai-frameworks` **0.1.7+**. Gemini uses `GOOGLE_API_KEY` or `GEMINI_API_KEY`. OpenAI models use ADK LiteLLM (`google-adk[extensions]`).
+Requires `praisonai-frameworks` **0.1.8+**. Gemini uses `GOOGLE_API_KEY` or `GEMINI_API_KEY`. OpenAI models use ADK LiteLLM (`google-adk[extensions]`).
 </Note>
 
 ## Quick Start
@@ -59,12 +59,35 @@ praisonai agents.yaml --framework google_adk
 |-------|---------|--------|
 | 1 | Single role, single task | Supported |
 | 2 | Sequential tasks with `context:` | Supported |
-| 3 | `handoff.to` | Not wired — warning logged |
+| 3 | `handoff.to` (single task → sub_agents + transfer) | Supported |
+
+## Handoffs
+
+Use the same `handoff.to` pattern as OpenAI Agents — one router role with a single task, specialists without tasks:
+
+```yaml
+framework: google_adk
+topic: language help
+roles:
+  triage:
+    role: Triage Agent
+    handoff:
+      to:
+        - English Agent
+    tasks:
+      route:
+        description: Help with {topic}
+  english:
+    role: English Agent
+    goal: Reply in English only
+    backstory: English specialist.
+```
+
+Multi-task configs with `handoff.to` fall back to sequential execution (OpenAI parity).
 
 ## Limitations
 
-- Phase 1–2 only; ADK Workflow graphs not used
-- `handoff.to` not implemented
+- ADK Workflow graphs not used
 - Workflow YAML does not support `framework: google_adk`
 - Local ADK execution — separate from PraisonAI remote `Session(agent_url=...)` pattern
 

--- a/docs/framework/google-adk.mdx
+++ b/docs/framework/google-adk.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Google ADK with PraisonAI"
+sidebarTitle: "Google ADK"
 description: "Run PraisonAI agents YAML with Google Agent Development Kit via praisonai-frameworks"
 icon: "google"
 ---

--- a/docs/framework/pydantic-ai.mdx
+++ b/docs/framework/pydantic-ai.mdx
@@ -1,10 +1,28 @@
 ---
 title: "Pydantic AI with PraisonAI"
+sidebarTitle: "Pydantic AI"
 description: "Run PraisonAI agents YAML with Pydantic AI via praisonai-frameworks"
 icon: "python"
 ---
 
-Use `framework: pydantic_ai` to run agents YAML through [Pydantic AI](https://github.com/pydantic/pydantic-ai).
+Run your agents YAML through [Pydantic AI](https://github.com/pydantic/pydantic-ai) by setting `framework: pydantic_ai`.
+
+```mermaid
+graph LR
+    subgraph "Pydantic AI Adapter"
+        Y[📄 agents.yaml] --> A[🔀 PraisonAI Router]
+        A --> B[🤖 Pydantic AI Agent]
+        B --> C[✅ Result]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Y input
+    class A,B process
+    class C output
+```
 
 <Note>
 Requires `praisonai-frameworks` **0.1.9+**. OpenAI models use `OPENAI_API_KEY`. Gemini uses `GOOGLE_API_KEY` or `GEMINI_API_KEY`.
@@ -17,7 +35,7 @@ Requires `praisonai-frameworks` **0.1.9+**. OpenAI models use `OPENAI_API_KEY`. 
 <Step title="Install">
 ```bash
 pip install "praisonai[pydantic-ai]"
-export OPENAI_API_KEY=your-key
+export OPENAI_API_KEY=sk-...
 ```
 </Step>
 
@@ -52,7 +70,18 @@ praisonai agents.yaml --framework pydantic_ai
 | `openai/gpt-4o-mini` | `OPENAI_API_KEY` |
 | `gemini-2.0-flash` | `GOOGLE_API_KEY` or `GEMINI_API_KEY` |
 
-## Supported patterns
+## Supported Patterns
+
+```mermaid
+graph TB
+    subgraph "Phase Selection"
+        P1[Phase 1\nSingle role + task] --> |add context| P2[Phase 2\nSequential tasks]
+        P2 --> |add handoff.to| P3[Phase 3\nHandoffs]
+    end
+
+    classDef phase fill:#8B0000,stroke:#7C90A0,color:#fff
+    class P1,P2,P3 phase
+```
 
 | Phase | Pattern | Status |
 |-------|---------|--------|
@@ -95,4 +124,36 @@ Multi-task configs with `handoff.to` fall back to sequential execution (OpenAI p
 | `output_schema` / structured deps | Not mapped in v1 |
 | A2A broker | Not supported |
 
-See also: [Framework Adapter Plugins](/docs/features/framework-adapter-plugins)
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Use Phase 1 for simple tasks">
+Start with a single role and single task to validate your setup before adding complexity.
+</Accordion>
+<Accordion title="Use Phase 2 for dependent steps">
+Add `context:` to tasks when each step needs output from the previous one.
+</Accordion>
+<Accordion title="Use Phase 3 for routing">
+Keep the router role to a single task with `handoff.to`; multi-task routers fall back to sequential.
+</Accordion>
+<Accordion title="Match model to API key">
+Set `OPENAI_API_KEY` for `openai/` prefixed models and `GOOGLE_API_KEY` for Gemini models to avoid auth errors.
+</Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Agno" icon="robot" href="/docs/framework/agno">
+  Run agents YAML through Agno framework
+</Card>
+<Card title="Google ADK" icon="google" href="/docs/framework/google-adk">
+  Run agents YAML through Google Agent Development Kit
+</Card>
+<Card title="Framework Adapter Plugins" icon="plug" href="/docs/features/framework-adapter-plugins">
+  All supported framework adapters
+</Card>
+<Card title="Agents YAML" icon="file-code" href="/docs/concepts/agents">
+  agents YAML reference
+</Card>
+</CardGroup>

--- a/docs/framework/pydantic-ai.mdx
+++ b/docs/framework/pydantic-ai.mdx
@@ -1,0 +1,98 @@
+---
+title: "Pydantic AI with PraisonAI"
+description: "Run PraisonAI agents YAML with Pydantic AI via praisonai-frameworks"
+icon: "python"
+---
+
+Use `framework: pydantic_ai` to run agents YAML through [Pydantic AI](https://github.com/pydantic/pydantic-ai).
+
+<Note>
+Requires `praisonai-frameworks` **0.1.9+**. OpenAI models use `OPENAI_API_KEY`. Gemini uses `GOOGLE_API_KEY` or `GEMINI_API_KEY`.
+</Note>
+
+## Quick Start
+
+<Steps>
+
+<Step title="Install">
+```bash
+pip install "praisonai[pydantic-ai]"
+export OPENAI_API_KEY=your-key
+```
+</Step>
+
+<Step title="Create agents.yaml">
+```yaml
+framework: pydantic_ai
+topic: math
+roles:
+  calculator:
+    role: Calculator
+    goal: Compute exactly
+    backstory: Return only the numeric answer.
+    tasks:
+      add:
+        description: What is 3 + 3?
+        expected_output: "6"
+```
+</Step>
+
+<Step title="Run">
+```bash
+praisonai agents.yaml --framework pydantic_ai
+```
+</Step>
+
+</Steps>
+
+## Models
+
+| Model | API key |
+|-------|---------|
+| `openai/gpt-4o-mini` | `OPENAI_API_KEY` |
+| `gemini-2.0-flash` | `GOOGLE_API_KEY` or `GEMINI_API_KEY` |
+
+## Supported patterns
+
+| Phase | Pattern | Status |
+|-------|---------|--------|
+| 1 | Single role, single task | Supported |
+| 2 | Sequential tasks with `context:` | Supported |
+| 3 | `handoff.to` (single task → delegation tools) | Supported |
+
+## Handoffs
+
+Use the same `handoff.to` pattern as OpenAI Agents — one router role with a single task, specialists without tasks:
+
+```yaml
+framework: pydantic_ai
+topic: language help
+roles:
+  triage:
+    role: Triage Agent
+    handoff:
+      to:
+        - English Agent
+    tasks:
+      route:
+        description: Help with {topic}
+  english:
+    role: English Agent
+    goal: Reply in English only
+    backstory: English specialist.
+```
+
+Multi-task configs with `handoff.to` fall back to sequential execution (OpenAI parity).
+
+## Limitations
+
+| Feature | Status |
+|---------|--------|
+| pydantic-graph workflows | Not used |
+| Agent spec YAML bridge | Not supported |
+| Built-in capabilities (WebSearch, Thinking) | Not mapped |
+| Workflow YAML with `framework: pydantic_ai` | Not supported |
+| `output_schema` / structured deps | Not mapped in v1 |
+| A2A broker | Not supported |
+
+See also: [Framework Adapter Plugins](/docs/features/framework-adapter-plugins)


### PR DESCRIPTION
## Summary
- Add `docs/framework/pydantic-ai.mdx` with install, models, phased patterns, handoffs, and v1 limitations
- Register page in docs.json navigation alongside Agno and Google ADK

## Notes
- Companion to praisonai-frameworks 0.1.9 (#25) and praisonai wrapper pydantic-ai extra (#2508)

## Test plan
- [x] Mintlify nav includes `docs/framework/pydantic-ai`
- [x] Page content matches live adapter behaviour (Phases 1–3, limitations table)
