### PR TITLE
Deconceptualise stray navigational links in tools/guides

### DIFF
--- a/docs/guides/deployment/production-minimal.mdx
+++ b/docs/guides/deployment/production-minimal.mdx
@@ -549,7 +549,7 @@ curl http://localhost:8082/health
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="Bot Integration" icon="robot" href="/docs/concepts/claw">
+  <Card title="Bot Integration" icon="robot" href="/docs/ui/claw">
     Connect to Slack, Discord, Telegram, and WhatsApp
   </Card>
   <Card title="Advanced Deployment" icon="gear" href="/docs/tutorials/production-deployment">

--- a/docs/guides/documentation-style-guide.mdx
+++ b/docs/guides/documentation-style-guide.mdx
@@ -752,10 +752,10 @@ Memory cache resets on restart — use `backend="disk"` to persist across sessio
 ## Related
 
 <CardGroup cols={2}>
-<Card title="Planning" icon="list-check" href="/docs/concepts/planning">
+<Card title="Planning" icon="list-check" href="/docs/features/planning-mode">
   Plan before executing to improve accuracy.
 </Card>
-<Card title="Memory" icon="brain" href="/docs/concepts/memory">
+<Card title="Memory" icon="brain" href="/docs/features/advanced-memory">
   Store and retrieve long-term information.
 </Card>
 </CardGroup>

--- a/docs/guides/multi-agent.mdx
+++ b/docs/guides/multi-agent.mdx
@@ -252,5 +252,5 @@ Give agents only the tools they need — fewer tools means fewer failure modes.
 ## Next Steps
 
 - [Workflows](/docs/guides/workflows/routing) - Advanced workflow patterns
-- [Handoff](/docs/concepts/handoff) - Agent handoff concepts
+- [Handoff](/docs/features/handoffs) - Agent handoff concepts
 - [Agents Module Reference](/docs/sdk/praisonaiagents/agents/agents) - Full API reference

--- a/docs/tools/langchain_tools.mdx
+++ b/docs/tools/langchain_tools.mdx
@@ -219,7 +219,7 @@ agents.start()
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Memory Integration" icon="brain" href="../concepts/memory">
+  <Card title="Memory Integration" icon="brain" href="/docs/features/advanced-memory">
     Learn how to combine LangChain tools with agent memory
   </Card>
   <Card title="Custom Tools" icon="wrench" href="./tools">

--- a/docs/tools/tools.mdx
+++ b/docs/tools/tools.mdx
@@ -37,7 +37,7 @@ flowchart TB
 
 ```
 
-| Feature | [Knowledge](/concepts/knowledge) | [Tools](/concepts/tools) |
+| Feature | [Knowledge](/docs/features/knowledge) | [Tools](/docs/features/toolsets) |
 |---------|--------------------------------|---------------------------|
 | Purpose | Static reference information | Dynamic interaction capabilities |
 | Access | Read-only reference | Execute actions and commands |


### PR DESCRIPTION
## Summary
- Repoint six navigational links in docs/tools and docs/guides from docs/concepts to docs/features peers (Bot Integration to /docs/ui/claw where no features peer exists).
- Fixes broken /docs/concepts/handoff link in multi-agent guide.
- Leaves intentional docs/concepts path references in the documentation style guide mapping table unchanged.

Refs #648

## Test plan
- [x] rg concepts/ in docs/tools shows 0 navigational hits
- [x] Stray guide nav links updated; style-guide folder-structure examples retained
- [ ] Mintlify preview (optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several in-doc links and navigation cards to point to the latest documentation paths.
  * Improved consistency across related guides by directing readers to the newer feature-oriented pages.
  * Adjusted a few page link targets in the documentation for Bot Integration, caching, agent handoff, memory, knowledge, and tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->