### PR TITLE
docs: fix #1275, #1274, #1209 (tool-config, scoped_bridge, STREAM_UNAVAILABLE)

### DIFF
--- a/docs/configuration/tool-config.mdx
+++ b/docs/configuration/tool-config.mdx
@@ -8,6 +8,11 @@ icon: wrench
 
 This page provides comprehensive documentation for configuring tools in PraisonAI, including timeout settings, performance optimization, error handling, and resource management.
 
+
+<Note>
+In YAML the field name is still `tool_timeout:`; in Python pass tool execution settings through `tool_config=ToolConfig(timeout=…)`. The standalone `tool_timeout`, `tool_retry_policy`, and `parallel_tool_calls` kwargs were removed and raise `TypeError`.
+</Note>
+
 ## Tool Timeout Configuration
 
 ### Basic Timeout Settings
@@ -27,13 +32,12 @@ tool = Tool(
     }
 )
 
+from praisonaiagents import ToolConfig
+
 agent = Agent(
     name="Researcher",
     tools=[tool],
-    tool_config={
-        "global_timeout": 60,  # Global timeout for all tools
-        "timeout_strategy": "graceful"  # or "immediate"
-    }
+    tool_config=ToolConfig(timeout=30),
 )
 ```
 
@@ -45,24 +49,14 @@ PraisonAI now provides a unified `ToolConfig` dataclass that consolidates tool-r
 from praisonaiagents import Agent, ToolConfig
 from praisonaiagents.tools.retry import RetryPolicy
 
-# Old approach (deprecated but still works)
 agent = Agent(
-    name="legacy_agent",
-    tools=[web_search],
-    tool_timeout=30,
-    parallel_tool_calls=True,
-    tool_retry_policy=RetryPolicy(max_attempts=3)
-)
-
-# New consolidated approach (preferred)
-agent = Agent(
-    name="modern_agent", 
+    name="researcher",
     tools=[web_search],
     tool_config=ToolConfig(
         timeout=30,
         parallel=True,
-        retry_policy=RetryPolicy(max_attempts=3)
-    )
+        retry_policy=RetryPolicy(max_attempts=3),
+    ),
 )
 ```
 
@@ -115,13 +109,23 @@ agent = Agent(tool_config={
 })
 ```
 
-### Deprecation Path
+### Removed legacy kwargs
 
-The standalone `tool_timeout`, `parallel_tool_calls`, and `tool_retry_policy` parameters are now deprecated and will emit `DeprecationWarning` in future versions. They still work for backward compatibility:
+The standalone `tool_timeout`, `parallel_tool_calls`, and `tool_retry_policy` keyword arguments on `Agent(...)` have been removed. Passing them raises `TypeError`:
 
-- **Precedence**: If `tool_config` is provided, it takes precedence over standalone parameters
-- **Merging**: If `tool_config` is omitted, standalone parameters are merged into a synthesized `ToolConfig`
-- **Migration**: Update existing code to use `tool_config=ToolConfig(...)` instead
+```text
+TypeError: Agent.__init__() got an unexpected keyword argument 'tool_timeout'
+```
+
+Pass these settings through `tool_config=ToolConfig(...)` instead.
+
+| Removed kwarg | New location |
+|---|---|
+| `tool_timeout=30` | `tool_config=ToolConfig(timeout=30)` |
+| `parallel_tool_calls=True` | `tool_config=ToolConfig(parallel=True)` |
+| `tool_retry_policy=RetryPolicy(...)` | `tool_config=ToolConfig(retry_policy=RetryPolicy(...))` |
+
+YAML and the CLI are unaffected — `tool_timeout:` in YAML and `--tool-timeout` on the CLI remain valid; the wrapper translates them into a `ToolConfig` before constructing the `Agent`.
 
 ### Agent-Level Tool Timeout
 
@@ -628,24 +632,17 @@ web_search_tool = Tool(
 )
 
 # Create agent with tool configuration
+from praisonaiagents import ToolConfig
+from praisonaiagents.tools.retry import RetryPolicy
+
 agent = Agent(
     name="SearchAgent",
     tools=[web_search_tool],
-    tool_config={
-        # Global timeout settings
-        "global_timeout": 300,
-        "timeout_strategy": "graceful",
-        
-        # Performance settings
-        "parallel_execution": True,
-        "max_parallel_tools": 3,
-        "cache_tool_results": True,
-        
-        # Monitoring
-        "track_metrics": True,
-        "log_slow_executions": True,
-        "slow_threshold": 10  # seconds
-    }
+    tool_config=ToolConfig(
+        timeout=30,
+        parallel=True,
+        retry_policy=RetryPolicy(max_attempts=3),
+    ),
 )
 ```
 

--- a/docs/features/async-bridge.mdx
+++ b/docs/features/async-bridge.mdx
@@ -403,7 +403,7 @@ graph LR
 |------------------|-----------|-------------|
 | `AsyncBridge` | `class AsyncBridge` | Per-instance async runner; create one per tenant or service. |
 | `AsyncBridge.run_sync` | `(self, coro, *, timeout=300) -> T` | Run a coroutine on this bridge's background loop. |
-| `AsyncBridge.shutdown` | `(self, timeout=5.0) -> None` | Cancel pending tasks and stop this bridge's loop. PR #2122: releases the bridge lock before awaiting cancellation and excludes the current task — safe to call from within an async tool on the bridge's loop. |
+| `AsyncBridge.shutdown` | `(self, timeout=5.0, *, permanent=False) -> None` | Cancel pending tasks and stop this bridge's loop. With `permanent=True`, the bridge cannot be reused; later `run_sync`/`submit` raise `RuntimeError`. `scoped_bridge()` uses `permanent=True` for scope-owned bridges. PR #2122: releases the bridge lock before awaiting cancellation. |
 | `AsyncBridge.submit` | `(self, coro) -> concurrent.futures.Future` | Submit without waiting; returns a `concurrent.futures.Future`. |
 | `AsyncBridge.get` | `(self) -> asyncio.AbstractEventLoop` | Get (lazily spawn) the bridge's event loop. |
 | `run_sync` (module-level) | `(coro, *, timeout=300) -> T` | Routes through the shared default `AsyncBridge`. Behaviour unchanged. |
@@ -483,6 +483,32 @@ async with scoped_bridge(bridge):
 
 The context manager uses a `ContextVar` so nested scopes work correctly in async tasks and threads — each concurrent task sees only its own bridge.
 
+<Warning>
+When `scoped_bridge()` creates the bridge for you (no argument), it shuts down with `permanent=True` on exit. If code tries to call `run_sync` or `submit` on that bridge afterward, you get:
+
+`RuntimeError: AsyncBridge has been shut down and cannot be reused; this usually means a context outlived its scoped_bridge() block`
+
+That guard stops an orphaned loop and thread from outliving the scope that owned them. The shared default bridge always shuts down with `permanent=False`.
+</Warning>
+
+
+### Scope-owned bridge (preferred)
+
+```python
+from praisonaiagents import Agent
+from praisonai._async_bridge import scoped_bridge, run_sync
+
+def handle_session(session_id: str, prompt: str) -> str:
+    with scoped_bridge() as bridge:
+        data = run_sync(fetch_session_data(session_id))
+        agent = Agent(name="Assistant", instructions=f"Context: {data}")
+        return agent.start(prompt)
+    # bridge.shutdown(permanent=True) ran automatically — do not reuse `bridge` here
+```
+
+With no argument, `scoped_bridge()` creates a fresh bridge and tears it down with `permanent=True` when the `with` block ends. Internal code that calls module-level `run_sync()` inside the block uses the scoped bridge via `contextvars` — no import changes required.
+
+
 ### `current_bridge()` for introspection
 
 `current_bridge()` returns the bridge bound to the current async task, or `None` when no scope is active. Use it to inspect which bridge is in use without passing it explicitly through call stacks.
@@ -529,8 +555,8 @@ asyncio.run(main())
 
 | Symbol | Signature | Description |
 |--------|-----------|-------------|
-| `scoped_bridge` | `async with scoped_bridge(bridge: AsyncBridge)` | Binds `bridge` to the current async task scope via a `ContextVar`. |
-| `current_bridge` | `() -> AsyncBridge \| None` | Returns the bridge bound to the current scope, or `None`. |
+| `scoped_bridge` | `(bridge: Optional[AsyncBridge] = None) -> Iterator[AsyncBridge]` | Context manager. Binds a per-scope bridge via `ContextVar`. With `None`, creates and owns a fresh bridge (shut down with `permanent=True` on exit). With a caller-provided bridge, the caller retains lifecycle ownership. |
+| `current_bridge` | `() -> AsyncBridge` | Returns the bridge bound by an enclosing `scoped_bridge()` block, else the shared default. |
 
 ---
 

--- a/docs/features/streaming-tool-events.mdx
+++ b/docs/features/streaming-tool-events.mdx
@@ -433,6 +433,28 @@ def on_event(event: StreamEvent) -> None:
 
 See [Tool Progress Streaming](/docs/features/tool-progress-streaming) for the full guide.
 
+
+### STREAM_UNAVAILABLE Event
+
+The agent or model adapter emits `STREAM_UNAVAILABLE` when token streaming cannot run in the current configuration — for example when a provider falls back to a non-streaming response instead of failing silently. Treat it as an observable fallback signal for UIs and loggers.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `string` | Always `"stream_unavailable"` |
+| `timestamp` | `float` | High-precision timestamp |
+| `error` | `string` | Human-readable summary (often `Streaming unavailable: …`) |
+| `metadata.reason` | `string` | Provider-specific reason code or message |
+
+```python
+from praisonaiagents.streaming import StreamEventType
+
+def on_event(event):
+    if event.type == StreamEventType.STREAM_UNAVAILABLE:
+        reason = (event.metadata or {}).get("reason") or event.error
+        print(f"Streaming fallback: {reason}")
+        # Continue with non-streaming UI or wait for DELTA_TEXT / final result
+```
+
 ---
 
 ## Related

--- a/docs/features/yaml-configuration-reference.mdx
+++ b/docs/features/yaml-configuration-reference.mdx
@@ -279,7 +279,7 @@ All recognized field names for agents in both `agents:` and `roles:` sections:
 | `system_template` | string | Custom system prompt |
 | `prompt_template` | string | Custom prompt template |
 | `response_template` | string | Custom response template |
-| `tool_timeout` | int | Per-call tool execution timeout in seconds. Enforced at **two layers** when running `framework: praisonai`: (1) the wrapper wraps every tool callable in a timeout-enforcing shim that returns a structured `{"error": "tool_timeout", ...}` dict on timeout, and (2) the SDK Agent's executor pool also honours the same value. Sync tools run in a daemon thread on the wrapper layer; async tools use `asyncio.wait_for`. See [Tool Configuration](/docs/configuration/tool-config) for the full shape. |
+| `tool_timeout` | int | Per-call tool execution timeout in seconds. Enforced at **two layers** when running `framework: praisonai`: (1) the wrapper wraps every tool callable in a timeout-enforcing shim that returns a structured `{"error": "tool_timeout", ...}` dict on timeout, and (2) the SDK Agent's executor pool also honours the same value. Sync tools run in a daemon thread on the wrapper layer; async tools use `asyncio.wait_for`. See [Tool Configuration](/docs/configuration/tool-config) for the full shape.. In Python this maps to `tool_config=ToolConfig(timeout=…)` — the standalone `tool_timeout=` kwarg on `Agent(...)` was removed. |
 | `tool_retry_policy` | object | Tool retry configuration with exponential backoff. See example below. |
 | `planning_tools` | array | Tools for planning |
 | `planning` | bool | Enable planning |


### PR DESCRIPTION
## Summary
- **#1275** — `docs/configuration/tool-config.mdx`: remove legacy `tool_timeout` / `parallel_tool_calls` / `tool_retry_policy` Agent kwargs (TypeError per PraisonAI #2469); fix invalid `tool_config` dict keys; YAML clarifier on `yaml-configuration-reference.mdx`.
- **#1274** — `docs/features/async-bridge.mdx`: document `scoped_bridge()` scope-owned shutdown with `permanent=True`, resurrection guard, and updated API signatures (complements #1295).
- **#1209** — `docs/features/streaming-tool-events.mdx`: add `STREAM_UNAVAILABLE` event reference and callback handling.

## Test plan
- [x] `grep` shows no `Agent(... tool_timeout=` / `parallel_tool_calls=` in docs (aside from unrelated pages)
- [x] No edits under `docs/concepts/`
- [x] Mintlify pages render (MDX structure unchanged)

Closes #1275, closes #1274, closes #1209

Made with [Cursor](https://cursor.com)