### PR TITLE
docs: ToolConfig parity for tool retry policy page

### DIFF
--- a/docs/features/tool-retry-policy.mdx
+++ b/docs/features/tool-retry-policy.mdx
@@ -8,7 +8,7 @@ icon: "rotate"
 Tool retry automatically re-runs a failing tool with exponential backoff so transient errors don't break your agent.
 
 ```python
-from praisonaiagents import Agent, tool
+from praisonaiagents import Agent, tool, ToolConfig
 from praisonaiagents.tools import RetryPolicy
 
 @tool
@@ -20,7 +20,7 @@ agent = Agent(
     name="researcher",
     instructions="Research topics on the web",
     tools=[web_search],
-    tool_retry_policy=RetryPolicy(),
+    tool_config=ToolConfig(retry_policy=RetryPolicy()),
 )
 agent.start("Find information about renewable energy")
 ```
@@ -53,14 +53,14 @@ graph LR
 Enable retry for all tools with safe defaults:
 
 ```python
-from praisonaiagents import Agent
+from praisonaiagents import Agent, ToolConfig
 from praisonaiagents.tools import RetryPolicy
 
 agent = Agent(
     name="researcher",
     instructions="Research topics on the web",
     tools=[web_search],
-    tool_retry_policy=RetryPolicy()  # 3 attempts, exponential backoff
+    tool_config=ToolConfig(retry_policy=RetryPolicy())  # 3 attempts, exponential backoff
 )
 
 agent.start("Find information about renewable energy")
@@ -71,19 +71,21 @@ agent.start("Find information about renewable energy")
 Configure specific retry behavior:
 
 ```python
-from praisonaiagents import Agent
+from praisonaiagents import Agent, ToolConfig
 from praisonaiagents.tools import RetryPolicy
 
 agent = Agent(
     name="api_agent", 
     instructions="Call external APIs",
     tools=[api_tool],
-    tool_retry_policy=RetryPolicy(
-        max_attempts=5,
-        retry_on={"timeout", "rate_limit", "connection_error"},
-        backoff_factor=2.0,
-        initial_delay_ms=1000,
-        jitter=True
+    tool_config=ToolConfig(
+        retry_policy=RetryPolicy(
+            max_attempts=5,
+            retry_on={"timeout", "rate_limit", "connection_error"},
+            backoff_factor=2.0,
+            initial_delay_ms=1000,
+            jitter=True,
+        ),
     )
 )
 ```
@@ -93,7 +95,7 @@ agent = Agent(
 Different tools may need different retry strategies:
 
 ```python
-from praisonaiagents import Agent, tool
+from praisonaiagents import Agent, tool, ToolConfig
 from praisonaiagents.tools import RetryPolicy
 
 @tool(retry_policy=RetryPolicy(max_attempts=5, backoff_factor=3.0))
@@ -105,7 +107,7 @@ def unreliable_api_call(query: str) -> str:
 agent = Agent(
     name="mixed_agent",
     tools=[local_tool, unreliable_api_call],
-    tool_retry_policy=RetryPolicy(max_attempts=2)  # Default for other tools
+    tool_config=ToolConfig(retry_policy=RetryPolicy(max_attempts=2))  # Default for other tools
 )
 ```
 </Step>
@@ -150,9 +152,8 @@ sequenceDiagram
 
 ```mermaid
 graph TB
-    A[🔧 @tool(retry_policy=...)] -->|Overrides| B[🤖 Agent(tool_retry_policy=...)]
-    B -->|Overrides| C[⚙️ Agent(tool_config=ToolConfig(retry_policy=...))]
-    C -->|Overrides| D[📋 Default RetryPolicy()]
+    A[🔧 @tool(retry_policy=...)] -->|Overrides| B[🤖 Agent(tool_config=ToolConfig(retry_policy=...))]
+    B -->|Overrides| C[📋 Default RetryPolicy()]
     
     classDef highest fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef agent fill:#189AB4,stroke:#7C90A0,color:#fff
@@ -160,8 +161,8 @@ graph TB
     classDef default fill:#10B981,stroke:#7C90A0,color:#fff
     
     class A highest
-    class B,C agent
-    class D default
+    class B agent
+    class C default
 ```
 
 **Tool-level (highest priority):**
@@ -173,7 +174,10 @@ def flaky_api():
 
 **Agent-level (medium priority):**
 ```python
-agent = Agent(tool_retry_policy=RetryPolicy(max_attempts=3))
+from praisonaiagents import Agent, ToolConfig
+from praisonaiagents.tools import RetryPolicy
+
+agent = Agent(tool_config=ToolConfig(retry_policy=RetryPolicy(max_attempts=3)))
 ```
 
 **Default (lowest priority):**
@@ -229,6 +233,9 @@ graph TB
 ### Per-tool override for unreliable API
 
 ```python
+from praisonaiagents import Agent, ToolConfig
+from praisonaiagents.tools import RetryPolicy
+
 @tool(retry_policy=RetryPolicy(
     max_attempts=5,
     backoff_factor=3.0,
@@ -242,11 +249,15 @@ def external_weather_api(location: str) -> str:
 agent = Agent(
     name="weather_bot",
     tools=[external_weather_api, local_calculation],
-    tool_retry_policy=RetryPolicy(max_attempts=2)  # Default for other tools
+    tool_config=ToolConfig(retry_policy=RetryPolicy(max_attempts=2))  # Default for other tools
 )
 ```
 
 ### YAML configuration
+
+<Note>
+In YAML the field name is still `tool_retry_policy:`; in Python pass retry settings through `tool_config=ToolConfig(retry_policy=…)`. The standalone `tool_retry_policy` kwarg on `Agent(...)` was removed and raises `TypeError`.
+</Note>
 
 ```yaml
 agents:
@@ -279,7 +290,7 @@ praisonai \
 Monitor retry attempts with hooks:
 
 ```python
-from praisonaiagents import Agent
+from praisonaiagents import Agent, ToolConfig
 from praisonaiagents.hooks import add_hook, HookEvent, HookResult, OnRetryInput
 from praisonaiagents.tools import RetryPolicy
 
@@ -292,7 +303,7 @@ def log_retry(event: OnRetryInput) -> HookResult:
 agent = Agent(
     name="monitored_agent",
     tools=[flaky_tool],
-    tool_retry_policy=RetryPolicy(max_attempts=3)
+    tool_config=ToolConfig(retry_policy=RetryPolicy(max_attempts=3)),
 )
 ```
 


### PR DESCRIPTION
## Summary
- Replace deprecated `Agent(..., tool_retry_policy=...)` examples with `tool_config=ToolConfig(retry_policy=...)` on `docs/features/tool-retry-policy.mdx`.
- Simplify the precedence diagram and add a YAML note aligned with `docs/configuration/tool-config.mdx` (YAML `tool_retry_policy:` unchanged; Python uses `ToolConfig`).

Follow-up to #1275 / #1329; aligns with PraisonAI MervinPraison/PraisonAI#2469.

## Test plan
- [x] Grep: no `tool_retry_policy=` Agent kwargs in `tool-retry-policy.mdx`
- [ ] Mintlify build (CI)