### PR TITLE
docs: document praisonai-code sibling package scaffold (C0)

### DIFF
--- a/docs/developers/development-setup.mdx
+++ b/docs/developers/development-setup.mdx
@@ -100,13 +100,83 @@ cd src/praisonai && uv publish
 ```
 praisonai-package/
 ├── src/
-│   ├── praisonai/           # Main CLI package
+│   ├── praisonai/           # Main user-facing CLI package (pip install praisonai)
+│   ├── praisonai-code/      # Agentic terminal CLI — extracted from praisonai (incremental C0–C6)
 │   ├── praisonai-agents/    # Agent SDK (praisonaiagents)
 │   ├── praisonai-ts/        # TypeScript SDK
 │   └── praisonai-rust/      # Rust SDK
 ├── examples/                # Example scripts
 └── tests/                   # Test suites
 ```
+
+---
+
+## praisonai-code Sibling Package
+
+`praisonai-code` hosts the **agentic terminal CLI** (`run`, `chat`, `code`, warm runtime, CLI backends) as an internal sibling package. `praisonai` remains the user-facing install; `praisonai-code` is not published standalone to PyPI during migration.
+
+**Status:** C0 scaffold merged in [PraisonAI#2520](https://github.com/MervinPraison/PraisonAI/pull/2520). Only `__version__` is exposed; no runtime code has moved yet.
+
+### Dependency Rules
+
+```
+praisonai (main)  →  depends on  praisonai-code
+praisonai-code    →  depends on  praisonaiagents ONLY (not praisonai)
+```
+
+```mermaid
+graph LR
+    Main[📦 praisonai<br/>user-facing install] --> Code[💻 praisonai-code<br/>agentic terminal CLI]
+    Code --> Agents[🤖 praisonaiagents<br/>agent SDK]
+
+    classDef main fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef code fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef sdk fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Main main
+    class Code code
+    class Agents sdk
+```
+
+### Dev Install
+
+<Steps>
+  <Step title="Install the sibling package in editable mode">
+
+```bash
+pip install -e src/praisonai-code
+```
+
+  </Step>
+  <Step title="Verify the install">
+
+```bash
+python -c "import praisonai_code; print(praisonai_code.__version__)"
+# → 0.0.1
+```
+
+  </Step>
+</Steps>
+
+### Migration Plan (C0–C6)
+
+| Step | Scope | Status |
+|------|-------|--------|
+| **C0** | Scaffold (this) | ✅ Merged in [#2520](https://github.com/MervinPraison/PraisonAI/pull/2520) |
+| C1 | `runtime/` + `cli_backends/` | Tracking |
+| C2 | `interactive/`, `execution/`, `ui/`, `output/`, `state/` | Tracking |
+| C3 | Agentic commands (80 files) | Tracking |
+| C4 | Agentic features (158 files) | Tracking |
+| C5 | `main.py`, `app.py`, config/session/utils + shims | Tracking |
+| C6 | Integration gate | Tracking |
+
+<Note>
+Users continue to `pip install praisonai` and run `praisonai [TASK]`. Existing imports like `from praisonai.cli.main import PraisonAI` continue to work through PEP 562 shims once C1–C5 land.
+</Note>
+
+<Warning>
+At C0, no PEP 562 shims are installed because no runtime code has moved. Direct imports from `praisonai_code.*` will succeed only for `__version__`. Wait for C1 (`runtime/` + `cli_backends/`) before importing anything else from `praisonai_code`.
+</Warning>
 
 ---
 
@@ -118,5 +188,8 @@ praisonai-package/
   </Card>
   <Card icon="book" href="/docs/developers/reference-home">
     SDK reference documentation
+  </Card>
+  <Card icon="github" href="https://github.com/MervinPraison/PraisonAI/issues/2512">
+    praisonai-code extraction (C0–C6 tracking issue)
   </Card>
 </CardGroup>


### PR DESCRIPTION
Documents the new praisonai-code sibling package scaffold (C0) introduced in MervinPraison/PraisonAI#2520.\n\nChanges to docs/developers/development-setup.mdx:\n- Updated Project Structure tree to include src/praisonai-code/\n- New praisonai-code Sibling Package section with dependency rules, Mermaid diagram, dev install Steps, C0-C6 migration table, Note and Warning components\n- Updated Related CardGroup with tracking issue link (MervinPraison/PraisonAI#2512)\n\nNo new pages created. No docs/concepts/ changes. docs.json unchanged.\n\nFixes #1331\n\nGenerated with [Claude Code](https://claude.ai/code)