### PR TITLE
docs(tools/file_tools): update read_file for coding-grade params

### DIFF
--- a/docs/tools/file_tools.mdx
+++ b/docs/tools/file_tools.mdx
@@ -140,23 +140,54 @@ from praisonaiagents import delete_file
 
 ## Function Details
 
-### read_file(filepath: str, encoding: str = 'utf-8')
+### read_file(filepath, encoding='utf-8', offset=None, limit=None, line_numbers=True, max_line_chars=2000)
 
-Reads content from a file:
-- Supports different encodings
-- Error handling for missing files
-- Automatic encoding detection
+Reads a windowed, line-numbered view of a file so a coding agent can reference exact lines for follow-up edits.
+
+| Argument | Type | Default | Description |
+|---|---|---|---|
+| `filepath` | `str` | — | Path to the file. |
+| `encoding` | `str` | `'utf-8'` | File encoding. |
+| `offset` | `int \| None` | `None` (start of file) | 1-based first line to read. |
+| `limit` | `int \| None` | `None` (up to 2000 lines) | Maximum lines to read. Negative → empty window. |
+| `line_numbers` | `bool` | `True` | Prefix each line with its 1-based number. Set `False` (with no `offset`/`limit`) for exact raw content. |
+| `max_line_chars` | `int` | `2000` | Truncate any single line longer than this with `"... (line truncated)"`. Negative disables. |
+
+Default output is line-numbered with a right-aligned gutter (width = `max(len(str(last_line)), 6)`, tab-separated):
+
+```
+    42	const x = ...
+```
+
+When the window doesn't reach the end of the file, a paging hint is appended so the agent knows where to continue:
+
+```
+... (showing lines 1-2000 of 4573; call again with offset=2001 for more)
+```
 
 ```python
-# Basic usage
+# Default — line-numbered output
 content = read_file("example.txt")
 
 # With specific encoding
 content = read_file("data.txt", encoding="latin-1")
 
-# Returns: str (file content)
+# Page a large file — first page; paging hint shows where to continue
+page1 = read_file("app.py", offset=1, limit=2000)
+
+# Continue where the hint pointed
+page2 = read_file("app.py", offset=2001, limit=2000)
+
+# Restore pre-2527 raw output (no gutter, no windowing)
+raw = read_file("small.txt", line_numbers=False)
+
+# Returns: str
 # Error case: Returns error message as string
 ```
+
+<Note>
+  **Backwards compatibility:** `read_file(path, line_numbers=False)` (with no `offset` or `limit`) returns the exact plain-string content identical to pre-2527 behaviour — useful when downstream code depends on the raw string shape.
+</Note>
 
 ### write_file(filepath: str, content: str, encoding: str = 'utf-8')
 
@@ -341,8 +372,8 @@ for file in files:
 
 3. File Processing:
 ```python
-# Read, process, and write files
-content = read_file("input.txt")
+# Read, process, and write files (use line_numbers=False for plain-string input)
+content = read_file("input.txt", line_numbers=False)
 processed = process_content(content)  # Your processing function
 write_file("output.txt", processed)
 ```


### PR DESCRIPTION
## Summary

Updates `docs/tools/file_tools.mdx` to reflect the new `read_file` function signature merged in `MervinPraison/PraisonAI#2527`.

### Changes

- **Updated `read_file` signature** in §Function Details to include `offset`, `limit`, `line_numbers`, `max_line_chars`
- **Added parameter table** with types, defaults, and descriptions matching SDK verbatim
- **Added paging example** showing `offset`/`limit` usage and the paging hint format
- **Added backwards-compat note**: `read_file(path, line_numbers=False)` restores pre-2527 plain-string output byte-for-byte
- **Removed incorrect "Automatic encoding detection"** bullet (the param is `encoding='utf-8'`, not auto-detection)
- **Updated Common Use Cases #3** to use `line_numbers=False` so the content fed to `process_content()` is plain string

### Verification checklist (from issue §E)
- [x] `read_file` signature in §Function Details matches the SDK verbatim (name, order, types, defaults)
- [x] `line_numbers=True` default is called out explicitly
- [x] `DEFAULT_MAX_LINES = 2000` behaviour + paging hint format shown once, verbatim
- [x] At least one paging example (`offset` + `limit` on a large file)
- [x] Backwards-compat one-liner (`read_file(path, line_numbers=False)`)
- [x] "Automatic encoding detection" bullet removed / corrected
- [x] "Common Use Cases" #3 updated to use `line_numbers=False`
- [x] No page in `docs/concepts/**` touched
- [x] No page in `docs/js/**` or `docs/rust/**` touched
- [x] Frontmatter / hero mermaid / Steps quickstart preserved unchanged

Fixes #1337

Generated with [Claude Code](https://claude.ai/code)