### PR TITLE
docs: refresh parity tracker to 100% + audit compliance fixes

### DIFF
--- a/docs/features/DOCS_PARITY.md
+++ b/docs/features/DOCS_PARITY.md
@@ -1,6 +1,6 @@
 # Documentation Parity Tracker (Python)
 
-> **Categories:** 66 | **Documented:** 65 | **Parity:** 98.5%
+> **Categories:** 66 | **Documented:** 66 | **Parity:** 100.0%
 
 This report compares **Python SDK feature categories** against **Python documentation** (docs/concepts, docs/features, etc.).
 
@@ -9,9 +9,9 @@ This report compares **Python SDK feature categories** against **Python document
 | Metric | Count |
 |--------|-------|
 | Feature Categories | 66 |
-| **Documented Categories** | **65** |
-| **Undocumented Categories** | **1** |
-| **Parity** | **98.5%** |
+| **Documented Categories** | **66** |
+| **Undocumented Categories** | **0** |
+| **Parity** | **100.0%** |
 
 ## Documented Categories
 
@@ -78,16 +78,11 @@ This report compares **Python SDK feature categories** against **Python document
 | ✅ Templates | 1 | 8 | 1655 |
 | ✅ Tools | 12 | 122 | 30097 |
 | ✅ Tracing | 3 | 2 | 139 |
+| ✅ Vector Store | 1 | 1 | 366 |
 | ✅ Video | 2 | 6 | 510 |
 | ✅ Vision | 2 | 1 | 283 |
 | ✅ Web | 3 | 8 | 1901 |
 | ✅ Workflows | 5 | 15 | 6439 |
-
-## Undocumented Categories (Need Documentation)
-
-| Category | Features |
-|----------|----------|
-| ❌ Vector Store | 1 |
 
 ## Documentation Without Features
 

--- a/docs/features/knowledge-backends.mdx
+++ b/docs/features/knowledge-backends.mdx
@@ -7,6 +7,18 @@ icon: "database"
 
 Choose the right storage backend for your knowledge base — from local development with Chroma to multi-tenant production with mem0.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Research Assistant",
+    instructions="You are a research assistant.",
+    knowledge=["./documents/"],
+)
+
+agent.start("What are the main findings?")
+```
+
 ```mermaid
 graph LR
     subgraph "Knowledge Backends"

--- a/docs/features/knowledge.mdx
+++ b/docs/features/knowledge.mdx
@@ -7,6 +7,18 @@ icon: "book"
 
 The knowledge system lets agents retrieve relevant information from PDFs, documents, and URLs before answering, grounding responses in your own sources.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Research Assistant",
+    instructions="Answer questions using the knowledge base.",
+    knowledge=["research_paper.pdf", "data.txt"],
+)
+
+agent.start("What are the key findings?")
+```
+
 ```mermaid
 graph TB
     subgraph Input Sources

--- a/docs/features/memory-advanced-search.mdx
+++ b/docs/features/memory-advanced-search.mdx
@@ -7,6 +7,17 @@ icon: "magnifying-glass-plus"
 
 Memory search in PraisonAI Agents provides advanced parameters for better control over search results, including reranking for improved relevance and cutoff thresholds for quality control.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    instructions="Search and retrieve with quality filtering.",
+    memory={"backend": "rag", "use_embedding": True},
+)
+
+agent.start("What is the capital of France?")
+```
+
 ```mermaid
 graph LR
     subgraph "Memory Advanced Search"

--- a/docs/features/memory-lifecycle-hooks.mdx
+++ b/docs/features/memory-lifecycle-hooks.mdx
@@ -7,6 +7,22 @@ icon: "webhook"
 
 Memory lifecycle hooks let your memory backend react when the agent compresses context, switches sessions, writes to memory, or delegates to a subagent.
 
+```python
+from praisonaiagents import Agent, Memory
+
+class MyMemory(Memory):
+    def on_pre_compress(self, messages):
+        return "User prefers concise answers"
+
+agent = Agent(
+    name="Assistant",
+    instructions="Help the user.",
+    memory=MyMemory(),
+)
+
+agent.start("Tell me about Mars")
+```
+
 ```mermaid
 graph LR
     subgraph "Memory Lifecycle Events"

--- a/docs/features/memory-troubleshooting.mdx
+++ b/docs/features/memory-troubleshooting.mdx
@@ -7,6 +7,18 @@ icon: "triangle-exclamation"
 
 Memory troubleshooting helps resolve common errors when configuring memory providers and debugging memory-related issues in PraisonAI agents.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    instructions="Help the user remember things.",
+    memory=True,
+)
+
+agent.start("Remember that I prefer concise answers.")
+```
+
 ```mermaid
 graph TB
     subgraph "Memory Provider Decision Tree"

--- a/praisonai/_dev/parity/docs_generator.py
+++ b/praisonai/_dev/parity/docs_generator.py
@@ -195,7 +195,6 @@ PYTHON_DOC_ORPHAN_EXCLUSIONS = frozenset({
 DOC_FEATURE_CATEGORY_ALIASES = {
     'Callbacks': 'Hooks',
     'Middleware': 'Hooks',
-    'Vector Store': 'Knowledge',
     'Token Management': 'Context Management',
     'Jobs': 'Workflows',
     'Chat': 'Agent',

--- a/praisonai/_dev/parity/python_extractor.py
+++ b/praisonai/_dev/parity/python_extractor.py
@@ -71,7 +71,7 @@ class PythonFeatureExtractor:
         'tools': ['tools.tools', 'tools.base', 'tools.decorator', 'tools.registry'],
         'llm': ['llm.llm', 'llm.failover'],
         'memory': ['memory.memory'],
-        'knowledge': ['knowledge.knowledge', 'knowledge.chunking'],
+        'knowledge': ['knowledge.knowledge', 'knowledge.chunking', 'knowledge.vector_store'],
         'db': ['db'],
         'obs': ['obs'],
         'mcp': ['mcp.mcp'],


### PR DESCRIPTION
## Summary

Fixes #1366 — addresses all three action items from the issue review:

### 1. AGENTS.md — no changes needed ✅
Verified §1.1 items 7–10, §5.2 friendly imports, and §6.1 additional style rules are all present in the current repo AGENTS.md. No regressions from the provided draft were applied.

### 2. Parity tracker refreshed to 100% ✅
- `docs/features/DOCS_PARITY.md`: Vector Store moved from ❌ to ✅ (66/66 = 100% parity)
- **Root cause fixed** in `praisonai/_dev/parity/docs_generator.py`: removed the `'Vector Store': 'Knowledge'` entry from `DOC_FEATURE_CATEGORY_ALIASES` — this alias was routing `vector-store.mdx` docs into the Knowledge bucket, leaving "Vector Store" appearing undocumented even though the page existed
- `praisonai/_dev/parity/python_extractor.py`: added `knowledge.vector_store` to `CATEGORY_MAPPING` so future parity runs correctly group VectorStore exports under Knowledge

### 3. Feature page audit — 5 compliance fixes ✅
Grep sweeps found zero forbidden phrases and zero `praisonaiagents.workflows` imports across `docs/features/*.mdx`. All Mermaid palettes are standard. Five pages were missing an agent-centric code opener before their hero Mermaid diagram (§1.1 item 9):

| Page | Fix |
|------|-----|
| `knowledge.mdx` | Added `Agent(knowledge=[...])` opener |
| `knowledge-backends.mdx` | Added `Agent(knowledge=[...])` opener |
| `memory-advanced-search.mdx` | Added `Agent(memory={...})` opener |
| `memory-lifecycle-hooks.mdx` | Added `Agent(memory=MyMemory())` opener |
| `memory-troubleshooting.mdx` | Added `Agent(memory=True)` opener |

No files in `docs/concepts/` were touched.

Generated with [Claude Code](https://claude.ai/code)