### PR TITLE
docs: cross-link Display Policy with bot/terminal pages (fixes #1281)

### DIFF
--- a/docs/features/bot-platform-capabilities.mdx
+++ b/docs/features/bot-platform-capabilities.mdx
@@ -7,6 +7,10 @@ icon: "sliders"
 
 Platform capabilities tell PraisonAI what your bot's platform can do, so streaming, chunking, and rate limiting work the same way everywhere.
 
+<Info>
+Capabilities describe what a channel **can** render; [Display Policy](/docs/features/display-policy) controls what you **want** shown.
+</Info>
+
 ```mermaid
 graph LR
     A[Bot Adapter] --> B[PlatformCapabilities]
@@ -167,6 +171,9 @@ Keeps registry caching consistent when platforms override defaults.
 <CardGroup cols={2}>
   <Card title="Durable Outbound Delivery" icon="shield-check" href="/docs/features/durable-delivery#effectively-once-delivery">
     Effectively-once delivery via crash reconciliation
+  </Card>
+  <Card title="Display Policy" icon="monitor" href="/docs/features/display-policy">
+    Operator policy for streaming and footers
   </Card>
   <Card title="Bot Platform Plugins" icon="puzzle-piece" href="/docs/features/bot-platform-plugins">
     Register custom adapters

--- a/docs/features/bot-streaming-replies.mdx
+++ b/docs/features/bot-streaming-replies.mdx
@@ -7,6 +7,10 @@ icon: "message-pen"
 
 Channel bots can post a quick placeholder message and progressively edit it in place as the agent's answer streams in — replacing the old "stare at a typing indicator for 45s, then a wall of text lands in one burst" experience.
 
+<Info>
+Session-level `streaming: true` is a shortcut. For unified per-platform defaults and overrides, use [Display Policy](/docs/features/display-policy).
+</Info>
+
 ```mermaid
 graph LR
     subgraph "Bot Streaming Flow"

--- a/docs/features/display-policy.mdx
+++ b/docs/features/display-policy.mdx
@@ -308,6 +308,12 @@ Only specify what you need to change. A global `display: { streaming: "progress"
 <Card title="Messaging Bots" icon="robot" href="/docs/features/messaging-bots">
   Deploy agents across Telegram, Slack, Discord, WhatsApp, and more
 </Card>
+<Card title="Platform Capabilities" icon="sliders" href="/docs/features/bot-platform-capabilities">
+  What each channel can render
+</Card>
+<Card title="Display System" icon="display" href="/docs/features/display-system">
+  Terminal output and Rich rendering
+</Card>
 <Card title="Bot Streaming Replies" icon="zap" href="/docs/features/bot-streaming-replies">
   Configure streaming for individual bot sessions
 </Card>

--- a/docs/features/display-system.mdx
+++ b/docs/features/display-system.mdx
@@ -7,6 +7,11 @@ icon: "display"
 
 The display system formats agent output in the terminal and exposes hooks for custom rendering.
 
+<Note>
+This page covers **terminal** output only. For per-channel presentation (streaming, tool progress, footers), see [Display Policy](/docs/features/display-policy).
+</Note>
+
+
 ```mermaid
 graph LR
     subgraph "Display System"


### PR DESCRIPTION
## Summary
- Adds see-also links between `display-policy`, `display-system`, `bot-platform-capabilities`, and `bot-streaming-replies`.
- Page content already on main at `docs/features/display-policy.mdx`; this closes the companion cross-link checklist from #1281.

## Test plan
- [x] Valid MDX links to `/docs/features/display-policy`
- [x] No `docs/concepts/` edits

Fixes #1281

Made with [Cursor](https://cursor.com)