### PR TITLE
docs: fix Vector Store parity tracker (#1284)

### DIFF
--- a/docs/features/DOCS_PARITY.md
+++ b/docs/features/DOCS_PARITY.md
@@ -18,7 +18,7 @@ This report compares **Python SDK feature categories** against **Python document
 | Category | Features | Docs | Lines |
 |----------|----------|------|-------|
 | ✅ AGUI | 1 | 2 | 420 |
-| ✅ Agent | 21 | 43 | 11901 |
+| ✅ Agent | 21 | 43 | 11893 |
 | ✅ Agent-to-Agent (A2A) | 1 | 7 | 2927 |
 | ✅ Agent-to-User (A2U) | 1 | 3 | 573 |
 | ✅ Approval | 1 | 4 | 1856 |
@@ -27,62 +27,62 @@ This report compares **Python SDK feature categories** against **Python document
 | ✅ Autonomy | 3 | 6 | 2148 |
 | ✅ Bots | 7 | 24 | 8439 |
 | ✅ Budget | 1 | 1 | 287 |
-| ✅ CLI | 5 | 111 | 28211 |
+| ✅ CLI | 5 | 111 | 28209 |
 | ✅ Chunking | 2 | 2 | 339 |
 | ✅ Citations | 2 | 1 | 202 |
 | ✅ Code Execution | 2 | 13 | 3739 |
 | ✅ Conditions | 1 | 3 | 1108 |
 | ✅ Configuration | 3 | 7 | 2281 |
-| ✅ Context Management | 16 | 33 | 11293 |
-| ✅ Database | 1 | 40 | 5669 |
+| ✅ Context Management | 16 | 33 | 11287 |
+| ✅ Database | 1 | 40 | 5663 |
 | ✅ Deep Research | 8 | 2 | 497 |
-| ✅ Display | 6 | 3 | 610 |
+| ✅ Display | 6 | 3 | 621 |
 | ✅ Embeddings | 6 | 23 | 1968 |
 | ✅ Evaluation | 1 | 6 | 2509 |
 | ✅ Events | 1 | 2 | 711 |
 | ✅ Execution | 3 | 4 | 1455 |
 | ✅ Failover | 2 | 1 | 398 |
-| ✅ Files | 2 | 6 | 1770 |
+| ✅ Files | 2 | 6 | 1801 |
 | ✅ Flow | 1 | 3 | 777 |
-| ✅ Gateway | 7 | 30 | 11244 |
-| ✅ Guardrails | 4 | 4 | 1637 |
+| ✅ Gateway | 7 | 36 | 12924 |
+| ✅ Guardrails | 4 | 4 | 1634 |
 | ✅ Handoffs | 11 | 6 | 2596 |
-| ✅ Hooks | 2 | 9 | 3482 |
-| ✅ Image | 1 | 11 | 1105 |
-| ✅ Knowledge | 4 | 24 | 4739 |
-| ✅ LLM | 3 | 11 | 4033 |
-| ✅ Loops | 4 | 3 | 778 |
-| ✅ MCP | 1 | 52 | 11147 |
-| ✅ Memory | 6 | 17 | 6103 |
-| ✅ OCR | 2 | 1 | 228 |
-| ✅ Observability | 2 | 23 | 2768 |
-| ✅ Optimizer | 1 | 2 | 750 |
-| ✅ Output | 3 | 5 | 1099 |
-| ✅ Parallel Execution | 3 | 2 | 364 |
-| ✅ Planning | 6 | 6 | 1423 |
-| ✅ Plugins | 8 | 3 | 971 |
-| ✅ Prompts | 2 | 7 | 1197 |
-| ✅ Providers | 1 | 54 | 6787 |
+| ✅ Hooks | 2 | 9 | 3475 |
+| ✅ Image | 1 | 11 | 1103 |
+| ✅ Knowledge | 4 | 12 | 3643 |
+| ✅ LLM | 3 | 11 | 4010 |
+| ✅ Loops | 4 | 3 | 774 |
+| ✅ MCP | 1 | 52 | 11137 |
+| ✅ Memory | 6 | 17 | 6136 |
+| ✅ OCR | 2 | 1 | 226 |
+| ✅ Observability | 2 | 23 | 2766 |
+| ✅ Optimizer | 1 | 2 | 746 |
+| ✅ Output | 3 | 5 | 1097 |
+| ✅ Parallel Execution | 3 | 2 | 362 |
+| ✅ Planning | 6 | 6 | 1412 |
+| ✅ Plugins | 8 | 3 | 969 |
+| ✅ Prompts | 2 | 7 | 1189 |
+| ✅ Providers | 1 | 54 | 7009 |
 | ✅ Query | 1 | 2 | 623 |
-| ✅ RAG | 5 | 15 | 2889 |
+| ✅ RAG | 5 | 15 | 2885 |
 | ✅ Realtime | 2 | 5 | 584 |
 | ✅ Reflection | 3 | 3 | 662 |
-| ✅ Retrieval | 2 | 5 | 903 |
-| ✅ Routing | 1 | 2 | 365 |
-| ✅ Sandbox | 5 | 6 | 2458 |
-| ✅ Security | 1 | 3 | 2772 |
-| ✅ Sessions | 4 | 12 | 4264 |
-| ✅ Skills | 6 | 13 | 4831 |
-| ✅ Tasks | 2 | 6 | 2709 |
-| ✅ Telemetry | 1 | 2 | 574 |
-| ✅ Templates | 1 | 8 | 1655 |
-| ✅ Tools | 12 | 122 | 30097 |
+| ✅ Retrieval | 2 | 5 | 899 |
+| ✅ Routing | 1 | 2 | 363 |
+| ✅ Sandbox | 5 | 6 | 2450 |
+| ✅ Security | 1 | 3 | 2770 |
+| ✅ Sessions | 4 | 12 | 4252 |
+| ✅ Skills | 6 | 13 | 4819 |
+| ✅ Tasks | 2 | 6 | 2703 |
+| ✅ Telemetry | 1 | 2 | 572 |
+| ✅ Templates | 1 | 8 | 1653 |
+| ✅ Tools | 12 | 123 | 30337 |
 | ✅ Tracing | 3 | 2 | 139 |
-| ✅ Vector Store | 1 | 1 | 366 |
+| ✅ Vector Store | 1 | 12 | 1114 |
 | ✅ Video | 2 | 6 | 510 |
 | ✅ Vision | 2 | 1 | 283 |
-| ✅ Web | 3 | 8 | 1901 |
-| ✅ Workflows | 5 | 15 | 6439 |
+| ✅ Web | 3 | 8 | 1897 |
+| ✅ Workflows | 5 | 16 | 6565 |
 
 ## Documentation Without Features
 


### PR DESCRIPTION
## Summary
- Regenerates `docs/features/DOCS_PARITY.md` after removing the incorrect `Vector Store` → `Knowledge` alias in the upstream `docs_generator` (see MervinPraison/PraisonAI#… companion PR).
- `vector-store.mdx` already exists (364+ lines); no new feature page.
- Parity: **66/66 (100%)**, `✅ Vector Store` documented.

## Test plan
- [x] `grep -A4 "Undocumented Categories" docs/features/DOCS_PARITY.md` → 0 undocumented
- [x] `python3 -c "import json; json.load(open('docs.json'))"`
- [x] §A confirmed on #1284 (no `AGENTS.md` change)

Closes #1284


Made with [Cursor](https://cursor.com)