### PR TITLE
Add praisonai-code C0 migration guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -135,6 +135,7 @@
             "pages": [
               "docs/guides/index",
               "docs/guides/documentation-style-guide",
+              "docs/guides/praisonai-code-migration",
               "docs/guides/single-agent",
               "docs/guides/multi-agent",
               {

--- a/docs/developers/development-setup.mdx
+++ b/docs/developers/development-setup.mdx
@@ -44,6 +44,10 @@ cd PraisonAI
 uv pip install -r pyproject.toml
 ```
 
+<Note>
+The `src/` directory now contains three sibling packages: `praisonai-agents/` (SDK), `praisonai-code/` (agentic terminal CLI — introduced in scaffold form at [PR #2539](https://github.com/MervinPraison/PraisonAI/pull/2539) as step C0 of the migration in [issue #2512](https://github.com/MervinPraison/PraisonAI/issues/2512)), and `praisonai/` (main user-facing wrapper). Install with `pip install -e src/praisonai` — this pulls in `praisonai-code` and `praisonai-agents` automatically via the workspace path deps. See [praisonai-code Migration](/docs/guides/praisonai-code-migration) for the full picture.
+</Note>
+
 </Step>
 
 <Step title="Install with Extras">

--- a/docs/developers/local-development.mdx
+++ b/docs/developers/local-development.mdx
@@ -1,7 +1,9 @@
 ---
 title: 'Local Development'
 description: 'Set up local development environment with Docker and live reload'
----
+---<Note>
+The PraisonAI monorepo includes sibling packages `praisonai-agents`, `praisonai-code`, and `praisonai`. See [praisonai-code Migration](/docs/guides/praisonai-code-migration) for how the agentic terminal CLI is being extracted (C0–C6).
+</Note>
 
 ## Logging
 ```bash

--- a/docs/guides/praisonai-code-migration.mdx
+++ b/docs/guides/praisonai-code-migration.mdx
@@ -1,0 +1,170 @@
+---
+title: "praisonai-code package migration"
+sidebarTitle: "praisonai-code Migration"
+description: "Where the agentic terminal CLI lives during the incremental C0–C6 extraction from the praisonai wrapper."
+icon: "package"
+---
+
+`praisonai-code` is a new sibling package that will host the agentic terminal CLI, extracted incrementally from the `praisonai` wrapper without breaking any existing install or import path.
+
+```mermaid
+graph LR
+    Agents[praisonaiagents<br/>SDK] --> Code[praisonai-code<br/>terminal CLI]
+    Code --> Main[praisonai<br/>wrapper + bots/gateway + shims]
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class Agents agent
+    class Code tool
+    class Main config
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Nothing changes for users">
+
+```bash
+pip install praisonai
+praisonai "say hello"
+```
+
+</Step>
+
+<Step title="Optional: install praisonai-code for development">
+
+From the [PraisonAI](https://github.com/MervinPraison/PraisonAI) monorepo root:
+
+```bash
+pip install -e src/praisonai-code
+python -c "import praisonai_code; print(praisonai_code.__version__)"
+```
+
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+Dependency flow is one-way: **`praisonai` → `praisonai-code` → `praisonaiagents`**. The `praisonai-code` package never declares a dependency on `praisonai`, which avoids a PyPI cycle. Bot, gateway, and daemon code stays in the main `praisonai` package throughout the migration.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as praisonai CLI
+    participant Code as praisonai_code.cli
+    participant Agent as praisonaiagents.Agent
+
+    Note over User,Agent: Future state (after C5)
+    User->>CLI: praisonai "say hello"
+    CLI->>Code: delegate agentic terminal path
+    Code->>Agent: run agent
+    Agent-->>Code: response
+    Code-->>CLI: output
+    CLI-->>User: terminal result
+```
+
+| Layer | Package | Role |
+|-------|---------|------|
+| SDK | `praisonaiagents` | Agents, tools, memory, workflows |
+| Terminal CLI | `praisonai-code` | `run`, `chat`, `code`, warm runtime, CLI backends |
+| User install | `praisonai` | `pip install praisonai`, bots/gateway/daemon, PEP 562 shims |
+
+---
+
+## Where should I work?
+
+```mermaid
+graph TB
+    Start{Who are you?}
+    Start -->|End user| User[pip install praisonai<br/>No change]
+    Start -->|Contributor on runtime / cli_backends| C1[After C1: praisonai_code.runtime<br/>praisonai_code.cli_backends]
+    Start -->|Contributor on bots / gateway / daemon| Main[Stay in praisonai.bots<br/>praisonai.gateway / daemon]
+    Start -->|Library using PraisonAI class| Shim[from praisonai.cli.main import PraisonAI<br/>Keeps working via PEP 562 shim after C5]
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class User success
+    class C1 tool
+    class Main agent
+    class Shim config
+```
+
+---
+
+## Roadmap
+
+| Step | Scope | Files | Status |
+|------|-------|------:|--------|
+| **C0** | Scaffold (this PR) | 5 | ✅ [PR #2539](https://github.com/MervinPraison/PraisonAI/pull/2539) |
+| C1 | `runtime/` + `cli_backends/` | 8 | ⏳ |
+| C2 | `interactive/`, `execution/`, `ui/`, `output/`, `state/` | 30 | ⏳ |
+| C3 | 80 agentic commands (9 bot-channel commands stay in main) | 80 | ⏳ |
+| C4 | 158 agentic features (5 bot-channel features stay in main) | 158 | ⏳ |
+| C5 | `main.py`, `app.py`, config/session/utils + PEP 562 shims | 26 | ⏳ |
+| C6 | Integration gate (smoke tests, import graph assertions, real agentic run) | — | ⏳ |
+
+Tracking issue: [PraisonAI#2512](https://github.com/MervinPraison/PraisonAI/issues/2512).
+
+---
+
+## Compatibility guarantees
+
+- **`pip install praisonai` remains the only user-facing install.** `praisonai-code` is not published to PyPI standalone during migration.
+- **Existing import paths keep working** — PEP 562 shims at old `praisonai.*` paths land as code moves in C1–C5. `from praisonai.cli.main import PraisonAI` continues unchanged (154+ tests depend on it).
+- **Console entry unchanged** — `praisonai = "praisonai.__main__:main"`.
+- **One-way dependencies** — `praisonai` → `praisonai-code` → `praisonaiagents`; `praisonai-code` never depends on `praisonai`.
+- **Scope split** — `praisonai-code` covers only the agentic terminal product; `bots/`, `gateway/`, and `daemon/` stay in `praisonai` throughout.
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Do not import praisonai_code in library code (during migration)">
+
+Application and library code should keep using `import praisonai` and `from praisonaiagents import Agent`. Direct `praisonai_code` imports are for contributors working inside the monorepo until the public surface is explicitly documented after C5.
+
+</Accordion>
+
+<Accordion title="Bot-channel modules stay in praisonai">
+
+These CLI commands never move: `gateway`, `bot`, `onboard`, `pairing`, `identity`, `kanban`, `mint_link`, `claw`, `dashboard`.
+
+These features never move: `gateway`, `bots_cli`, `onboard`, `approval`, `serve`.
+
+</Accordion>
+
+<Accordion title="New agentic CLI features go into praisonai_code.cli.* (after C5)">
+
+Once C5 lands the layout, new terminal-agent commands and features belong under `praisonai_code.cli.*`, with shims left at the old `praisonai.cli.*` paths for compatibility.
+
+</Accordion>
+
+<Accordion title="PEP 562 shims are load-bearing">
+
+Removing shims would break 154+ tests and every `from praisonai.cli.main import PraisonAI` importer. Shim removal is tracked as a **5.0.0**-track breaking change on [issue #2512](https://github.com/MervinPraison/PraisonAI/issues/2512).
+
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Python wrapper" icon="box" href="/docs/developers/wrapper">
+  Public `praisonai.run`, `PraisonAI`, and `praisonai.arun` surface
+</Card>
+<Card title="Development setup" icon="wrench" href="/docs/developers/development-setup">
+  Clone the monorepo and install editable packages with uv
+</Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Adds contributor-facing `docs/guides/praisonai-code-migration.mdx` for the C0 scaffold and C1–C6 extraction roadmap (PraisonAI #2539 / #2512).
- Registers the page under **Guides** in `docs.json`.
- Adds short monorepo notes to `development-setup.mdx` and `local-development.mdx` linking to the migration guide.

## Test plan
- [x] `docs.json` validates as JSON
- [x] No edits under `docs/concepts/`
- [ ] Mintlify preview / deploy check on merge

## Follow-ups (separate PRs when upstream lands)
- C1–C6: update roadmap status and source-path notes per issue #1339 checklist

Closes #1339

Made with [Cursor](https://cursor.com)