### PR TITLE
docs: JOB_COMPLETED hook + gateway rate-limit cross-links (partial #1345)

### DIFF
--- a/docs/features/channels-gateway.mdx
+++ b/docs/features/channels-gateway.mdx
@@ -198,6 +198,11 @@ The gateway serves:
 - WebSocket at `ws://localhost:8080/ws`
 - Bot integrations auto-start based on environment variables
 
+<Note>
+WebSocket gateway YAML may include a `gateway.rate_limit:` block (`max_requests`, `window_seconds`, `lockout_seconds`). See [Gateway Rate Limit Policy](/docs/features/gateway-rate-limit-policy) and [Gateway Handshake Protocol](/docs/features/gateway-handshake-protocol) for how denials surface as `rate_limited` during connect.
+</Note>
+
+
 ### Legacy Mode
 
 For callback-only integration without provider wiring:

--- a/docs/features/gateway-handshake-protocol.mdx
+++ b/docs/features/gateway-handshake-protocol.mdx
@@ -219,6 +219,10 @@ Example wire frame (rate-limited):
 | `origin_not_allowed` | Origin not in allowed list (CSWSH defence) | `do_not_retry` |
 | `configuration_error` | Server is misconfigured (e.g. external bind with no allowlist) | `do_not_retry` |
 
+<Note>
+The `rate_limited` code is driven by an injectable `RateLimitPolicyProtocol` — see [Gateway Rate Limit Policy](/docs/features/gateway-rate-limit-policy) for `SlidingWindowRateLimitPolicy`, YAML `gateway.rate_limit`, and custom policies.
+</Note>
+
 ### ConnectRecoveryStep
 
 Machine-readable recovery hint. Clients branch on `(code, next_step)` instead of parsing `message`.

--- a/docs/features/gateway-rate-limit-policy.mdx
+++ b/docs/features/gateway-rate-limit-policy.mdx
@@ -103,7 +103,7 @@ sequenceDiagram
     end
 ```
 
-`allowed=False` maps to `ConnectErrorCode.RATE_LIMITED` on the wire and sets `HelloError.retry_after_seconds` so clients know when to retry. The shape is symmetric with `SendPolicy`, `ConcurrencyLimitPolicy`, and `DrainPolicy`.
+`allowed=False` maps to `ConnectErrorCode.RATE_LIMITED` on the wire and sets `HelloError.retry_after_seconds` so clients know when to retry. The shape is symmetric with `SendPolicy`, `ConcurrencyLimitPolicy`, and `DrainPolicy`. Wire details for `rate_limited` and `retry_after_seconds` are in [Gateway Handshake Protocol](/docs/features/gateway-handshake-protocol).
 
 ---
 

--- a/docs/features/hook-events.mdx
+++ b/docs/features/hook-events.mdx
@@ -446,15 +446,16 @@ def on_gateway_stop(event_data):
     return HookResult.allow()
 ```
 
-### Schedule Events
+### Schedule & background events
 
-Schedule hooks fire when scheduled jobs are managed and triggered by `BotOS`.
+Schedule hooks fire when scheduled jobs are managed and triggered by `BotOS`. `JOB_COMPLETED` fires when a background subagent job launched via `spawn_subagent(background=True)` reaches a terminal state — after the internal `on_complete` callback runs, best-effort (a raising handler cannot crash the worker).
 
 | Event | Trigger | Input Type | Key Fields | Use Case |
 |-------|---------|------------|------------|----------|
 | `SCHEDULE_ADD` | Schedule job added | — | — | Audit schedule changes |
 | `SCHEDULE_REMOVE` | Schedule job removed | — | — | Audit schedule changes |
 | `SCHEDULE_TRIGGER` | Scheduled job runs | `ScheduleTriggerInput` | `job_name`, `job_id`, `message` | Observability, metrics |
+| `JOB_COMPLETED` | Background job reaches terminal state (`COMPLETED` or `FAILED`) | `JobCompletedInput` | `job_id`, `status`, `result`, `error`, `deliver`, `platform`, `chat_id`, `thread_id` | Observability, custom delivery routing, chat-back delivery (see [Background Subagents](/docs/features/background-subagents)) |
 
 ```python
 @registry.on(HookEvent.SCHEDULE_TRIGGER)
@@ -462,6 +463,13 @@ def on_schedule_trigger(event_data):
     print(f"Job fired: {event_data.job_name}")
     print(f"Job ID: {event_data.job_id}")
     print(f"Message: {event_data.message}")
+    return HookResult.allow()
+
+@registry.on(HookEvent.JOB_COMPLETED)
+def on_job_completed(event_data):
+    print(f"Job finished: {event_data.job_id} → {event_data.status}")
+    if event_data.error:
+        print(f"Error: {event_data.error}")
     return HookResult.allow()
 
 @registry.on(HookEvent.SCHEDULE_ADD)
@@ -562,6 +570,7 @@ def on_auto_promotion(event_data):
 | `SCHEDULE_ADD` | Schedule | Schedule job added |
 | `SCHEDULE_REMOVE` | Schedule | Schedule job removed |
 | `SCHEDULE_TRIGGER` | Schedule | Scheduled job runs |
+| `JOB_COMPLETED` | Background | Background job finished (success or failure) |
 | `TOOL_RESULT_PERSIST` | Storage | Before result storage |
 | `KANBAN_TASK_CREATED` | Kanban | Task added to board |
 | `KANBAN_TASK_CLAIMED` | Kanban | Task assigned |


### PR DESCRIPTION
## Summary
- Documents `HookEvent.JOB_COMPLETED` / `JobCompletedInput` in `docs/features/hook-events.mdx` (schedule & background section, example handler, reference table row), aligned with SDK fields and linked to [Background Subagents](/docs/features/background-subagents).
- Adds minimal gateway cross-links for issue #1345 remaining gaps: `RateLimitPolicyProtocol` note on handshake `rate_limited`, `gateway.rate_limit` note on channels gateway Pattern C, and handshake link from gateway rate-limit policy.

Refs #1345 — does **not** close the issue (deliverables 2–4 and full deliverable 1 background-subagents checklist remain).

## Test plan
- [x] Diff limited to four `docs/features/` pages (no `docs/concepts/`)
- [x] `docs.json` unchanged
- [ ] Mintlify preview / CI green