### PR TITLE
docs: ToolSourceRegistry, lazy persistence, vector-store registration (closes #1336)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -592,6 +592,7 @@
                   "docs/features/task-retry-policy",
                   "docs/features/security-environment-variables",
                   "docs/features/tool-resolver",
+                  "docs/features/tool-source-registry",
                   "docs/features/tool-discovery-order",
                   "docs/features/local-tools-loading",
                   "docs/features/tool-output-store",

--- a/docs/features/persistence-backend-plugins.mdx
+++ b/docs/features/persistence-backend-plugins.mdx
@@ -61,15 +61,20 @@ store = create_conversation_store(
 Register a custom backend at runtime:
 
 ```python
-from praisonai.persistence.registry import CONVERSATION_STORES
+from praisonai.persistence import get_default_registry
 
 def my_store_factory(url=None, **kwargs):
     from my_pkg import MyConversationStore
     return MyConversationStore(url=url, **kwargs)
 
-CONVERSATION_STORES.register("mybackend", my_store_factory, aliases=("mb",))
-store = CONVERSATION_STORES.create("mb", url="proto://host")
+registry = get_default_registry("conversation")
+registry.register("mybackend", my_store_factory, aliases=("mb",))
+store = registry.create("mb", url="proto://host")
 ```
+
+<Note>
+`CONVERSATION_STORES`, `KNOWLEDGE_STORES`, and `STATE_STORES` are still importable from `praisonai.persistence.registry` for backward compatibility — they are now **lazy attributes** that build on first access via `__getattr__`. New code should prefer `get_default_registry(kind)` for clarity.
+</Note>
 
 Package it as an entry point in `pyproject.toml`:
 
@@ -84,6 +89,10 @@ mybackend = "my_pkg.factory:create_store"
 ---
 
 ## How It Works
+
+<Note>
+**No import-time cost.** Importing `praisonai.persistence.registry` no longer walks Python entry points or registers the ~40 built-in loaders as a side effect — each kind's registry is built lazily the first time you call `get_default_registry(kind)` (or reference the legacy `*_STORES` names). `import praisonai` is now safe to run in tests, notebooks, and multi-tenant runtimes without side effects.
+</Note>
 
 Three global registries cover each storage kind:
 
@@ -106,11 +115,41 @@ sequenceDiagram
     Store-->>App: store instance
 ```
 
+
+---
+
+## Multi-tenant isolation
+
+All three factory functions accept an injected `registry=` — pass your own `StoreRegistry` to keep tenant registrations from leaking into the process-default registry.
+
+```python
+from praisonai.persistence import StoreRegistry, create_conversation_store
+
+def tenant_a_factory(url=None, **kwargs):
+    from my_pkg import MyConversationStore
+    return MyConversationStore(url=url, **kwargs)
+
+tenant_a = StoreRegistry("conversation", "praisonai.conversation_stores")
+tenant_a.register("mystore", tenant_a_factory)
+
+store = create_conversation_store(
+    "mystore",
+    url="proto://host",
+    registry=tenant_a,   # scoped — does not touch the process default
+)
+```
+
+Same shape for `create_knowledge_store(..., registry=)` and `create_state_store(..., registry=)`. See [Registry Dependency Injection](/docs/features/registry-dependency-injection) for the wider pattern.
+
 ---
 
 ## Configuration Options
 
 ### StoreRegistry API
+
+<Info>
+Third-party backend authors register plugins via the same three entry-point groups (`praisonai.conversation_stores` / `praisonai.knowledge_stores` / `praisonai.state_stores`). Lazy loading means the entry-point scan runs on **first use of that kind** only, not on every `import praisonai`.
+</Info>
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
@@ -118,6 +157,7 @@ sequenceDiagram
 | `create` | `create(name, **kwargs)` | Create a store instance by name or alias |
 | `list_registered` | `() -> list[str]` | All registered backend names |
 | `list_aliases` | `() -> dict[str, str]` | Alias → canonical name mappings |
+| `get_default_registry` | `get_default_registry(kind: str) -> StoreRegistry` | Return the process-default registry for `"conversation"` / `"knowledge"` / `"state"`, building it lazily on first call. Prefer DI (`registry=`) in library code. |
 
 ### Built-in conversation backends
 

--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -405,6 +405,7 @@ sequenceDiagram
 |-----------|-------|------|---------|-------------|
 | `tools_py_path` | `ToolResolver(...)` constructor | `Optional[str]` | `"tools.py"` | Path to the `tools.py` file to load (resolved eagerly against the current working directory). |
 | `instantiate` | `resolver.resolve(name, ...)` | `bool` | `False` | When `True`, class tools (BaseTool subclasses, `langchain_community.tools.*` classes) are instantiated before being returned. Plain function tools are returned as-is. Safe with cache warm-up via `has_tool()` (since [PR #1858](https://github.com/MervinPraison/PraisonAI/pull/1858)). |
+| `source_registry` | `ToolResolver(...)` constructor | `Optional[ToolSourceRegistry]` | Process-default (lazy, discovers `praisonai.tool_sources` entry points) | Injects a registry supplying third-party tool sources. See [Tool Source Registry](/docs/features/tool-source-registry). Pass `ToolSourceRegistry(discover_entry_points=False)` to opt out of third-party sources. |
 
 ```python
 # Load from non-default path
@@ -642,6 +643,21 @@ resolver = ToolResolver(sources=[MyToolSource()])
 tool = resolver.resolve("my_custom_tool")
 ```
 
+### Entry-point tool sources
+
+Third-party packages can register `ToolSource` implementations via the `praisonai.tool_sources` entry-point group — `ToolResolver` appends them after the default 5-step chain. See [Tool Source Registry](/docs/features/tool-source-registry) for the full pattern, plugin authoring, and opt-out.
+
+```python
+from praisonai.tool_resolver import ToolResolver, ToolSourceRegistry
+
+# Opt out of installed third-party tool sources
+resolver = ToolResolver(
+    source_registry=ToolSourceRegistry(discover_entry_points=False),
+)
+```
+
+The built-in chain (local `tools.py` → wrapper registry → `praisonaiagents` → `praisonai-tools` → core registry) is **owned by `ToolResolver.default_sources()`** and is unaffected by the registry — entry-point sources are always appended, never inserted, so a third-party plugin cannot silently shadow a first-party tool.
+
 **Composing custom and default sources:**
 
 The `default_sources(registry=None)` method returns the historical 5-step resolution chain as a list of `ToolSource` objects (`local-tools.py` → `wrapper-registry` → `praisonaiagents` → `praisonai-tools` → `core-registry`). Prepend your custom source to search it first while keeping all built-in sources:
@@ -779,6 +795,9 @@ export PRAISONAI_ALLOW_LOCAL_TOOLS=true
 ## Related
 
 <CardGroup cols={2}>
+<Card title="Tool Source Registry" icon="puzzle-piece" href="/docs/features/tool-source-registry">
+  Plug third-party tool sources via entry points
+</Card>
 <Card title="Tools Resolve (CLI)" icon="terminal" href="/docs/cli/tools-resolve">
   Recipe and template tool resolution via resolve_tools()
 </Card>

--- a/docs/features/tool-source-registry.mdx
+++ b/docs/features/tool-source-registry.mdx
@@ -1,0 +1,263 @@
+---
+title: "Tool Source Registry"
+sidebarTitle: "Tool Source Registry"
+description: "Plug third-party tool sources into ToolResolver via Python entry points"
+icon: "puzzle-piece"
+---
+
+`ToolSourceRegistry` lets a Python package expose new tool-resolution sources through the `praisonai.tool_sources` entry-point group — no subclassing, no monkey-patching.
+
+```python
+from praisonaiagents import Agent
+
+# Once `pip install praisonai-corp-tools` is done, corp-tools registers
+# itself via the praisonai.tool_sources entry point. Nothing else to wire up.
+agent = Agent(
+    name="Finance Bot",
+    instructions="Use corporate tools to answer",
+    tools=["corp.pay_invoice"],   # resolved through the plugin source
+)
+agent.start("Pay invoice INV-42 for $1200")
+```
+
+```mermaid
+graph LR
+    subgraph "Tool Source Registry"
+        EP[📦 Entry Point<br/>praisonai.tool_sources] --> Reg[📝 ToolSourceRegistry]
+        Reg --> Resolver[🔧 ToolResolver]
+        Resolver --> Agent[🤖 Agent]
+    end
+
+    classDef ep fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef reg fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef resolver fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class EP ep
+    class Reg reg
+    class Resolver resolver
+    class Agent agent
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Simple usage">
+
+Install a plugin package, then use tool names from that source on any agent:
+
+```bash
+pip install praisonai-corp-tools
+```
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Finance Bot",
+    instructions="Use corporate tools to answer",
+    tools=["corp.pay_invoice"],
+)
+agent.start("Pay invoice INV-42 for $1200")
+```
+
+</Step>
+
+<Step title="Direct Python (DI)">
+
+Construct a `ToolResolver` with `source_registry=` to isolate a tenant or a test:
+
+```python
+from praisonai.tool_resolver import ToolResolver, ToolSourceRegistry
+
+registry = ToolSourceRegistry()          # discovers praisonai.tool_sources plugins
+resolver = ToolResolver(source_registry=registry)
+tool = resolver.resolve("corp.pay_invoice")
+```
+
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Resolver as ToolResolver
+    participant BuiltIn as Built-in chain
+    participant Plugins as ToolSourceRegistry
+
+    Agent->>Resolver: resolve(name)
+    Resolver->>BuiltIn: local tools.py → wrapper → agents → praisonai-tools → core
+    BuiltIn-->>Resolver: result or None
+    alt still None
+        Resolver->>Plugins: entry-point ToolSource.lookup(name)
+        Plugins-->>Resolver: result or None
+    end
+    Resolver-->>Agent: first non-None wins
+```
+
+Resolution walks the built-in chain first (local `tools.py`, wrapper registry, `praisonaiagents.tools`, `praisonai-tools`, core SDK registry), then each `ToolSource` from `ToolSourceRegistry`. Entry-point sources are **appended** to the built-in chain — they extend rather than replace it. When you pass `sources=` explicitly, entry-point sources are **not** appended; you fully own the chain.
+
+---
+
+## Building a Tool Source Plugin
+
+### Implement the `ToolSource` protocol
+
+```python
+# praisonai_corp_tools/source.py
+from typing import Callable, Optional
+
+_CORP_TOOL_MAP: dict[str, Callable] = {}
+
+class CorpToolsSource:
+    name = "corp-tools"
+
+    def lookup(self, name: str) -> Optional[Callable]:
+        if not name.startswith("corp."):
+            return None
+        short = name.removeprefix("corp.")
+        return _CORP_TOOL_MAP.get(short)
+```
+
+### Register the entry point in `pyproject.toml`
+
+```toml
+[project.entry-points."praisonai.tool_sources"]
+corp-tools = "praisonai_corp_tools.source:CorpToolsSource"
+```
+
+The entry-point value may be:
+
+- a `ToolSource` **class** (instantiated once — `CorpToolsSource`),
+- a **factory function** returning a `ToolSource` instance, or
+- an **already-constructed** `ToolSource` instance.
+
+Factory example:
+
+```toml
+[project.entry-points."praisonai.tool_sources"]
+corp-tools = "praisonai_corp_tools.source:build_source"
+```
+
+```python
+import os
+
+def build_source():
+    return CorpToolsSource(base_url=os.environ["CORP_URL"])
+```
+
+### Ship it
+
+After `pip install`, the source is live in every `ToolResolver` that uses the process-default registry (or any resolver you construct with a registry that discovers entry points).
+
+---
+
+## Configuration Options
+
+| Option | Where | Type | Default | Description |
+|--------|-------|------|---------|-------------|
+| `source_registry` | `ToolResolver(...)` constructor | `Optional[ToolSourceRegistry]` | Process-default registry (lazy) | Registry supplying third-party entry-point tool sources. Pass an empty registry to opt out. |
+| `discover_entry_points` | `ToolSourceRegistry(...)` constructor | `bool` | `True` | When `False`, the registry does **not** scan the `praisonai.tool_sources` entry-point group on construction. Use for tests or a hard opt-out. |
+
+---
+
+## Common Patterns
+
+<Tabs>
+<Tab title="Opt out of third-party sources">
+
+```python
+from praisonai.tool_resolver import ToolResolver, ToolSourceRegistry
+
+empty = ToolSourceRegistry(discover_entry_points=False)
+resolver = ToolResolver(source_registry=empty)
+# Only the built-in chain is used; installed plugins are ignored.
+```
+
+</Tab>
+
+<Tab title="Isolate a plugin for a specific tenant">
+
+```python
+from praisonai.tool_resolver import ToolResolver, ToolSourceRegistry
+
+class TenantToolsSource:
+    name = "tenant-tools"
+
+    def lookup(self, name: str):
+        return None
+
+registry = ToolSourceRegistry(discover_entry_points=False)
+registry.register("tenant-tools", TenantToolsSource)
+
+resolver = ToolResolver(source_registry=registry)
+```
+
+</Tab>
+
+<Tab title="Deterministic tests">
+
+Use `discover_entry_points=False` so tests stay reproducible regardless of what is installed in the environment — the same pattern as `test_tool_source_registry.py` in the PraisonAI SDK:
+
+```python
+from praisonai.tool_resolver import ToolResolver, ToolSourceRegistry
+
+registry = ToolSourceRegistry(discover_entry_points=False)
+registry.register("fake", MyTestSource)
+
+resolver = ToolResolver(source_registry=registry)
+assert resolver.resolve("fake_tool") is not None
+```
+
+</Tab>
+</Tabs>
+
+---
+
+## Safety
+
+- A plugin that raises during loading is **logged and skipped** — resolution never breaks for other callers.
+- A plugin that resolves to an object **not** matching the `ToolSource` protocol (missing `name: str` or callable `lookup`) is rejected with a `TypeError` inside `_coerce_source` and skipped — it never gets appended to the chain.
+- Behaviour is covered by `test_misbehaving_plugin_is_skipped` and `test_invalid_shape_plugin_is_skipped` in the SDK test suite.
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Namespace your tool names">
+Use a prefix like `corp.` so plugin tools do not collide with built-in names.
+</Accordion>
+<Accordion title="Return None fast for names you do not own">
+`lookup()` runs in chain order; bail out quickly when a name is not yours.
+</Accordion>
+<Accordion title="Never raise from lookup() for expected misses">
+Raise only for genuine errors — the registry logs and skips your source on failure, so a raise looks like a broken plugin.
+</Accordion>
+<Accordion title="Register a class, not an instance, when the source is cheap to build">
+Avoids stale process-wide state in long-running services.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Tool Resolver" icon="wrench" href="/docs/features/tool-resolver">
+  Single source of truth for loading tools
+</Card>
+<Card title="Persistence Backend Plugins" icon="puzzle-piece" href="/docs/features/persistence-backend-plugins">
+  Same PluginRegistry pattern for stores
+</Card>
+<Card title="Framework Adapter Plugins" icon="puzzle-piece" href="/docs/features/framework-adapter-plugins">
+  Entry-point plugins for execution frameworks
+</Card>
+<Card title="Registry Dependency Injection" icon="code-branch" href="/docs/features/registry-dependency-injection">
+  Registry DI pattern across the wrapper
+</Card>
+</CardGroup>

--- a/docs/features/vector-store.mdx
+++ b/docs/features/vector-store.mdx
@@ -129,6 +129,29 @@ graph TB
 
 ---
 
+
+
+---
+
+## Registering the Chroma / Pinecone adapters
+
+Importing `praisonai.adapters.vector_stores` no longer auto-registers `ChromaVectorStore` / `PineconeVectorStore` into the core SDK vector-store registry. If you want these adapters wired in — for example so `KnowledgeConfig(vector_store={"provider": "chroma"})` picks up the wrapper's Chroma implementation — call the explicit hook once:
+
+```python
+from praisonai.adapters.vector_stores import register_default_vector_stores
+
+register_default_vector_stores()
+# Now:
+#   from praisonaiagents.knowledge.vector_store import get_vector_store_registry
+#   store = get_vector_store_registry().get("chroma")
+```
+
+<Note>
+This was previously a side effect of `import praisonai.adapters.vector_stores`. Removing it means the wrapper no longer mutates a **core-SDK** registry as an import side effect, and does not probe for `chromadb` / `pinecone` on disk unless the caller explicitly asks. The change is backward-compatible for callers that already use `praisonaiagents.knowledge` directly with their own `VectorStoreProtocol` implementations.
+</Note>
+
+---
+
 ## How It Works
 
 A user question flows through the agent to the vector store, which finds the closest matching content using cosine similarity.

--- a/docs/persistence/overview.mdx
+++ b/docs/persistence/overview.mdx
@@ -151,26 +151,30 @@ ALTER TABLE praison_messages ADD COLUMN tool_call_id TEXT;
 Register custom storage backends with the persistence registry, including optional aliases:
 
 ```python
-from praisonai.persistence.registry import StoreRegistry
+from praisonai.persistence import get_default_registry
+from praisonaiagents import Agent
 
-# Example custom store factory
 def my_custom_store(connection_string, **kwargs):
     return CustomStoreImplementation(connection_string, **kwargs)
 
-# Register with aliases
-conversation_registry = StoreRegistry("conversation", "praisonai.conversation_stores")
-conversation_registry.register_store(
-    "my_store", 
-    my_custom_store, 
-    aliases=("mine", "ms", "custom_db")
+# Register on the shared default so Agent(memory={"db": "my_store://..."}) sees it
+registry = get_default_registry("conversation")
+registry.register_store(
+    "my_store",
+    my_custom_store,
+    aliases=("mine", "ms", "custom_db"),
 )
 
-# Now all these work:
+# All of these now resolve to my_custom_store
 agent = Agent(memory={"db": "my_store://config"})
-agent = Agent(memory={"db": "mine://config"})      # Alias
-agent = Agent(memory={"db": "ms://config"})        # Alias
-agent = Agent(memory={"db": "custom_db://config"}) # Alias
+agent = Agent(memory={"db": "mine://config"})       # alias
+agent = Agent(memory={"db": "ms://config"})         # alias
+agent = Agent(memory={"db": "custom_db://config"})  # alias
 ```
+
+<Note>
+The shared default registry is what agents use at runtime. Constructing a fresh `StoreRegistry(...)` registers backends only on that isolated instance — use `get_default_registry("conversation")` when you want `Agent(memory=...)` to see your backend immediately.
+</Note>
 
 <Note>
 The `register_store()` method is the canonical API. The `register()` method is preserved as a backward-compatible alias.


### PR DESCRIPTION
## Summary
- Adds `docs/features/tool-source-registry.mdx` for `ToolSourceRegistry` and `praisonai.tool_sources` entry points (PraisonAI #2511).
- Updates tool resolver, persistence backend plugins, persistence overview, and vector store pages for `source_registry=`, `get_default_registry(kind)`, lazy registries, and `register_default_vector_stores()`.
- Registers the new page in `docs.json` under Features (no Concepts changes).

## Test plan
- [x] `docs.json` parses as valid JSON
- [x] Hero examples use `from praisonaiagents import Agent` where required
- [x] Claims cross-checked against PraisonAI `tool_resolver`, `persistence/registry`, `persistence/factory`, and `adapters/vector_stores`
- [ ] Mintlify preview / CI green

Closes #1336

Made with [Cursor](https://cursor.com)