### PR TITLE
docs: complete v4.6.104 gateway/background coverage (closes #1345)

### DIFF
--- a/docs/features/background-subagents.mdx
+++ b/docs/features/background-subagents.mdx
@@ -54,6 +54,24 @@ graph LR
     class OUT out
 ```
 
+
+```mermaid
+sequenceDiagram
+    participant U as User (chat)
+    participant B as BotOS
+    participant A as Agent
+    participant BG as BackgroundJobManager
+    U->>B: research X in the background
+    B->>A: turn
+    A->>BG: spawn_subagent(..., background=True, deliver="origin")
+    BG-->>A: job_id
+    A-->>B: Started; I will ping you when done
+    B-->>U: reply (turn ends)
+    Note over BG: job runs...
+    BG->>B: on_background_job_complete(job_info)  JOB_COMPLETED
+    B-->>U: result delivered (no active turn)
+```
+
 ## Quick Start
 
 <Steps>
@@ -148,6 +166,30 @@ agent.start("Research the latest Python 3.13 features and let me know when done"
 
 ---
 
+## Deliver Back to Chat
+
+When the agent runs behind `BotOS`, a background subagent can push its finished result to the originating chat — the same delivery tokens as `schedule_add`, with no polling.
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools.subagent_tool import create_subagent_tools
+
+agent = Agent(
+    name="Researcher",
+    instructions=(
+        "When the user asks for research, spawn a background subagent with "
+        "deliver='origin' so the finished result is delivered back to this chat "
+        "automatically. Tell the user you will ping them when it is ready."
+    ),
+    tools=create_subagent_tools(),
+)
+```
+
+<Note>`deliver="origin"` only works when the agent is running behind `BotOS` — the wrapper injects `platform`, `chat_id`, `thread_id`, and `session_id` automatically. In a bare `Agent`, use `deliver="telegram:12345"` or leave it empty (pull-only).</Note>
+
+
+---
+
 ## How It Works
 
 ```mermaid
@@ -209,6 +251,33 @@ graph LR
 
 ---
 
+## Delivery Tokens
+
+| Token | Meaning |
+|-------|---------|
+| `""` (empty) | Pull-only via `subagent_result` (unchanged legacy behaviour) |
+| `"origin"` | Deliver back to the platform/chat id captured at spawn |
+| `"all"` | Broadcast to all registered channels |
+| `"platform:chat_id"` | Deliver to a specific channel (e.g. `"telegram:12345"`) |
+| `"platform:chat_id:thread_id"` | Deliver to a specific thread or reply context |
+
+<Warning>**Failure delivery:** On failure, a short notice is delivered to the same target instead of the full result. `HookEvent.JOB_COMPLETED` fires for both terminal states. The internal `on_complete` callback and hook handlers are best-effort — a raised exception is swallowed and logged at DEBUG so the worker never crashes.</Warning>
+
+### Subscribe to `JOB_COMPLETED`
+
+For observability or custom side effects when a background job finishes, register on `HookEvent.JOB_COMPLETED` (see [Hook Events](/docs/features/hook-events)):
+
+```python
+from praisonaiagents.hooks import HookEvent, register_hook
+
+@register_hook(HookEvent.JOB_COMPLETED)
+def log_completion(input):
+    print(f"job {input.job_info.job_id} → {input.job_info.status.value}")
+```
+
+
+---
+
 ## Tool Parameters
 
 ### `spawn_subagent`
@@ -221,10 +290,10 @@ graph LR
 | `tools` | `list` | `[]` | Tools to give the subagent |
 | `background` | `bool` | `False` | When `True`, return immediately with a `job_id` |
 | `deliver` | `str` | `""` | Delivery target: `"origin"` (originating chat), `"all"` (all channels), or `"platform:chat_id"`. Empty = no delivery (pull-only). |
-| `platform` | `str` | `None` | Explicit platform hint (e.g. `"telegram"`, `"discord"`) for delivery routing |
-| `chat_id` | `str` | `None` | Explicit chat/channel id for delivery |
-| `thread_id` | `str` | `None` | Thread id for platforms that scope by thread |
-| `session_id` | `str` | `None` | Session id for continuity |
+| `platform` | `str` | `""` | Origin platform (e.g. `"telegram"`, `"slack"`). Usually supplied by the gateway context. Required for `deliver="origin"`. |
+| `chat_id` | `str` | `""` | Origin chat or channel id. Required for `deliver="origin"`. |
+| `thread_id` | `str` | `""` | Optional origin thread id. |
+| `session_id` | `str` | `""` | Optional origin session id to preserve context. |
 
 **Returns (foreground):** Full result dict with `output`, `success`, `error`.
 
@@ -290,7 +359,7 @@ In a bot context, `deliver='origin'` is simpler than polling: the parent can clo
 <Card title="Background Tasks" icon="clock" href="/docs/features/background-tasks">
   Other background task patterns for long-running work
 </Card>
-<Card title="Gateway Hooks" icon="webhook" href="/docs/features/gateway-hooks">
+<Card title="Hook Events" icon="webhook" href="/docs/features/hook-events">
   JOB_COMPLETED and other observable hook events
 </Card>
 <Card title="Proactive Delivery" icon="bell" href="/docs/features/proactive-delivery">

--- a/docs/features/channels-gateway.mdx
+++ b/docs/features/channels-gateway.mdx
@@ -224,7 +224,7 @@ Use `BotOS` for advanced multi-platform management:
 from praisonai.bots import BotOS
 
 # Initialize BotOS with all available platforms
-bot_os = BotOS()
+bot_os = BotOS(reliability="production")  # optional: production drain + admission preset
 
 # Platforms auto-detected from environment variables
 available_platforms = bot_os.get_available_platforms()

--- a/docs/features/gateway-rate-limit-policy.mdx
+++ b/docs/features/gateway-rate-limit-policy.mdx
@@ -177,6 +177,11 @@ limiter = SlidingWindowRateLimitPolicy(
 )
 ```
 
+## State ownership
+
+The built-in `SlidingWindowRateLimitPolicy` is not internally synchronised and reclaims `(scope, identity)` entries lazily on the next check. Use it for bounded identity spaces (authenticated tenants, endpoint classes). For unbounded or untrusted identity keys (for example raw per-IP strings), implement `RateLimitPolicyProtocol` in the wrapper layer and run periodic reclamation yourself.
+
+
 ---
 
 ## Common Patterns

--- a/docs/features/reliability.mdx
+++ b/docs/features/reliability.mdx
@@ -6,7 +6,7 @@ icon: "shield-check"
 ---
 
 <Note>
-This page covers **task/workflow-level** reliability (retry jitter, `workflow_timeout`, `fail_on_callback_error`). If you are looking for the **gateway-level** reliability preset (`reliability="production"` on `BotOS` / gateway YAML / CLI), see [Gateway Reliability Preset](/docs/features/gateway-reliability-preset) — it is a separate feature that composes drain and admission control.
+This page covers **task/workflow-level** reliability (retry jitter, `workflow_timeout`, `fail_on_callback_error`). If you are looking for the **gateway-level** reliability preset (`reliability="production"` on `BotOS` / gateway YAML / CLI), see [Gateway Reliability Preset](/docs/features/gateway-reliability) — it is a separate feature that composes drain and admission control.
 </Note>
 
 Make agents survive flaky LLMs, hung workflows, and broken callbacks with built-in retry jitter and configurable failure policies.

--- a/docs/gateway.mdx
+++ b/docs/gateway.mdx
@@ -87,6 +87,15 @@ sequenceDiagram
 | **Unified** | All services combined | Default mode |
 | **Services** | Independent scaling | Service-specific |
 
+
+<Tip>
+For bot gateways, use the one-line **`reliability="production"`** preset on `BotOS`, gateway YAML, or `praisonai gateway start --reliability production` instead of tuning drain and admission separately. See [Gateway Reliability](/docs/features/gateway-reliability).
+</Tip>
+
+## Hot Reload
+
+Edit `gateway.yaml` while the gateway is running — file watch (with optional `watchdog`) and `SIGHUP` share the same diff-driven reload path, with drain-coordinated channel restarts. See [Gateway Config Reload](/docs/features/gateway-config-reload).
+
 For proactive/scheduled outbound delivery routing — including friendly alias targets like `"family"` or `"ops"` — see [Friendly Aliases for Scheduled Delivery](/docs/features/proactive-delivery#friendly-aliases-for-scheduled-delivery).
 
 ---

--- a/docs/guides/troubleshoot-gateway.mdx
+++ b/docs/guides/troubleshoot-gateway.mdx
@@ -686,6 +686,21 @@ schtasks /Query /TN PraisonAIGateway
 
 ---
 
+
+## Config reload did not apply
+
+**Symptom:** You edited `gateway.yaml` or sent `SIGHUP`, but channels or agents still run the old configuration.
+
+| Check | What to look for |
+|-------|------------------|
+| Log line | A successful reload logs a summary such as `reload applied: agents; restart[telegram]` — if absent, the watcher may not have fired or SIGHUP was ignored (Windows has no SIGHUP) |
+| Drain window | Channel restarts wait up to `gateway.reload_drain_timeout` (falls back to `drain_timeout`) — a slow turn can delay the visible restart |
+| Install | `pip install "praisonai[gateway]"` enables `watchdog`; without it, mtime polling (about 5 s) still reloads but more slowly |
+
+See [Gateway Config Reload](/docs/features/gateway-config-reload) for file-watch vs SIGHUP paths and YAML keys.
+
+---
+
 ## Multi-Channel Troubleshooting
 
 Common failure modes when using multiple bots on the same platform:

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -62,6 +62,10 @@ graph TB
 
     The complete package — CLI, gateway, bots, integrations, YAML-driven multi-bot orchestration. Pulls `praisonai-code` and `praisonaiagents` automatically.
 
+<Note>
+For gateway hot reload (event-driven `gateway.yaml` watching via `watchdog`), install the gateway extra: `pip install "praisonai[gateway]"`.
+</Note>
+
     <Steps>
       <Step title="Create Virtual Environment (Optional)">
         <CodeGroup>


### PR DESCRIPTION
## Summary
- Completes remaining **#1345** deliverables after partial **#1378** (hook-events + rate-limit cross-links already on `main`).
- **Deliverable 1:** `background-subagents.mdx` — BotOS chat-back sequence, Deliver Back to Chat section, delivery-token table, failure delivery note, `JOB_COMPLETED` subscribe pattern, SDK-default fixes (`""` for origin fields).
- **Deliverables 2–4 cross-links:** `docs/gateway.mdx` reliability tip + hot reload; `installation.mdx` `praisonai[gateway]`; `troubleshoot-gateway.mdx` reload runbook; `channels-gateway.mdx` `reliability=` example; `reliability.mdx` link to gateway preset page; rate-limit state-ownership caveat.

Closes #1345

## Test plan
- [x] `python3 -c "import json; json.load(open('docs.json'))"`
- [ ] Mintlify preview for touched pages (background-subagents, gateway, installation, troubleshoot-gateway)

Made with [Cursor](https://cursor.com)