### PR TITLE
docs(developers): C1 merged in development-setup (#1341)

### DIFF
--- a/docs/developers/development-setup.mdx
+++ b/docs/developers/development-setup.mdx
@@ -119,13 +119,13 @@ praisonai-package/
 
 `praisonai-code` hosts the **agentic terminal CLI** (`run`, `chat`, `code`, warm runtime, CLI backends) as an internal sibling package. `praisonai` remains the user-facing install; `praisonai-code` is not published standalone to PyPI during migration.
 
-**Status:** C0 scaffold merged in [PraisonAI#2520](https://github.com/MervinPraison/PraisonAI/pull/2520). Only `__version__` is exposed; no runtime code has moved yet.
+**Status:** C0 scaffold merged in [PraisonAI#2520](https://github.com/MervinPraison/PraisonAI/pull/2520). C1 moved `runtime/` and `cli_backends/` into `praisonai_code` in [PraisonAI#2523](https://github.com/MervinPraison/PraisonAI/pull/2523); PEP 562 shims keep the old import paths working. See the [praisonai-code migration guide](/docs/guides/praisonai-code-migration) for the full C0–C6 roadmap and shim behaviour.
 
 ### Dependency Rules
 
 ```
 praisonai (main)  →  depends on  praisonai-code
-praisonai-code    →  depends on  praisonaiagents ONLY (not praisonai)
+praisonai-code    →  depends on  praisonaiagents (core SDK)
 ```
 
 ```mermaid
@@ -164,10 +164,12 @@ python -c "import praisonai_code; print(praisonai_code.__version__)"
 
 ### Migration Plan (C0–C6)
 
+Track upstream progress in the [praisonai-code migration guide](/docs/guides/praisonai-code-migration) and [PraisonAI#2512](https://github.com/MervinPraison/PraisonAI/issues/2512).
+
 | Step | Scope | Status |
 |------|-------|--------|
 | **C0** | Scaffold (this) | ✅ Merged in [#2520](https://github.com/MervinPraison/PraisonAI/pull/2520) |
-| C1 | `runtime/` + `cli_backends/` | Tracking |
+| C1 | `runtime/` + `cli_backends/` | ✅ Merged in [#2523](https://github.com/MervinPraison/PraisonAI/pull/2523) |
 | C2 | `interactive/`, `execution/`, `ui/`, `output/`, `state/` | Tracking |
 | C3 | Agentic commands (80 files) | Tracking |
 | C4 | Agentic features (158 files) | Tracking |
@@ -175,11 +177,11 @@ python -c "import praisonai_code; print(praisonai_code.__version__)"
 | C6 | Integration gate | Tracking |
 
 <Note>
-Users continue to `pip install praisonai` and run `praisonai [TASK]`. Existing imports like `from praisonai.cli.main import PraisonAI` continue to work through PEP 562 shims once C1–C5 land.
+Users continue to `pip install praisonai` and run `praisonai [TASK]`. From C1 onward, `from praisonai.runtime import …` and `from praisonai.cli_backends import …` forward to `praisonai_code` via PEP 562 shims; later C steps add shims for the rest of the agentic CLI. Details: [praisonai-code migration guide](/docs/guides/praisonai-code-migration).
 </Note>
 
 <Warning>
-At C0, no PEP 562 shims are installed because no runtime code has moved. Direct imports from `praisonai_code.*` will succeed only for `__version__`. Wait for C1 (`runtime/` + `cli_backends/`) before importing anything else from `praisonai_code`.
+During C1–C5 migration, `praisonai-code` may still import selected symbols from the wrapper (for example `praisonai._registry` in `cli_backends/registry.py`). That deliberate trade-off is removed in later steps — see the migration note in `src/praisonai-code/README.md` on the monorepo.
 </Warning>
 
 ---
@@ -193,7 +195,10 @@ At C0, no PEP 562 shims are installed because no runtime code has moved. Direct 
   <Card icon="book" href="/docs/developers/reference-home">
     SDK reference documentation
   </Card>
+  <Card icon="route" href="/docs/guides/praisonai-code-migration">
+    praisonai-code migration (C0–C6)
+  </Card>
   <Card icon="github" href="https://github.com/MervinPraison/PraisonAI/issues/2512">
-    praisonai-code extraction (C0–C6 tracking issue)
+    praisonai-code extraction (upstream tracking issue)
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Mark C1 (`runtime/` + `cli_backends/`) as merged in [PraisonAI#2523](https://github.com/MervinPraison/PraisonAI/pull/2523) on the C0–C6 table in `docs/developers/development-setup.mdx`.
- Refresh status, dependency wording, and C1-era Note/Warning; link the [praisonai-code migration guide](/docs/guides/praisonai-code-migration) from the migration plan and Related cards.

Closes #1341

## Test plan
- [x] `python3 -m json.tool docs.json` validates
- [x] No edits under `docs/concepts/`
- [x] Internal links use `/docs/guides/praisonai-code-migration`