### PR TITLE
docs: AGENTS alignment batch 2 (features, #1351)

### DIFF
--- a/docs/features/background-subagents.mdx
+++ b/docs/features/background-subagents.mdx
@@ -25,6 +25,9 @@ coordinator.start(
 )
 ```
 
+The user asks for parallel research; background subagents return job IDs while the parent keeps working.
+
+
 ```mermaid
 graph LR
     subgraph "Background Subagents"

--- a/docs/features/context-window-management.mdx
+++ b/docs/features/context-window-management.mdx
@@ -5,6 +5,15 @@ description: "Automatic token limit handling, context optimization, and intellig
 icon: "window-maximize"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="long-context", instructions="Handle large inputs safely.")
+agent.start("Summarise this 50-page report")
+```
+
+The user sends a large prompt; context management trims or summarises input to fit the model window.
+
 ```mermaid
 flowchart LR
     Input[Large Input] --> Analyzer[Context Analyzer]
@@ -27,14 +36,15 @@ flowchart LR
     Direct --> LLM[LLM Processing]
     Optimized --> LLM
 
-    style Input fill:#8B0000,color:#fff
-    style Analyzer fill:#2E8B57,color:#fff
-    style LLM fill:#4682B4,color:#fff
-    style Optimized fill:#FFD700,color:#000
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef highlight fill:#F59E0B,stroke:#7C90A0,color:#fff
+    class Input agent
+    class Analyzer,Counter,Truncate,Chunk,Summarize,Priority,Direct,LLM tool
+    class Optimized highlight
 
 ```
 
-Context Window Management automatically handles token limits across different models, ensuring optimal use of available context while preserving important information.
 
 ## Quick Start
 

--- a/docs/features/custom-actions.mdx
+++ b/docs/features/custom-actions.mdx
@@ -36,10 +36,14 @@ flowchart TD
     F -- Yes --> G["Run built-in<br/>(e.g. bump-version)"]
     F -- No --> H["Error: Unknown action"]
     
-    style C fill:#10B981,color:#fff
-    style E fill:#6366F1,color:#fff
-    style G fill:#F59E0B,color:#fff
-    style H fill:#EF4444,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef tool fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef warn fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef error fill:#8B0000,stroke:#7C90A0,color:#fff
+    class C success
+    class E tool
+    class G warn
+    class H error
 
 ```
 

--- a/docs/features/generate-reasoning.mdx
+++ b/docs/features/generate-reasoning.mdx
@@ -5,6 +5,15 @@ description: "Learn how to generate chain-of-thought reasoning data using Praiso
 icon: "brain"
 ---
 
+```python
+from praisonaiagents import Agent
+
+coordinator = Agent(name="CoT Coordinator", instructions="Generate and evaluate reasoning datasets.")
+coordinator.start("Generate chain-of-thought examples for maths word problems")
+```
+
+The user starts the workflow; agents generate, evaluate, and upload chain-of-thought training data.
+
 ```mermaid
 flowchart TD
     Start[Start] --> Generator[Question Answer Generator Agent]
@@ -14,12 +23,10 @@ flowchart TD
     COT --> Upload[HuggingFace Uploader Agent]
     Upload --> End[End]
     
-    style Start fill:#8B0000,color:#fff
-    style Generator fill:#2E8B57,color:#fff
-    style Evaluator fill:#2E8B57,color:#fff
-    style COT fill:#2E8B57,color:#fff
-    style Upload fill:#2E8B57,color:#fff
-    style End fill:#8B0000,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    class Start,End agent
+    class Generator,Evaluator,COT,Upload tool
 
 ```
 

--- a/docs/features/injected-state.mdx
+++ b/docs/features/injected-state.mdx
@@ -7,6 +7,21 @@ icon: "wrench"
 
 Injected state lets tools receive hidden context — session ID, agent ID, previous results — without users or the LLM ever seeing those parameters in the tool schema.
 
+```python
+from praisonaiagents import Agent, tool
+from praisonaiagents.tools import Injected
+
+@tool
+def search(query: str, state=Injected()) -> str:
+    """Search with hidden session context."""
+    return f"Results for {query} (session={state.get(session_id)})"
+
+agent = Agent(name="assistant", tools=[search])
+agent.start("Find recent orders")
+```
+
+The user asks a question; hidden state is injected into the tool without appearing in the schema.
+
 ```mermaid
 graph LR
     S[Agent State] --> I[Injected param]

--- a/docs/features/llm-as-judge.mdx
+++ b/docs/features/llm-as-judge.mdx
@@ -20,18 +20,18 @@ Use an LLM to evaluate and score agent outputs for accuracy, quality, and custom
 ```mermaid
 flowchart LR
     subgraph Input
-        A[Agent Output]:::agent
-        B[Expected Output]:::agent
+        A[Agent Output]
+        B[Expected Output]
     end
     
     subgraph Judge
-        C[LLM Evaluator]:::tool
+        C[LLM Evaluator]
     end
     
     subgraph Result
-        D[Score 1-10]:::agent
-        E[Pass/Fail]:::agent
-        F[Suggestions]:::agent
+        D[Score 1-10]
+        E[Pass/Fail]
+        F[Suggestions]
     end
     
     A --> C
@@ -39,7 +39,12 @@ flowchart LR
     C --> D
     C --> E
     C --> F
-    
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    class A,B,D,E,F agent
+    class C tool
+
 ```
 
 <CardGroup cols={2}>

--- a/docs/features/migrate.mdx
+++ b/docs/features/migrate.mdx
@@ -12,6 +12,7 @@ agent = Agent(name="migration-helper", instructions="Help migrate from older Pra
 agent.start("Migrate my agents.yaml from v1 format to v2 format.")
 ```
 
+The user points the migration agent at a project; AgentFlow converts and validates the codebase.
 
 Migrate your existing agent projects to PraisonAI using an **AI-driven workflow** that understands your entire codebase and converts it intelligently. Supported source frameworks include **Pydantic AI**, Agno, Google ADK, CrewAI, and AutoGen.
 
@@ -48,15 +49,13 @@ flowchart TB
     E -->|Fail| F
     F -->|Retry max 3| C
     G --> H
-    
-    style A fill:#8B0000,color:#fff
-    style B fill:#8B0000,color:#fff
-    style C fill:#189AB4,color:#fff
-    style D fill:#189AB4,color:#fff
-    style E fill:#189AB4,color:#fff
-    style F fill:#189AB4,color:#fff
-    style G fill:#8B0000,color:#fff
-    style H fill:#8B0000,color:#fff
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    class A,B agent
+    class C,D,E,F tool
+    class G,H success
 ```
 
 ## Quick Start
@@ -181,11 +180,8 @@ flowchart LR
     E -->|Yes| A
     E -->|No| F[❌ Manual Review]
     
-    style A fill:#189AB4,color:#fff
     style B fill:#189AB4,color:#fff
-    style C fill:#8B0000,color:#fff
     style D fill:#189AB4,color:#fff
-    style F fill:#8B0000,color:#fff
 ```
 
 <Note>
@@ -262,11 +258,8 @@ flowchart LR
     A -->|"TypeError"| X[Rejected]
     B -->|"Migrate"| D
     
-    style A fill:#8B0000,color:#fff
     style B fill:#8B0000,color:#fff
-    style C fill:#189AB4,color:#fff
     style D fill:#189AB4,color:#fff
-    style X fill:#8B0000,color:#fff
 ```
 
 ### Quick Migration

--- a/docs/features/model-capabilities.mdx
+++ b/docs/features/model-capabilities.mdx
@@ -5,6 +5,15 @@ description: "Comprehensive model feature detection, comparison, and capability 
 icon: "star"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="capability-router", instructions="Match tasks to model strengths.")
+agent.start("Which model fits a 200k-token code review?")
+```
+
+The user describes a task; capability detection scores models and selects the best fit.
+
 ```mermaid
 flowchart TB
     subgraph Models
@@ -37,10 +46,14 @@ flowchart TB
     Capabilities --> Detection
     Detection --> Output[Optimal Model]
 
-    style Models fill:#2E8B57,color:#fff
-    style Capabilities fill:#4682B4,color:#fff
-    style Detection fill:#8B0000,color:#fff
-    style Output fill:#FFD700,color:#000
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef success fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef highlight fill:#F59E0B,stroke:#7C90A0,color:#fff
+    class GPT4,Claude,Gemini,Llama,Mistral success
+    class C1,C2,C3,C4,C5,C6,C7 tool
+    class D1,D2,D3,D4 agent
+    class Output highlight
 ```
 
 The Model Capabilities system provides comprehensive feature detection and comparison across different LLMs, enabling intelligent model selection based on specific task requirements.

--- a/docs/features/model-router.mdx
+++ b/docs/features/model-router.mdx
@@ -5,6 +5,15 @@ description: "Intelligent LLM selection based on task requirements and model cap
 icon: "route"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="router-demo", instructions="Pick the best model for each task.")
+agent.start("Summarise this long document cheaply")
+```
+
+The user submits a task; the router picks the model that best matches requirements and cost.
+
 ```mermaid
 flowchart LR
     Task[Task Input] --> Router[Model Router]
@@ -23,14 +32,14 @@ flowchart LR
     Gemini --> Output
     Llama --> Output
     
-    style Task fill:#8B0000,color:#fff
-    style Router fill:#2E8B57,color:#fff
-    style Analyze fill:#4682B4,color:#fff
-    style Select fill:#4682B4,color:#fff
-    style Output fill:#8B0000,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef route fill:#10B981,stroke:#7C90A0,color:#fff
+    class Task,Output agent
+    class Analyze,Select,GPT4,GPT35,Claude,Gemini,Llama tool
+    class Router route
 ```
 
-The Model Router System intelligently selects the most appropriate LLM for each task based on requirements, capabilities, and cost considerations, ensuring optimal performance and resource utilization.
 
 ## Quick Start
 

--- a/docs/features/nested-workflows.mdx
+++ b/docs/features/nested-workflows.mdx
@@ -7,6 +7,16 @@ icon: "layer-group"
 
 Nested workflows allow you to combine workflow patterns like loops, parallel execution, and routing to create sophisticated data processing pipelines.
 
+```python
+from praisonaiagents import Agent
+
+runner = Agent(name="Pipeline", instructions="Run nested loop workflows from YAML config.")
+runner.start("Process the 3x3 matrix pipeline")
+```
+
+The user runs a pipeline; nested loops and parallel steps process each item in order.
+
+
 ```mermaid
 flowchart TD
     subgraph Outer["Outer Loop"]
@@ -20,12 +30,10 @@ flowchart TD
         E[Process A] --> F[Process B]
     end
     
-    style Outer fill:#8B0000,color:#fff
-    style Inner fill:#189AB4,color:#fff
-    style A fill:#8B0000,color:#fff
-    style C fill:#8B0000,color:#fff
-    style E fill:#189AB4,color:#fff
-    style F fill:#189AB4,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    class Outer,A,C agent
+    class Inner,E,F tool
 ```
 
 ## Quick Start

--- a/docs/features/permission-modes.mdx
+++ b/docs/features/permission-modes.mdx
@@ -25,6 +25,9 @@ agent = Agent(
 agent.start("Explore the auth module without making changes")
 ```
 
+The user delegates exploration; permission mode controls whether subagents can edit or must stay read-only.
+
+
 ```mermaid
 graph LR
     Agent[🤖 Lead Agent] --> Spawn[🔧 spawn_subagent]

--- a/docs/features/post-edit-formatter.mdx
+++ b/docs/features/post-edit-formatter.mdx
@@ -21,6 +21,9 @@ coder = Agent(
 coder.start("Refactor utils.py to use list comprehensions")
 ```
 
+The user asks for a refactor; the formatter runs automatically after each file edit.
+
+
 ```mermaid
 graph LR
     A[🤖 Agent] --> B[edit_file]

--- a/docs/features/routing.mdx
+++ b/docs/features/routing.mdx
@@ -31,6 +31,9 @@ workflow = AgentFlow(steps=[
 result = workflow.start("How does machine learning work?")
 ```
 
+The user sends a request; the classifier routes it to the best handler agent.
+
+
 ```mermaid
 flowchart LR
     In[Input] --> Router[Classifier]

--- a/docs/features/save-output.mdx
+++ b/docs/features/save-output.mdx
@@ -17,6 +17,9 @@ agent = Agent(
 agent.start("Write a poem about nature")
 ```
 
+The user asks for content; the agent writes the response to the configured output file.
+
+
 ```mermaid
 flowchart LR
     subgraph Agent["🤖 Agent"]
@@ -32,10 +35,10 @@ flowchart LR
     A --> F
     A --> C
     
-    style In fill:#8B0000,color:#fff
-    style A fill:#189AB4,color:#fff
-    style F fill:#8B0000,color:#fff
-    style C fill:#8B0000,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
+    class In,F,C agent
+    class A tool
 ```
 
 ## Quick Start

--- a/docs/features/skill-manage.mdx
+++ b/docs/features/skill-manage.mdx
@@ -18,6 +18,9 @@ agent = Agent(
 agent.start("Create a skill called 'weekly-summary' that summarises the week's work.")
 ```
 
+The user teaches the agent; skill changes stay pending until a human approves them.
+
+
 <Tip>
 To trigger skill creation **automatically** after every task instead of having the model call `skill_manage` on its own, see [Self-Improving Agents](/docs/features/self-improve).
 </Tip>

--- a/docs/features/subagent-delegation.mdx
+++ b/docs/features/subagent-delegation.mdx
@@ -23,6 +23,9 @@ coordinator = Agent(
 coordinator.start("Find where authentication is implemented")
 ```
 
+The user asks the coordinator; delegated subagents explore with scoped permissions.
+
+
 ```mermaid
 graph LR
     subgraph "Subagent Delegation"

--- a/docs/features/subagent-tool.mdx
+++ b/docs/features/subagent-tool.mdx
@@ -20,6 +20,9 @@ parent = Agent(
 parent.start("Explore the auth module read-only")
 ```
 
+The user asks the coordinator; the parent spawns a subagent with the requested permissions.
+
+
 ```mermaid
 graph LR
     subgraph "Subagent Tool Flow"

--- a/docs/features/tool-availability.mdx
+++ b/docs/features/tool-availability.mdx
@@ -10,7 +10,7 @@ Tool availability gating filters unavailable tools at schema-build time, prevent
 ```python
 import os
 from praisonaiagents import Agent
-from praisonaiagents.tools import tool
+from praisonaiagents import tool
 
 @tool(availability=lambda: (bool(os.getenv("SERP_API_KEY")), "SERP_API_KEY not set"))
 def search_web(query: str) -> str:
@@ -49,7 +49,7 @@ graph LR
 
 ```python
 import os
-from praisonaiagents.tools import tool
+from praisonaiagents import tool
 
 @tool(availability=lambda: (bool(os.getenv("SERP_API_KEY")), "SERP_API_KEY not set"))
 def search_web(query: str) -> str:
@@ -75,7 +75,7 @@ agent.start("Research quantum computing")
 <Step title="Class-Based Tool with Availability">
 
 ```python
-from praisonaiagents.tools.base import BaseTool
+from praisonaiagents import BaseTool
 
 class DatabaseTool(BaseTool):
     name = "query_database"
@@ -140,7 +140,7 @@ sequenceDiagram
 ### Function Decorator
 
 ```python
-from praisonaiagents.tools import tool
+from praisonaiagents import tool
 import os
 
 # Simple environment check
@@ -167,7 +167,7 @@ def docker_command(cmd: str) -> str:
 ### BaseTool Protocol
 
 ```python
-from praisonaiagents.tools.base import BaseTool
+from praisonaiagents import BaseTool
 from praisonaiagents.tools.protocols import ToolAvailabilityProtocol
 
 class CloudTool(BaseTool, ToolAvailabilityProtocol):
@@ -278,7 +278,7 @@ register_tool(simple_function)
 
 ```python
 import os
-from praisonaiagents.tools import tool
+from praisonaiagents import tool
 
 def check_environment(required_vars: list[str]):
     """Factory for environment-based availability checks."""
@@ -303,7 +303,7 @@ def notify_team(message: str) -> str:
 ### Service Discovery
 
 ```python
-from praisonaiagents.tools import tool
+from praisonaiagents import tool
 import socket
 
 def check_service_available(host: str, port: int):

--- a/docs/features/tool-schema-validation.mdx
+++ b/docs/features/tool-schema-validation.mdx
@@ -19,6 +19,9 @@ agent = Agent(instructions="You search the web", tools=[search])
 agent.start("Find AI news")
 ```
 
+The user asks the agent to search; schema validation runs before the tool reaches the LLM.
+
+
 ```mermaid
 graph LR
     subgraph "Tool Schema Validation Flow"

--- a/docs/features/yaml-configuration-reference.mdx
+++ b/docs/features/yaml-configuration-reference.mdx
@@ -9,6 +9,15 @@ icon: "book"
 
 Complete reference for all configuration options in `agents.yaml` and `workflow.yaml` files.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="yaml-runner", instructions="Behaviour defined in agents.yaml")
+agent.start("Run the workflow defined in YAML")
+```
+
+The user maintains YAML config; the agent loads it and executes the requested workflow.
+
 ```mermaid
 graph TB
     subgraph "Configuration Files"
@@ -38,13 +47,12 @@ graph TB
     AG --> EX
     ST --> EX
     
-    style A fill:#8B0000,stroke:#7C90A0,color:#fff
-    style W fill:#8B0000,stroke:#7C90A0,color:#fff
-    style AG fill:#189AB4,stroke:#7C90A0,color:#fff
-    style ST fill:#189AB4,stroke:#7C90A0,color:#fff
-    style VR fill:#189AB4,stroke:#7C90A0,color:#fff
-    style TL fill:#189AB4,stroke:#7C90A0,color:#fff
-    style EX fill:#2E8B57,stroke:#7C90A0,color:#fff
+    classDef config fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef feature fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef exec fill:#10B981,stroke:#7C90A0,color:#fff
+    class A,W config
+    class AG,ST,VR,TL feature
+    class EX exec
 ```
 
 <Info>


### PR DESCRIPTION
## Summary

- Aligns **20** `docs/features/*.mdx` pages with AGENTS.md (#1351): hero Mermaid `classDef` palette, agent-centric openers where missing, one-line user-interaction flow, and friendly `from praisonaiagents import tool` / `BaseTool` on tool-availability.
- Follows batch 1 (#1383); **no** `docs/concepts/` edits.

## AGENTS.md checklist (per batch)

| Rule | Change |
|------|--------|
| §3.3 hero Mermaid + `classDef` | Converted `style`/`:::` diagrams on 10 pages; all `docs/features/*.mdx` now include `classDef` where Mermaid is present |
| §1.1(9) agent-centric opener | Added hero `Agent(...)` / workflow openers on yaml ref, model-router, model-capabilities, context-window, generate-reasoning, injected-state, nested-workflows |
| §1.1(10) user-interaction flow | One-sentence flow after hero code on each touched page |
| §5.2 / §6.1 friendly imports | `tool-availability.mdx`: `praisonaiagents.tools` → top-level `tool` / `BaseTool` |

## Test plan

- [x] `python3 -c "import json; json.load(open(docs.json))"`
- [ ] Mintlify preview for a sample of edited pages (Steps / Mermaid render)

Refs #1351