### PR TITLE
docs: AGENTS alignment batch 3 (features, #1351)

### DIFF
--- a/docs/features/a2a-tasks.mdx
+++ b/docs/features/a2a-tasks.mdx
@@ -12,6 +12,8 @@ agent = Agent(name="task-manager", instructions="Manage A2A tasks via JSON-RPC."
 agent.start("List all active A2A tasks and cancel any that are overdue.")
 ```
 
+The user asks for task status; the agent calls A2A JSON-RPC to list or cancel remote tasks.
+
 
 Tasks are the core unit of work in the A2A protocol, managing the complete lifecycle from submission to completion with built-in state tracking and storage.
 

--- a/docs/features/agent-as-tool.mdx
+++ b/docs/features/agent-as-tool.mdx
@@ -9,6 +9,21 @@ icon: "wrench"
 **New in v2.x**: Convert any agent into a callable tool with `agent.as_tool()`.
 </Info>
 
+```python
+from praisonaiagents import Agent
+
+researcher = Agent(name="Researcher", instructions="Research topics thoroughly")
+writer = Agent(
+    name="Writer",
+    instructions="Write polished copy using specialist tools",
+    tools=[researcher.as_tool()],
+)
+writer.start("Write a short post about quantum computing with cited facts")
+```
+
+The user asks for a polished article; the writer agent invokes the researcher as a tool.
+
+
 ## Overview
 
 The `as_tool()` method allows you to use one agent as a tool for another agent. This enables **hierarchical agent composition** where a parent agent can invoke specialist agents as subordinate tools.

--- a/docs/features/agent-profiles.mdx
+++ b/docs/features/agent-profiles.mdx
@@ -16,6 +16,8 @@ agent = Agent(
 agent.start("Help a customer reset their password.")
 ```
 
+The user describes a support issue; the agent loads the right profile and responds in that mode.
+
 
 Use built-in agent profiles and modes to spin up specialised assistants without rewriting prompts from scratch.
 

--- a/docs/features/agent-retry.mdx
+++ b/docs/features/agent-retry.mdx
@@ -38,6 +38,8 @@ agent = Agent(
 agent.start("Find recent papers on diffusion models")
 ```
 
+The user sends a research query; transient LLM failures trigger automatic retries with backoff.
+
 `retry=True` enables retry with sensible defaults: 3 retries, 5 s → 10 s → 20 s exponential schedule, capped at 120 s, with 50% additive jitter.
 </Step>
 

--- a/docs/features/agents.mdx
+++ b/docs/features/agents.mdx
@@ -18,6 +18,8 @@ agent = Agent(
 agent.start("What are the main benefits of solar energy?")
 ```
 
+The user asks a question; the agent runs a single turn and returns the answer.
+
 ```mermaid
 graph LR
     subgraph "Agent Flow"

--- a/docs/features/allowed-tools.mdx
+++ b/docs/features/allowed-tools.mdx
@@ -47,6 +47,8 @@ agent = Agent(
 
 agent.start("Find recent news and message me a summary")
 ```
+
+The user requests news and a message; only tools on the allow-list are exposed to the model.
 </Step>
 
 <Step title="Programmatic Usage">

--- a/docs/features/approval.mdx
+++ b/docs/features/approval.mdx
@@ -7,6 +7,20 @@ icon: "shield-check"
 
 Approval pauses an agent before it runs a risky tool and asks a human (or another channel) to allow or deny it.
 
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Coder",
+    instructions="Refactor safely",
+    tools=["shell", "write_file"],
+)
+agent.start("Remove unused imports in utils.py")
+```
+
+The user requests a code change; the agent pauses for approval before running dangerous tools.
+
 <Note>
 **Durability:** For chat bots, pending approvals can survive a gateway restart when you configure an [`ApprovalStore`](/docs/features/durable-approvals). Each `ApprovalRequest` includes `approval_id`, `agent_name`, and `session_id` for correlation.
 </Note>

--- a/docs/features/artifact-storage.mdx
+++ b/docs/features/artifact-storage.mdx
@@ -49,6 +49,8 @@ agent.start("Summarise the latest LangChain release notes")
 # Large results are now saved to ~/.praisonai/artifacts/
 # instead of being silently truncated.
 ```
+
+The user asks for a summary; the agent reads artefacts from storage and replies.
 </Step>
 
 <Step title="With configuration">

--- a/docs/features/async-bridge.mdx
+++ b/docs/features/async-bridge.mdx
@@ -52,6 +52,8 @@ agent = Agent(
 )
 agent.start("Summarise https://example.com")
 ```
+
+The user runs sync code that needs async I/O; the bridge executes coroutines without nested event loops.
 </Step>
 
 <Step title="From an async tool">

--- a/docs/features/async-db-hooks.mdx
+++ b/docs/features/async-db-hooks.mdx
@@ -7,6 +7,22 @@ icon: "database"
 
 Async DB hooks enable non-blocking database operations in async agents through automatic async/sync detection and `asyncio.to_thread` fallback.
 
+
+```python
+from praisonaiagents import Agent, PraisonAIDB
+
+agent = Agent(
+    name="Assistant",
+    instructions="You are a helpful assistant.",
+    db=PraisonAIDB("sqlite:///agent_data.db"),
+    async_mode=True,
+)
+
+# In async code: await agent.achat("Remember my preferences")
+```
+
+The user chats asynchronously; DB hooks persist messages without blocking the event loop.
+
 <Warning>
 **Breaking Change in PR #1829**: The `async_*` prefixed methods have been removed from async stores. The orchestrator now uses `isinstance(store, AsyncConversationStore)` for dispatch instead of runtime method introspection.
 

--- a/docs/features/async-jobs.mdx
+++ b/docs/features/async-jobs.mdx
@@ -18,6 +18,8 @@ async def main():
 asyncio.run(main())
 ```
 
+The user submits a long job; the agent runs asynchronously and returns when the job completes.
+
 
 Submit long-running agent tasks and recipes, then retrieve results asynchronously via a jobs server.
 

--- a/docs/features/async-scheduler.mdx
+++ b/docs/features/async-scheduler.mdx
@@ -7,6 +7,22 @@ icon: "clock"
 
 Async-native agent scheduler that replaces daemon threads with proper async execution and cooperative cancellation.
 
+```python
+import asyncio
+from praisonaiagents import Agent
+from praisonai.scheduler import AsyncAgentScheduler
+
+async def main():
+    agent = Agent(name="NewsChecker", instructions="Summarise the latest AI news.")
+    scheduler = AsyncAgentScheduler(agent=agent, task="Top 3 AI stories")
+    await scheduler.start("hourly", run_immediately=True)
+
+asyncio.run(main())
+```
+
+The user schedules recurring agent work; the async scheduler runs jobs with cooperative cancellation.
+
+
 ```mermaid
 graph LR
     subgraph "Async Scheduler Flow"

--- a/docs/features/async-self-reflection.mdx
+++ b/docs/features/async-self-reflection.mdx
@@ -7,6 +7,27 @@ icon: "rotate"
 
 Self-reflection enables agents to evaluate and improve their responses in async execution, bringing full feature parity with sync agents.
 
+
+```python
+import asyncio
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Writer",
+    instructions="Write concise product blurbs.",
+    self_reflect=True,
+    min_reflect=1,
+    max_reflect=3,
+)
+
+async def main():
+    await agent.achat("Write a one-line blurb for a smart mug.")
+
+asyncio.run(main())
+```
+
+The user asks for copy; the agent drafts, self-reflects, and improves the answer before replying.
+
 ```mermaid
 graph LR
     subgraph "Async Self-Reflection"

--- a/docs/features/custom-tool-safe-eval.mdx
+++ b/docs/features/custom-tool-safe-eval.mdx
@@ -7,6 +7,22 @@ icon: "shield-check"
 
 Use an AST allow-list instead of `eval()` when a custom tool evaluates user-supplied math.
 
+
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def safe_calculator(expression: str) -> str:
+    """Evaluate basic arithmetic safely (no code execution)."""
+    from praisonaiagents.tools.safe_eval import safe_math_eval
+    return str(safe_math_eval(expression))
+
+agent = Agent(name="calc", tools=[safe_calculator])
+agent.start("What is 15 + 27 * 3?")
+```
+
+The user supplies a maths expression; the tool evaluates it via an AST allow-list, not raw eval().
+
 ```mermaid
 graph LR
     subgraph "Safe Math Evaluation"

--- a/docs/features/dynamic-tool-schemas.mdx
+++ b/docs/features/dynamic-tool-schemas.mdx
@@ -35,8 +35,7 @@ graph LR
 Use the `@tool` decorator with `dynamic_schema_overrides` to create a tool whose schema changes based on runtime state.
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.tools import tool
+from praisonaiagents import Agent, tool
 
 # Runtime configuration that can change
 current_limit = {"max_concurrent": 1}
@@ -75,6 +74,8 @@ agent = Agent(
 current_limit["max_concurrent"] = 5  # Schema updates on next agent turn
 agent.start("Delegate three research tasks with different priorities")
 ```
+
+The user delegates research; dynamic tool schemas expose only the fields each sub-task needs.
 </Step>
 
 <Step title="Using BaseTool Subclass">

--- a/docs/features/lite-package.mdx
+++ b/docs/features/lite-package.mdx
@@ -18,6 +18,21 @@ graph LR
 
 # Lite Package (BYO-LLM)
 
+
+```python
+from praisonaiagents.lite import LiteAgent, create_openai_llm_fn
+
+llm_fn = create_openai_llm_fn(model="gpt-4o-mini")
+agent = LiteAgent(
+    name="MyAgent",
+    llm_fn=llm_fn,
+    instructions="You are a helpful assistant.",
+)
+agent.chat("Hello!")
+```
+
+The user sends a chat message; LiteAgent calls your LLM function with minimal framework overhead.
+
 The `praisonaiagents.lite` subpackage provides a minimal agent framework that lets you bring your own LLM client. It has no dependency on `litellm` and uses minimal memory.
 
 ## Installation

--- a/docs/features/loop-guardrails.mdx
+++ b/docs/features/loop-guardrails.mdx
@@ -47,6 +47,8 @@ agent = Agent(
 agent.start("Your request")
 ```
 
+The user starts a workflow loop; guardrails cap iterations and stop runaway tool calls.
+
 </Step>
 
 <Step title="Custom Limit">
@@ -54,8 +56,7 @@ agent.start("Your request")
 Adjust the limit for your use case:
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.config import ExecutionConfig
+from praisonaiagents import Agent, ExecutionConfig
 
 agent = Agent(
     name="Custom Protected Agent",
@@ -152,8 +153,7 @@ graph TB
 ### Pattern 1: Protecting Experimental Tools
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.config import ExecutionConfig
+from praisonaiagents import Agent, ExecutionConfig
 
 agent = Agent(
     name="Experimental Agent",
@@ -166,8 +166,7 @@ agent = Agent(
 ### Pattern 2: Complex Research Agent
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.config import ExecutionConfig
+from praisonaiagents import Agent, ExecutionConfig
 
 agent = Agent(
     name="Research Agent",

--- a/docs/features/mcp-tool-filtering.mdx
+++ b/docs/features/mcp-tool-filtering.mdx
@@ -35,8 +35,7 @@ graph LR
 <Step title="Whitelist Specific Tools">
 Only allow safe file operations:
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 
 agent = Agent(
     name="safe-fs",
@@ -48,13 +47,14 @@ agent = Agent(
 )
 agent.start("What files are in /tmp?")
 ```
+
+The user asks about files on disk; MCP tools are filtered before the model sees them.
 </Step>
 
 <Step title="Blacklist Dangerous Tools">
 Block destructive operations:
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 
 agent = Agent(
     name="no-destructive",
@@ -116,8 +116,7 @@ flowchart TD
 Restrict to read-only operations:
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 
 # File system - read only
 safe_agent = Agent(
@@ -135,8 +134,7 @@ safe_agent = Agent(
 Block specific risky tools:
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 
 # GitHub without destructive actions
 github_agent = Agent(
@@ -159,8 +157,7 @@ github_agent = Agent(
 Apply different filters to different servers:
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 
 # Combine filtered servers
 agent = Agent(

--- a/docs/features/mcp.mdx
+++ b/docs/features/mcp.mdx
@@ -8,8 +8,7 @@ icon: "plug"
 MCP (Model Context Protocol) lets agents connect to external tool servers, instantly adding file system access, database queries, API integrations, and more.
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 
 agent = Agent(
     name="FileAgent",
@@ -19,6 +18,8 @@ agent = Agent(
 
 agent.start("List all files in the /tmp directory.")
 ```
+
+The user asks to inspect the filesystem; the agent calls MCP tools on the connected server.
 
 ```mermaid
 graph LR
@@ -46,8 +47,7 @@ graph LR
 <Steps>
 <Step title="Connect to an MCP server">
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 
 agent = Agent(
     instructions="You can read and write files.",
@@ -59,8 +59,7 @@ agent.start("Create a file called notes.txt with the text 'Hello World'.")
 
 <Step title="SSE-based MCP server">
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 
 agent = Agent(
     instructions="You can search and retrieve web content.",
@@ -72,8 +71,7 @@ agent.start("Search for the latest news about AI.")
 
 <Step title="Multiple MCP servers">
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 
 filesystem_tools = MCP("npx -y @modelcontextprotocol/server-filesystem /home/user")
 database_tools = MCP("npx -y @modelcontextprotocol/server-sqlite /db/app.sqlite")
@@ -140,8 +138,7 @@ graph TB
 
 ### Pattern 1 — File management agent
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 
 agent = Agent(
     name="FileManager",
@@ -154,8 +151,7 @@ print(response)
 
 ### Pattern 2 — Database agent
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 
 agent = Agent(
     name="DBAgent",
@@ -167,8 +163,7 @@ agent.start("Show me all users who signed up in the last 30 days.")
 
 ### Pattern 3 — GitHub integration
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.mcp import MCP
+from praisonaiagents import Agent, MCP
 import os
 
 agent = Agent(

--- a/docs/features/multimodal-tool-output.mdx
+++ b/docs/features/multimodal-tool-output.mdx
@@ -35,8 +35,8 @@ graph LR
 A `@tool`-decorated function captures a screenshot and hands the PNG bytes back to the agent. The vision model sees the actual image on the next turn.
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.tools import tool, multimodal_content, text_part, image_part
+from praisonaiagents import Agent, tool
+from praisonaiagents.tools import multimodal_content, text_part, image_part
 
 @tool
 def take_screenshot() -> dict:
@@ -63,6 +63,8 @@ agent = Agent(
 
 agent.start("Take a screenshot and describe what is on screen.")
 ```
+
+The user asks for a screenshot summary; the tool returns multimodal content the model can read.
 </Step>
 
 <Step title="Remote image via URL">
@@ -70,8 +72,8 @@ agent.start("Take a screenshot and describe what is on screen.")
 No downloading needed — pass `url=` directly and the model fetches it.
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.tools import tool, multimodal_content, text_part, image_part
+from praisonaiagents import Agent, tool
+from praisonaiagents.tools import multimodal_content, text_part, image_part
 
 @tool
 def fetch_chart(symbol: str) -> dict:
@@ -97,8 +99,7 @@ agent.start("Show me the chart for AAPL and describe the recent trend.")
 Skip the helper — return a plain list of part-dicts. The runtime normalises it automatically.
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.tools import tool
+from praisonaiagents import Agent, tool
 
 @tool
 def render_diagram(code: str) -> list:
@@ -216,8 +217,8 @@ from praisonaiagents.tools import multimodal_content, text_part, image_part, fil
 ### Screenshot tool
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.tools import tool, multimodal_content, text_part, image_part
+from praisonaiagents import Agent, tool
+from praisonaiagents.tools import multimodal_content, text_part, image_part
 import io
 
 @tool
@@ -249,8 +250,8 @@ agent.start("What application is currently open?")
 ### Chart renderer (matplotlib → PNG)
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.tools import tool, multimodal_content, text_part, image_part
+from praisonaiagents import Agent, tool
+from praisonaiagents.tools import multimodal_content, text_part, image_part
 import io
 
 @tool
@@ -286,8 +287,7 @@ agent.start("Plot 10,25,15,40,30 and describe the trend.")
 MCP servers often return image blocks with a `mimeType` key. Return the block as-is — the runtime normalises `mimeType` → `mime` automatically.
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.tools import tool
+from praisonaiagents import Agent, tool
 
 @tool
 def mcp_screenshot() -> dict:


### PR DESCRIPTION
## Summary

- Adds hero **user-interaction flow** lines (and agent-centric openers where missing) on **20** `docs/features/*.mdx` pages for #1351.
- Replaces non-friendly imports with top-level exports where confirmed in `praisonaiagents/__init__.py`: `tool`, `MCP`, `ExecutionConfig`.
- Clears remaining `from praisonaiagents.tools import tool` usage in `docs/features/` (dynamic-tool-schemas, multimodal-tool-output).

## AGENTS.md rules

- §1.1(10) user-interaction flow
- §5.2 / §6.1 friendly imports
- No `docs/concepts/` edits

## Gap metrics (`docs/features/`)

| Heuristic | Before | After |
|-----------|--------|-------|
| User-flow gaps (no `The user` / User Interaction Flow in hero) | 474 | 454 |
| Deep import lines (`from praisonaiagents.<submodule>`) | 619 | 602 |
| `from praisonaiagents.tools import tool` | 7 | 0 |

## Test plan

- [x] `python3 -m json.tool docs.json` valid
- [x] No edits under `docs/concepts/`

Refs #1351