### PR TITLE
docs: document top-level praisonai doctor fix command

### DIFF
--- a/docs/cli/doctor-cli.mdx
+++ b/docs/cli/doctor-cli.mdx
@@ -15,7 +15,15 @@ praisonai doctor --version
 
 # List all available checks
 praisonai doctor --list-checks
+
+# Preview auto-fix for common setup issues (dry-run, no files changed)
+praisonai doctor fix
+
+# Apply auto-fix and write changes
+praisonai doctor fix --execute
 ```
+
+See the [Setup Auto-Fix](/docs/cli/doctor#setup-auto-fix) section for the full flag reference (`--dry-run`/`--execute`, `--no-backup`, `--file/-f`, `--quiet/-q`).
 
 ## Subcommand Reference
 

--- a/docs/cli/doctor.mdx
+++ b/docs/cli/doctor.mdx
@@ -46,6 +46,7 @@ praisonai doctor ci
 | `memory-store` | Check memory store backends |
 | `metadata-store` | Check metadata store configuration |
 | `runtime` | Runtime preflight for team YAML (`--team`) and migrate legacy `cli_backend` settings (`--fix`) |
+| `fix` | Apply safe auto-remediation for common setup issues (dry-run by default; `--execute` to apply). Phase 1 scope: migrate deprecated `cli_backend` YAML. |
 
 ## Global Flags
 
@@ -203,6 +204,36 @@ praisonai doctor runtime --fix --execute
 # Target a specific file
 praisonai doctor runtime --fix --execute --file ./teams/agents.yaml
 ```
+
+### Setup Auto-Fix
+
+Apply safe remediations for common setup issues. Dry-run by default; use `--execute` to write changes. Currently migrates deprecated `cli_backend` YAML.
+
+```bash
+# Preview proposed changes (dry-run — no files touched)
+praisonai doctor fix
+
+# Apply fixes with a .bak backup alongside the target file
+praisonai doctor fix --execute
+
+# Apply fixes without creating a backup
+praisonai doctor fix --execute --no-backup
+
+# Target a specific config file
+praisonai doctor fix --execute --file ./my-agents.yaml
+
+# Minimal output (for scripts / CI)
+praisonai doctor fix --execute --quiet
+```
+
+<Note>
+`praisonai doctor fix` and `praisonai doctor runtime --fix` currently share the same underlying migration logic (`_run_fix_mode`) but expose different flag shapes and backup formats:
+
+- `doctor fix` — `--dry-run`/`--execute` toggle · `.bak` backup file
+- `doctor runtime --fix` — `--fix` + `--execute` · `<stem>.backup.<YYYYMMDD_HHMMSS>.yaml` backup
+
+Prefer `doctor fix` for new usage; `runtime --fix` remains supported.
+</Note>
 
 ### Docker Checks
 
@@ -437,7 +468,7 @@ graph LR
 - Team YAML runtime compatibility (`--team`)
 - Handoff and capability validation across agents
 - Mixed-runtime warnings
-- Legacy `cli_backend` migration (`--fix`, `--execute`)
+- Legacy `cli_backend` migration (`--fix`, `--execute`) — also reachable via top-level [`praisonai doctor fix`](#setup-auto-fix)
 - Workflow YAML placeholder (`--workflow` — returns SKIP)
 
 ### Serve & Endpoints (`serve`)

--- a/docs/features/cli-backend-protocol.mdx
+++ b/docs/features/cli-backend-protocol.mdx
@@ -6,7 +6,7 @@ icon: "plug"
 ---
 
 <Warning>
-**Deprecated — use [Runtime Selection](/docs/features/runtime-selection) instead.** `cli_backend` still works through 2.0.0 but emits `DeprecationWarning`. For YAML migration, run `praisonai doctor runtime --fix --execute` — see [Runtime Config Migration](/docs/features/doctor-runtime-migration).
+**Deprecated — use [Runtime Selection](/docs/features/runtime-selection) instead.** `cli_backend` still works through 2.0.0 but emits `DeprecationWarning`. For YAML migration, run `praisonai doctor fix --execute` (or the equivalent `praisonai doctor runtime --fix --execute`) — see [Runtime Config Migration](/docs/features/doctor-runtime-migration).
 
 ```python
 # Before

--- a/docs/features/doctor-runtime-migration.mdx
+++ b/docs/features/doctor-runtime-migration.mdx
@@ -7,12 +7,16 @@ icon: "stethoscope"
 
 `praisonai doctor runtime` detects legacy `cli_backend` fields in your agent YAML and migrates them to the new `models.default.runtime` field.
 
+<Tip>
+The shortest command for this migration is now **`praisonai doctor fix --execute`** (added in PraisonAI 4.6.108+). It runs the same migration logic as `praisonai doctor runtime --fix --execute` but with a simpler flag shape. Both remain supported — see the [Doctor CLI setup auto-fix](/docs/cli/doctor#setup-auto-fix) section for the flag comparison.
+</Tip>
+
 ```python
 from praisonaiagents import Agent
 
 # After migration, runtime lives under models.default in agents.yaml
 agent = Agent(name="coder", instructions="Write code.")
-# praisonai doctor runtime --fix --execute
+# praisonai doctor fix --execute  (or: praisonai doctor runtime --fix --execute)
 ```
 
 ```mermaid
@@ -93,9 +97,29 @@ praisonai doctor runtime --fix --execute
 A backup is created at `agents.backup.20240115_143022.yaml` alongside your original file.
 </Step>
 
+<Step title="Shorter equivalent: doctor fix">
+The `doctor fix` subcommand runs the same migration with a simpler flag shape:
+
+```bash
+# Apply with a .bak backup (different format from runtime --fix)
+praisonai doctor fix --execute
+
+# Skip backup creation
+praisonai doctor fix --execute --no-backup
+```
+
+<Note>
+The backup file format differs between the two commands:
+- `doctor fix` creates `agents.yaml.bak`
+- `doctor runtime --fix --execute` creates `agents.backup.<YYYYMMDD_HHMMSS>.yaml`
+</Note>
+</Step>
+
 <Step title="Target a specific file">
 ```bash
 praisonai doctor runtime --fix --execute --file my-agents.yaml
+# or equivalently:
+praisonai doctor fix --execute --file my-agents.yaml
 ```
 </Step>
 </Steps>
@@ -187,6 +211,19 @@ sequenceDiagram
 ---
 
 ## Flags Reference
+
+**`doctor fix` flag equivalents** — use either command; they share the same migration logic:
+
+| `doctor fix` flag | `doctor runtime` equivalent | Purpose |
+|---|---|---|
+| _(no flag)_ | — | Dry-run preview (default) |
+| `--execute` | `--fix --execute` | Apply changes |
+| `--dry-run` | `--fix` | Explicit dry-run |
+| `--no-backup` | _(not available)_ | Skip backup file creation |
+| `--file, -f` | `--file, -f` | Target config file |
+| `--quiet, -q` | _(not available)_ | Minimal output |
+
+**`doctor runtime` flags:**
 
 | Flag | Default | Purpose |
 |------|---------|---------|

--- a/docs/features/runtime-selection.mdx
+++ b/docs/features/runtime-selection.mdx
@@ -241,7 +241,7 @@ agents:
     llm: claude-3-sonnet
 ```
 
-For automatic YAML migration, run `praisonai doctor runtime --fix --execute` — see [Runtime Config Migration](/docs/features/doctor-runtime-migration).
+For automatic YAML migration, run `praisonai doctor fix --execute` (or `praisonai doctor runtime --fix --execute`) — see [Runtime Config Migration](/docs/features/doctor-runtime-migration).
 
 Agent-level YAML warning:
 
@@ -265,7 +265,7 @@ Typo'd runtime IDs should fail at startup, not silently fall back to the built-i
 </Accordion>
 
 <Accordion title="Migrate cli_backend to runtime">
-Use the migration table above or `praisonai doctor runtime --fix` before 2.0.0 removes `cli_backend`.
+Use the migration table above or `praisonai doctor fix` (the shorter equivalent of `praisonai doctor runtime --fix`) before 2.0.0 removes `cli_backend`.
 </Accordion>
 </AccordionGroup>
 

--- a/docs/features/yaml-configuration-reference.mdx
+++ b/docs/features/yaml-configuration-reference.mdx
@@ -296,7 +296,7 @@ All recognized field names for agents in both `agents:` and `roles:` sections:
 | `approval` | bool | Require human approval |
 | `skills` | array | Skill definitions |
 | `runtime` | string / dict | Per-agent runtime override. Requires `framework: praisonai`. See [Runtime Selection](/docs/features/runtime-selection). |
-| `cli_backend` | string / dict | **Deprecated** — use `runtime` or `models.<name>.runtime` instead. Still works through 2.0.0 with `DeprecationWarning`. Run `praisonai doctor runtime --fix --execute` to migrate. See [Runtime Selection](/docs/features/runtime-selection). |
+| `cli_backend` | string / dict | **Deprecated** — use `runtime` or `models.<name>.runtime` instead. Still works through 2.0.0 with `DeprecationWarning`. Run `praisonai doctor fix --execute` (or `praisonai doctor runtime --fix --execute`) to migrate. See [Runtime Selection](/docs/features/runtime-selection). |
 | `reflection` | bool/object | Reflection configuration |
 
 ### Unknown-Field Warnings


### PR DESCRIPTION
## Summary

- Adds `fix` subcommand row to Subcommands table in `docs/cli/doctor.mdx`
- Adds **Setup Auto-Fix** example section with all 4 flags (`--dry-run`/`--execute`, `--no-backup`, `--file/-f`, `--quiet/-q`) and a Note distinguishing `.bak` vs `.backup.<YYYYMMDD_HHMMSS>.yaml` backup formats
- Adds `doctor fix` basic command examples to `docs/cli/doctor-cli.mdx` with forward link
- Adds Tip callout and new Quick Start step in `docs/features/doctor-runtime-migration.mdx` + flags equivalents table
- Updates deprecation Warning in `docs/features/cli-backend-protocol.mdx` to match SDK `DeprecationWarning.alternative` string (`praisonai doctor fix --execute`)
- Updates `docs/features/runtime-selection.mdx` migration sentence and Accordion
- Updates `docs/features/yaml-configuration-reference.mdx` `cli_backend` row

Fixes #1388

Generated with [Claude Code](https://claude.ai/code)