### PR TITLE
docs: cover doctor optional-deps parallelization (broken/slow buckets)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -464,6 +464,7 @@
                       "docs/features/prepared-turn-context",
                       "docs/features/runtime-capabilities",
                       "docs/features/doctor-runtime-migration",
+                      "docs/features/doctor-optional-deps",
                       "docs/features/runtime-preflight",
                       "docs/features/external-agents-ui",
                       "docs/features/resource-lifecycle",

--- a/docs/cli/doctor-cli.mdx
+++ b/docs/cli/doctor-cli.mdx
@@ -77,6 +77,38 @@ praisonai doctor --only gateway_env_substitution
 | `gateway_config_migration` | MEDIUM | Legacy format migration opportunities. |
 | `gateway_env_substitution` | MEDIUM | All `${VAR}` references resolve. |
 
+### Environment Deep Check — Optional Dependencies
+
+```bash
+# Probe optional packages in parallel (requires --deep)
+praisonai doctor env --deep
+
+# JSON output for CI gating
+praisonai doctor env --deep --json
+```
+
+Expected output shape (available / missing / broken / slow buckets):
+
+```json
+{
+  "id": "optional_deps",
+  "status": "WARN",
+  "message": "5 optional packages available, 2 not installed, 1 broken",
+  "details": "Missing: gradio (Gradio UI), tavily (Tavily search); Broken install: chromadb (Knowledge/RAG features)",
+  "remediation": "Reinstall the broken optional package(s): chromadb (Knowledge/RAG features)",
+  "metadata": {
+    "available": ["mem0ai", "litellm", "praisonaiui", "crawl4ai", "duckduckgo_search"],
+    "missing":   ["gradio (Gradio UI)", "tavily (Tavily search)"],
+    "broken":    ["chromadb (Knowledge/RAG features)"],
+    "slow":      []
+  }
+}
+```
+
+<Note>
+See [Optional Dependencies Check](/docs/features/doctor-optional-deps) for the full four-bucket table, per-package timeout formula, and CI gating examples.
+</Note>
+
 ### Packaging Checks
 
 Diagnose Windows daemon and entry-point issues (`python -m praisonai` vs the `praisonai` console script):

--- a/docs/cli/doctor.mdx
+++ b/docs/cli/doctor.mdx
@@ -55,7 +55,7 @@ praisonai doctor ci
 | `--format text\|json` | Output format (default: text) |
 | `--output PATH` | Write report to file |
 | `--deep` | Enable deeper probes (DB connects, network checks) |
-| `--timeout SEC` | Per-check timeout in seconds (default: 10) |
+| `--timeout SEC` | Per-check timeout in seconds (default: 10). For `optional_deps` the timeout is split across packages (`max(1, min(3, timeout/4))s` each), so `--timeout 20` gives up to 3s per package plus safety margin. |
 | `--strict` | Treat warnings as failures |
 | `--quiet` | Minimal output |
 | `--no-color` | Disable ANSI colors |
@@ -92,6 +92,22 @@ praisonai doctor env
 # Check with API key visibility
 praisonai doctor env --show-keys
 ```
+
+#### Optional Dependencies (deep mode)
+
+```bash
+# Probe all eight optional packages in parallel
+praisonai doctor env --deep
+
+# Machine-readable output for CI
+praisonai doctor env --deep --json
+```
+
+`--deep` enables the `optional_deps` check, which probes eight optional packages on daemon threads and reports each as `available`, `missing`, `broken`, or `slow`. A `broken` package (installed but failing to import) surfaces as `WARN` with a remediation message; `missing` and `slow` packages do not fail the check.
+
+<Note>
+See [Optional Dependencies Check](/docs/features/doctor-optional-deps) for the four-bucket table, per-package timeout formula, and CI gating examples.
+</Note>
 
 ### Configuration Validation
 

--- a/docs/features/doctor-optional-deps.mdx
+++ b/docs/features/doctor-optional-deps.mdx
@@ -18,16 +18,16 @@ graph LR
 
     classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
     classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef gate fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef neutral fill:#6366F1,stroke:#7C90A0,color:#fff
     classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
     classDef warn fill:#8B0000,stroke:#7C90A0,color:#fff
 
     class A input
     class B process
-    class C gate
-    class D,E ok
+    class C neutral
+    class D ok
+    class E,G neutral
     class F warn
-    class G gate
 ```
 
 ## Quick Start

--- a/docs/features/doctor-optional-deps.mdx
+++ b/docs/features/doctor-optional-deps.mdx
@@ -82,7 +82,9 @@ The `metadata` object contains one list per bucket:
 
 ---
 
-## The Four Outcome Buckets
+## How It Works
+
+### The Four Outcome Buckets
 
 Each optional package lands in exactly one bucket per run:
 
@@ -97,9 +99,7 @@ Each optional package lands in exactly one bucket per run:
 A `broken` result is distinct from `missing`: the package is installed but its import fails with a non-`ImportError` (e.g. a corrupted C extension). The check surfaces this as `WARN` rather than masking it as "not installed" — which would misleadingly tell users to install a package that is already there.
 </Note>
 
----
-
-## The Eight Optional Packages
+### The Eight Optional Packages
 
 | Package | Feature area |
 |---------|--------------|
@@ -112,9 +112,7 @@ A `broken` result is distinct from `missing`: the package is installed but its i
 | `tavily` | Tavily search |
 | `duckduckgo_search` | DuckDuckGo search |
 
----
-
-## Per-Package Timeout
+### Per-Package Timeout
 
 Each import runs on its own daemon thread with an individual deadline computed from the global `--timeout`:
 
@@ -146,13 +144,44 @@ graph LR
 | 20 | 3.0s | 16.0s |
 | 4 | 1.0s | 3.2s |
 
----
-
-## Why Daemon Threads
+### Why Daemon Threads
 
 <Note>
 Daemon threads (rather than a `ThreadPoolExecutor`) are used deliberately: a pool's worker threads are joined by its internal `atexit` handler at interpreter shutdown even after `shutdown(wait=False)`, so a truly hanging import would still stall CLI exit. Daemon threads are abandoned on exit, so a hanging import can never block the process from terminating.
 </Note>
+
+---
+
+## Configuration Options
+
+| Flag | Description |
+|------|-------------|
+| `--deep` | Enable deeper probes, including the `optional_deps` parallel import check |
+| `--timeout SEC` | Global timeout in seconds (default: 10). Per-package deadline: `max(1.0, min(3.0, timeout/4))` |
+| `--json` | Output in JSON format for CI gating |
+| `--only optional_deps` | Run only the optional deps check |
+| `--skip optional_deps` | Skip the optional deps check |
+
+---
+
+## Common Patterns
+
+**Gate CI on broken packages only:**
+```bash
+praisonai doctor env --deep --json > deps.json
+broken=$(python3 -c "import json; d=json.load(open('deps.json')); print(len(d.get('results',[{}])[0].get('metadata',{}).get('broken',[])))" 2>/dev/null || echo "0")
+[ "$broken" -gt "0" ] && { echo "Broken optional packages — see deps.json"; exit 1; }
+```
+
+**Raise per-package timeout for slow environments:**
+```bash
+praisonai doctor env --deep --timeout 20
+```
+
+**Run only the optional deps check:**
+```bash
+praisonai doctor env --deep --only optional_deps
+```
 
 ---
 

--- a/docs/features/doctor-optional-deps.mdx
+++ b/docs/features/doctor-optional-deps.mdx
@@ -1,0 +1,225 @@
+---
+title: "Optional Dependencies Check"
+sidebarTitle: "Optional Deps"
+description: "How praisonai doctor env --deep probes optional packages — available, missing, broken, or slow"
+icon: "stethoscope"
+---
+
+`praisonai doctor env --deep` probes eight optional packages in parallel and reports each as available, missing, broken, or slow — no single hanging import can stall the check.
+
+```mermaid
+graph LR
+    A["praisonai doctor env --deep"] --> B["8 daemon threads\none per optional package"]
+    B --> C["per-package gate\nmax(1.0, min(3.0, timeout/4))"]
+    C --> D["available"]
+    C --> E["missing"]
+    C --> F["broken"]
+    C --> G["slow"]
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef gate fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef warn fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class A input
+    class B process
+    class C gate
+    class D,E ok
+    class F warn
+    class G gate
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Check before wiring up knowledge features">
+An agent that uses `chromadb` for RAG will fail at runtime if the package is broken. Run the check first:
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Knowledge Assistant",
+    instructions="Answer using indexed documents.",
+    knowledge=["docs/manual.pdf"],   # requires chromadb
+)
+agent.start("How do I configure auth?")
+```
+
+```bash
+# Confirm chromadb is present before wiring up knowledge features
+praisonai doctor env --deep
+```
+</Step>
+
+<Step title="CI/CD — capture the JSON report">
+Export the structured result so CI can gate on specific buckets:
+
+```bash
+praisonai doctor env --deep --json > deps.json
+```
+
+The `metadata` object contains one list per bucket:
+
+```json
+{
+  "id": "optional_deps",
+  "status": "WARN",
+  "message": "5 optional packages available, 2 not installed, 1 broken",
+  "details": "Missing: gradio (Gradio UI), tavily (Tavily search); Broken install: chromadb (Knowledge/RAG features)",
+  "remediation": "Reinstall the broken optional package(s): chromadb (Knowledge/RAG features)",
+  "metadata": {
+    "available": ["mem0ai", "litellm", "praisonaiui", "crawl4ai", "duckduckgo_search"],
+    "missing":   ["gradio (Gradio UI)", "tavily (Tavily search)"],
+    "broken":    ["chromadb (Knowledge/RAG features)"],
+    "slow":      []
+  }
+}
+```
+</Step>
+</Steps>
+
+---
+
+## The Four Outcome Buckets
+
+Each optional package lands in exactly one bucket per run:
+
+| Bucket | When | Status | Remediation |
+|--------|------|--------|-------------|
+| `available` | Import succeeded | `PASS` | — |
+| `missing` | `ImportError` — package not installed | `PASS` | Install the package if you need that feature |
+| `broken` | Import raised a non-`ImportError` (broken C extension, missing shared object) | **`WARN`** | *"Reinstall the broken optional package(s): {names}"* |
+| `slow` | Import didn't finish inside per-package timeout | `PASS` | Retry with a higher `--timeout`; skip if it's a known-slow package |
+
+<Note>
+A `broken` result is distinct from `missing`: the package is installed but its import fails with a non-`ImportError` (e.g. a corrupted C extension). The check surfaces this as `WARN` rather than masking it as "not installed" — which would misleadingly tell users to install a package that is already there.
+</Note>
+
+---
+
+## The Eight Optional Packages
+
+| Package | Feature area |
+|---------|--------------|
+| `chromadb` | Knowledge/RAG features |
+| `mem0ai` | Memory features |
+| `litellm` | Multi-provider LLM support |
+| `praisonaiui` | aiui (Chat/Dashboard UI) |
+| `gradio` | Gradio UI |
+| `crawl4ai` | Web crawling |
+| `tavily` | Tavily search |
+| `duckduckgo_search` | DuckDuckGo search |
+
+---
+
+## Per-Package Timeout
+
+Each import runs on its own daemon thread with an individual deadline computed from the global `--timeout`:
+
+```
+per_package_timeout = max(1.0, min(3.0, config.timeout / 4))
+```
+
+With the default `--timeout 10`, each package gets **2.5 seconds**. The overall aggregate deadline is `max(per_package_timeout, config.timeout * 0.8)` — the check never exceeds 80% of the engine budget.
+
+```mermaid
+graph LR
+    N["--timeout N"] --> D["N / 4"]
+    D --> MN["min(3.0, …)"]
+    MN --> MX["max(1.0, …)"]
+    MX --> R["per-package deadline"]
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef step fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class N input
+    class D,MN,MX step
+    class R result
+```
+
+| `--timeout` | Per-package deadline | Aggregate cap |
+|-------------|---------------------|---------------|
+| 10 (default) | 2.5s | 8.0s |
+| 20 | 3.0s | 16.0s |
+| 4 | 1.0s | 3.2s |
+
+---
+
+## Why Daemon Threads
+
+<Note>
+Daemon threads (rather than a `ThreadPoolExecutor`) are used deliberately: a pool's worker threads are joined by its internal `atexit` handler at interpreter shutdown even after `shutdown(wait=False)`, so a truly hanging import would still stall CLI exit. Daemon threads are abandoned on exit, so a hanging import can never block the process from terminating.
+</Note>
+
+---
+
+## CI/JSON Output
+
+Gate CI on `metadata.broken` being empty. A `broken` install is actionable; a `missing` install often is not.
+
+```jsonc
+{
+  "id": "optional_deps",
+  "status": "WARN",
+  "message": "5 optional packages available, 2 not installed, 1 broken",
+  "details": "Missing: gradio (Gradio UI), tavily (Tavily search); Broken install: chromadb (Knowledge/RAG features)",
+  "remediation": "Reinstall the broken optional package(s): chromadb (Knowledge/RAG features)",
+  "metadata": {
+    "available": ["mem0ai", "litellm", "praisonaiui", "crawl4ai", "duckduckgo_search"],
+    "missing":   ["gradio (Gradio UI)", "tavily (Tavily search)"],
+    "broken":    ["chromadb (Knowledge/RAG features)"],
+    "slow":      []
+  }
+}
+```
+
+Check the `broken` list in a shell script:
+
+```bash
+praisonai doctor env --deep --json > deps.json
+broken=$(python3 -c "import json,sys; d=json.load(open('deps.json')); print(len(d.get('results',[{}])[0].get('metadata',{}).get('broken',[])))" 2>/dev/null || echo "0")
+if [ "$broken" -gt "0" ]; then
+  echo "Broken optional packages detected — check deps.json for remediation"
+  exit 1
+fi
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Gate CI on broken, not missing">
+Gate CI on `metadata.broken` being empty — a broken install is actionable, a missing install often isn't.
+</Accordion>
+
+<Accordion title="Handle slow packages in short-timeout environments">
+If a package repeatedly lands in `slow`, add it to `--skip optional_deps` in short-timeout environments rather than raising the global `--timeout`.
+</Accordion>
+
+<Accordion title="Reinstall a broken package">
+Reinstall commands: `pip install --force-reinstall {package}` clears a broken C-extension cache.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Doctor CLI" icon="stethoscope" href="/docs/cli/doctor">
+  Full reference for praisonai doctor health checks and subcommands
+</Card>
+<Card title="Doctor CLI Reference" icon="terminal" href="/docs/cli/doctor-cli">
+  CLI command reference for all doctor subcommands
+</Card>
+<Card title="Runtime Config Migration" icon="arrows-rotate" href="/docs/features/doctor-runtime-migration">
+  Detect and migrate legacy cli_backend fields with praisonai doctor runtime
+</Card>
+<Card title="Vector Store" icon="database" href="/docs/features/vector-store">
+  chromadb-backed vector storage for knowledge and RAG features
+</Card>
+</CardGroup>

--- a/docs/features/doctor-optional-deps.mdx
+++ b/docs/features/doctor-optional-deps.mdx
@@ -226,11 +226,11 @@ Gate CI on `metadata.broken` being empty — a broken install is actionable, a m
 </Accordion>
 
 <Accordion title="Handle slow packages in short-timeout environments">
-If a package repeatedly lands in `slow`, add it to `--skip optional_deps` in short-timeout environments rather than raising the global `--timeout`.
+If a package repeatedly lands in `slow`, raise `--timeout` or skip the entire check with `--skip optional_deps` in short-timeout environments.
 </Accordion>
 
 <Accordion title="Reinstall a broken package">
-Reinstall commands: `pip install --force-reinstall {package}` clears a broken C-extension cache.
+`pip install --force-reinstall <package>` clears a broken C-extension cache.
 </Accordion>
 </AccordionGroup>
 

--- a/docs/features/doctor-runtime-migration.mdx
+++ b/docs/features/doctor-runtime-migration.mdx
@@ -319,4 +319,7 @@ Use `pyproject.toml` entry-points rather than `register_rule()` in application c
 <Card title="CLI Backend Protocol" icon="plug" href="/docs/features/cli-backend-protocol">
   The cli_backend field and CLI backend registration system
 </Card>
+<Card title="Optional Dependencies Check" icon="stethoscope" href="/docs/features/doctor-optional-deps">
+  How praisonai doctor env --deep probes optional packages with broken/slow buckets
+</Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

Documents the `praisonai doctor env --deep` optional dependencies parallelization feature from [MervinPraison/PraisonAI#2557](https://github.com/MervinPraison/PraisonAI/pull/2557) (merged 2026-07-02).

- **New page** `docs/features/doctor-optional-deps.mdx`: full coverage of the four outcome buckets (`available`/`missing`/`broken`/`slow`), per-package timeout formula (`max(1.0, min(3.0, config.timeout / 4))`), daemon-thread design rationale (verbatim from docstring), the eight optional packages (verbatim from source), and CI gating examples
- **Updated** `docs/cli/doctor.mdx`: added Optional Dependencies subsection under Environment Checks; expanded `--timeout` flag description with the per-package formula
- **Updated** `docs/cli/doctor-cli.mdx`: added `env --deep` example with JSON output shape showing all four metadata buckets
- **Updated** `docs.json`: added `features/doctor-optional-deps` under Features group alongside `doctor-runtime-migration`
- **Updated** `docs/features/doctor-runtime-migration.mdx`: added Related card linking to the new page

All bucket names, metadata keys, remediation strings, package tuples, timeout formulas, and the daemon-thread design rationale are sourced verbatim from `env_checks.py` at head SHA `86dae919c37bdf5e11b380466088824955933c03`.

Fixes #1389

Generated with [Claude Code](https://claude.ai/code)