### PR TITLE
docs: audit 540 docs/features/*.mdx against AGENTS.md principles

### DIFF
--- a/docs/features/AUDIT_2026-07.md
+++ b/docs/features/AUDIT_2026-07.md
@@ -1,0 +1,629 @@
+# docs/features Audit Report — July 2026
+
+> **Reference implementation:** [`docs/features/planning.mdx`](/docs/features/planning.mdx) — use this as the template when refactoring any page below.
+
+**Audit date:** 2026-07-02  
+**Files audited:** 540  
+**Auditor:** Claude (automated grep audit per Issue #1385)  
+**Branch:** `claude/issue-1385-20260702-0642`
+
+---
+
+## Summary Statistics
+
+| Criterion | Passing | Failing | Pass Rate |
+|-----------|---------|---------|-----------|
+| Hero diagram (`graph LR`) | 466 | 74 | 86% |
+| `<Steps>` component | 538 | 2 | 99% |
+| `<AccordionGroup>` component | 538 | 2 | 99% |
+| `<CardGroup>` component | 540 | 0 | 100% |
+| `sequenceDiagram` (user-interaction flow) | 340 | 200 | 62% |
+| Agent-centric code (`Agent()`) | 507 | 33 | 93% |
+| Agent `.start()` call | 441 | 99 | 81% |
+| Friendly imports (no deep namespace) | 30 | 510 | 5% |
+| No forbidden phrases | 540 | 0 | 100% |
+
+---
+
+## Audit Criteria
+
+Each column maps to a principle from `AGENTS.md`:
+
+| Column | Principle | AGENTS.md Section |
+|--------|-----------|--------|
+| **hero-diagram** | Page starts with a `graph LR` Mermaid diagram using the standard color scheme (#8B0000/#189AB4/#10B981/#F59E0B/#6366F1, white text, #7C90A0 stroke) | §3.3 |
+| **decision-diagram** | `graph TB` present when page documents multiple modes/options | §3.2, §6.1 |
+| **Steps** | `<Steps>` component present in Quick Start section | §2, §4.1 |
+| **AccordionGroup** | `<AccordionGroup>` present in Best Practices section | §2, §4.1 |
+| **CardGroup** | `<CardGroup>` present in Related section | §2, §4.1 |
+| **sequenceDiagram** | User-interaction flow via `sequenceDiagram` (User → Agent → Feature → User) | §1.1 item 10, §3.4 |
+| **friendly-imports** | Code uses `from praisonaiagents import ...` (top-level only) — NOT `from praisonaiagents.X import ...` deep namespace | §5.2 |
+| **no-forbidden-phrases** | None of: "In this section", "As you can see", "important to note", "Please note that", "take a look", "following example shows" | §6.3 |
+
+> **Note on decision-diagram column:** The table uses `ok`/`FAIL` uniformly. For simple single-concept pages, absence of `graph TB` may be acceptable (N/A semantically) — only pages documenting 2+ modes/options strictly require it per §6.1.
+
+---
+
+## Top 10 Pages to Refactor First
+
+Ranked by number of failing criteria. Each should be addressed in a separate follow-up issue/PR.
+
+| Rank | File | Failures | Missing Criteria |
+|------|------|----------|-----------------|
+| 1 | `agent-as-tool.mdx` | 4 | hero-diagram, sequenceDiagram, .start(), deep-namespace imports |
+| 2 | `chat.mdx` | 4 | hero-diagram, sequenceDiagram, .start(), deep-namespace imports |
+| 3 | `conditions.mdx` | 4 | hero-diagram, sequenceDiagram, .start(), deep-namespace imports |
+| 4 | `context-budgeter.mdx` | 4 | hero-diagram, sequenceDiagram, .start(), deep-namespace imports |
+| 5 | `context-monitor.mdx` | 4 | hero-diagram, sequenceDiagram, .start(), deep-namespace imports |
+| 6 | `context-strategies.mdx` | 4 | hero-diagram, sequenceDiagram, .start(), deep-namespace imports |
+| 7 | `job-completed-hook.mdx` | 4 | AccordionGroup, sequenceDiagram, .start(), deep-namespace imports |
+| 8 | `standalone-llm-modules.mdx` | 4 | hero-diagram, Steps, sequenceDiagram, deep-namespace imports |
+| 9 | `tool-discovery-order.mdx` | 4 | Steps, AccordionGroup, sequenceDiagram, deep-namespace imports |
+| 10 | `workflow-hierarchical.mdx` | 4 | hero-diagram, sequenceDiagram, .start(), deep-namespace imports |
+
+> Use [`docs/features/planning.mdx`](/docs/features/planning.mdx) as the reference implementation for all criteria when refactoring these pages.
+
+---
+
+## Full Audit Table
+
+**Legend:** `ok` = passes criterion | `FAIL` = fails criterion
+
+| File | hero-diagram | decision-diagram | Steps | AccordionGroup | CardGroup | sequenceDiagram | friendly-imports | no-forbidden-phrases |
+|------|-------------|-----------------|-------|----------------|-----------|-----------------|-----------------|----------------------|
+| `a2a-client.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `a2a-push-notifications.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `a2a-security.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `a2a-tasks.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `a2a.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `a2ui.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `activity-log.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `advanced-features.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `advanced-memory.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `agent-api-launch.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `agent-as-tool.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `agent-centric-api.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `agent-cloning.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `agent-learn-skill.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `agent-max-budget.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `agent-presets-and-modes.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `agent-profiles.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `agent-retry.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `agent-run-outcomes.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `agent-runtime-protocol.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `agent-server.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `agents.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `aiui-backends.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `allowed-tools.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `api-server-auth.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `approval-backends.mdx` | FAIL | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `approval-protocol.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `approval-secure-backend.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `approval.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `artifact-storage.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `assign-agents.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `async-agent-scheduler.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `async-bridge.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `async-conversation-store.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `async-crew-kickoff.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `async-db-hooks.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `async-jobs.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `async-scheduler.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `async-self-reflection.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `async-tool-safety.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `async.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `audio-tools.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `audit-logging.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `auto-generator-providers.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `autoagents.mdx` | FAIL | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `autonomous-workflow.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `autonomy-loop.mdx` | FAIL | ok | ok | ok | ok | ok | FAIL | ok |
+| `autonomy.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `background-subagents.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `background-tasks.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `bot-command-access-control.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `bot-commands.mdx` | FAIL | ok | ok | ok | ok | ok | FAIL | ok |
+| `bot-default-tools.mdx` | FAIL | ok | ok | ok | ok | ok | FAIL | ok |
+| `bot-gateway.mdx` | FAIL | ok | ok | ok | ok | ok | FAIL | ok |
+| `bot-inbound-media.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `bot-intentional-silence.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `bot-lifecycle-hooks.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `bot-pairing.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `bot-platform-capabilities.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `bot-platform-plugins.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `bot-presentations.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `bot-rate-limiting.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `bot-routing.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `bot-run-control.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `bot-session-compaction.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `bot-session-reset.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `bot-status-reactions.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `bot-streaming-replies.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `bot-typing-indicators.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `bot-unknown-user-pairing.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `botos.mdx` | FAIL | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `browser-agent-deep-dive.mdx` | FAIL | ok | ok | ok | ok | ok | ok | ok |
+| `browser-agent.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `caching.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `callbacks.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `camera-integration.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `channel-capabilities.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `channels-gateway.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `chat-with-pdf.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `chat.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `checkpoints.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `chunking-strategies.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `clarify-tool.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `claude-memory-tool.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `cli-backend-protocol.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `cli-budget-handling.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `cli-command-lazy-dispatch.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `cli-configuration.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `cli-direct-prompt.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `cli-dispatcher.mdx` | FAIL | ok | ok | ok | ok | ok | FAIL | ok |
+| `cli-oauth-login.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `cli.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `cloud-databases.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `cloud-provider-registry.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `cockroachdb.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `code-execution-with-tools.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `code.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `codeagent.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `command-aware-permissions.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `concurrency.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `conditional-branching.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `conditions.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `config-file.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `configurable-model.mdx` | FAIL | ok | ok | ok | ok | ok | FAIL | ok |
+| `context-api.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-budgeter-cli.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-budgeter.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-cli-reference.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-compaction-policy.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `context-compaction.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `context-compression.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-estimation-validation.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-files.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `context-ledger.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-management.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-manager-module.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-monitor-cli.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-monitor.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-multi-agent-policies.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-observability.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-overview.mdx` | FAIL | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `context-per-tool-budgets.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-security-redaction.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-snapshot-hooks.mdx` | FAIL | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `context-strategies.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-token-estimation-cli.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-token-estimation.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `context-window-management.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `core-controls.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `correlation-ids.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `cross-platform-mirror.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `cross-session-recall.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `custom-actions.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `custom-agents-commands.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `custom-memory-adapters.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `custom-tool-safe-eval.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `daemon.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `database-persistence.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `dead-target-registry.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `declarative-permissions.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `default-model-selection.mdx` | FAIL | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `delivery-config.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `display-callbacks.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `display-policy.mdx` | FAIL | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `display-system.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `doctor-runtime-migration.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `doom-loop-detection.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `durable-approvals.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `durable-delivery.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `durable-outbound-delivery.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `dynamic-context-discovery.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `dynamic-judge.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `dynamic-tool-schemas.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `dynamic-variables.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `email-bot.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `endpoint-provider-registry.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `endpoints-code.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `error-handling.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `escalation-pipeline.mdx` | FAIL | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `evaluator-optimiser.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `event-bus.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `execution-systems.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `execution.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `external-agents-ui.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `external-cli-integrations.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `fail-loud-defaults.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `failover.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `fast-context.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `file-editing.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `file-snapshot.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `first-run-onboarding.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `framework-adapter-plugins.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `framework-availability.mdx` | ok | FAIL | ok | ok | ok | FAIL | ok | ok |
+| `framework-default-change.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-admission-control.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-agent-defaults.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-bind-aware-auth.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `gateway-channel-supervision.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `gateway-cli.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `gateway-client.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-code-skew-guard.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-config-migration.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `gateway-config-reload.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `gateway-drain-trigger.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `gateway-error-handling.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-exit-codes.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `gateway-flow-control.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-forensics.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `gateway-graceful-drain.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-handshake-protocol.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-hooks.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-hot-reload.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `gateway-inbound-hooks.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `gateway-metrics.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-operator-scopes.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `gateway-overview.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-rate-limit-policy.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-rate-limit.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `gateway-rate-limiting.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `gateway-relay-transport.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `gateway-reliability-preset.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `gateway-reliability.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `gateway-route-bindings.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-scale-to-zero.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-session-continuity.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-session-persistence.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `gateway-telegram-multichannel.mdx` | FAIL | ok | ok | ok | ok | ok | FAIL | ok |
+| `gateway-tool-policy.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `gateway-windows-deployment.mdx` | FAIL | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `gateway.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `generate-reasoning.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `generative-ui.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `graph-memory.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `guardrails.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `handoff-filters.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `handoff-tool-policy.mdx` | FAIL | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `handoffs.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `heartbeat.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `hermes-openclaw-skills-import.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `hierarchical-config.mdx` | FAIL | ok | ok | ok | ok | ok | FAIL | ok |
+| `hierarchical-summaries.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `history-injection.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `hook-events.mdx` | FAIL | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `hooks-before-tool-definitions.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `hooks.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `host-integration.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `hosted-agent.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `hybrid-workflows.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `image-generation.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `inbound-dlq.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `inbound-journal.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `incremental-indexing.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `index.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `industry-templates/agriculture.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `industry-templates/energy.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `industry-templates/healthcare.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `industry-templates/manufacturing.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `industry-templates/overview.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `industry-templates/transportation.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `injected-state.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `installation-extras.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `integrate-a2ui-frontend.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `integration-patterns.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `integration-registry.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `intelligent-conversation-compaction.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `interactive-approval.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `interactive-bot-actions.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `interactive-callback-authorization.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `job-completed-hook.mdx` | ok | FAIL | ok | FAIL | ok | FAIL | FAIL | ok |
+| `job-workflows.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `kanban-cli.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `kanban.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `knowledge-backends.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `knowledge.mdx` | FAIL | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `l3-dashboard-pages.mdx` | FAIL | ok | ok | ok | ok | ok | FAIL | ok |
+| `langchain.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `large-context-overview.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `lazy-imports.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `learn-skill.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `learn.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `learning-retention.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `linear-bot.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `lite-package.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `llm-as-judge.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `llm-autogen-config-list.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `llm-config.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `llm-context-compression.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `llm-endpoint-config.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `llm-error-classification.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `llm-gateways.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `load-mcp-tools.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `local-agent.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `local-tools-loading.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `logging-configuration.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `long-running-bots.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `loop-guard.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `loop-guardrails.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `managed-agent-lifecycle.mdx` | FAIL | FAIL | ok | ok | ok | ok | ok | ok |
+| `managed-agent-persistence.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `managed-agents-session-info.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `managed-backend-plugins.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `managed-cli.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `managed-runtime-protocol.mdx` | FAIL | FAIL | ok | ok | ok | ok | ok | ok |
+| `managed-typed-configs.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `managed-vault.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `mathagent.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `mcp-cli-tools-path-safety.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `mcp-client-protocol.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `mcp-lifecycle.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `mcp-tool-filtering.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `mcp-yaml-config.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `mcp.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `memory-advanced-search.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `memory-lifecycle-hooks.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `memory-troubleshooting.mdx` | FAIL | ok | ok | ok | ok | ok | FAIL | ok |
+| `memory.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `message-presentation.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `message-steering.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `messaging-bots.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `messaging-channels-strategy.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `middleware.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `migrate.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `mini.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `model-capabilities.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `model-fallback.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `model-router.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `models-cli.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `modular-recipes.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `mongodb-memory.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `multi-agent-context-safety.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `multi-agent-execution.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `multi-agent-hooks.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `multi-agent-memory.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `multi-agent-output.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `multi-agent-patterns.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `multi-agent-pipelines.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `multi-agent-planning.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `multi-channel-bots.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `multi-model-panel.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `multi-provider-advanced.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `multimodal-tool-output.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `multimodal.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `multitool-hermes-only-tools.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `n8n-api.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `n8n-integration.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `n8n-tools.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `n8n-visual-editor.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `neon.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `nested-workflows.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `non-fatal-errors.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `observability-hooks.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `ocr.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `onboard.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `openai-compatible-server.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `openai-quickstart.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `optimizer-cli.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `optimizer.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `orchestrator-worker.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `outbound-media-delivery.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `outbound-resilience.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `output-styles.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `output.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `pairing-protocols.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `panel-llm.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `parallelisation.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `per-chat-session-scope.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `performance-benchmarks.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `permission-modes.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `permissions.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `persistence-backend-plugins.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `persistence-clickhouse.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `persistence-conversation-mysql.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `persistence-json.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `persistence-mongodb.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `persistence-mysql.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `persistence-postgres.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `persistence-redis.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `persistence-sqlite.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `persistence.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `planning-mode.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `planning.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `platform-aware-agents.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `platform-client-sdk-testing.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `platform-labels.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `platform-python-sdk.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `platform-sdk.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `platform-workspace-context.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `platform/activity-log.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `platform/agents.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `platform/auth-configuration.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `platform/auth-me-endpoint-fix.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `platform/authentication.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `platform/cli.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `platform/comments.mdx` | ok | ok | ok | ok | ok | ok | ok | ok |
+| `platform/data-model.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `platform/dependencies.mdx` | ok | ok | ok | ok | ok | ok | ok | ok |
+| `platform/exceptions.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `platform/issue-ids.mdx` | ok | ok | ok | ok | ok | ok | ok | ok |
+| `platform/issues.mdx` | ok | ok | ok | ok | ok | ok | ok | ok |
+| `platform/labels.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `platform/members.mdx` | ok | ok | ok | ok | ok | ok | ok | ok |
+| `platform/pagination.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `platform/projects.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `platform/rbac-enforcement.mdx` | ok | ok | ok | ok | ok | ok | ok | ok |
+| `platform/sdk-client.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `platform/workspaces.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `plugins.mdx` | FAIL | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `policy-engine.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `post-edit-formatter.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `praisonai-code-cli.mdx` | ok | FAIL | ok | ok | ok | ok | ok | ok |
+| `prepared-turn-context.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `proactive-delivery.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `profiler.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `profiling.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `project-agents-md.mdx` | FAIL | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `project-sessions.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `prompt-cache-optimization.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `prompt-caching.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `prompt-injection-protection.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `promptchaining.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `protected-paths.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `push-notifications.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `quality-based-rag.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `quality-checking.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `rag-scoping.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `rag.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `rate-limiter.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `real-api-testing.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `reasoning-extract.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `reasoning.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `recipe-registry.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `recipe-serve-advanced.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `recipe-serve-code.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `recursive-context.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `reflection.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `registry-dependency-injection.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `relay-transport.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `reliability.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `repetitive.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `replay.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `resource-lifecycle.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `retrieval-strategies.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `retrieval.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `rfc-microsoft-teams-integration.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `robustness.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `routing.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `rules.mdx` | FAIL | ok | ok | ok | ok | ok | FAIL | ok |
+| `run-history.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `run-stream-events.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `runtime-capabilities.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `runtime-config.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `runtime-mcp.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `runtime-preflight.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `runtime-resolution.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `runtime-selection.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `runtime-tool-result-middleware.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `runtime.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `safe-tools-by-default.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `sandbox-backends.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `sandbox.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `sandboxed-agent.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `save-output.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `scheduled-run-policy.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `scheduler-pre-run-gate.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `scientific-writer-agent.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `search-provider-registry.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `security-environment-variables.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `self-improve.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `selfreflection.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `send-message-tool.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `send-policy.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `session-hierarchy.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `session-persistence.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `session-protocol.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `session-runtime-state.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `session-store.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `sessions.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `single-source-config.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `skill-bundles.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `skill-capability-gates.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `skill-fallback.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `skill-fallbacks.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `skill-lifecycle.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `skill-manage.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `skills-invocation.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `skills-vs-tools.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `skills.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `smart-retrieval.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `spawn-announce.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `specialized-agents.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `standalone-llm-modules.mdx` | FAIL | ok | FAIL | ok | ok | FAIL | FAIL | ok |
+| `stateful-agents.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `streaming-tool-events.mdx` | FAIL | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `streaming.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `structured-llm-errors.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `structured.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `subagent-delegation.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `subagent-tool.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `subscription-auth.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `supabase.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `task-context-control.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `task-retry-policy.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `task-validation-feedback.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `telemetry.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `templates.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `terminal-bench.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `test-documentation.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `thinking-budgets.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `thread-safety.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `todo-planning.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `token-budgeting.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `token-usage-protocol.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `tool-availability.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `tool-circuit-breaker.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `tool-config.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `tool-discovery-order.mdx` | ok | FAIL | FAIL | FAIL | ok | FAIL | FAIL | ok |
+| `tool-output-store.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `tool-parameter-types.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `tool-progress-streaming.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `tool-registry-autogen-migration.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `tool-resolver.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `tool-retry-backoff.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `tool-retry-policy.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `tool-schema-validation.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `tool-search.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `tool-source-registry.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `tools.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `toolsets.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `tui/commands.mdx` | ok | FAIL | ok | ok | ok | FAIL | ok | ok |
+| `tui/overview.mdx` | ok | FAIL | ok | ok | ok | FAIL | ok | ok |
+| `tui/queue.mdx` | ok | FAIL | ok | ok | ok | FAIL | ok | ok |
+| `tui/simulation.mdx` | ok | FAIL | ok | ok | ok | FAIL | ok | ok |
+| `turso.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `typed-handoffs.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `ui-presets.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `variable-substitution.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `vector-store.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `web.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `webhook-verification.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `whatsapp-bot.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `windows-openclaw-setup.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `windows-sdk-quickstart.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `windows-terminal-encoding.mdx` | FAIL | ok | ok | ok | ok | ok | FAIL | ok |
+| `workflow-error-recovery.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `workflow-errors.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `workflow-hierarchical.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `workflow-loop.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `workflow-parallel.mdx` | FAIL | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `workflow-patterns.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `workflow-repeat.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `workflow-routing.mdx` | FAIL | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `workflow-validation.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `workflow-yaml-framework-field.mdx` | ok | ok | ok | ok | ok | ok | FAIL | ok |
+| `workflows.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `workspace.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `xata.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `yaml-configuration-reference.mdx` | ok | ok | ok | ok | ok | FAIL | FAIL | ok |
+| `yaml-template-variables.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+| `yaml-workflows.mdx` | ok | FAIL | ok | ok | ok | FAIL | FAIL | ok |
+| `zep-memory.mdx` | ok | FAIL | ok | ok | ok | ok | FAIL | ok |
+
+---
+
+## Notes
+
+- **`friendly-imports` is the most pervasive issue:** 510 / 540 files contain at least one `from praisonaiagents.<submodule>` deep-namespace import. The correct pattern per AGENTS.md §5.2 is `from praisonaiagents import ...` (top-level). This should be addressed via a systematic find-and-replace pass rather than page-by-page.
+- **`sequenceDiagram` gap:** 200 files lack a `sequenceDiagram`. Many are infrastructure/gateway pages where a sequence diagram may not be the most natural fit, but §1.1 item 10 requires showing the user-interaction flow (User → Agent → Feature → User).
+- **`hero-diagram` gap:** 74 files lack a `graph LR` hero diagram — the second most common structural gap after deep imports.
+- **`no-forbidden-phrases` is 100% passing** — no files contain any of the §6.3 forbidden phrases. This criterion needs no remediation.
+- **`Steps` / `AccordionGroup` / `CardGroup`:** Near-universal compliance. Only 2 files lack `<Steps>`, 2 lack `<AccordionGroup>`, 0 lack `<CardGroup>`.
+- **`platform/` subdirectory:** The `platform/` subdirectory files generally pass all criteria; they lack deep imports and have no forbidden phrases.
+- **Part A (AGENTS.md reconciliation):** No changes to `AGENTS.md` were made by this PR. The current in-repo version is more polished than the submitted draft in all delta rows reviewed in Issue #1385.
+
+---
+
+*Generated by Claude Code per Issue #1385. Refresh by re-running the audit script.*

--- a/docs/features/AUDIT_2026-07.md
+++ b/docs/features/AUDIT_2026-07.md
@@ -11,17 +11,20 @@
 
 ## Summary Statistics
 
-| Criterion | Passing | Failing | Pass Rate |
-|-----------|---------|---------|-----------|
-| Hero diagram (`graph LR`) | 466 | 74 | 86% |
-| `<Steps>` component | 538 | 2 | 99% |
-| `<AccordionGroup>` component | 538 | 2 | 99% |
-| `<CardGroup>` component | 540 | 0 | 100% |
-| `sequenceDiagram` (user-interaction flow) | 340 | 200 | 62% |
-| Agent-centric code (`Agent()`) | 507 | 33 | 93% |
-| Agent `.start()` call | 441 | 99 | 81% |
-| Friendly imports (no deep namespace) | 30 | 510 | 5% |
-| No forbidden phrases | 540 | 0 | 100% |
+| Criterion | Passing | Failing | Pass Rate | In full table? |
+|-----------|---------|---------|-----------|----------------|
+| Hero diagram (`graph LR`) | 466 | 74 | 86% | ✅ |
+| Decision diagram (`graph TB`) | 174 | 366 | 32% | ✅ |
+| `<Steps>` component | 538 | 2 | 99% | ✅ |
+| `<AccordionGroup>` component | 538 | 2 | 99% | ✅ |
+| `<CardGroup>` component | 540 | 0 | 100% | ✅ |
+| `sequenceDiagram` (user-interaction flow) | 340 | 200 | 62% | ✅ |
+| Agent-centric code (`Agent()`) | 507 | 33 | 93% | ❌ (grep-only) |
+| Agent `.start()` call | 441 | 99 | 81% | ❌ (grep-only) |
+| Friendly imports (no deep namespace) | 30 | 510 | 5% | ✅ |
+| No forbidden phrases | 540 | 0 | 100% | ✅ |
+
+> **Note on "grep-only" rows:** "Agent-centric code" and "Agent `.start()` call" were measured via grep pass and are summarised here but not tracked as columns in the per-file table below (adding two more columns to a 540-row table would reduce readability). Use the Top 10 section for files that fail these criteria.
 
 ---
 


### PR DESCRIPTION
Fixes #1385

## Summary

Delivers the Part B deliverable from Issue 1385: a comprehensive audit of all 540 .mdx files under docs/features/ against the 10 pre-creation principles declared in AGENTS.md.

Part A (AGENTS.md reconciliation): No changes to AGENTS.md - current in-repo version is more polished than the submitted draft in all 11 delta rows. Per the issue recommendation, no action is needed.

## Top 10 pages to refactor first

1. agent-as-tool.mdx - 4 failures: hero-diagram, sequenceDiagram, .start(), deep-imports
2. chat.mdx - 4 failures: hero-diagram, sequenceDiagram, .start(), deep-imports
3. conditions.mdx - 4 failures: hero-diagram, sequenceDiagram, .start(), deep-imports
4. context-budgeter.mdx - 4 failures: hero-diagram, sequenceDiagram, .start(), deep-imports
5. context-monitor.mdx - 4 failures: hero-diagram, sequenceDiagram, .start(), deep-imports
6. context-strategies.mdx - 4 failures: hero-diagram, sequenceDiagram, .start(), deep-imports
7. job-completed-hook.mdx - 4 failures: AccordionGroup, sequenceDiagram, .start(), deep-imports
8. standalone-llm-modules.mdx - 4 failures: hero-diagram, Steps, sequenceDiagram, deep-imports
9. tool-discovery-order.mdx - 4 failures: Steps, AccordionGroup, sequenceDiagram, deep-imports
10. workflow-hierarchical.mdx - 4 failures: hero-diagram, sequenceDiagram, .start(), deep-imports

## Key findings

- Friendly imports (most pervasive): 510/540 files have deep-namespace imports
- Hero diagram gap: 74/540 files missing graph LR hero diagram
- sequenceDiagram gap: 200/540 files missing user-interaction flow
- No forbidden phrases: 0/540 files (100% clean on §6.3)
- Steps/AccordionGroup/CardGroup: Near-universal compliance (99%+)

## Changes

- docs/features/AUDIT_2026-07.md - new audit report covering all 540 files
- AGENTS.md - unchanged (per Part A recommendation)
- No docs/concepts/, docs/js/, or docs/rust/ files modified
- docs.json - unchanged

Generated with Claude Code