### PR TITLE
docs: AGENTS alignment batch 6 (features, #1351)

### DIFF
--- a/docs/features/bot-gateway.mdx
+++ b/docs/features/bot-gateway.mdx
@@ -12,6 +12,9 @@ agent = Agent(name="gateway-bot", instructions="Handle messages from Telegram, S
 agent.start("Set up the bot gateway for all chat platforms.")
 ```
 
+The user messages on Telegram, Slack, or Discord; the gateway routes each channel to the right agent.
+
+
 
 ```mermaid
 flowchart LR

--- a/docs/features/bot-inbound-media.mdx
+++ b/docs/features/bot-inbound-media.mdx
@@ -7,6 +7,19 @@ icon: "image"
 
 Bot adapters forward inbound photos and documents to your agent's vision capability — validated, size-capped, and SSRF-safe.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    instructions="Describe photos and documents users send in chat.",
+)
+
+agent.start("What is in this image?")
+```
+
+The user sends a photo or document in WhatsApp or Telegram; the bot validates the file and passes it to the agent vision model.
+
 ```mermaid
 graph LR
     subgraph "Inbound Media Flow"

--- a/docs/features/bot-intentional-silence.mdx
+++ b/docs/features/bot-intentional-silence.mdx
@@ -7,6 +7,15 @@ icon: "volume-xmark"
 
 With `allow_silence: true`, an agent can return `NO_REPLY` (or a custom token) to send nothing — no message, no typing indicator, no error.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="group-bot", instructions="Reply in group chats only when helpful.")
+agent.start("Should I respond to this off-topic message?")
+```
+
+The user posts in a group chat; with `allow_silence: true`, the agent can return `NO_REPLY` so nothing is sent.
+
 ```mermaid
 graph LR
     Msg[📨 Group message] --> Policy[group_policy gate]

--- a/docs/features/bot-lifecycle-hooks.mdx
+++ b/docs/features/bot-lifecycle-hooks.mdx
@@ -7,6 +7,15 @@ icon: "webhook"
 
 Bot lifecycle hooks let you watch your bot start and stop, see every user session begin and end, and react when scheduled jobs fire — without changing your agent code.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="You are a helpful messaging bot.")
+agent.start("Log when sessions start and end.")
+```
+
+The user opens a chat session; lifecycle hooks fire on gateway start, session boundaries, and scheduled jobs without changing agent code.
+
 <Note>
 This page covers **in-process outbound lifecycle hooks** (GATEWAY_START, SESSION_START, SCHEDULE_TRIGGER) that fire inside the running gateway. For **HTTP inbound triggers** that let external services start agent runs via `POST /hooks/<path>`, see [Gateway Inbound Hooks](/docs/features/gateway-inbound-hooks).
 </Note>

--- a/docs/features/bot-pairing.mdx
+++ b/docs/features/bot-pairing.mdx
@@ -7,6 +7,16 @@ icon: "handshake"
 
 Bot pairing lets unknown users self-request access to your bot with secure 8-character codes that you approve from the CLI.
 
+```python
+from praisonaiagents import Agent, BotConfig
+
+agent = Agent(name="assistant", instructions="You are a helpful assistant.")
+config = BotConfig(unknown_user_policy="pair")
+agent.start("An unknown user wants access — generate a pairing code.")
+```
+
+The user DMs the bot for the first time; PraisonAI issues an 8-character code you approve from the CLI.
+
 ```mermaid
 graph LR
     subgraph "Pairing Flow"

--- a/docs/features/bot-platform-capabilities.mdx
+++ b/docs/features/bot-platform-capabilities.mdx
@@ -7,6 +7,15 @@ icon: "sliders"
 
 Platform capabilities tell PraisonAI what your bot's platform can do, so streaming, chunking, and rate limiting work the same way everywhere.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="Reply on Telegram with streaming when supported.")
+agent.start("Send a long answer with progressive updates.")
+```
+
+The user receives a reply; platform capabilities tell PraisonAI how to chunk, stream, and rate-limit on that channel.
+
 <Info>
 Capabilities describe what a channel **can** render; [Display Policy](/docs/features/display-policy) controls what you **want** shown.
 </Info>

--- a/docs/features/bot-platform-plugins.mdx
+++ b/docs/features/bot-platform-plugins.mdx
@@ -12,6 +12,9 @@ agent = Agent(name="platform-bot", instructions="Use platform-specific bot plugi
 agent.start("Enable Telegram and Discord plugins for this bot.")
 ```
 
+The user installs a third-party bot package; entry points register new platforms alongside built-in channels.
+
+
 
 Third-party bot packages can register via Python entry points to extend PraisonAI with custom messaging platforms.
 

--- a/docs/features/bot-presentations.mdx
+++ b/docs/features/bot-presentations.mdx
@@ -7,6 +7,15 @@ icon: "display"
 
 Agents can reply with structured interactive messages — buttons, dropdowns, dividers, context text — and each channel adapter renders them as native widgets.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="Offer clear yes/no choices in chat.")
+agent.start("Ask the user to approve the deployment with buttons.")
+```
+
+The user taps an inline button or dropdown; each channel renders the same structured presentation natively.
+
 ```mermaid
 graph LR
     subgraph "One model, three channels"

--- a/docs/features/bot-rate-limiting.mdx
+++ b/docs/features/bot-rate-limiting.mdx
@@ -6,13 +6,15 @@ icon: "gauge"
 ---
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.bots import BotConfig
+from praisonaiagents import Agent, BotConfig
 
 agent = Agent(name="rate-limited-bot", instructions="Respond to users within rate limits.")
 config = BotConfig(rate_limit_per_user=10)
 agent.start("Apply rate limiting: max 10 requests per user per minute.")
 ```
+
+The user sends many messages quickly; outbound replies are throttled so the platform does not return HTTP 429 errors.
+
 
 
 Bot Rate Limiting prevents messaging platform 429 errors by throttling outbound messages to channels, respecting platform-specific limits and per-channel delays.

--- a/docs/features/bot-routing.mdx
+++ b/docs/features/bot-routing.mdx
@@ -13,6 +13,9 @@ support_agent = Agent(name="support", instructions="Handle support requests.")
 personal_agent.start("Route DMs to me, group messages to support.")
 ```
 
+The user messages in a DM or group; the gateway matches the chat context and forwards the turn to the configured agent.
+
+
 `routes:` is the preferred field name for gateway routing configuration — gateway runtime accepts both `routing:` and `routes:` interchangeably in YAML.
 
 ```mermaid

--- a/docs/features/bot-run-control.mdx
+++ b/docs/features/bot-run-control.mdx
@@ -7,6 +7,15 @@ icon: "octagon-pause"
 
 Bot run control provides responsive feedback during long-running agent tasks, eliminating silent blocking where follow-up messages queue invisibly.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="You are a helpful assistant.")
+agent.start("Research solar energy trends while the user sends follow-ups.")
+```
+
+The user sends a message while a long run is active; the bot acknowledges busy state, queues follow-ups, or honours `/stop`.
+
 ```mermaid
 graph LR
     User[👤 User message] --> Check{🔍 Run active?}

--- a/docs/features/bot-session-compaction.mdx
+++ b/docs/features/bot-session-compaction.mdx
@@ -7,6 +7,15 @@ icon: "compress"
 
 Long-lived bot conversations get a compact summary of older turns instead of having them silently dropped.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="Maintain context across a long Telegram thread.")
+agent.start("Summarise what we discussed last week.")
+```
+
+The user continues a long-lived bot thread; older turns are summarised instead of being dropped silently.
+
 ```mermaid
 graph LR
     subgraph "Bot Session Compaction"

--- a/docs/features/bot-session-reset.mdx
+++ b/docs/features/bot-session-reset.mdx
@@ -6,13 +6,15 @@ icon: "rotate"
 ---
 
 ```python
-from praisonaiagents import Agent
-from praisonaiagents.bots import BotConfig
+from praisonaiagents import Agent, BotConfig
 
 agent = Agent(name="assistant", instructions="You are a helpful assistant.")
 config = BotConfig(session_reset_hours=24)
 agent.start("Reset sessions after 24 hours of inactivity.")
 ```
+
+The user returns after idle time; session reset clears stale history so the agent starts fresh.
+
 
 Session reset policies automatically clear bot conversation history after inactivity or at a scheduled time, preventing unbounded context growth.
 

--- a/docs/features/bot-streaming-replies.mdx
+++ b/docs/features/bot-streaming-replies.mdx
@@ -7,6 +7,15 @@ icon: "message-pen"
 
 Channel bots can post a quick placeholder message and progressively edit it in place as the agent's answer streams in — replacing the old "stare at a typing indicator for 45s, then a wall of text lands in one burst" experience.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="You are a helpful assistant.")
+agent.start("Explain quantum computing in simple terms.")
+```
+
+The user waits on Telegram or Discord; a placeholder message updates in place as the agent streams its answer.
+
 <Info>
 Session-level `streaming: true` is a shortcut. For unified per-platform defaults and overrides, use [Display Policy](/docs/features/display-policy).
 </Info>

--- a/docs/features/bot-typing-indicators.mdx
+++ b/docs/features/bot-typing-indicators.mdx
@@ -7,6 +7,15 @@ icon: "keyboard"
 
 Typing indicators tell users the bot is working — with automatic keepalive resends, a circuit breaker on failures, and a safety TTL so a stuck indicator never hangs forever.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="You are a helpful assistant.")
+agent.start("Look up today weather for London.")
+```
+
+The user sends a message; a typing indicator shows while the agent works, with keepalive and automatic timeout.
+
 ```mermaid
 graph LR
     A[Agent Run Start] --> T[TypingManager]

--- a/docs/features/bot-unknown-user-pairing.mdx
+++ b/docs/features/bot-unknown-user-pairing.mdx
@@ -7,6 +7,16 @@ icon: "user-check"
 
 Bot pairing enables owner-approval for unknown users with inline Approve/Deny buttons sent directly to your DM.
 
+```python
+from praisonaiagents import Agent, BotConfig
+
+agent = Agent(name="assistant", instructions="You are a helpful assistant.")
+config = BotConfig(unknown_user_policy="pair", owner_user_id="123456789")
+agent.start("Unknown user requests access — notify the owner.")
+```
+
+The user messages the bot before they are allowlisted; the owner receives Approve/Deny buttons in DM.
+
 ```mermaid
 graph LR
     subgraph "Unknown User Pairing Flow"

--- a/docs/features/botos.mdx
+++ b/docs/features/botos.mdx
@@ -5,6 +5,17 @@ description: "Run AI agents across Telegram, Discord, Slack, WhatsApp — and cu
 icon: "robot"
 ---
 
+```python
+from praisonai import BotOS
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="You are a helpful assistant.")
+botos = BotOS(agent=agent, platforms=["telegram", "discord"])
+botos.run()
+```
+
+The user chats on Telegram or Discord; one shared agent brain answers on every connected platform.
+
 ```mermaid
 flowchart TB
     Supervisor[Channel Supervisor] --> Monitor[Health Monitor]

--- a/docs/features/browser-agent-deep-dive.mdx
+++ b/docs/features/browser-agent-deep-dive.mdx
@@ -5,6 +5,15 @@ description: "Comprehensive guide to browser automation modes, APIs, and integra
 icon: "microscope"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="browser-agent", instructions="Browse the web and complete tasks in Chrome.")
+agent.start("Search for PraisonAI documentation and summarise the install steps.")
+```
+
+The user describes a web goal; the browser agent drives Chrome via extension, CDP, or Playwright.
+
 # Browser Agent Deep Dive
 
 This guide explains how PraisonAI browser automation works under the hood, covering all execution modes, APIs, and integration patterns.

--- a/docs/features/browser-agent.mdx
+++ b/docs/features/browser-agent.mdx
@@ -12,6 +12,9 @@ agent = Agent(name="browser-agent", instructions="Browse the web and extract inf
 agent.start("Go to https://example.com and summarise the main content.")
 ```
 
+The user states a browsing goal; the Chrome extension and bridge execute actions until the task completes.
+
+
 
 Control web browsers with AI agents through a Chrome Extension connected to PraisonAI.
 

--- a/docs/features/caching.mdx
+++ b/docs/features/caching.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("What is your return policy?")
 ```
 
+The user asks the same support question again; a cache hit returns the prior answer without another LLM call.
+
+
 ```mermaid
 graph LR
     subgraph "Caching Flow"


### PR DESCRIPTION
## Summary

- Adds hero **user-interaction flow** lines (and agent-centric openers where missing) on **20** `docs/features/*.mdx` pages for #1351.
- Replaces `from praisonaiagents.bots import BotConfig` with `from praisonaiagents import Agent, BotConfig` in hero openers where confirmed in `praisonaiagents/__init__.py`.
- No `docs/concepts/` edits.

## AGENTS.md rules

- §1.1(9–10) agent-centric opening and user-interaction flow
- §5.2 / §6.1 friendly imports (BotConfig in hero)

## Gap metrics (`docs/features/`)

| Heuristic | Before | After |
|-----------|--------|-------|
| User-flow gaps (no `The user` / User Interaction Flow in hero before first mermaid fence) | 433 | 413 |
| Deep import lines (`from praisonaiagents.<submodule>`) | unchanged in batch scope (hero-only BotConfig fixes) |

Verified on `origin/main` vs branch worktree with the same Python heuristic used in batch 5.

## Pages

bot-gateway, bot-inbound-media, bot-intentional-silence, bot-lifecycle-hooks, bot-pairing, bot-platform-capabilities, bot-platform-plugins, bot-presentations, bot-rate-limiting, bot-routing, bot-run-control, bot-session-compaction, bot-session-reset, bot-streaming-replies, bot-typing-indicators, bot-unknown-user-pairing, botos, browser-agent-deep-dive, browser-agent, caching

## Test plan

- [x] `python3 -m json.tool docs.json` valid
- [x] No edits under `docs/concepts/`

Refs #1351
