### PR TITLE
docs: AGENTS alignment batch 8 (features, #1351)

### DIFF
--- a/docs/features/context-management.mdx
+++ b/docs/features/context-management.mdx
@@ -5,6 +5,16 @@ description: "Best-in-class context management with auto-compaction, session tra
 icon: "layer-group"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="context-agent",
+    instructions="Manage long conversations without overflowing the context window.",
+)
+agent.start("Summarise our thread so far and continue the task.")
+```
+
 # AI Agents with Context Management
 
 <Tip>
@@ -13,6 +23,9 @@ This page covers **Context Window Management** - token budgeting, compaction, an
 </Tip>
 
 PraisonAI provides **industry-leading context management** with features no other framework offers: LLM-driven compression with session lineage and intelligent conversation compaction.
+
+The user runs a long chat; context management keeps token use within budget and compacts history before the model overflows.
+
 
 ```mermaid
 flowchart TB

--- a/docs/features/context-manager-module.mdx
+++ b/docs/features/context-manager-module.mdx
@@ -19,6 +19,9 @@ agent.start("Process this document while managing context carefully.")
 
 The `ContextManager` orchestrates budgeting, composition, optimisation, and monitoring through one interface.
 
+The user sends a large thread; the context manager budgets tokens and returns an optimised message list for the next LLM call.
+
+
 ```mermaid
 graph LR
     Messages[💬 Messages] --> CM[🧠 ContextManager]

--- a/docs/features/context-monitor-cli.mdx
+++ b/docs/features/context-monitor-cli.mdx
@@ -16,6 +16,9 @@ agent.start("Display live context usage metrics for this session.")
 Configure context monitoring via CLI flags and interactive commands.
 
 
+The user launches `praisonai chat --context-monitor` and watches live context usage update after each turn.
+
+
 ```mermaid
 flowchart LR
     In[Input] --> Agent[Agent]

--- a/docs/features/context-monitor.mdx
+++ b/docs/features/context-monitor.mdx
@@ -5,9 +5,23 @@ description: "Real-time context snapshots for debugging and optimization"
 icon: "eye"
 ---
 
+```python
+from praisonaiagents import Agent, ManagerConfig
+
+agent = Agent(
+    name="monitored-agent",
+    instructions="You are helpful.",
+    context=ManagerConfig(monitor_enabled=True, monitor_path="./context.txt"),
+)
+agent.start("Hello — log what context you send to the model.")
+```
+
 # Context Monitor
 
 The Context Monitor writes runtime context snapshots to disk, providing visibility into exactly what's being sent to the model.
+
+
+The user enables context monitoring on an agent; each turn writes a snapshot so they can inspect exactly what reached the model.
 
 
 ```mermaid

--- a/docs/features/context-multi-agent-policies.mdx
+++ b/docs/features/context-multi-agent-policies.mdx
@@ -16,6 +16,9 @@ agent1.start("Apply shared context policy across both agents.")
 
 `MultiAgentContextManager` gives each agent isolated context with controlled sharing on handoffs.
 
+The user hands off from a researcher agent to a writer; shared context policies control what crosses the boundary.
+
+
 ```mermaid
 graph LR
     A1[🤖 Researcher] --> Handoff[↔️ Handoff policy]

--- a/docs/features/context-observability.mdx
+++ b/docs/features/context-observability.mdx
@@ -19,6 +19,9 @@ agent.start("Trace all context events for this task.")
 Context observability provides optimization history tracking, event logging, and debugging tools.
 
 
+The user debugs a run; context observability logs compaction and overflow events with token savings.
+
+
 ```mermaid
 flowchart LR
     In[Input] --> Agent[Agent]

--- a/docs/features/context-overview.mdx
+++ b/docs/features/context-overview.mdx
@@ -21,6 +21,9 @@ agent.start("Summarise the last 10 messages without losing context.")
 This page provides a comprehensive visual guide to how context management works in PraisonAI Agents.
 
 
+The user opens this overview to see how budgeting, compaction, and monitoring fit together before tuning an agent.
+
+
 ```mermaid
 flowchart LR
     In[Input] --> Agent[Agent]

--- a/docs/features/context-per-tool-budgets.mdx
+++ b/docs/features/context-per-tool-budgets.mdx
@@ -5,7 +5,20 @@ description: "Configure token limits per tool for fine-grained output control"
 icon: "sliders"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="budgeted-agent",
+    instructions="Use tools without flooding context.",
+)
+agent.start("Search the web and keep only the most relevant snippets.")
+```
+
 Per-tool budgets cap how much of each tool's output enters agent context — noisy tools get tighter limits, critical tools stay protected.
+
+The user caps noisy tool output; per-tool budgets truncate oversized results before they fill the context window.
+
 
 ```mermaid
 graph LR

--- a/docs/features/context-security-redaction.mdx
+++ b/docs/features/context-security-redaction.mdx
@@ -19,6 +19,9 @@ agent.start("Process this document and redact all PII.")
 Context security features protect sensitive data in snapshots and validate output paths.
 
 
+The user sends messages containing secrets; redaction strips sensitive fields before context reaches the LLM.
+
+
 ```mermaid
 flowchart LR
     In[Input] --> Agent[Agent]

--- a/docs/features/context-snapshot-hooks.mdx
+++ b/docs/features/context-snapshot-hooks.mdx
@@ -44,6 +44,9 @@ manager.register_snapshot_callback(on_llm_call)
 
 ## Architecture
 
+The user registers snapshot hooks; each context change triggers a callback for auditing or custom pipelines.
+
+
 ```mermaid
 sequenceDiagram
     participant A as Agent

--- a/docs/features/context-strategies.mdx
+++ b/docs/features/context-strategies.mdx
@@ -5,6 +5,16 @@ description: "Complete guide to context management strategies, defaults, and cus
 icon: "sliders"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="strategy-agent",
+    instructions="Apply the right context strategy when history grows.",
+)
+agent.start("Continue this long task without losing important details.")
+```
+
 # Context Strategies & Defaults
 
 This is the master reference for context management in PraisonAI Agents. It covers all strategies, default behaviors, and how to customize them.
@@ -12,6 +22,9 @@ This is the master reference for context management in PraisonAI Agents. It cove
 <Note>
 Context management is **opt-in** via the `context=` parameter. When disabled (default), there is zero performance overhead.
 </Note>
+
+
+The user picks a compaction strategy; the agent applies truncation, chunking, or summarisation when context nears the limit.
 
 
 ```mermaid

--- a/docs/features/context-token-estimation-cli.mdx
+++ b/docs/features/context-token-estimation-cli.mdx
@@ -5,7 +5,17 @@ description: "Configure how PraisonAI estimates token counts from the CLI"
 icon: "calculator"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="estimator", instructions="Preview token usage before heavy runs.")
+agent.start("Estimate how many tokens this prompt will use.")
+```
+
 Control token estimation mode from the CLI — choose fast heuristics or accurate tiktoken counts when debugging context usage.
+
+The user runs CLI token estimation to preview context size before starting an expensive chat session.
+
 
 ```mermaid
 graph LR

--- a/docs/features/context-token-estimation.mdx
+++ b/docs/features/context-token-estimation.mdx
@@ -18,6 +18,9 @@ agent.start("Estimate how many tokens this message will consume.")
 PraisonAI provides fast, offline token estimation that works without API calls. This enables real-time context budget tracking and optimization decisions.
 
 
+The user estimates tokens for a prompt; heuristics predict cost before the agent calls the model.
+
+
 ```mermaid
 flowchart LR
     In[Input] --> Agent[Agent]

--- a/docs/features/core-controls.mdx
+++ b/docs/features/core-controls.mdx
@@ -7,6 +7,19 @@ icon: "sliders"
 
 Four small switches that make a PraisonAI agent **safer, more deterministic, and easier to interrupt** in production.
 
+The user starts a run; core controls enforce safety policies during execution.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="assistant",
+    instructions="Run with guardrails, interrupts, and validation enabled",
+)
+
+agent.start("Execute this task safely")
+```
+
 ```mermaid
 graph TD
     Caller["📞 Your Code"] -->|"agent.chat(..., seed=42, cancel_token=tok)"| Agent["🤖 Agent"]
@@ -25,19 +38,6 @@ graph TD
     class Reject gate
 
 ```
-
-```python
-from praisonaiagents import Agent
-
-agent = Agent(
-    name="assistant",
-    instructions="Run with guardrails, interrupts, and validation enabled",
-)
-
-agent.start("Execute this task safely")
-```
-
-The user starts a run; core controls enforce safety policies during execution.
 
 ## Quick Start
 

--- a/docs/features/correlation-ids.mdx
+++ b/docs/features/correlation-ids.mdx
@@ -5,7 +5,22 @@ description: "Join ingress, session, and agent-run logs on one stable id per mes
 icon: "link"
 ---
 
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def log_correlation() -> str:
+    from praisonai.bots import current_correlation_id
+    return f"correlation_id={current_correlation_id()}"
+
+agent = Agent(name="ops", instructions="Be helpful.", tools=[log_correlation])
+agent.start("Who am I in the logs?")
+```
+
 One id per message — read it inside any tool, log it on any hop, and `grep` your logs to follow a single request end to end.
+
+The user sends a message; the same correlation id appears in bot logs, agent tools, and delivery traces for end-to-end debugging.
+
 
 ```mermaid
 graph LR

--- a/docs/features/cross-platform-mirror.mdx
+++ b/docs/features/cross-platform-mirror.mdx
@@ -46,6 +46,9 @@ BotOS(
 </Tab>
 </Tabs>
 
+The user continues the same conversation on Telegram, then Discord; identity linking mirrors session history across platforms.
+
+
 ```mermaid
 graph LR
     subgraph "Cross-Platform Mirror"

--- a/docs/features/cross-session-recall.mdx
+++ b/docs/features/cross-session-recall.mdx
@@ -5,7 +5,21 @@ description: "Let agents search their own past conversations across sessions"
 icon: "magnifying-glass-clock"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="recall-agent",
+    instructions="Search past sessions when the user asks about earlier decisions.",
+    tools=["session_search"],
+)
+agent.start("What did we decide about the billing migration?")
+```
+
 An agent can now search its own past conversation transcripts — asking "what did we decide about the billing migration?" across every stored session.
+
+The user asks what was decided last week; session search recalls matching turns from prior stored conversations.
+
 
 ```mermaid
 graph LR

--- a/docs/features/custom-actions.mdx
+++ b/docs/features/custom-actions.mdx
@@ -26,6 +26,9 @@ That single line triggers a **3-tier resolution chain** to find and run the acti
 
 ## How Actions Resolve
 
+The user triggers a workflow step; the resolver finds the YAML, file, or built-in action and runs it.
+
+
 ```mermaid
 flowchart TD
     A["action: my-action"] --> B{"Defined in<br/>YAML actions: block?"}

--- a/docs/features/custom-agents-commands.mdx
+++ b/docs/features/custom-agents-commands.mdx
@@ -15,6 +15,9 @@ agent.start("Register /summarise as a custom command that summarises the chat.")
 
 Drop Markdown or YAML files into `.praisonai/agents/` and `.praisonai/commands/` to extend the CLI without writing Python.
 
+The user runs `praisonai run --agent researcher`; discovery loads custom agents and slash commands from `.praisonai/`.
+
+
 ```mermaid
 graph LR
     U[~/.praisonai/] --> D[Discovery]


### PR DESCRIPTION
## Summary

- Adds hero **user-interaction flow** lines (and agent-centric openers where missing) on **19** `docs/features/*.mdx` pages for #1351 (`context-window-management` already compliant).
- Reorders **core-controls** hero so agent opener and user flow appear before the first mermaid diagram.
- No `docs/concepts/` edits.

## AGENTS.md rules

- §1.1(9–10) agent-centric opening and user-interaction flow

## Gap metrics (`docs/features/`)

| Heuristic | Before | After |
|-----------|--------|-------|
| User-flow gaps (no `The user` / User Interaction Flow in hero before first mermaid fence) | 422 | 403 |
| Deep import lines (`from praisonaiagents.<submodule>`) in hero | 34 | 34 |

## Pages

context-management, context-manager-module, context-monitor-cli, context-monitor, context-multi-agent-policies, context-observability, context-overview, context-per-tool-budgets, context-security-redaction, context-snapshot-hooks, context-strategies, context-token-estimation-cli, context-token-estimation, core-controls, correlation-ids, cross-platform-mirror, cross-session-recall, custom-actions, custom-agents-commands

## Test plan

- [x] `python3 -m json.tool docs.json` valid
- [x] No edits under `docs/concepts/`

Refs #1351


Made with [Cursor](https://cursor.com)