### PR TITLE
docs: AGENTS alignment batch 7 (features, #1351)

### DIFF
--- a/docs/features/callbacks.mdx
+++ b/docs/features/callbacks.mdx
@@ -4,6 +4,21 @@ sidebarTitle: "Callbacks Agent"
 description: "Learn how to implement callbacks to monitor and log AI agent interactions, errors, and task completions."
 icon: "bell"
 ---
+Learn how to implement callbacks to monitor and log AI agent interactions, errors, and task completions.
+
+```python
+from praisonaiagents import Agent, register_display_callback
+
+def on_interaction(message=None, response=None, **kwargs):
+    print(f"Turn: {message} -> {response}")
+
+register_display_callback("interaction", on_interaction, is_async=False)
+
+agent = Agent(name="Monitor", instructions="Answer helpfully while callbacks log each turn.")
+agent.start("Hello")
+```
+
+The user sends a message; your callback logs the interaction while the agent replies.
 
 ```mermaid
 flowchart LR

--- a/docs/features/camera-integration.mdx
+++ b/docs/features/camera-integration.mdx
@@ -7,6 +7,19 @@ icon: "camera"
 
 PraisonAI supports camera integration for real-time visual analysis through multimodal agents. While there's no built-in camera capture, you can easily integrate camera feeds by capturing frames or videos and passing them to vision agents.
 
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="vision",
+    instructions="Analyse images captured from a camera feed.",
+)
+agent.start("Describe what you see in this frame.")
+```
+
+The user captures a camera frame; the vision agent analyses it and returns a description.
+
 ```mermaid
 graph LR
     subgraph "Camera Integration"

--- a/docs/features/channel-capabilities.mdx
+++ b/docs/features/channel-capabilities.mdx
@@ -7,6 +7,16 @@ icon: "list-check"
 
 Each channel declares what it supports — live message edits, reactions, typing indicators, and text limits — so engines adapt automatically without platform-specific agent code.
 
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="bot", instructions="Reply on Telegram with streaming when the channel supports it.")
+agent.start("Send a long answer with progressive updates.")
+```
+
+The user receives a reply; channel capabilities tell PraisonAI how to stream, react, and chunk on that platform.
+
 ```mermaid
 graph LR
     subgraph "Capability-aware engines"

--- a/docs/features/channels-gateway.mdx
+++ b/docs/features/channels-gateway.mdx
@@ -12,6 +12,7 @@ agent = Agent(name="channel-agent", instructions="Route messages across multiple
 agent.start("Handle messages from Telegram, Slack, and Discord via the gateway.")
 ```
 
+The user messages on Telegram, Slack, or Discord; the gateway routes each channel to your agent.
 
 Connect PraisonAI agents to popular chat platforms through the channels gateway integration.
 

--- a/docs/features/chat-with-pdf.mdx
+++ b/docs/features/chat-with-pdf.mdx
@@ -4,6 +4,21 @@ sidebarTitle: "Chat with PDF"
 description: "Learn how to create AI agents that can intelligently chat with PDF documents using vector databases for efficient information retrieval."
 icon: "file-pdf"
 ---
+A PDF-centric workflow where Chat agents interact with vector databases to store and retrieve information from PDF documents, enabling natural conversations and intelligent question-answering capabilities.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="researcher",
+    instructions="Answer questions using the uploaded PDF",
+    knowledge=True,
+)
+
+agent.start("Summarise chapter 2 of the document")
+```
+
+The user uploads a PDF and asks questions; answers cite the indexed content.
 
 ```mermaid
 flowchart LR
@@ -25,24 +40,8 @@ flowchart LR
     class B,C tool
 
 ```
-    classDef agent fill:#8B0000,color:#fff
+classDef agent fill:#8B0000,color:#fff
     classDef tool fill:#189AB4,color:#fff
-
-A PDF-centric workflow where Chat agents interact with vector databases to store and retrieve information from PDF documents, enabling natural conversations and intelligent question-answering capabilities.
-
-```python
-from praisonaiagents import Agent
-
-agent = Agent(
-    name="researcher",
-    instructions="Answer questions using the uploaded PDF",
-    knowledge=True,
-)
-
-agent.start("Summarise chapter 2 of the document")
-```
-
-The user uploads a PDF and asks questions; answers cite the indexed content.
 
 ## Quick Start
 

--- a/docs/features/chat.mdx
+++ b/docs/features/chat.mdx
@@ -10,6 +10,16 @@ icon: "comments"
 PraisonAI Chat is a powerful, modern chat interface designed for AI agent interactions. It provides a beautiful UI for interacting with PraisonAI agents with features like streaming responses, tool call visualization, and session management.
 
 
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="chat-ui", instructions="Help users in the PraisonAI Chat interface.")
+agent.start("Explain what you can do in this session.")
+```
+
+The user types in PraisonAI Chat; the agent streams replies with tool calls and session history visible in the UI.
+
 ```mermaid
 flowchart LR
     In[Input] --> Agent[Agent]

--- a/docs/features/checkpoints.mdx
+++ b/docs/features/checkpoints.mdx
@@ -7,6 +7,16 @@ icon: "clock-rotate-left"
 
 Save and rewind workspace snapshots before agents change files — powered by a shadow git repository.
 
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="coder", instructions="Edit project files safely.")
+agent.start("Refactor the auth module.")
+```
+
+The user runs an agent that edits files; checkpoints snapshot the workspace so you can diff or restore before bad changes land.
+
 ```mermaid
 graph LR
     Agent[🤖 Agent run] --> Save[📸 Auto checkpoint]

--- a/docs/features/chunking-strategies.mdx
+++ b/docs/features/chunking-strategies.mdx
@@ -5,6 +5,22 @@ description: "Document chunking strategies for optimal RAG performance using the
 icon: "scissors"
 ---
 
+PraisonAI integrates [chonkie](https://github.com/chonkie-inc/chonkie) for high-performance document chunking.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="researcher",
+    instructions="Use chunked knowledge for long documents",
+    knowledge=True,
+)
+
+agent.start("Find the section about deployment limits")
+```
+
+The user queries long sources; chunking controls what reaches retrieval.
+
 ```mermaid
 flowchart LR
     Document[Document] --> Agent{Agent}
@@ -33,24 +49,6 @@ flowchart LR
     class D success
 
 ```
-
-```python
-from praisonaiagents import Agent
-
-agent = Agent(
-    name="researcher",
-    instructions="Use chunked knowledge for long documents",
-    knowledge=True,
-)
-
-agent.start("Find the section about deployment limits")
-```
-
-The user queries long sources; chunking controls what reaches retrieval.
-
-    classDef agent fill:#8B0000,color:#fff
-    classDef tool fill:#189AB4,color:#fff
-
 PraisonAI integrates [chonkie](https://github.com/chonkie-inc/chonkie) for high-performance document chunking.
 
 ## Quick Start

--- a/docs/features/clarify-tool.mdx
+++ b/docs/features/clarify-tool.mdx
@@ -4,8 +4,20 @@ sidebarTitle: "Clarify Tool"
 description: "Ask focused clarifying questions when agents need user input to proceed"
 icon: "messages-question"
 ---
-
 Clarify enables agents to pause mid-task and ask focused questions instead of guessing, improving decision accuracy and user control.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="assistant",
+    instructions="Ask clarifying questions when the request is ambiguous",
+)
+
+agent.start("Help me set up monitoring")
+```
+
+The user gives a vague request; the agent uses clarify before acting.
 
 ```mermaid
 graph LR
@@ -27,20 +39,6 @@ graph LR
     class C input
     class D continue
 ```
-
-```python
-from praisonaiagents import Agent
-
-agent = Agent(
-    name="assistant",
-    instructions="Ask clarifying questions when the request is ambiguous",
-)
-
-agent.start("Help me set up monitoring")
-```
-
-The user gives a vague request; the agent uses clarify before acting.
-
 ## Quick Start
 
 <Steps>

--- a/docs/features/claude-memory-tool.mdx
+++ b/docs/features/claude-memory-tool.mdx
@@ -13,6 +13,20 @@ Enable Claude to autonomously store and retrieve information across conversation
 This feature requires Anthropic Claude models and uses the beta header `context-management-2025-06-27`.
 </Note>
 
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="assistant",
+    instructions="Remember user preferences across conversations.",
+    llm="anthropic/claude-sonnet-4-20250514",
+)
+agent.start("What did I tell you about my project last week?")
+```
+
+The user asks across sessions; Claude uses the native memory tool to store and recall facts from `/memories/`.
+
 ```mermaid
 graph LR
     subgraph Claude

--- a/docs/features/cli-backend-protocol.mdx
+++ b/docs/features/cli-backend-protocol.mdx
@@ -17,6 +17,16 @@ agent = Agent(instructions="...", runtime="claude-code")
 ```
 </Warning>
 
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="cli-worker", instructions="Run this turn via an external CLI backend.", runtime="claude-code")
+agent.start("Implement the login form.")
+```
+
+The user runs an agent turn; the CLI backend resolver spawns the external CLI and returns the result through the same Agent API.
+
 CLI Backends let you run an agent's turn through an external CLI tool (like Claude Code) instead of a Python LLM client, while keeping the same `Agent`/`Task` API.
 
 ```mermaid

--- a/docs/features/cli-budget-handling.mdx
+++ b/docs/features/cli-budget-handling.mdx
@@ -7,6 +7,16 @@ icon: "wallet"
 
 When a `praisonai` CLI run goes over its budget, you get a clean error message and exit-code `1` — no Python traceback.
 
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="Stay within budget on every LLM call.")
+agent.start("Summarise this document.")
+```
+
+The user runs `praisonai` from the terminal; when the agent exceeds its budget cap, the CLI exits with a clean message instead of a traceback.
+
 ```mermaid
 graph LR
     subgraph "CLI Budget Guard"

--- a/docs/features/cli-command-lazy-dispatch.mdx
+++ b/docs/features/cli-command-lazy-dispatch.mdx
@@ -7,6 +7,16 @@ icon: "bolt"
 
 Sub-commands load on demand — only the module you actually use is imported, so every `praisonai` invocation starts in milliseconds regardless of how many commands exist.
 
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="You are a helpful CLI assistant.")
+agent.start("Hello from a fast-starting CLI session.")
+```
+
+The user runs `praisonai chat`; only the chat module loads, so startup stays fast even with many subcommands installed.
+
 ```mermaid
 graph LR
     A[📝 You run<br/>praisonai chat] --> B{🔍 Sub-command?}

--- a/docs/features/cli-configuration.mdx
+++ b/docs/features/cli-configuration.mdx
@@ -7,6 +7,16 @@ icon: "gear"
 
 The `praisonai` CLI reads defaults from a layered hierarchy so you can set a model once and have it work everywhere — globally, per project, or per command.
 
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="assistant", instructions="Use project defaults from .praisonai/config.yaml.")
+agent.start("What model am I using?")
+```
+
+The user sets a default model in config once; every `praisonai` command in that project picks it up without repeating flags.
+
 ```mermaid
 graph TB
     subgraph "Configuration Precedence (highest wins)"

--- a/docs/features/cli-direct-prompt.mdx
+++ b/docs/features/cli-direct-prompt.mdx
@@ -12,6 +12,7 @@ agent = Agent(name="cli-agent", instructions="Process CLI prompts directly.")
 agent.start("Answer: What is the capital of France?")
 ```
 
+The user passes a bare prompt to `praisonai`; the dispatcher runs a one-shot agent without YAML or a subcommand.
 
 Run an agent with a single bare command — the fastest way to get something done.
 

--- a/docs/features/cli-dispatcher.mdx
+++ b/docs/features/cli-dispatcher.mdx
@@ -12,6 +12,7 @@ agent = Agent(name="dispatcher", instructions="Dispatch CLI commands to the righ
 agent.start("Run the deploy command with the staging environment.")
 ```
 
+The user types `praisonai …`; the dispatcher routes to Typer subcommands, version flags, or the legacy prompt path.
 
 PraisonAI picks one of five paths based on what you type — and adding a new subcommand means it Just Works.
 

--- a/docs/features/cli-oauth-login.mdx
+++ b/docs/features/cli-oauth-login.mdx
@@ -19,6 +19,8 @@ agent = Agent(
 agent.start("What is the weather like today?")
 ```
 
+The user runs `praisonai auth login`; OAuth tokens are stored and refreshed so agents call the provider without pasting API keys.
+
 ```mermaid
 graph LR
     subgraph "OAuth Login Flow"

--- a/docs/features/cli.mdx
+++ b/docs/features/cli.mdx
@@ -12,6 +12,7 @@ agent = Agent(name="cli-assistant", instructions="Help users with CLI commands."
 agent.start("List all available praisonai CLI commands.")
 ```
 
+The user runs a `praisonai` command in the terminal; the CLI loads config and drives the agent to completion.
 
 ```mermaid
 flowchart LR

--- a/docs/features/cloud-databases.mdx
+++ b/docs/features/cloud-databases.mdx
@@ -7,6 +7,19 @@ icon: "cloud-sql"
 
 PraisonAI supports cloud-native serverless databases that automatically scale to zero when idle, reducing costs for bursty AI agent workloads.
 
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="data-agent",
+    instructions="Persist session state to a serverless database.",
+)
+agent.start("Save this conversation to Neon.")
+```
+
+The user connects a serverless database URL; PraisonAI detects the provider and uses scale-to-zero persistence for bursty agent workloads.
+
 ```mermaid
 graph LR
     subgraph "Cloud-Native Database Flow"

--- a/docs/features/cloud-provider-registry.mdx
+++ b/docs/features/cloud-provider-registry.mdx
@@ -7,6 +7,16 @@ icon: "cloud"
 
 Deploy your agent to AWS, Azure or GCP with the same command — swap providers by name.
 
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="deploy", instructions="Package this agent for cloud deployment.")
+agent.start("Deploy to AWS with the default registry entry.")
+```
+
+The user picks AWS, Azure, or GCP by name; the registry resolves the same deploy command to the right cloud backend.
+
 ```mermaid
 graph LR
     A[Agent / deploy config] --> B[CloudProviderRegistry]


### PR DESCRIPTION
## Summary

- Adds hero **user-interaction flow** lines (and agent-centric openers where missing) on **20** `docs/features/*.mdx` pages for #1351 (alphabetically after `caching`).
- No `docs/concepts/` edits.

## AGENTS.md rules

- §1.1(9–10) agent-centric opening and user-interaction flow

## Gap metrics (`docs/features/`)

| Heuristic | Before | After |
|-----------|--------|-------|
| User-flow gaps (no `The user` / User Interaction Flow in hero before first mermaid fence) | 413 | 393 |

Verified on `main` vs branch with the same Python heuristic used in batches 5–6.

## Pages

callbacks, camera-integration, channel-capabilities, channels-gateway, chat-with-pdf, chat, checkpoints, chunking-strategies, clarify-tool, claude-memory-tool, cli-backend-protocol, cli-budget-handling, cli-command-lazy-dispatch, cli-configuration, cli-direct-prompt, cli-dispatcher, cli-oauth-login, cli, cloud-databases, cloud-provider-registry

## Test plan

- [x] `python3 -m json.tool docs.json` valid
- [x] No edits under `docs/concepts/`

Refs #1351

Made with [Cursor](https://cursor.com)