### PR TITLE
docs: AGENTS alignment batch 18 (features, #1351)

### DIFF
--- a/docs/features/multimodal.mdx
+++ b/docs/features/multimodal.mdx
@@ -7,6 +7,19 @@ icon: "images"
 
 Multimodal agents process text, images, and video in a single workflow — attach media to tasks or pass ephemeral attachments at chat time.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="VisionAnalyst",
+    instructions="Analyse images and video and describe what you see.",
+    llm="gpt-4o-mini",
+)
+agent.start("Describe the landmark in this image.")
+```
+
+The user attaches media; the agent returns a single analysis covering text and visuals.
+
 ```mermaid
 graph LR
     subgraph "Multimodal Agent"

--- a/docs/features/multitool-hermes-only-tools.mdx
+++ b/docs/features/multitool-hermes-only-tools.mdx
@@ -7,6 +7,21 @@ icon: "filter"
 
 Multi-environment agent setups create tool conflicts when different capabilities overlap or shadow each other. HERMES_ONLY_TOOLS provides deterministic tool filtering for production deployments.
 
+```python
+import os
+from praisonaiagents import Agent
+
+os.environ["HERMES_ONLY_TOOLS"] = "web_search,send_email"
+agent = Agent(
+    name="Focused Agent",
+    instructions="Use only whitelisted tools.",
+    tools=["web_search", "send_email", "file_read"],
+)
+agent.start("Search the web and email a summary.")
+```
+
+The user runs a multi-tool agent; HERMES_ONLY_TOOLS keeps the exposed tool set deterministic.
+
 ```mermaid
 graph LR
     subgraph "Tool Collision Problem"

--- a/docs/features/n8n-api.mdx
+++ b/docs/features/n8n-api.mdx
@@ -15,6 +15,8 @@ agent.start("Trigger the n8n lead-processing workflow for this new contact.")
 
 The n8n API integration enables n8n workflows to invoke PraisonAI agents via HTTP endpoints, allowing bidirectional automation between the platforms.
 
+The user triggers an n8n workflow; HTTP nodes call PraisonAI agents and return structured responses.
+
 ```mermaid
 graph LR
     subgraph "n8n → PraisonAI API Flow"

--- a/docs/features/n8n-integration.mdx
+++ b/docs/features/n8n-integration.mdx
@@ -4,8 +4,21 @@ sidebarTitle: "n8n"
 description: "Bidirectional workflow automation between PraisonAI and n8n"
 icon: "diagram-project"
 ---
-
 n8n integration enables bidirectional workflow automation, connecting PraisonAI agents to n8n's 400+ integrations including Slack, Gmail, Notion, databases, and APIs.
+
+```python
+from praisonaiagents import Agent
+from praisonai_tools.n8n import n8n_workflow
+
+agent = Agent(
+    name="automation-agent",
+    instructions="Execute n8n workflows for automation tasks",
+    tools=[n8n_workflow],
+)
+agent.start("Send a Slack message to #general saying Hello!")
+```
+
+The user asks the agent to automate a task; the agent invokes n8n workflows and integrations on their behalf.
 
 ```mermaid
 graph LR

--- a/docs/features/n8n-tools.mdx
+++ b/docs/features/n8n-tools.mdx
@@ -4,8 +4,21 @@ sidebarTitle: "n8n Tools"
 description: "Execute n8n workflows from PraisonAI agents"
 icon: "wrench"
 ---
-
 n8n tools enable PraisonAI agents to execute n8n workflows, providing access to 400+ integrations including Slack, Gmail, Notion, databases, and APIs.
+
+```python
+from praisonaiagents import Agent
+from praisonai_tools.n8n import n8n_workflow
+
+agent = Agent(
+    name="automation-agent",
+    instructions="Execute n8n workflows for automation tasks",
+    tools=[n8n_workflow],
+)
+agent.start("Execute the slack-notify workflow to send a welcome message")
+```
+
+The user describes an automation goal; the agent runs the matching n8n workflow and returns integration results.
 
 ```mermaid
 graph LR

--- a/docs/features/n8n-visual-editor.mdx
+++ b/docs/features/n8n-visual-editor.mdx
@@ -15,6 +15,8 @@ agent.start("Build a workflow that sends a Slack message when a form is submitte
 
 The n8n Visual Workflow Editor converts PraisonAI YAML workflows to n8n format, enabling visual editing and execution through n8n's drag-and-drop interface.
 
+The user exports a YAML workflow, edits it visually in n8n, and syncs changes back to PraisonAI.
+
 ```mermaid
 graph LR
     subgraph "Visual Editor Workflow"

--- a/docs/features/neon.mdx
+++ b/docs/features/neon.mdx
@@ -4,8 +4,20 @@ sidebarTitle: "Neon"
 description: "Scale-to-zero PostgreSQL with automatic branching and instant provisioning"
 icon: "leaf"
 ---
-
 Neon provides serverless PostgreSQL with automatic scaling, branching, and point-in-time recovery for your AI agents.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Neon Agent",
+    instructions="You are a helpful assistant with persistent memory.",
+    db={"database_url": "postgresql://user:pass@ep-xxx.neon.tech/db?sslmode=require"},
+)
+agent.start("Remember that I work at TechCorp as a developer")
+```
+
+The user chats with an agent; Neon wakes on demand, stores session state, and scales to zero when idle.
 
 ```mermaid
 graph LR

--- a/docs/features/non-fatal-errors.mdx
+++ b/docs/features/non-fatal-errors.mdx
@@ -7,6 +7,16 @@ icon: "triangle-exclamation"
 
 Non-fatal errors expose callback and memory failures that used to be silently swallowed, so your agent can see what went wrong without crashing the workflow.
 
+```python
+from praisonaiagents import Agent, Task, PraisonAIAgents
+
+agent = Agent(name="Reporter", instructions="Summarise the input.")
+task = Task(description="Summarise 'hello'", agent=agent)
+PraisonAIAgents(agents=[agent], tasks=[task]).start()
+```
+
+The user runs a workflow; callback or memory failures surface on the task output without stopping the run.
+
 <Note>
 **Important Change**: LLM errors are no longer non-fatal by default. They now raise `LLMError` exceptions instead of being captured as non-fatal errors. See [Structured LLM Errors](/features/structured-llm-errors) for details.
 </Note>

--- a/docs/features/observability-hooks.mdx
+++ b/docs/features/observability-hooks.mdx
@@ -18,6 +18,8 @@ agent.start("Process this request and emit trace events.")
 
 Observability Hooks provide a centralized entry and exit point for observability providers (AgentOps, future Langfuse, W&B) in PraisonAI and custom framework adapters.
 
+The user starts an orchestrated run; init and finalize hooks emit traces to AgentOps and other providers.
+
 ```mermaid
 graph LR
     A[🚀 Orchestrator] --> B[🪝 init_observability]

--- a/docs/features/ocr.mdx
+++ b/docs/features/ocr.mdx
@@ -7,6 +7,17 @@ icon: "file-lines"
 
 Extract text from PDFs and images with `OCRAgent` — pass a URL or base64 source and get markdown-ready text back.
 
+```python
+from praisonaiagents import Agent, OCRAgent
+
+ocr = OCRAgent()
+text = ocr.read("https://arxiv.org/pdf/2201.04234")
+agent = Agent(name="Reader", instructions="Summarise documents clearly.")
+agent.start(f"Summarise this paper:\n\n{text[:4000]}")
+```
+
+The user supplies a document URL; OCR extracts text and the agent summarises it.
+
 ```mermaid
 graph LR
     D[Document URL] --> O[OCRAgent]

--- a/docs/features/onboard.mdx
+++ b/docs/features/onboard.mdx
@@ -15,6 +15,8 @@ agent.start("Set up my PraisonAI environment with default settings.")
 
 Interactive wizard that configures messaging bots and automatically installs the daemon service to run them in the background.
 
+The user runs the wizard, picks a channel, and the daemon installs so bots stay online.
+
 ```mermaid
 graph LR
     User[👤 User] --> Wizard[🧙 Onboard Wizard]

--- a/docs/features/openai-compatible-server.mdx
+++ b/docs/features/openai-compatible-server.mdx
@@ -19,6 +19,8 @@ agent.start("Process this chat completion request.")
 
 `praisonai serve openai` starts a FastAPI server that exposes OpenAI-compatible HTTP endpoints — point any existing OpenAI SDK code at it and it works as a drop-in replacement.
 
+The user points an OpenAI SDK client at the server; chat completions route to your PraisonAI agent.
+
 ```mermaid
 graph LR
     subgraph "OpenAI-Compatible Server"

--- a/docs/features/openai-quickstart.mdx
+++ b/docs/features/openai-quickstart.mdx
@@ -4,8 +4,19 @@ sidebarTitle: "OpenAI Quickstart"
 description: "Complete OpenAI onboarding guide for all platforms - Windows, macOS, and Linux"
 icon: "bolt"
 ---
-
 Get started with PraisonAI and OpenAI in under 5 minutes, with instructions that work on Windows, macOS, and Linux.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    instructions="You are a helpful AI assistant.",
+)
+agent.start("What is the capital of France?")
+```
+
+The user installs PraisonAI, sets an API key, and runs their first agent in one session.
 
 ```mermaid
 graph LR

--- a/docs/features/optimizer-cli.mdx
+++ b/docs/features/optimizer-cli.mdx
@@ -15,6 +15,8 @@ agent.start("Optimise this agent's system prompt for better accuracy.")
 
 Configure context optimization behaviour via CLI flags and interactive commands.
 
+The user chats in the CLI; context flags compact history before the model hits token limits.
+
 ```mermaid
 graph LR
     subgraph "Optimizer CLI"

--- a/docs/features/optimizer.mdx
+++ b/docs/features/optimizer.mdx
@@ -21,6 +21,8 @@ agent = Agent(
 response = agent.chat("Hello!")
 ```
 
+The user keeps chatting; the optimizer compacts context automatically when usage nears the model limit.
+
 ## Which Strategy Should I Pick?
 
 ```mermaid

--- a/docs/features/orchestrator-worker.mdx
+++ b/docs/features/orchestrator-worker.mdx
@@ -5,6 +5,21 @@ description: "Learn how to create AI agents that orchestrate and distribute task
 icon: "sitemap"
 ---
 
+A workflow with a central orchestrator directing multiple worker LLMs to perform subtasks, synthesizing their outputs for complex, coordinated operations.
+
+```python
+from praisonaiagents import Agent, AgentFlow
+
+orchestrator = Agent(
+    name="Orchestrator",
+    instructions="Route each task to the research, code, or writing worker.",
+)
+flow = AgentFlow(start=orchestrator)
+flow.start("Research AI trends and draft a one-page summary.")
+```
+
+The user submits a complex task; the orchestrator routes subtasks to workers and synthesises the final answer.
+
 ```mermaid
 flowchart LR
     In[In] --> Router[LLM Call Router]
@@ -22,8 +37,6 @@ flowchart LR
     class In,Out agent
     class Router,LLM1,LLM2,LLM3,Synthesizer process
 ```
-
-A workflow with a central orchestrator directing multiple worker LLMs to perform subtasks, synthesizing their outputs for complex, coordinated operations.
 
 ## Quick Start
 

--- a/docs/features/outbound-media-delivery.mdx
+++ b/docs/features/outbound-media-delivery.mdx
@@ -7,6 +7,18 @@ icon: "photo-film"
 
 Agents can now return images, charts, and files that are automatically delivered through the bot adapter's native upload primitive — Telegram `send_photo`, Slack `files_upload_v2`, Discord file send, and more.
 
+```python
+from praisonaiagents import Agent
+
+chart_agent = Agent(
+    name="ChartAgent",
+    instructions="Generate charts and return file paths in the media field.",
+)
+chart_agent.start("Draw a sales chart for Q1 and send it to the user.")
+```
+
+The user messages the bot; generated images and files upload through the channel adapter automatically.
+
 <Note>
 Outbound media delivery uses the same `OutboundResilienceMixin` now applied to all six channels: Slack, Discord, WhatsApp, Email, Linear, AgentMail, and Telegram. See [Durable Delivery](/docs/features/durable-delivery) for retry and crash-safe persistence.
 </Note>

--- a/docs/features/outbound-resilience.mdx
+++ b/docs/features/outbound-resilience.mdx
@@ -7,6 +7,20 @@ icon: "shield"
 
 Outbound Resilience makes sure your agent's reply actually reaches the user on every channel, retrying transient send errors and parking permanently-failed replies in a DLQ for later replay.
 
+```python
+from praisonaiagents import Agent
+from praisonai.bots import SlackBot
+
+agent = Agent(
+    name="Support Bot",
+    instructions="Answer customer questions politely.",
+)
+bot = SlackBot(token="xoxb-...", agent=agent)
+bot.start()
+```
+
+The user sends a message on Slack; transient send failures retry with backoff until the reply is delivered or parked in the DLQ.
+
 ```mermaid
 graph LR
     subgraph "Outbound Resilience"

--- a/docs/features/output-styles.mdx
+++ b/docs/features/output-styles.mdx
@@ -18,6 +18,8 @@ agent = Agent(
 result = agent.start("What is the capital of France?")
 ```
 
+The user runs the agent; output presets control whether responses stay silent, stream, or show status lines.
+
 ```mermaid
 graph LR
     subgraph "Output Styles"


### PR DESCRIPTION
## Summary

Alignment sweep for **batch 18** (~20 `docs/features/*.mdx` pages after the batch 17 slice: `multimodal.mdx` through `output-styles.mdx`):

- Hero **user-interaction flow** lines before Mermaid
- **Agent-centric openers** where missing
- Hero reorder on `neon`, `openai-quickstart`, and `orchestrator-worker`

Refs #1351. **No `docs/concepts/` changes.**

| File | Changes |
|------|---------|
| `multimodal.mdx` | Agent opener + user flow |
| `multitool-hermes-only-tools.mdx` | Agent opener + user flow |
| `n8n-api.mdx` | User flow |
| `n8n-integration.mdx` | Agent opener + user flow |
| `n8n-tools.mdx` | Agent opener + user flow |
| `n8n-visual-editor.mdx` | User flow |
| `neon.mdx` | Agent opener + user flow + reorder |
| `nested-workflows.mdx` | Already compliant (unchanged) |
| `non-fatal-errors.mdx` | Agent opener + user flow |
| `observability-hooks.mdx` | User flow |
| `ocr.mdx` | Agent opener + user flow |
| `onboard.mdx` | User flow |
| `openai-compatible-server.mdx` | User flow |
| `openai-quickstart.mdx` | Agent opener + user flow + reorder |
| `optimizer-cli.mdx` | User flow |
| `optimizer.mdx` | User flow |
| `orchestrator-worker.mdx` | Agent opener + user flow + reorder |
| `outbound-media-delivery.mdx` | Agent opener + user flow |
| `outbound-resilience.mdx` | Agent opener + user flow |
| `output-styles.mdx` | User flow |

## AGENTS.md rules

- §1.1(9–10) agent-centric opener + user-interaction flow
- §3.3 hero Mermaid preserved
- §6.3 forbidden phrases — grep clean on touched files
- §1.9 `concepts/` — not modified

## Gap counts (batch 18 slice)

| Gap | Before | After |
|-----|--------|-------|
| Missing user flow before hero mermaid | 19 | 0 |
| Missing agent opener before hero mermaid | 8 | 0 |
| Hero python after mermaid | 2 | 0 |

**Repo-wide user-flow gap (features with Mermaid):** 244 → **225** (−19).

## Test plan

- [x] `python3 -c "import json; json.load(open('docs.json'))"`
- [x] Batch slice audit (20 files, 19 edited)
- [x] No `from praisonaiagents.workflows` in batch


Made with [Cursor](https://cursor.com)