### PR TITLE
docs: AGENTS alignment batch 21 (features, #1351)

### DIFF
--- a/docs/features/protected-paths.mdx
+++ b/docs/features/protected-paths.mdx
@@ -21,6 +21,9 @@ agent.start("Append 'test' to /etc/passwd")
 # Tool returns: Path '/etc/passwd' is protected
 ```
 
+The user asks the agent to change files; protected-path rules block dangerous writes before the tool runs.
+
+
 ```mermaid
 graph LR
     T[Tool call] --> C{Protected?}

--- a/docs/features/push-notifications.mdx
+++ b/docs/features/push-notifications.mdx
@@ -27,6 +27,9 @@ await client.subscribe("alerts")
 await client.wait_closed()
 ```
 
+The user subscribes to a channel; push events arrive over WebSocket and the agent summarises each message.
+
+
 <Note>
 `PushClient` ships in the `praisonai` wrapper (`pip install praisonai`). Core `praisonaiagents.push` exports protocols and `ChannelMessage` only.
 </Note>

--- a/docs/features/quality-based-rag.mdx
+++ b/docs/features/quality-based-rag.mdx
@@ -24,6 +24,9 @@ agent = Agent(
 agent.start("What are the key product features?")
 ```
 
+The user asks a question; retrieval scores and filters chunks before the agent answers from high-quality sources.
+
+
 ```mermaid
 graph LR
     Q[Query] --> R[Retrieve]

--- a/docs/features/quality-checking.mdx
+++ b/docs/features/quality-checking.mdx
@@ -26,6 +26,9 @@ task = Task(
 AgentTeam(agents=[agent], tasks=[task]).start()
 ```
 
+The user runs a team task; quality scoring decides whether outputs land in long-term memory.
+
+
 ```mermaid
 graph LR
     T[Task output] --> A[Assess]

--- a/docs/features/rag-scoping.mdx
+++ b/docs/features/rag-scoping.mdx
@@ -20,6 +20,9 @@ agent = Agent(
 agent.start("What was the status of my refund request?")
 ```
 
+The user asks in a scoped session; retrieval filters by tenant and user so answers stay isolated.
+
+
 ```mermaid
 graph LR
     Q[Query + scopes] --> S[Vector search]

--- a/docs/features/rag.mdx
+++ b/docs/features/rag.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("What is KAG in one line?")
 ```
 
+The user asks from their documents; the agent retrieves relevant chunks and grounds the reply.
+
+
 ```mermaid
 graph LR
     D[Documents] --> V[(Vector DB)]

--- a/docs/features/rate-limiter.mdx
+++ b/docs/features/rate-limiter.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("Summarise the latest Mars rover news")
 ```
 
+The user runs agents at scale; the limiter queues or throttles LLM calls so quotas are not exceeded.
+
+
 <Note>
 For **bot/messaging rate limiting** (Telegram, Discord, Slack), see [Bot Rate Limiting](/docs/features/bot-rate-limiting). This page covers **LLM API** rate limiting.
 </Note>

--- a/docs/features/real-api-testing.mdx
+++ b/docs/features/real-api-testing.mdx
@@ -26,6 +26,9 @@ def test_agent_simple_chat():
     assert len(response) > 0
 ```
 
+The developer sets `RUN_REAL_KEY_TESTS=1`; pytest runs a real agent chat against live provider keys.
+
+
 ```mermaid
 graph LR
     E[RUN_REAL_KEY_TESTS=1] --> G{Gate}

--- a/docs/features/reasoning-extract.mdx
+++ b/docs/features/reasoning-extract.mdx
@@ -34,6 +34,9 @@ team = AgentTeam(
 team.start()
 ```
 
+The user asks a hard question; a reasoner thinks step-by-step and an extractor returns a concise answer.
+
+
 ```mermaid
 graph LR
     I[Input] --> R[Reasoner]

--- a/docs/features/reasoning.mdx
+++ b/docs/features/reasoning.mdx
@@ -18,6 +18,9 @@ agent = Agent(
 agent.start("Analyse the pros and cons of electric vehicles")
 ```
 
+The user poses a complex problem; the agent reasons step-by-step before responding.
+
+
 ```mermaid
 graph LR
     subgraph "Reasoning Flow"

--- a/docs/features/recipe-registry.mdx
+++ b/docs/features/recipe-registry.mdx
@@ -12,6 +12,9 @@ agent = Agent(name="recipe-agent", instructions="Use recipes from the recipe reg
 agent.start("Load the customer-support recipe and start handling tickets.")
 ```
 
+The user pulls a published recipe bundle and the agent runs that workflow for their request.
+
+
 
 Publish and share `.praison` recipe bundles from a local folder or remote HTTP registry.
 

--- a/docs/features/recipe-serve-advanced.mdx
+++ b/docs/features/recipe-serve-advanced.mdx
@@ -12,6 +12,9 @@ agent = Agent(name="recipe-server", instructions="Serve advanced recipes as HTTP
 agent.start("Serve the data-analysis recipe on port 8000.")
 ```
 
+The user calls a hardened recipe HTTP endpoint; rate limits, metrics, and auth guard production traffic.
+
+
 
 Harden a recipe HTTP server with rate limits, Prometheus metrics, admin reload, and distributed tracing.
 

--- a/docs/features/recipe-serve-code.mdx
+++ b/docs/features/recipe-serve-code.mdx
@@ -12,6 +12,9 @@ agent = Agent(name="code-recipe-agent", instructions="Execute code-based recipes
 agent.start("Run the code-generation recipe to scaffold a new FastAPI project.")
 ```
 
+The user hits the recipe server over HTTP; Python `serve()` config controls auth, CORS, and ports.
+
+
 
 Expose recipe workflows over HTTP — configure auth, CORS, and deployment from Python or YAML.
 

--- a/docs/features/recursive-context.mdx
+++ b/docs/features/recursive-context.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("Analyse 5000 tickets and count billing issues")
 ```
 
+The user requests analysis on huge data; the agent stores artifacts and delegates instead of overfilling context.
+
+
 ```mermaid
 graph LR
     subgraph "Recursive Context"

--- a/docs/features/reflection.mdx
+++ b/docs/features/reflection.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("Explain how TCP/IP handshakes work.")
 ```
 
+The user asks a question; the agent drafts, self-reviews, and refines before returning the final answer.
+
+
 ```mermaid
 graph LR
     subgraph "Reflection Flow"

--- a/docs/features/registry-dependency-injection.mdx
+++ b/docs/features/registry-dependency-injection.mdx
@@ -12,6 +12,9 @@ agent = Agent(name="di-agent", instructions="Use dependency injection via the ag
 agent.start("Resolve and inject the database service for this task.")
 ```
 
+The user runs generation with a custom adapter registry so tenants or tests stay isolated.
+
+
 
 Inject a custom adapter registry when you need tenant isolation, parallel test safety, or per-run plugin overrides.
 

--- a/docs/features/relay-transport.mdx
+++ b/docs/features/relay-transport.mdx
@@ -7,6 +7,19 @@ icon: "arrow-left-right"
 
 A relay transport lets a lightweight **connector** process own the Telegram/Discord/WhatsApp socket while a separate **headless gateway** handles all agent logic — enabling NAT-friendly hosting, one gateway fronting many connectors, and lossless scale-to-zero.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Support",
+    instructions="Answer messages routed from the connector gateway.",
+)
+
+agent.start("Summarise this inbound chat thread")
+```
+
+The user messages on a chat platform; the connector relays events to a private gateway that runs the agent.
+
 ```mermaid
 graph LR
     subgraph "Connector (public)"

--- a/docs/features/reliability.mdx
+++ b/docs/features/reliability.mdx
@@ -28,6 +28,9 @@ workflow = PraisonAIAgents(
 workflow.start()
 ```
 
+The user starts a workflow; retries, timeouts, and failure policies keep flaky LLM or callback errors from aborting the run.
+
+
 ```mermaid
 graph LR
     subgraph "Agent Reliability Flow"

--- a/docs/features/repetitive.mdx
+++ b/docs/features/repetitive.mdx
@@ -26,6 +26,9 @@ workflow = AgentFlow(
 result = workflow.start("Research and summarise these AI topics")
 ```
 
+The user supplies a list of items; the workflow loops the agent over each entry then summarises results.
+
+
 ```mermaid
 graph LR
     In[Input] --> LoopAgent[Looping Agent]

--- a/docs/features/replay.mdx
+++ b/docs/features/replay.mdx
@@ -12,6 +12,9 @@ agent = Agent(name="replay-agent", instructions="Replay recorded agent sessions 
 agent.start("Replay the session from yesterday to reproduce the bug.")
 ```
 
+The user saves a trace during a run, then steps through recorded context events to debug handoffs and tools.
+
+
 
 Record agent context events during a run, then step through them interactively to debug handoffs, tool calls, and token growth.
 


### PR DESCRIPTION
## Summary
- Adds hero **user-interaction flow** sentences (§1.1(10)) on the 20-file slice **protected-paths → replay** (after batch 20).
- Adds **agent-centric opener** on `relay-transport.mdx` (§1.1(9)), which previously jumped straight to Mermaid.

Refs #1351

## Checklist (AGENTS.md)
- [x] Agent-centric code before hero diagram where missing (`relay-transport`)
- [x] User-interaction flow sentence after hero opener on all 20 pages
- [x] No `docs/concepts/` edits
- [x] No forbidden phrases in touched files
- [x] `docs.json` validates

## Files (20)
protected-paths, push-notifications, quality-based-rag, quality-checking, rag-scoping, rag, rate-limiter, real-api-testing, reasoning-extract, reasoning, recipe-registry, recipe-serve-advanced, recipe-serve-code, recursive-context, reflection, registry-dependency-injection, relay-transport, reliability, repetitive, replay

## Test plan
- [x] Spot-check Mintlify structure (Steps / mermaid fences intact)
- [x] `python3 -m json.tool docs.json`


Made with [Cursor](https://cursor.com)