### PR TITLE
docs: AGENTS alignment batch 19 (features, #1351)

### DIFF
--- a/docs/features/output.mdx
+++ b/docs/features/output.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("Explain how neural networks learn.")
 ```
 
+
+The user runs the agent; output mode controls how much detail prints or streams during the run.
+
 ```mermaid
 graph LR
     subgraph "Output Modes"

--- a/docs/features/pairing-protocols.mdx
+++ b/docs/features/pairing-protocols.mdx
@@ -5,6 +5,8 @@ description: "Plug in your own auth, pairing store, or session binding using run
 icon: "plug"
 ---
 
+Plug custom auth, pairing stores, or session binding into your gateway via runtime-checkable Protocols.
+
 ```python
 from praisonaiagents import Agent
 
@@ -12,8 +14,7 @@ agent = Agent(name="pairing-agent", instructions="Use pairing protocols for agen
 agent.start("Pair this conversation session with a specialist agent.")
 ```
 
-
-Plug custom auth, pairing stores, or session binding into your gateway via runtime-checkable Protocols.
+The user pairs through the gateway; custom Protocol implementations back auth, pairing codes, and session binding.
 
 ```python
 from praisonaiagents.gateway.protocols import PairingProtocol

--- a/docs/features/panel-llm.mdx
+++ b/docs/features/panel-llm.mdx
@@ -22,6 +22,9 @@ agent = Agent(
 agent.start("Which SSD is faster, X or Y, and why?")
 ```
 
+
+The user asks a tough question; reference models consult first, then the aggregator answers with tools.
+
 ```mermaid
 graph LR
     User["👤 User"] --> Agent["🤖 Agent"]

--- a/docs/features/parallelisation.mdx
+++ b/docs/features/parallelisation.mdx
@@ -21,6 +21,9 @@ workflow = AgentFlow(steps=[
 result = workflow.start("Research AI trends")
 ```
 
+
+The user sends one request; parallel agents run at the same time before an aggregator merges results.
+
 ```mermaid
 graph LR
     In["Input"] --> A1["Agent 1"]

--- a/docs/features/per-chat-session-scope.mdx
+++ b/docs/features/per-chat-session-scope.mdx
@@ -4,6 +4,7 @@ sidebarTitle: "Per-Chat Sessions"
 description: "Share one transcript across a group with sender attribution"
 icon: "users"
 ---
+In group chats, share one transcript across all participants — each message prefixed with the sender's name.
 
 ```python
 from praisonaiagents import Agent
@@ -15,8 +16,7 @@ agent = Agent(
 agent.start("This is a new session — remember nothing from before.")
 ```
 
-
-In group chats, share one transcript across all participants — each message prefixed with the sender's name.
+The user messages in a group chat; everyone shares one transcript with sender names attached.
 
 ```yaml
 # gateway.yaml

--- a/docs/features/performance-benchmarks.mdx
+++ b/docs/features/performance-benchmarks.mdx
@@ -15,6 +15,9 @@ agent = Agent(name="Bench", instructions="You are helpful.")
 result = agent.start("Say hello in one word")
 ```
 
+
+The user runs a lightweight agent; benchmarks verify import time and lazy-loading stay within targets.
+
 ```mermaid
 graph LR
     subgraph "Performance Checks"

--- a/docs/features/permissions.mdx
+++ b/docs/features/permissions.mdx
@@ -28,6 +28,9 @@ agent = Agent(
 agent.start("List files in the project root")
 ```
 
+
+The user prompts the agent; permission rules allow, deny, or ask before each tool executes.
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Check{Permission Check}

--- a/docs/features/persistence-backend-plugins.mdx
+++ b/docs/features/persistence-backend-plugins.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("Hello — save this conversation")
 ```
 
+
+The user chats with the agent; registered plugins persist conversations, knowledge, and state.
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Registry[📝 StoreRegistry]

--- a/docs/features/persistence-clickhouse.mdx
+++ b/docs/features/persistence-clickhouse.mdx
@@ -22,6 +22,9 @@ agent = Agent(
 agent.start("Summarise our refund policy")
 ```
 
+
+The user asks from your knowledge base; ClickHouse vector search retrieves relevant chunks at scale.
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Knowledge[📚 Knowledge]

--- a/docs/features/persistence-conversation-mysql.mdx
+++ b/docs/features/persistence-conversation-mysql.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("Hello — save this conversation")
 ```
 
+
+The user continues a thread; MySQL stores messages with connection pooling and auto schema.
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Store[🗃️ MySQL Store]

--- a/docs/features/persistence-json.mdx
+++ b/docs/features/persistence-json.mdx
@@ -18,6 +18,9 @@ agent = Agent(
 agent.start("Hello — this conversation is saved to JSON files")
 ```
 
+
+The user chats locally; JSON files persist the session without installing a database.
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Store[📄 Session Store]

--- a/docs/features/persistence-mongodb.mdx
+++ b/docs/features/persistence-mongodb.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("Store my preferences in MongoDB state")
 ```
 
+
+The user sets preferences; MongoDB stores flexible agent state as documents.
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Store[🍃 MongoDB State]

--- a/docs/features/persistence-mysql.mdx
+++ b/docs/features/persistence-mysql.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("Hello — save this to MySQL")
 ```
 
+
+The user resumes a session; MySQL persists the full conversation history.
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Store[🗃️ MySQL Store]

--- a/docs/features/persistence-postgres.mdx
+++ b/docs/features/persistence-postgres.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("Hello — save this to PostgreSQL")
 ```
 
+
+The user talks to production agents; PostgreSQL stores conversations with JSONB metadata.
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Store[🗃️ Postgres Store]

--- a/docs/features/persistence-redis.mdx
+++ b/docs/features/persistence-redis.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("Store my preferences in Redis")
 ```
 
+
+The user updates session state; Redis serves fast reads while SQL can hold conversation history.
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Store[📦 Redis State]

--- a/docs/features/persistence-sqlite.mdx
+++ b/docs/features/persistence-sqlite.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("Hello — saved to SQLite")
 ```
 
+
+The user develops locally; SQLite writes conversations to a single file on disk.
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Store[💬 Conversation Store]

--- a/docs/features/persistence.mdx
+++ b/docs/features/persistence.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("Hello — saved automatically")
 ```
 
+
+The user returns later; the configured backend restores conversation history and agent state.
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Conv[💬 Conversations]

--- a/docs/features/planning-mode.mdx
+++ b/docs/features/planning-mode.mdx
@@ -18,6 +18,9 @@ agent = Agent(
 agent.start("Research AI trends in 2025 and write a summary")
 ```
 
+
+The user requests complex work; the agent drafts a reviewable plan before executing changes.
+
 ```mermaid
 graph LR
     subgraph "Planning Phase"

--- a/docs/features/planning.mdx
+++ b/docs/features/planning.mdx
@@ -19,6 +19,9 @@ agent = Agent(
 agent.start("Research the top 5 electric vehicle manufacturers and compare their market share.")
 ```
 
+
+The user asks a multi-step question; the agent creates a plan first, then executes each step.
+
 ```mermaid
 graph LR
     subgraph "Planning Flow"


### PR DESCRIPTION
## Summary
- Aligns 20 feature pages (sorted slice **output** → **planning**, after `output-styles`) with AGENTS.md §1.1(9–10).
- Adds **user-interaction flow** sentences between agent-centric openers and hero Mermaid diagrams.
- Reorders hero on **pairing-protocols** and **per-chat-session-scope** (intro → `Agent` opener → flow → diagram).
- **permission-modes** already complied; unchanged.

Refs #1351

## Checklist (AGENTS.md)
- [x] Agent-centric code + `agent.start` / workflow opener in hero
- [x] One-sentence user-interaction flow (`The user …`)
- [x] Hero ` ```mermaid ` before Quick Start (unchanged palette)
- [x] No edits under `docs/concepts/`
- [x] No `from praisonaiagents.workflows` in touched files
- [x] `docs.json` valid JSON

## Files (20-page slice, 19 edited)
output, pairing-protocols, panel-llm, parallelisation, per-chat-session-scope, performance-benchmarks, permission-modes*, permissions, persistence-backend-plugins, persistence-clickhouse, persistence-conversation-mysql, persistence-json, persistence-mongodb, persistence-mysql, persistence-postgres, persistence-redis, persistence-sqlite, persistence, planning-mode, planning

\* already aligned

## Gap count (this slice)
- **Before:** 19/20 pages missing hero user-flow and/or opener ordering
- **After:** 0/20
- **Repo-wide features hero user-flow gaps remaining:** 164/511

## Test plan
- [x] Mintlify component structure preserved
- [x] `python3 -c "import json; json.load(open('docs.json'))"`

Made with [Cursor](https://cursor.com)