### PR TITLE
docs: AGENTS alignment batch 20 (features, #1351)

### DIFF
--- a/docs/features/platform-aware-agents.mdx
+++ b/docs/features/platform-aware-agents.mdx
@@ -20,6 +20,9 @@ bot = Bot("telegram", agent=agent)
 bot.run()
 ```
 
+The user messages on Telegram; the gateway agent replies with platform-aware routing.
+
+
 ```mermaid
 graph LR
     Msg[📨 Incoming Message] --> Origin[🌐 Detect Origin]

--- a/docs/features/platform-client-sdk-testing.mdx
+++ b/docs/features/platform-client-sdk-testing.mdx
@@ -32,6 +32,9 @@ async def test_register_and_workspace():
     assert workspace["name"] == "Test Workspace"
 ```
 
+The user asks the agent to run SDK tests; pytest exercises every PlatformClient endpoint.
+
+
 ```mermaid
 graph LR
     Tests[🧪 Test Suite] --> SDK[📦 PlatformClient]

--- a/docs/features/platform-labels.mdx
+++ b/docs/features/platform-labels.mdx
@@ -25,6 +25,9 @@ async with PlatformClient(
     await client.add_label_to_issue("ws-123", "issue-456", label["id"])
 ```
 
+The user asks to triage issues; the agent creates labels and attaches them on the platform.
+
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> SDK[📦 PlatformClient]

--- a/docs/features/platform-python-sdk.mdx
+++ b/docs/features/platform-python-sdk.mdx
@@ -24,6 +24,9 @@ async with PlatformClient(
     workspace = await client.create_workspace("My Team")
 ```
 
+The user manages team work; the agent creates workspaces and issues via the platform SDK.
+
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> SDK[📦 PlatformClient]

--- a/docs/features/platform-sdk.mdx
+++ b/docs/features/platform-sdk.mdx
@@ -25,6 +25,9 @@ async with PlatformClient(
     issue = await client.create_issue(workspace["id"], "Fix login bug")
 ```
 
+The user tracks bugs; the agent uses PlatformClient to log and update workspace issues.
+
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Client[📦 PlatformClient]

--- a/docs/features/platform-workspace-context.mdx
+++ b/docs/features/platform-workspace-context.mdx
@@ -30,6 +30,9 @@ agent = Agent(
 )
 ```
 
+The user opens a workspace thread; the agent loads scoped instructions from platform context.
+
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Ctx[📋 WorkspaceContext]

--- a/docs/features/plugins.mdx
+++ b/docs/features/plugins.mdx
@@ -20,6 +20,9 @@ agent = Agent(
 agent.start("What's the weather in Paris?")
 ```
 
+The user asks a question; plugins add tools and hooks before the agent answers.
+
+
 ```mermaid
 graph TB
     subgraph "Plugin Types"

--- a/docs/features/policy-engine.mdx
+++ b/docs/features/policy-engine.mdx
@@ -31,6 +31,9 @@ agent.policy = engine
 agent.start("Help me organise my project files")
 ```
 
+The user requests a risky action; policy rules allow or deny tools before execution.
+
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Engine[🛡️ PolicyEngine]

--- a/docs/features/praisonai-code-cli.mdx
+++ b/docs/features/praisonai-code-cli.mdx
@@ -7,6 +7,18 @@ icon: "terminal"
 
 > `praisonai-code` is the terminal-native agent CLI — install it on its own for a smaller footprint when you only need agentic commands.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="assistant",
+    instructions="You are a helpful coding assistant.",
+)
+agent.start("Summarise the top 3 arXiv papers on RAG this week")
+```
+
+The user runs a terminal prompt; `praisonai-code` executes the agent and streams the reply.
+
 ```mermaid
 graph LR
     subgraph "pip install praisonai-code"

--- a/docs/features/prepared-turn-context.mdx
+++ b/docs/features/prepared-turn-context.mdx
@@ -16,6 +16,9 @@ context = default_context_builder.build_context(agent, "Who built the Eiffel Tow
 print(context.to_dict())
 ```
 
+The user sends a prompt; the runtime builds one shared PreparedTurnContext for the turn.
+
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Builder[📋 ContextBuilder]

--- a/docs/features/proactive-delivery.mdx
+++ b/docs/features/proactive-delivery.mdx
@@ -26,6 +26,9 @@ async def notify():
 asyncio.run(notify())
 ```
 
+The user triggers an alert; BotOS delivers the agent's message to the target channel.
+
+
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> BotOS[BotOS]

--- a/docs/features/profiler.mdx
+++ b/docs/features/profiler.mdx
@@ -7,6 +7,18 @@ icon: "gauge-high"
 
 Profile agent execution with per-agent isolation, latency percentiles, memory snapshots, and HTML/JSON reports.
 
+```python
+from praisonaiagents import Agent
+from praisonai.profiler import _ProfilerImpl, set_profiler, get_profiler
+
+set_profiler(_ProfilerImpl())
+agent = Agent(name="assistant", instructions="Be helpful")
+agent.start("Explain quicksort in one paragraph")
+get_profiler().print_summary()
+```
+
+The user runs the agent; the profiler captures latency, streaming, and memory for that turn.
+
 ```mermaid
 graph LR
     subgraph "Profiler"

--- a/docs/features/profiling.mdx
+++ b/docs/features/profiling.mdx
@@ -22,6 +22,9 @@ result = run_task("Summarise quarterly sales")
 print(Profiler.get_statistics())
 ```
 
+The user runs a profiled task; timing and memory stats accumulate in a bounded buffer.
+
+
 ```mermaid
 graph LR
     A[🤖 Agent run] --> B[📊 Record timing]

--- a/docs/features/project-agents-md.mdx
+++ b/docs/features/project-agents-md.mdx
@@ -18,6 +18,9 @@ agent = Agent(
 agent.start("How should I structure new modules in this project?")
 ```
 
+The user asks a coding question; AGENTS.md from the project root is injected automatically.
+
+
 ```mermaid
 graph TB
     subgraph "Project AGENTS.md Auto-Discovery"

--- a/docs/features/project-sessions.mdx
+++ b/docs/features/project-sessions.mdx
@@ -13,10 +13,7 @@ agent.start("Load my marketing-campaign project session and continue where we le
 ```
 
 
-Each project keeps its own conversation history — resume in the same folder and prior turns load automatically.
-
-
-Each project keeps its own conversation history and cumulative cost totals — resume in the same folder and prior turns plus usage load automatically.
+The user resumes work in the same project folder; prior turns and cumulative usage load automatically.
 
 ```bash
 cd ~/code/my-app && praisonai run "Build a TODO app"

--- a/docs/features/prompt-cache-optimization.mdx
+++ b/docs/features/prompt-cache-optimization.mdx
@@ -21,6 +21,9 @@ agent.start("Summarise the latest report")
 agent.start("What changed since yesterday?")
 ```
 
+The user chats across turns; stable prefixes stay cached for lower cost.
+
+
 ```mermaid
 graph LR
     subgraph "Cache Optimisation Pipeline"

--- a/docs/features/prompt-caching.mdx
+++ b/docs/features/prompt-caching.mdx
@@ -22,6 +22,9 @@ agent.start("What did we learn last week about prompt caching?")
 agent.start("What are the cost savings?")  # cache hit on stable prefix
 ```
 
+The user continues the conversation; cached instructions and memory skip repeat token charges.
+
+
 ```mermaid
 graph LR
     subgraph "Prompt Caching Strategy"

--- a/docs/features/prompt-injection-protection.mdx
+++ b/docs/features/prompt-injection-protection.mdx
@@ -21,6 +21,9 @@ agent.start("Find recent AI safety papers")
 # duckduckgo results auto-wrapped in <external_tool_result> markers
 ```
 
+The user searches the web; external tool output is wrapped so the model treats it as data.
+
+
 ```mermaid
 graph LR
     subgraph "Trust-Aware Tool Execution"

--- a/docs/features/promptchaining.mdx
+++ b/docs/features/promptchaining.mdx
@@ -18,6 +18,9 @@ result = flow.start("Benefits of renewable energy")
 print(result["output"])
 ```
 
+The user submits one goal; each agent step passes its output to the next.
+
+
 ```mermaid
 graph LR
     In["Input"] --> S1["Step 1"]


### PR DESCRIPTION
## Summary
- Adds user-interaction flow sentences (§1.1(10)) before hero Mermaid on the batch-20 slice:  through  (after batch 19 / ).
- Adds agent-centric openers on  and  (§1.1(9)).
- Deduplicates intro copy on .
- **Gap count this batch:** 19 pages updated (1 already compliant: ).

## AGENTS.md checklist
- [x] Agent-centric opener + user flow before hero diagram
- [x] No  edits
- [x] No forbidden phrases / non-friendly workflow imports in touched files
- [x]  valid JSON

## Test plan
- [x] Local audit: 0 gaps in batch-20 file list
- [ ] Mintlify preview (optional)

Refs #1351