### PR TITLE
docs: AGENTS alignment batch 22 (features, #1351)

### DIFF
--- a/docs/features/resource-lifecycle.mdx
+++ b/docs/features/resource-lifecycle.mdx
@@ -19,6 +19,9 @@ with PraisonAIAgents(agents=[researcher], tasks=[task]) as workflow:
 print(result)
 ```
 
+The user runs agents inside a context manager; leaving the block closes agents, memory stores, and connections automatically.
+
+
 ```mermaid
 graph LR
     subgraph "Resource Lifecycle"

--- a/docs/features/retrieval-strategies.mdx
+++ b/docs/features/retrieval-strategies.mdx
@@ -18,6 +18,9 @@ agent = Agent(
 response = agent.start("What are the key features?")
 ```
 
+The user asks a question; PraisonAI selects the best retrieval strategy for the indexed corpus size.
+
+
 ```mermaid
 graph LR
     Corpus[Indexed Corpus] --> Select{Auto Select}

--- a/docs/features/retrieval.mdx
+++ b/docs/features/retrieval.mdx
@@ -22,6 +22,9 @@ agent = Agent(
 response = agent.start("What are the key findings?")
 ```
 
+The user asks a question; the agent retrieves relevant chunks from configured knowledge sources before answering.
+
+
 ```mermaid
 flowchart LR
     Query[User Query] --> Agent[Agent]

--- a/docs/features/rfc-microsoft-teams-integration.mdx
+++ b/docs/features/rfc-microsoft-teams-integration.mdx
@@ -26,6 +26,9 @@ bot = Bot(
 bot.run()
 ```
 
+The user messages in Microsoft Teams; BotOS routes the conversation to the same agent used on other channels.
+
+
 ```mermaid
 graph LR
     A[Agent] --> B[Teams Bot]

--- a/docs/features/robustness.mdx
+++ b/docs/features/robustness.mdx
@@ -23,6 +23,9 @@ workflow = AgentFlow(
 result = workflow.start("AI agents 2025")
 ```
 
+The user starts a multi-step workflow; optional steps can fail without aborting the run, with execution history for debugging.
+
+
 ```mermaid
 graph LR
     Input[Input] --> Task1[Task 1]

--- a/docs/features/rules.mdx
+++ b/docs/features/rules.mdx
@@ -15,6 +15,9 @@ agent = Agent(name="Assistant", instructions="You are helpful.")
 agent.start("Help me with Python")
 ```
 
+The user works in a repo with instruction files; PraisonAI discovers them and injects the rules into the agent system prompt.
+
+
 ```mermaid
 graph TB
     subgraph "Rule Sources"

--- a/docs/features/run-history.mdx
+++ b/docs/features/run-history.mdx
@@ -19,6 +19,9 @@ runs = db.get_runs(session_id=agent.session_id)
 print(f"{len(runs)} run(s) for this session")
 ```
 
+The user runs an agent, then reads persisted runs and traces from the state store for that session.
+
+
 ```mermaid
 graph LR
     Agent[🧠 Agent] --> StateStore[💾 State Store]

--- a/docs/features/run-stream-events.mdx
+++ b/docs/features/run-stream-events.mdx
@@ -19,6 +19,9 @@ agent.start("Process this request and stream each step as it completes.")
 praisonai run --output stream-json "Find the weather in London"
 ```
 
+The user runs the CLI with stream-json output; each agent step emits a versioned NDJSON line for scripts and CI.
+
+
 ```mermaid
 graph LR
     subgraph "praisonai run --output stream-json"

--- a/docs/features/runtime-capabilities.mdx
+++ b/docs/features/runtime-capabilities.mdx
@@ -20,6 +20,9 @@ agent = Agent(
 agent.start("Find the top 3 papers on RLHF this month")
 ```
 
+The user declares required runtime capabilities on the agent; the framework validates support before execution starts.
+
+
 ```mermaid
 graph LR
     subgraph "Runtime Capability Validation"

--- a/docs/features/runtime-config.mdx
+++ b/docs/features/runtime-config.mdx
@@ -22,6 +22,9 @@ agent = Agent(
 agent.start("Tell me about AI")
 ```
 
+The user sets runtime requirements on the agent; compatibility is checked before the first turn runs.
+
+
 ```mermaid
 graph LR
     subgraph "Runtime Selection"

--- a/docs/features/runtime-mcp.mdx
+++ b/docs/features/runtime-mcp.mdx
@@ -15,6 +15,9 @@ agent.add_mcp_server("notion", MCP("npx -y @notionhq/notion-mcp-server"))
 agent.start("Summarise my latest Notion page about Q3 planning")
 ```
 
+The user attaches or detaches MCP servers on a live agent; new tools appear on the next turn without restarting.
+
+
 ```mermaid
 graph LR
     subgraph "Runtime MCP Management"

--- a/docs/features/runtime-preflight.mdx
+++ b/docs/features/runtime-preflight.mdx
@@ -19,6 +19,9 @@ team = AgentTeam(agents=[researcher, writer], tasks=[task])
 team.start()
 ```
 
+The user validates team YAML with doctor before team.start(), catching handoff and runtime issues without LLM calls.
+
+
 ```mermaid
 graph LR
     YAML[team.yaml] --> Doctor[doctor runtime --team]

--- a/docs/features/runtime-resolution.mdx
+++ b/docs/features/runtime-resolution.mdx
@@ -30,6 +30,9 @@ writer.start("Research and write about ocean currents")
 **Handoffs no longer use this subsystem.** As of [PR #2178](https://github.com/MervinPraison/PraisonAI/pull/2178), handoffs always delegate directly to `agent.chat()` / `agent.achat()`. The runtime-resolution layer is used by other parts of the SDK for agent-level runtime configuration. If you came here for handoff execution behaviour, see [Agent Handoffs](/docs/features/handoffs).
 </Warning>
 
+The user changes model or runtime references on an agent; the resolver picks the concrete runtime on the next turn.
+
+
 ```mermaid
 graph LR
     subgraph "Runtime Resolution"

--- a/docs/features/runtime-selection.mdx
+++ b/docs/features/runtime-selection.mdx
@@ -18,6 +18,9 @@ agent = Agent(
 agent.start("Build a CLI tool that lists open PRs")
 ```
 
+The user chooses a runtime backend for the agent; PraisonAI resolves CLI versus native execution for each model.
+
+
 ```mermaid
 graph LR
     subgraph "Runtime Resolution Order"

--- a/docs/features/runtime-tool-result-middleware.mdx
+++ b/docs/features/runtime-tool-result-middleware.mdx
@@ -14,6 +14,9 @@ agent = Agent(name="assistant", instructions="Be helpful")
 agent.start("What is 2 + 2?")  # native praisonai runtime — no middleware needed
 ```
 
+The user runs tools through a plugin harness; middleware normalises vendor-shaped results before hooks and memory run.
+
+
 ```mermaid
 graph LR
     H[Plugin Harness] --> T[Tool Execution]

--- a/docs/features/runtime.mdx
+++ b/docs/features/runtime.mdx
@@ -22,6 +22,9 @@ agent = Agent(
 agent.start("Explain the latest developments in fusion energy.")
 ```
 
+The user enables runtime configuration on the agent; declared capabilities are validated at startup before the run proceeds.
+
+
 ```mermaid
 graph LR
     subgraph "Runtime Selection"

--- a/docs/features/safe-tools-by-default.mdx
+++ b/docs/features/safe-tools-by-default.mdx
@@ -22,6 +22,9 @@ agent = Agent(
 agent.start("Refactor main.py")
 ```
 
+The user asks the agent to run shell commands or edit files; dangerous built-in tools pause for interactive approval first.
+
+
 ```mermaid
 graph LR
     subgraph "Safe Tools by Default"

--- a/docs/features/sandbox-backends.mdx
+++ b/docs/features/sandbox-backends.mdx
@@ -18,6 +18,9 @@ agent = Agent(
 agent.start("List Python files in the current directory")
 ```
 
+The user runs commands through the agent; the sandbox backend isolates execution with explicit shell control.
+
+
 ```mermaid
 graph LR
     subgraph "Sandbox Command Execution"

--- a/docs/features/sandbox.mdx
+++ b/docs/features/sandbox.mdx
@@ -22,6 +22,9 @@ agent.start("Calculate fibonacci(10) and print the result")
 Need model-generated code to call your registered tools? See [Code Execution with Tools](./code-execution-with-tools). The subprocess sandbox backend cannot see the agent's tool registry, so the tool bridge runs in-process rather than in a subprocess sandbox.
 </Note>
 
+The user asks the agent to execute generated code; work stays inside an isolated sandbox instead of the host shell.
+
+
 ```mermaid
 graph LR
     subgraph "Sandbox Code Execution"


### PR DESCRIPTION
## Summary
- Adds user-interaction flow sentences before hero Mermaid on the batch-22 slice: resource-lifecycle through sandbox (after batch 21 / replay).
- Agent-centric openers already present on this slice; no new opener blocks required.
- Gap count this batch: 19 pages updated (1 already compliant: routing).
- Remaining features user-flow gaps: 139 of 511 feature pages (hero Mermaid missing a leading "The user …" sentence).

## AGENTS.md checklist
- [x] Agent-centric opener + user flow before hero diagram
- [x] No concepts/ edits
- [x] docs.json valid JSON

## Test plan
- [x] Local audit: 0 gaps in batch-22 file list
- [ ] Mintlify preview (optional)

Refs #1351
