### PR TITLE
docs: AGENTS alignment batch 24 (features, #1351)

### DIFF
--- a/docs/features/skill-fallback.mdx
+++ b/docs/features/skill-fallback.mdx
@@ -18,6 +18,8 @@ agent = Agent(
 agent.start("Find recent papers on diffusion models.")
 ```
 
+The user asks for research; a fallback skill is offered only when the primary tool is absent.
+
 The fallback declaration lives in the **skill** itself — the agent code doesn't change at all.
 
 ```mermaid

--- a/docs/features/skill-fallbacks.mdx
+++ b/docs/features/skill-fallbacks.mdx
@@ -7,6 +7,19 @@ icon: "puzzle-piece"
 
 Fallback skills are offered only when a needed tool or MCP server is absent.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Researcher",
+    instructions="Answer research questions.",
+    skills=["./skills/web-via-terminal", "./skills/summarise"],
+)
+agent.start("Find recent papers on diffusion models.")
+```
+
+The user runs the agent; fallback skills appear in the listing only when required tools or servers are missing.
+
 ```mermaid
 graph LR
     subgraph "Skill Fallback Logic"

--- a/docs/features/skill-lifecycle.mdx
+++ b/docs/features/skill-lifecycle.mdx
@@ -18,6 +18,8 @@ agent = Agent(
 agent.start("Learn how to summarise weekly reports, then save that as a skill.")
 ```
 
+The user teaches a workflow; lifecycle tools track creation, usage, archive, and rollback.
+
 ```mermaid
 graph LR
     subgraph "Skill Lifecycle"

--- a/docs/features/skills-invocation.mdx
+++ b/docs/features/skills-invocation.mdx
@@ -17,6 +17,8 @@ agent = Agent(
 agent.start("/deploy staging prod")
 ```
 
+The user sends a slash command or normal prompt; the agent routes to skill invoke or LLM handling.
+
 ```mermaid
 graph LR
     subgraph "Skill Invocation"

--- a/docs/features/skills-vs-tools.mdx
+++ b/docs/features/skills-vs-tools.mdx
@@ -19,6 +19,8 @@ agent = Agent(
 agent.start("Review app.py for security issues")
 ```
 
+The user submits a task; skills supply knowledge while tools execute concrete actions.
+
 ```mermaid
 graph LR
     subgraph "Skills vs Tools Overview"

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -18,6 +18,8 @@ agent = Agent(
 agent.start("Extract the main findings from report.pdf")
 ```
 
+The user asks about a document; the agent loads the matching skill only when the task needs it.
+
 <Note>
 **Agent-created skills are staged for approval by default.** When an agent calls `skill_manage` to create, edit, or delete a skill, the mutation is held in a pending store until a human approves it — disk is not touched. Reading and using existing skills is unaffected. See [Skill Manage](/docs/features/skill-manage) for the full approval gate docs.
 </Note>

--- a/docs/features/smart-retrieval.mdx
+++ b/docs/features/smart-retrieval.mdx
@@ -18,6 +18,8 @@ agent = Agent(
 response = agent.start("How does API authentication work?")
 ```
 
+The user asks a question; hybrid retrieval and reranking surface the best knowledge snippets.
+
 ```mermaid
 graph LR
     Query[User Query] --> Hybrid[Hybrid Search]

--- a/docs/features/spawn-announce.mdx
+++ b/docs/features/spawn-announce.mdx
@@ -19,6 +19,8 @@ team.spawn_sub_agent(researcher, task)
 # Parent continues immediately — no blocking
 ```
 
+The user delegates parallel work; the parent spawns sub-agents and keeps running without blocking.
+
 ```mermaid
 graph LR
     subgraph "Spawn & Announce Pattern"

--- a/docs/features/specialized-agents.mdx
+++ b/docs/features/specialized-agents.mdx
@@ -14,6 +14,8 @@ artist = ImageAgent(llm="openai/dall-e-3")
 artist.generate("A mountain landscape at sunset", output="sunset.png")
 ```
 
+The user requests media or OCR in a workflow; the specialised agent type handles that step.
+
 ```mermaid
 graph LR
     Workflow[Workflow Step] --> Type{Agent Type}

--- a/docs/features/standalone-llm-modules.mdx
+++ b/docs/features/standalone-llm-modules.mdx
@@ -24,6 +24,8 @@ agent = Agent(
 agent.start("Which OpenAI model supports vision and tool calling?")
 ```
 
+The user asks about models; catalogue and credential helpers from praisonai-code answer without wrapper imports.
+
 ```mermaid
 graph TB
     subgraph "pip install praisonai-code"

--- a/docs/features/stateful-agents.mdx
+++ b/docs/features/stateful-agents.mdx
@@ -18,6 +18,8 @@ agent = Agent(
 agent.start("I prefer concise answers to technical questions")
 ```
 
+The user shares preferences; session memory persists them for later turns.
+
 ```mermaid
 graph LR
     subgraph "Stateful Agents"

--- a/docs/features/streaming-tool-events.mdx
+++ b/docs/features/streaming-tool-events.mdx
@@ -21,6 +21,8 @@ agent.stream_emitter.add_callback(on_stream_event)
 agent.start("Use the search tool to find information about Python")
 ```
 
+The user runs a tool-heavy prompt; streaming events mark when each tool finishes.
+
 ```mermaid
 sequenceDiagram
     participant Agent

--- a/docs/features/streaming.mdx
+++ b/docs/features/streaming.mdx
@@ -16,6 +16,8 @@ for chunk in agent.start("Explain streaming in one sentence", stream=True):
     print(chunk, end="", flush=True)
 ```
 
+The user sends a prompt; tokens stream back incrementally instead of waiting for the full reply.
+
 ```mermaid
 graph LR
     subgraph "Streaming Flow"

--- a/docs/features/structured-llm-errors.mdx
+++ b/docs/features/structured-llm-errors.mdx
@@ -19,6 +19,8 @@ agent = Agent(
 agent.start("Hello")
 ```
 
+The user sends a prompt; structured errors route retries, compression, or model fallback.
+
 <Note>
 LLM errors now also carry typed `AgentErrorKind` classifications for more precise error handling. See [LLM Error Classification](/docs/features/llm-error-classification) for the complete taxonomy and failover decision system.
 </Note>

--- a/docs/features/structured.mdx
+++ b/docs/features/structured.mdx
@@ -19,6 +19,8 @@ result = agent.chat("List 3 AI topics", output_pydantic=TopicList)
 print(result.topics)
 ```
 
+The user asks for structured data; the agent returns validated Pydantic output for downstream code.
+
 ```mermaid
 graph LR
     subgraph "Structured Outputs"

--- a/docs/features/subscription-auth.mdx
+++ b/docs/features/subscription-auth.mdx
@@ -19,6 +19,8 @@ agent = Agent(
 agent.start("Hello")
 ```
 
+The user chats via the agent; subscription auth supplies credentials instead of a raw API key.
+
 ```mermaid
 graph LR
     subgraph "Subscription Auth Flow"

--- a/docs/features/supabase.mdx
+++ b/docs/features/supabase.mdx
@@ -22,6 +22,8 @@ agent = Agent(
 agent.start("Remember that I am building a chatbot")
 ```
 
+The user stores facts; Supabase-backed db config persists memory across sessions.
+
 ```mermaid
 graph LR
     subgraph "Supabase Dual Mode"


### PR DESCRIPTION
## Summary
- Adds hero user-interaction flow lines and agent-centric openers for the 20-file slice **skill-fallback → supabase** (after batch 23).
- Adds missing agent opener on `skill-fallbacks.mdx`.
- No `docs/concepts/` changes.

## AGENTS.md rules
- §1.1(9–10) agent-centric opener + user-interaction flow before hero Mermaid
- §3.3 hero diagrams unchanged (already present)

## Pages (20)
skill-fallback, skill-fallbacks, skill-lifecycle, skill-manage, skills-invocation, skills-vs-tools, skills, smart-retrieval, spawn-announce, specialized-agents, standalone-llm-modules, stateful-agents, streaming-tool-events, streaming, structured-llm-errors, structured, subagent-delegation, subagent-tool, subscription-auth, supabase

## Test plan
- [x] `python3 -m json.tool docs.json`
- [x] Mintlify components unchanged on edited pages

Refs #1351

Made with [Cursor](https://cursor.com)