### PR TITLE
docs: AGENTS alignment batch 23 (features, #1351)

### DIFF
--- a/docs/features/sandboxed-agent.mdx
+++ b/docs/features/sandboxed-agent.mdx
@@ -21,6 +21,11 @@ agent = Agent(name="coder", backend=sandboxed)
 agent.start("Create a Python script that prints hello")
 ```
 
+
+The user asks the agent to run code; tool calls execute in E2B or Docker sandboxes instead of on the host.
+
+
+
 ```mermaid
 graph LR
     subgraph "Sandboxed Agent Architecture"

--- a/docs/features/scheduled-run-policy.mdx
+++ b/docs/features/scheduled-run-policy.mdx
@@ -18,6 +18,11 @@ agent = Agent(
 # executor = ScheduledAgentExecutor(runner=runner, agent_resolver=lambda _: agent, run_policy=RunPolicy())
 ```
 
+
+The user schedules an unattended run; RunPolicy scopes tools, scans the prompt, and audits output before delivery.
+
+
+
 ```mermaid
 graph LR
     subgraph "Scheduled Run Policy"

--- a/docs/features/scheduler-pre-run-gate.mdx
+++ b/docs/features/scheduler-pre-run-gate.mdx
@@ -23,6 +23,11 @@ job = ScheduleJob(
 )
 ```
 
+
+The user schedules a tick with a `pre_run` shell hook; the agent only runs when the gate script reports work to do.
+
+
+
 ```mermaid
 graph LR
     Tick[⏰ Tick due] --> Gate{🚦 pre_run?}

--- a/docs/features/scientific-writer-agent.mdx
+++ b/docs/features/scientific-writer-agent.mdx
@@ -18,6 +18,11 @@ Scientific Writer Agent created LaTeX-formatted academic papers using the CAJAL 
 # paper = agent.write_paper("Machine Learning in Healthcare")
 ```
 
+
+The user requested a LaTeX paper topic; the removed Scientific Writer agent drafted academic output via CAJAL (historical only).
+
+
+
 ```mermaid
 graph LR
     subgraph "Scientific Paper Generation"

--- a/docs/features/search-provider-registry.mdx
+++ b/docs/features/search-provider-registry.mdx
@@ -18,6 +18,11 @@ agent = Agent(
 agent.start("Latest news on renewable energy")
 ```
 
+
+The user enables `web=True`; PraisonAI routes searches through DuckDuckGo, Tavily, Serper, or a custom provider.
+
+
+
 ```mermaid
 graph LR
     A[Agent] --> B[SearchProviderRegistry]

--- a/docs/features/security-environment-variables.mdx
+++ b/docs/features/security-environment-variables.mdx
@@ -20,6 +20,11 @@ agent = Agent(
 agent.start("Calculate using local tools")
 ```
 
+
+The user opts in with `PRAISONAI_ALLOW_LOCAL_TOOLS`; without it, dangerous local tools stay blocked by default.
+
+
+
 ```mermaid
 graph LR
     subgraph "Security Model"

--- a/docs/features/self-improve.mdx
+++ b/docs/features/self-improve.mdx
@@ -18,6 +18,11 @@ agent = Agent(
 agent.start("Debug this flaky deploy script and fix it.")
 ```
 
+
+The user assigns a task; after each run the agent may write or patch a skill when it learns something reusable.
+
+
+
 ```mermaid
 graph LR
     subgraph "Self-Improvement Loop"

--- a/docs/features/selfreflection.mdx
+++ b/docs/features/selfreflection.mdx
@@ -18,6 +18,11 @@ agent = Agent(
 agent.start("Summarise recent AI safety developments")
 ```
 
+
+The user asks a question; the agent drafts an answer, reflects on quality, then returns the improved response.
+
+
+
 ```mermaid
 graph LR
     subgraph "Self-Reflection Loop"

--- a/docs/features/send-message-tool.mdx
+++ b/docs/features/send-message-tool.mdx
@@ -19,6 +19,11 @@ agent = Agent(
 agent.start("Generate the weekly report and notify me when it's ready.")
 ```
 
+
+The user starts a long job; the agent proactively messages them on Telegram, Slack, or email when it finishes.
+
+
+
 ```mermaid
 graph LR
     subgraph "Send Message Flow"

--- a/docs/features/send-policy.mdx
+++ b/docs/features/send-policy.mdx
@@ -20,6 +20,11 @@ Bot(
 ).start()
 ```
 
+
+The user restricts outbound channels; SendPolicy blocks deliveries that are not on the allow list.
+
+
+
 ```mermaid
 graph LR
     subgraph "Send Policy Guard"

--- a/docs/features/session-hierarchy.mdx
+++ b/docs/features/session-hierarchy.mdx
@@ -22,6 +22,11 @@ agent = Agent(
 agent.start("I want to visit Japan in spring")
 ```
 
+
+The user forks or snapshots a chat session; hierarchical stores keep branches safe across workers.
+
+
+
 ```mermaid
 graph LR
     subgraph "Hierarchical Sessions"

--- a/docs/features/session-persistence.mdx
+++ b/docs/features/session-persistence.mdx
@@ -18,6 +18,11 @@ agent = Agent(
 agent.start("Summarise the auth module")
 ```
 
+
+The user returns with the same `session_id`; prior turns reload automatically from disk.
+
+
+
 ```mermaid
 graph LR
     subgraph "Session Persistence"

--- a/docs/features/session-protocol.mdx
+++ b/docs/features/session-protocol.mdx
@@ -17,6 +17,11 @@ agent = Agent(
 agent.start("Hello!")
 ```
 
+
+The user plugs in a custom session backend; agents call the same protocol methods regardless of storage.
+
+
+
 ```mermaid
 graph LR
     Agent([🤖 Agent]) --> Protocol{SessionStoreProtocol}

--- a/docs/features/session-runtime-state.mdx
+++ b/docs/features/session-runtime-state.mdx
@@ -17,6 +17,11 @@ agent = Agent(
 agent.start("Run a tool turn — enable mirror_runtime_state on your gateway SessionConfig")
 ```
 
+
+The user hands off between native and plugin runtimes; mirrored state preserves tool IDs and transcript slices each turn.
+
+
+
 ```mermaid
 graph LR
     N[Native Runtime] --> S[(Session runtime_state)]

--- a/docs/features/session-store.mdx
+++ b/docs/features/session-store.mdx
@@ -18,6 +18,11 @@ agent.start("Remember I like tea.")
 agent.start("What do I like?")  # History restored from ~/.praisonai/sessions/
 ```
 
+
+The user chats across restarts; the session store persists history under `~/.praisonai/sessions/`.
+
+
+
 ```mermaid
 graph LR
     A[Agent] --> P[SessionStoreProtocol]

--- a/docs/features/sessions.mdx
+++ b/docs/features/sessions.mdx
@@ -18,6 +18,11 @@ agent = Agent(
 agent.start("My name is Alice")
 ```
 
+
+The user sends follow-up messages; the session keeps context across process restarts and remote agents.
+
+
+
 ```mermaid
 graph LR
     User([👤 User]) --> Agent[🤖 Agent]

--- a/docs/features/single-source-config.mdx
+++ b/docs/features/single-source-config.mdx
@@ -19,6 +19,11 @@ One `.praisonai/config.yaml` wires your project's full agent runtime — model, 
 praisonai run "Open the docs site and screenshot the home page"
 ```
 
+
+The user keeps settings in `.praisonai/config.yaml`; every `praisonai run` in the project loads that single source.
+
+
+
 ```mermaid
 graph LR
     subgraph "Single-Source Config"

--- a/docs/features/skill-bundles.mdx
+++ b/docs/features/skill-bundles.mdx
@@ -18,6 +18,11 @@ agent = Agent(
 agent.start("Refactor the users table migration.")
 ```
 
+
+The user selects `@backend-dev`; all skills in the bundle load together for that agent.
+
+
+
 ```mermaid
 graph LR
     Agent["🤖 Agent"] --> Bundle["📦 @backend-dev bundle"]

--- a/docs/features/skill-capability-gates.mdx
+++ b/docs/features/skill-capability-gates.mdx
@@ -18,6 +18,11 @@ agent = Agent(
 agent.start("Extract text from invoice.pdf")
 ```
 
+
+The user invokes a skill with declared requirements; gates enforce tools, MCP servers, and env vars at runtime.
+
+
+
 ```mermaid
 graph LR
     subgraph "Skill Capability Gates"


### PR DESCRIPTION
## Summary
- Adds hero **user-interaction flow** sentences (§1.1(10)) on the 20-file slice **sandboxed-agent → skill-capability-gates** (after batch 22 / `sandbox.mdx`).
- Agent-centric openers already present on this slice; no `docs/concepts/` edits.
- **Gap count this batch:** 19 pages updated (1 already compliant: `save-output.mdx`).

## AGENTS.md checklist
- [x] Agent-centric opener + user flow before hero diagram
- [x] No `docs/concepts/` edits
- [x] No forbidden phrases / non-friendly workflow imports in touched files
- [x] `docs.json` valid JSON

## Test plan
- [x] Local audit: 0 gaps in batch-23 file list
- [ ] Mintlify preview (optional)

Refs #1351

Made with [Cursor](https://cursor.com)