### PR TITLE
docs: AGENTS alignment batch 25 (features, #1351)

### DIFF
--- a/docs/features/task-context-control.mdx
+++ b/docs/features/task-context-control.mdx
@@ -32,6 +32,10 @@ team = AgentTeam(agents=[processor], tasks=[extract, analyse], process="sequenti
 team.start()
 ```
 
+
+
+The user runs a sequential team workflow; each step receives either just the prior task output or the full history, depending on retain_full_context.
+
 ```mermaid
 graph LR
     A[Task 1<br/>Full Context] -->|Only Output| B[Task 2<br/>Minimal Context]

--- a/docs/features/task-retry-policy.mdx
+++ b/docs/features/task-retry-policy.mdx
@@ -23,6 +23,10 @@ team = AgentTeam(agents=[agent], tasks=[task])
 team.start()
 ```
 
+
+
+The user kicks off a team run; when a task fails, PraisonAI retries with exponential backoff until max_retries is reached or the task succeeds.
+
 ```mermaid
 graph LR
     subgraph "Task Retry Flow"

--- a/docs/features/task-validation-feedback.mdx
+++ b/docs/features/task-validation-feedback.mdx
@@ -28,6 +28,10 @@ task = Task(
 AgentTeam(agents=[writer], tasks=[task]).start()
 ```
 
+
+
+The user asks for output that must meet a guardrail; failed validation sends feedback into the next retry until the check passes or retries are exhausted.
+
 ```mermaid
 graph LR
     subgraph "Task Validation & Feedback"

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -14,6 +14,10 @@ agent = Agent(name="Assistant", instructions="You are helpful.")
 agent.start("Hello")  # telemetry counts this run automatically
 ```
 
+
+
+The user runs an agent as usual; anonymous run metrics are recorded automatically unless telemetry is opted out.
+
 ```mermaid
 graph LR
     subgraph "Telemetry Flow"

--- a/docs/features/templates.mdx
+++ b/docs/features/templates.mdx
@@ -20,6 +20,10 @@ agent = Agent(
 agent.start("How do I reset my password?")
 ```
 
+
+
+The user sends a message; system, prompt, and response templates shape what the agent sees and how it replies.
+
 ```mermaid
 graph LR
     subgraph "Template System"

--- a/docs/features/terminal-bench.mdx
+++ b/docs/features/terminal-bench.mdx
@@ -18,6 +18,10 @@ agent = Agent(
 # Wrap with Harbor's PraisonAIExternalAgent — see Integration Approaches below
 ```
 
+
+
+The user benchmarks a terminal agent; Harbor runs PraisonAI inside Docker against Terminal-Bench tasks and records pass or fail scores.
+
 ```mermaid
 graph LR
     subgraph "Terminal-Bench Integration"

--- a/docs/features/test-documentation.mdx
+++ b/docs/features/test-documentation.mdx
@@ -17,6 +17,10 @@ agent = Agent(
 agent.start("What makes good agent documentation?")
 ```
 
+
+
+The user reads a reference page; the hero example and diagram show how feature docs should open with Agent code and a user flow.
+
 ```mermaid
 graph LR
     subgraph "Documentation Workflow"

--- a/docs/features/thinking-budgets.mdx
+++ b/docs/features/thinking-budgets.mdx
@@ -19,6 +19,10 @@ agent.thinking_budget = ThinkingBudget.high()
 agent.start("Solve this optimisation problem...")
 ```
 
+
+
+The user asks a hard reasoning question; the agent spends extended thinking tokens up to the configured ThinkingBudget before answering.
+
 ```mermaid
 graph LR
     subgraph "Thinking Budget Flow"

--- a/docs/features/thread-safety.mdx
+++ b/docs/features/thread-safety.mdx
@@ -23,6 +23,10 @@ for t in threads:
     t.join()
 ```
 
+
+
+The user drives one agent from several threads; locks keep chat history and caches consistent without corrupted state.
+
 ```mermaid
 graph LR
     subgraph "Thread Safety"

--- a/docs/features/todo-planning.mdx
+++ b/docs/features/todo-planning.mdx
@@ -18,6 +18,10 @@ agent = Agent(
 agent.start("Plan a blog launch — research, draft, publish.")
 ```
 
+
+
+The user gives a multi-step goal; the agent breaks it into todos, tracks progress, and executes items in order.
+
 ```mermaid
 graph LR
     subgraph "Planning Flow"

--- a/docs/features/token-budgeting.mdx
+++ b/docs/features/token-budgeting.mdx
@@ -18,6 +18,10 @@ agent = Agent(
 agent.start("What are the key features?")
 ```
 
+
+
+The user asks a knowledge-heavy question; token budgeting trims retrieved chunks so the prompt stays within the model window.
+
 ```mermaid
 graph LR
     subgraph "Token Budget Flow"

--- a/docs/features/token-usage-protocol.mdx
+++ b/docs/features/token-usage-protocol.mdx
@@ -19,6 +19,10 @@ agent = Agent(name="Assistant")
 agent.start("Hello world")  # tokens tracked automatically
 ```
 
+
+
+The user runs agents normally; each completion flows through TokenCollector into the configured usage sink for analytics.
+
 ```mermaid
 graph LR
     subgraph "Token Usage Flow"

--- a/docs/features/tool-availability.mdx
+++ b/docs/features/tool-availability.mdx
@@ -21,6 +21,10 @@ agent = Agent(name="Researcher", tools=[search_web])
 agent.start("Research quantum computing")  # tool hidden if key missing
 ```
 
+
+
+The user requests work that needs a gated tool; unavailable tools are hidden from the schema so the model cannot call them.
+
 ```mermaid
 graph LR
     subgraph "Availability Gating"

--- a/docs/features/tool-circuit-breaker.mdx
+++ b/docs/features/tool-circuit-breaker.mdx
@@ -27,6 +27,10 @@ agent.start("Search quantum computing")  # circuit breaker protects automaticall
 This tool-level circuit breaker is separate from the new [LLM idle-timeout circuit breaker](/features/llm-error-classification#idle-timeout-circuit-breaker), which protects against LLM provider stalls during model calls.
 </Note>
 
+
+
+The user triggers a flaky tool; repeated failures open the breaker so later calls fail fast instead of looping on errors.
+
 ```mermaid
 graph LR
     subgraph "Circuit Breaker Flow"

--- a/docs/features/tool-config.mdx
+++ b/docs/features/tool-config.mdx
@@ -25,6 +25,10 @@ result = agent.start("Analyze the sales data and generate a report")
 print(result)
 ```
 
+
+
+The user asks the agent to use tools; ToolConfig controls timeouts, retries, parallel execution, and artifact storage for those calls.
+
 ```mermaid
 graph LR
     subgraph "Tool Execution"

--- a/docs/features/tool-discovery-order.mdx
+++ b/docs/features/tool-discovery-order.mdx
@@ -7,6 +7,26 @@ icon: "list-tree"
 
 When you ask for `tools=["read_notes"]`, PraisonAI checks four places in a fixed order and stops at the first match.
 
+
+
+```python
+from praisonaiagents import Agent
+import os
+
+os.environ["PRAISONAI_ALLOW_LOCAL_TOOLS"] = "true"
+
+agent = Agent(
+    name="Notes Helper",
+    instructions="Use local tools when available.",
+    tools=["read_notes"],
+)
+agent.start("Read my latest notes")
+```
+
+
+
+The user lists a tool by name on Agent(...); PraisonAI resolves it through local files, built-ins, praisonai-tools, then plugins.
+
 ```mermaid
 graph LR
     subgraph "Tool Discovery Pipeline"

--- a/docs/features/tool-output-store.mdx
+++ b/docs/features/tool-output-store.mdx
@@ -23,6 +23,10 @@ agent = Agent(
 agent.start("Fetch the latest report")
 ```
 
+
+
+The user asks for a large tool result; oversized output is stored on disk and the agent gets a preview plus a path to read the full file.
+
 ```mermaid
 graph LR
     Tool[🔧 Tool Output] --> Check{📏 Size Check}

--- a/docs/features/tool-parameter-types.mdx
+++ b/docs/features/tool-parameter-types.mdx
@@ -20,6 +20,10 @@ agent = Agent(name="Analyst", tools=[analyse])
 agent.start("Analyse this document in deep mode")
 ```
 
+
+
+The user asks the agent to call a typed tool; annotations become JSON Schema so the model passes valid parameters.
+
 ```mermaid
 graph LR
     subgraph "Tool Parameter Type System"

--- a/docs/features/tool-progress-streaming.mdx
+++ b/docs/features/tool-progress-streaming.mdx
@@ -28,6 +28,10 @@ agent = Agent(
 agent.start("Compress data.log")
 ```
 
+
+
+The user runs a long tool with streaming enabled; partial progress events surface in the UI while the tool still runs.
+
 ```mermaid
 graph LR
     Tool["🔧 Tool (running)"] -->|emit_tool_progress| Sink["📡 Sink"]

--- a/docs/features/tool-registry-autogen-migration.mdx
+++ b/docs/features/tool-registry-autogen-migration.mdx
@@ -27,6 +27,10 @@ praison.run()
 **Breaking change (PR #2248):** `ToolRegistry` AutoGen adapter methods — `register_autogen_adapter`, `get_autogen_adapter`, `list_autogen_adapters`, and `register_builtin_autogen_adapters` — have been **removed**. Migrate to `AutoGenAdapter` from `praisonai.framework_adapters` or `praisonai.persistence.factory`.
 </Warning>
 
+
+
+The user migrates legacy AutoGen ToolRegistry wiring; new integrations use AutoGenAdapter while removed registry methods are replaced.
+
 ```mermaid
 graph LR
     subgraph "Migration Path"


### PR DESCRIPTION
## Summary
- Adds hero **user-interaction flow** paragraphs ("The user…") immediately before the first mermaid diagram on 20  pages alphabetically after  ( through ).
- Adds an **agent-centric hero opener** on  (was diagram-only).
- Does **not** touch .

Refs #1351

## Test plan
- [x] 20 files updated, no concepts changes
- [x] Each page has "The user" before first mermaid
- [x]  opens with  example