### PR TITLE
docs(cli/chat): document non-zero exit code on authentication failure

### DIFF
--- a/docs/cli/chat.mdx
+++ b/docs/cli/chat.mdx
@@ -102,6 +102,39 @@ praisonai chat --no-rules "Hello, ignore project rules"
 
 The chat session normally inherits `AGENTS.md`/`CLAUDE.md`/`PRAISON.md` from the working directory. `--no-rules` runs the assistant with only its built-in instructions.
 
+## Exit codes
+
+`praisonai chat` returns a non-zero exit code on failure so shell scripts and CI can detect problems without parsing stderr.
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Prompt executed successfully. |
+| `1` | Authentication failed (invalid or missing API key), the agent raised an exception, or a profiled run finished with no response and a logged auth error. |
+
+<Note>
+Exit-code semantics apply to single-prompt / non-interactive invocations (`praisonai chat "..."` and `praisonai chat --profile ...`). The interactive TUI (`praisonai chat` with no prompt) always exits `0` when you leave the session.
+</Note>
+
+### Detect failures in a script
+
+```bash
+if ! praisonai chat "Summarise the changelog" >/dev/null; then
+  echo "chat failed — check credentials or provider status" >&2
+  exit 1
+fi
+```
+
+### CI example (GitHub Actions)
+
+```yaml
+- name: Smoke-test chat
+  run: praisonai chat "Say hello" > /tmp/chat.out
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+The step fails automatically if the key is invalid — no extra parsing needed.
+
 ## Project context
 
 By default, `praisonai chat` walks up from the current directory to your git root and prepends any `AGENTS.md` / `CLAUDE.md` / `agents.md` / `.agents/AGENTS.md` it finds to the agent's system prompt, layered on top of `~/.praisonai/AGENTS.md`. Pass `--no-context` (or set `PRAISON_NO_CONTEXT=true`) to disable. See [Context Files](/docs/features/context-files) for details.

--- a/docs/cli/chat.mdx
+++ b/docs/cli/chat.mdx
@@ -118,7 +118,7 @@ Exit-code semantics apply to single-prompt / non-interactive invocations (`prais
 ### Detect failures in a script
 
 ```bash
-if ! praisonai chat "Summarise the changelog" >/dev/null; then
+if ! praisonai chat "Summarize the changelog" >/dev/null; then
   echo "chat failed — check credentials or provider status" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Adds an **Exit codes** section to `docs/cli/chat.mdx` documenting the exit-code semantics introduced by PraisonAI PR #2564.

## Changes

- New **Exit codes** section added after the Examples section in `docs/cli/chat.mdx`
- Documents exit code `0` (success) and exit code `1` (auth failure / exception / profiled run with no response)
- Clarifies that exit-code semantics apply only to single-prompt / non-interactive invocations
- Includes a shell script detection example and a GitHub Actions CI example

## Verification checklist

- [x] `docs/cli/chat.mdx` has an "Exit codes" section documenting the `0` / `1` semantics
- [x] Section clarifies that only single-prompt / non-interactive invocations get the new exit code
- [x] Includes at least one shell / CI example demonstrating detection
- [x] Does not enumerate internal auth signatures (user-facing docs only)
- [x] No changes outside `docs/cli/chat.mdx`; no `docs/concepts/` edits
- [x] `docs.json` unchanged

Fixes #1420

Generated with [Claude Code](https://claude.ai/code)