### PR TITLE
docs: C7.1 package boundaries + wrapper-bridge graceful degradation

### DIFF
--- a/docs/cli/doctor.mdx
+++ b/docs/cli/doctor.mdx
@@ -357,7 +357,7 @@ graph LR
 ## Check Categories
 
 <Note>
-When running `praisonai doctor` on a standalone `praisonai-code` install (no wrapper), several check families skip with an explicit "Install full wrapper: pip install praisonai" reason instead of failing. Install `praisonai` (the full wrapper) to run these checks — or use `--skip runtime,bots,gateway,serve,acp,config_wrapper` to hide them entirely.
+When running `praisonai-code doctor` on a standalone `praisonai-code` install (no wrapper), several check families skip with an explicit "Install full wrapper: pip install praisonai" reason instead of failing. Install `praisonai` (the full wrapper) to run these checks — or use `--skip runtime,bots,gateway,serve,acp,config_wrapper` to hide them entirely.
 </Note>
 
 ### Environment (`env`)

--- a/docs/cli/doctor.mdx
+++ b/docs/cli/doctor.mdx
@@ -356,6 +356,10 @@ graph LR
 
 ## Check Categories
 
+<Note>
+When running `praisonai doctor` on a standalone `praisonai-code` install (no wrapper), several check families skip with an explicit "Install full wrapper: pip install praisonai" reason instead of failing. Install `praisonai` (the full wrapper) to run these checks — or use `--skip runtime,bots,gateway,serve,acp,config_wrapper` to hide them entirely.
+</Note>
+
 ### Environment (`env`)
 - Python version validation
 - Package installation checks
@@ -440,6 +444,8 @@ graph LR
 - Legacy `cli_backend` migration (`--fix`, `--execute`)
 - Workflow YAML placeholder (`--workflow` — returns SKIP)
 
+*Skips with reason "Install full wrapper: pip install praisonai" when `pip install praisonai-code` is used without the `praisonai` wrapper.*
+
 ### Serve & Endpoints (`serve`)
 - Serve module availability
 - Endpoints module availability
@@ -451,6 +457,8 @@ graph LR
 - FastAPI availability
 - Uvicorn availability
 
+*Skips with reason "Install full wrapper: pip install praisonai" when `pip install praisonai-code` is used without the `praisonai` wrapper.*
+
 ### Bots (`bots`)
 - Bot token environment variables (`bot_tokens`)
 - Bot.yaml configuration file validation (`bot_config`)
@@ -460,6 +468,15 @@ graph LR
 - Gateway security settings (`gateway_security`) — **HIGH**
 - Gateway config migration (`gateway_config_migration`) — **MEDIUM**
 - Gateway environment variables (`gateway_env_substitution`) — **MEDIUM**
+
+*Skips with reason "Install full wrapper: pip install praisonai" when `pip install praisonai-code` is used without the `praisonai` wrapper.*
+
+### ACP
+- ACP server reachability
+- ACP protocol handshake validation
+- Agent Client Protocol configuration
+
+*Skips with reason "Install full wrapper: pip install praisonai" when `pip install praisonai-code` is used without the `praisonai` wrapper.*
 
 #### Multi-Channel Token Check Details
 

--- a/docs/features/praisonai-code-cli.mdx
+++ b/docs/features/praisonai-code-cli.mdx
@@ -22,10 +22,10 @@ The user runs a terminal prompt; `praisonai-code` executes the agent and streams
 ```mermaid
 graph LR
     subgraph "pip install praisonai-code"
-        A[praisonai-code CLI] --> A1[run · chat · code · daemon · doctor · version · …]
+        A[praisonai-code CLI] --> A1[run · chat · code · doctor · version · …]
     end
     subgraph "pip install praisonai"
-        B[praisonai CLI] --> B1[gateway · bot · onboard · pairing · identity · kanban · claw · dashboard]
+        B[praisonai CLI] --> B1[gateway · bot · daemon · onboard · pairing · identity · kanban · claw · dashboard]
         B --> A
     end
     A --> C[praisonaiagents core]

--- a/docs/features/praisonai-code-cli.mdx
+++ b/docs/features/praisonai-code-cli.mdx
@@ -94,13 +94,13 @@ Hard imports through the bridge raise the same hint: `Install the full wrapper: 
 
 | Standalone (`pip install praisonai-code`) | Wrapper-only (`pip install praisonai`) |
 |-------------------------------------------|----------------------------------------|
-| acp · agent · agents · attach · auth · batch · benchmark · browser · call · chat · checkpoint · code · command · commit · completion · config · context · daemon · debug · deploy · diag · docs · doctor · endpoints · env · eval · examples · flow · github · hooks · init · knowledge · langextract · langfuse · loop · lsp · managed · mcp · memory · models · n8n · obs · package · paths · permissions · plugins · port · profile · publish · rag · realtime · recipe · registry · replay · research · rules · run · sandbox · schedule · serve · session · setup · skills · templates · test · todo · tools · traces · tracker · train · ui · up · validate · version · workflow | bot · claw · dashboard · gateway · identity · kanban · onboard · pairing |
+| acp · agent · agents · attach · auth · batch · benchmark · browser · call · chat · checkpoint · code · command · commit · completion · config · context · debug · deploy · diag · docs · doctor · endpoints · env · eval · examples · flow · github · hooks · init · knowledge · langextract · langfuse · loop · lsp · managed · mcp · memory · models · n8n · obs · package · paths · permissions · plugins · port · profile · publish · rag · realtime · recipe · registry · replay · research · rules · run · sandbox · schedule · serve · session · setup · skills · templates · test · todo · tools · traces · tracker · train · ui · up · validate · version · workflow | bot · claw · daemon · dashboard · gateway · identity · kanban · onboard · pairing |
 
 Wrapper-only names stay out of `--help` on a standalone install. Invoking them without the wrapper does not load the Typer module.
 
 ### Wrapper-command loading
 
-Wrapper-only commands (`bot`, `gateway`, `pairing`, `identity`, `onboard`, `kanban`, `dashboard`, `claw`) are Typer sub-apps whose implementations live in the `praisonai` wrapper. When you install `praisonai-code` standalone, these commands are not listed in `--help` and are not resolvable — `get_command()` returns `None` instead of loading a module that doesn't exist in `praisonai_code`.
+Wrapper-only commands (`bot`, `gateway`, `pairing`, `identity`, `onboard`, `kanban`, `dashboard`, `claw`, `daemon`) are Typer sub-apps whose implementations live in the `praisonai` wrapper. When you install `praisonai-code` standalone, these commands are not listed in `--help` and are not resolvable — `get_command()` returns `None` instead of loading a module that doesn't exist in `praisonai_code`.
 
 ```bash
 # Standalone install, wrapper-only command
@@ -109,7 +109,7 @@ $ praisonai-code bot --help
 Error: No such command 'bot'.
 ```
 
-To use `bot`, `gateway`, `pairing`, `identity`, `onboard`, `kanban`, `dashboard`, or `claw`, install the full wrapper:
+To use `bot`, `gateway`, `pairing`, `identity`, `onboard`, `kanban`, `dashboard`, `claw`, or `daemon`, install the full wrapper:
 
 ```bash
 pip install praisonai

--- a/docs/features/praisonai-code-cli.mdx
+++ b/docs/features/praisonai-code-cli.mdx
@@ -98,6 +98,23 @@ Hard imports through the bridge raise the same hint: `Install the full wrapper: 
 
 Wrapper-only names stay out of `--help` on a standalone install. Invoking them without the wrapper does not load the Typer module.
 
+### Wrapper-command loading
+
+Wrapper-only commands (`bot`, `gateway`, `pairing`, `identity`, `onboard`, `kanban`, `dashboard`, `claw`) are Typer sub-apps whose implementations live in the `praisonai` wrapper. When you install `praisonai-code` standalone, these commands are not listed in `--help` and are not resolvable — `get_command()` returns `None` instead of loading a module that doesn't exist in `praisonai_code`.
+
+```bash
+# Standalone install, wrapper-only command
+$ pip install praisonai-code
+$ praisonai-code bot --help
+Error: No such command 'bot'.
+```
+
+To use `bot`, `gateway`, `pairing`, `identity`, `onboard`, `kanban`, `dashboard`, or `claw`, install the full wrapper:
+
+```bash
+pip install praisonai
+```
+
 ## Configuration and environment
 
 | Variable / command | Behaviour |

--- a/docs/features/standalone-llm-modules.mdx
+++ b/docs/features/standalone-llm-modules.mdx
@@ -243,4 +243,7 @@ inject_credentials_into_env()
   <Card title="PraisonAI Code CLI" icon="terminal" href="/docs/features/praisonai-code-cli">
     The standalone CLI runtime these modules power
   </Card>
+  <Card icon="layer-group" href="/docs/sdk/praisonai-code#package-boundaries-c71">
+    Three-tier ownership and the `_wrapper_bridge` pattern
+  </Card>
 </CardGroup>

--- a/docs/features/standalone-llm-modules.mdx
+++ b/docs/features/standalone-llm-modules.mdx
@@ -243,7 +243,7 @@ inject_credentials_into_env()
   <Card title="PraisonAI Code CLI" icon="terminal" href="/docs/features/praisonai-code-cli">
     The standalone CLI runtime these modules power
   </Card>
-  <Card icon="layer-group" href="/docs/sdk/praisonai-code#package-boundaries-c71">
+  <Card title="Package Boundaries (C7.1)" icon="layer-group" href="/docs/sdk/praisonai-code#package-boundaries-c71">
     Three-tier ownership and the `_wrapper_bridge` pattern
   </Card>
 </CardGroup>

--- a/docs/guides/praisonai-code-migration.mdx
+++ b/docs/guides/praisonai-code-migration.mdx
@@ -118,6 +118,10 @@ Tracking issue: [PraisonAI#2512](https://github.com/MervinPraison/PraisonAI/issu
 
 ## Compatibility guarantees
 
+<Note>
+**C7.1 (2026-07-02, PR #2559):** Package boundaries are now formally documented in-repo, and the `_wrapper_bridge` pattern is enforced by CI (`scripts/check_c7_imports.sh`, baseline 225 direct wrapper import lines). The regression gate blocks any new module-level wrapper imports outside the sanctioned allowlist. Standalone `praisonai-code` installs degrade gracefully for wrapper-only features rather than raising.
+</Note>
+
 - **`pip install praisonai` remains the only user-facing install.** `praisonai-code` is not published to PyPI standalone during migration.
 - **Existing import paths keep working** — PEP 562 shims at old `praisonai.*` paths land as code moves in C1–C5. `from praisonai.cli.main import PraisonAI` continues unchanged (154+ tests depend on it).
 - **Console entry unchanged** — `praisonai = "praisonai.__main__:main"`.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -375,7 +375,7 @@ graph TB
 | Install command | What you get | Agentic CLI (`run`, `chat`, `code`, …) | Bot / gateway / pairing |
 |-----------------|--------------|----------------------------------------|-------------------------|
 | `pip install praisonai` | Wrapper + code + agents | ✅ Full | ✅ Yes |
-| `pip install praisonai-code` | Terminal-native agent CLI | ✅ Hot path — `run`, `chat`, `code`, daemon | ❌ No (graceful skip) |
+| `pip install praisonai-code` | Terminal-native agent CLI | ✅ Hot path — `run`, `chat`, `code` | ❌ No (graceful skip) |
 | `pip install praisonaiagents` | Core SDK — Python API only | ❌ No CLI | N/A |
 
 <Note>
@@ -392,7 +392,7 @@ graph TB
 | `praisonai run --file agents.yaml --framework crewai` | ❌ Needs wrapper adapters | ✅ Yes |
 | `praisonai agents.yaml` (legacy) | ❌ No | ✅ Yes |
 | `praisonai gateway …` / `praisonai bot …` | ❌ No | ✅ Yes |
-| `python -m praisonai.cli.main --help` | ✅ Help only (framework paths need wrapper) | ✅ Yes |
+| `python -m praisonai_code.cli.main --help` | ✅ Help only (framework paths need wrapper) | ✅ Yes |
 
 For the full three-tier boundary model and the `_wrapper_bridge` API, see [Package Boundaries (C7.1)](/docs/sdk/praisonai-code#package-boundaries-c71).
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -375,12 +375,26 @@ graph TB
 | Install command | What you get | Agentic CLI (`run`, `chat`, `code`, …) | Bot / gateway / pairing |
 |-----------------|--------------|----------------------------------------|-------------------------|
 | `pip install praisonai` | Wrapper + code + agents | ✅ Full | ✅ Yes |
-| `pip install praisonai-code` | Terminal-native agent CLI | ⚠️ Partial — wrapper commands hidden at runtime | ❌ No |
+| `pip install praisonai-code` | Terminal-native agent CLI | ✅ Hot path — `run`, `chat`, `code`, daemon | ❌ No (graceful skip) |
 | `pip install praisonaiagents` | Core SDK — Python API only | ❌ No CLI | N/A |
 
-<Warning>
-**`praisonai-code` standalone is not yet production-ready.** Running `pip install praisonai-code` without `praisonai` hides wrapper-required commands (`bot`, `gateway`, `pairing`, …) and leaves ~170 reverse imports unsatisfied. Use `pip install praisonai` for production deployments. Standalone `praisonai-code` support is planned for a future release (C7).
-</Warning>
+<Note>
+**Standalone `pip install praisonai-code` is supported for the code/run/chat hot path as of PraisonAI 4.6.108+ (C7.1).** Wrapper-only features (`bot`, `gateway`, `pairing`, framework adapters, YAML `--framework crewai/autogen`) require `pip install praisonai`, but they now **degrade gracefully** rather than raising — doctor checks skip with a "wrapper not installed" reason, and features like the recipe creator fall back to defaults.
+</Note>
+
+### C7.1 invocation matrix
+
+| Invocation | Standalone (`pip install praisonai-code`) | Full (`pip install praisonai`) |
+|------------|-------------------------------------------|--------------------------------|
+| `praisonai-code run "prompt"` | ✅ Yes | ✅ Yes |
+| `praisonai-code run --help` | ✅ Yes | ✅ Yes |
+| `praisonai run "prompt"` | ❌ N/A (needs wrapper meta) | ✅ Yes |
+| `praisonai run --file agents.yaml --framework crewai` | ❌ Needs wrapper adapters | ✅ Yes |
+| `praisonai agents.yaml` (legacy) | ❌ No | ✅ Yes |
+| `praisonai gateway …` / `praisonai bot …` | ❌ No | ✅ Yes |
+| `python -m praisonai.cli.main --help` | ✅ Help only (framework paths need wrapper) | ✅ Yes |
+
+For the full three-tier boundary model and the `_wrapper_bridge` API, see [Package Boundaries (C7.1)](/docs/sdk/praisonai-code#package-boundaries-c71).
 
 ### PyPI publish order
 

--- a/docs/sdk/praisonai-code/index.mdx
+++ b/docs/sdk/praisonai-code/index.mdx
@@ -17,6 +17,49 @@ graph LR
     classDef success fill:#10B981,stroke:#7C90A0,color:#fff
 ```
 
+## Package Boundaries (C7.1)
+
+`praisonai-code` sits between `praisonaiagents` (SDK) and `praisonai` (wrapper) — it never imports the wrapper at module load, and reaches wrapper-only features through a single bridge.
+
+You can build an `Agent` and call `agent.start()` standalone; only gateway/bot serving needs the wrapper.
+
+```mermaid
+graph TB
+    A[praisonaiagents\nSDK]:::pkg --> B[praisonai-code\nTerminal CLI]:::pkg
+    B -->|_wrapper_bridge| D{wrapper_available?}:::decision
+    D -->|Yes| C[praisonai\nWrapper]:::wrapper
+    D -->|No — standalone| E[Graceful degradation\nskip / default]:::ok
+
+    classDef pkg fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef wrapper fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef bridge fill:#189AB4,stroke:#7C90A0,color:#fff
+```
+
+### Three-tier ownership
+
+| Package | Owns | Must not depend on |
+|---------|------|-------------------|
+| `praisonaiagents` | Agent, tools, memory, hooks, framework **protocols** | `praisonai`, `praisonai-code` |
+| `praisonai-code` | Terminal CLI: `run`/`chat`/`code`, Typer, runtime, llm, tool resolution | PyPI cycle on `praisonai` (lazy bridge only) |
+| `praisonai` wrapper | Gateway, bots, serve orchestration, framework adapters, heavy integrations | — |
+
+**Publish order:** `praisonaiagents` → `praisonai-code` → `praisonai`
+
+### Wrapper bridge
+
+The **only** sanctioned way for `praisonai-code` code to reach wrapper modules is through `praisonai_code._wrapper_bridge`. This makes standalone installs work — every wrapper call is guarded, so a missing `praisonai` package downgrades cleanly instead of raising `ImportError` at import time.
+
+| Helper | Purpose |
+|--------|---------|
+| `wrapper_available()` | Probe if `praisonai` is importable — no side effects |
+| `import_wrapper_module(name)` | Import a wrapper module (e.g. `"praisonai.framework_adapters.registry"`) with an install-hint error if missing |
+| `get_wrapper_attr(module, attr)` | Fetch a wrapper attribute; raise with install hint if missing |
+| `optional_wrapper_attr(module, attr, default)` | Fetch an attribute or return the supplied default — used by e.g. `recipe_creator.py` for graceful fallback |
+
+---
+
 ## Quick Start
 
 <Steps>


### PR DESCRIPTION
Fixes #1416

## Summary
- **installation.mdx**: Replaces outdated "not yet production-ready" Warning with a C7.1 Note + invocation matrix sourced verbatim from C7.1_BOUNDARIES.md
- **sdk/praisonai-code/index.mdx**: Adds "Package Boundaries (C7.1)" section with three-tier ownership table, wrapper-bridge API table, and hero Mermaid diagram
- **features/praisonai-code-cli.mdx**: Adds "Wrapper-command loading" subsection documenting _WRAPPER_COMMANDS behaviour and graceful skip on standalone install
- **cli/doctor.mdx**: Adds top-of-section Note + per-category skip annotations (Runtime, Serve, Bots, ACP) for standalone install
- **features/standalone-llm-modules.mdx**: Adds CardGroup cross-link to new Package Boundaries section
- **guides/praisonai-code-migration.mdx**: Adds C7.1 sign-off Note preserving existing "not published to PyPI standalone" line

## Verification
- docs.json unchanged and valid (python3 -m json.tool passes)
- Zero writes under docs/concepts/, docs/js/, docs/rust/
- All source strings verified verbatim against C7.1_BOUNDARIES.md, _wrapper_bridge.py, _wrapper_checks.py, cli/app.py

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which commands and features are available in standalone `praisonai-code` versus the full `praisonai` install.
  * Added guidance on how wrapper-only features behave when the wrapper is missing, including graceful skips and fallback behavior.
  * Expanded installation, migration, and CLI docs with command matrices, examples, and package boundary details.
  * Added new package-boundary guidance and related documentation links for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->