### PR TITLE
docs: complete AGENTS alignment batch 26 (features, #1351)

### DIFF
--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -20,6 +20,8 @@ agent = Agent(
 agent.start("Calculate something using my tools")
 ```
 
+The user asks for a calculation; ToolResolver loads callables and BaseTool classes from tools.py for the agent.
+
 ```mermaid
 graph LR
     subgraph "Tool Resolution Flow"

--- a/docs/features/tool-retry-backoff.mdx
+++ b/docs/features/tool-retry-backoff.mdx
@@ -19,6 +19,8 @@ agent = Agent(name="Resilient Agent", tools=[fetch_report], max_retry_limit=3)
 agent.start("Get me the latest report")
 ```
 
+The user requests a report; transient tool failures retry with exponential backoff and jitter until success or the limit is reached.
+
 ```mermaid
 graph LR
     Request[📝 Request] --> Tool[🔧 Tool]

--- a/docs/features/tool-retry-policy.mdx
+++ b/docs/features/tool-retry-policy.mdx
@@ -25,6 +25,8 @@ agent = Agent(
 agent.start("Find information about renewable energy")
 ```
 
+The user asks for web research; RetryPolicy re-runs retryable tool errors with backoff before surfacing a failure.
+
 ```mermaid
 graph LR
     Call[🔧 Tool Call] --> Try{🔄 Attempt}

--- a/docs/features/tool-search.mdx
+++ b/docs/features/tool-search.mdx
@@ -18,6 +18,8 @@ agent = Agent(
 agent.start("Find the design review thread on Slack")
 ```
 
+The user asks about Slack; tool_search discloses only the tools needed so large MCP catalogues stay out of context.
+
 ```mermaid
 graph LR
     subgraph "Tool Search Flow"


### PR DESCRIPTION
## Summary
- Completes batch 26 slice ( … ): adds hero **The user…** interaction lines before the first mermaid on the four files missed in #1425 (, , , ).
- Remaining 16 files in the slice were already aligned in #1425 / #1424.

## AGENTS.md rules
- §1.1(10) user-interaction flow before hero mermaid
- §1.1(9) agent-centric opener (already present on these pages)

## Test plan
- [x] All 20 batch-26 slice files have `The user` before first ```mermaid`
- [x] `docs.json` valid JSON
- [x] No `docs/concepts/` edits

Refs #1351