### PR TITLE
docs: AGENTS alignment batch 28 (features, #1351)

### DIFF
--- a/docs/features/a2a-tasks.mdx
+++ b/docs/features/a2a-tasks.mdx
@@ -12,10 +12,11 @@ agent = Agent(name="task-manager", instructions="Manage A2A tasks via JSON-RPC."
 agent.start("List all active A2A tasks and cancel any that are overdue.")
 ```
 
-The user asks for task status; the agent calls A2A JSON-RPC to list or cancel remote tasks.
 
 
 Tasks are the core unit of work in the A2A protocol, managing the complete lifecycle from submission to completion with built-in state tracking and storage.
+
+The user asks for task status; the agent calls A2A JSON-RPC to list or cancel remote tasks.
 
 ```mermaid
 graph LR

--- a/docs/features/a2ui.mdx
+++ b/docs/features/a2ui.mdx
@@ -7,6 +7,18 @@ icon: "window"
 
 A2UI lets agents send declarative JSON UI specs that clients render with trusted component catalogues — integrate via the optional `a2ui-agent-sdk` package.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="assistant",
+    instructions="Return declarative UI when a rich layout helps",
+)
+agent.start("Show a summary card with a primary action")
+```
+
+The user sends a chat message; the agent may respond with A2UI JSON for the client to render.
+
 ```mermaid
 graph LR
     A[Agent] --> J[A2UI JSON]
@@ -20,19 +32,6 @@ graph LR
     class A agent
     class J,P,R,U tool
 ```
-
-```python
-from praisonaiagents import Agent
-
-agent = Agent(
-    name="assistant",
-    instructions="Return declarative UI when a rich layout helps",
-)
-
-agent.start("Show a summary card with a primary action")
-```
-
-The user sends a chat message; the agent may respond with A2UI JSON for the client to render.
 
 <Warning>
 Install the optional extra: `pip install praisonaiagents[a2ui]`

--- a/docs/features/advanced-memory.mdx
+++ b/docs/features/advanced-memory.mdx
@@ -18,6 +18,8 @@ agent = Agent(
 agent.start("What did we decide about the launch date?")
 ```
 
+The user chats across turns; multi-tier memory stores and scores context for later retrieval.
+
 ```mermaid
 graph TB
     subgraph Memory Tiers

--- a/docs/features/agent-as-tool.mdx
+++ b/docs/features/agent-as-tool.mdx
@@ -21,12 +21,13 @@ writer = Agent(
 writer.start("Write a short post about quantum computing with cited facts")
 ```
 
-The user asks for a polished article; the writer agent invokes the researcher as a tool.
 
 
 ## Overview
 
 The `as_tool()` method allows you to use one agent as a tool for another agent. This enables **hierarchical agent composition** where a parent agent can invoke specialist agents as subordinate tools.
+
+The user asks for a polished article; the writer agent invokes the researcher as a tool.
 
 ```mermaid
 flowchart LR

--- a/docs/features/agent-cloning.mdx
+++ b/docs/features/agent-cloning.mdx
@@ -7,6 +7,14 @@ icon: "copy"
 
 Clone agents to give each channel, tenant, or session its own isolated instance — without losing config or hitting `RLock` pickling errors.
 
+```python
+from praisonaiagents import Agent
+
+base = Agent(name="Support", instructions="Help customers consistently.")
+clone = base.clone(name="Support-Telegram")
+clone.start("Hello from Telegram")
+```
+
 The user deploys one base agent to several channels; each clone keeps the same instructions with isolated session state.
 
 ```mermaid

--- a/docs/features/agent-learn-skill.mdx
+++ b/docs/features/agent-learn-skill.mdx
@@ -12,9 +12,10 @@ agent = Agent(name="Skill Author", instructions="Distil reusable skills from sou
 agent.learn("Create a deploy-flow skill from this repo and runbook.")
 ```
 
-The user points the agent at repos or docs; it distils a reusable SKILL.md the team can invoke on later runs.
 
 Point an agent at real source material and get one grounded `SKILL.md` back — ready to reuse immediately.
+
+The user points the agent at repos or docs; it distils a reusable SKILL.md the team can invoke on later runs.
 
 ```mermaid
 graph LR

--- a/docs/features/agent-max-budget.mdx
+++ b/docs/features/agent-max-budget.mdx
@@ -11,6 +11,17 @@ Cap how much an agent can spend per run with `ExecutionConfig(max_budget=...)` â
 **Async enforcement.** `max_budget` is now enforced on async paths (`astart()` / `achat()`) as well as sync paths. Gateway bots using async agents will receive `BudgetExceededError` when their configured ceiling is reached. Previously only sync dispatch enforced the limit.
 </Note>
 
+```python
+from praisonaiagents import Agent, ExecutionConfig
+
+agent = Agent(
+    name="Researcher",
+    instructions="You research topics thoroughly",
+    execution=ExecutionConfig(max_budget=0.50),
+)
+agent.start("Summarise today's AI news")
+```
+
 The user sets a spend cap; the agent stops the run and raises `BudgetExceededError` once estimated cost exceeds the limit.
 
 ```mermaid

--- a/docs/features/agent-profiles.mdx
+++ b/docs/features/agent-profiles.mdx
@@ -16,10 +16,11 @@ agent = Agent(
 agent.start("Help a customer reset their password.")
 ```
 
-The user describes a support issue; the agent loads the right profile and responds in that mode.
 
 
 Use built-in agent profiles and modes to spin up specialised assistants without rewriting prompts from scratch.
+
+The user describes a support issue; the agent loads the right profile and responds in that mode.
 
 ```mermaid
 graph LR

--- a/docs/features/agent-retry.mdx
+++ b/docs/features/agent-retry.mdx
@@ -7,6 +7,19 @@ icon: "clock-rotate-left"
 
 Agent retry automatically re-runs failed LLM calls with jittered exponential backoff so transient rate limits, overloads, and network blips don't break your agent.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Researcher",
+    instructions="Research topics on the web",
+    retry=True,
+)
+agent.start("Find recent papers on diffusion models")
+```
+
+The user runs an agent; transient LLM failures retry automatically with jittered backoff.
+
 ```mermaid
 graph LR
     Call[📨 LLM Call] --> Try{🔄 Attempt}

--- a/docs/features/agent-run-outcomes.mdx
+++ b/docs/features/agent-run-outcomes.mdx
@@ -7,6 +7,14 @@ icon: "circle-check"
 
 Run outcomes give every agent execution a typed status so your code can handle success, failure, timeout, cancellation, and invalid output exhaustively — no string matching.
 
+```python
+from praisonaiagents import Agent, AgentRunOutcome
+
+agent = Agent(name="Research Agent", instructions="Research and report clearly")
+outcome = agent.start("Summarise agent run outcomes")
+assert isinstance(outcome, AgentRunOutcome)
+```
+
 The user handles every finish state in code; the agent returns a typed `AgentRunOutcome` instead of an ambiguous string.
 
 ```mermaid

--- a/docs/features/allowed-tools.mdx
+++ b/docs/features/allowed-tools.mdx
@@ -7,6 +7,19 @@ icon: "shield-check"
 
 Tool whitelisting prevents agent confusion by filtering visible tools to only those explicitly allowed, solving collision problems in multi-environment deployments.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    instructions="Use only whitelisted tools",
+    tools=["search", "send_message"],
+)
+agent.start("Search the docs and send a summary")
+```
+
+The user restricts visible tools; the agent only sees whitelisted names from the environment or config.
+
 ```mermaid
 graph LR
     subgraph "Tool Collision Resolution"

--- a/docs/features/approval-backends.mdx
+++ b/docs/features/approval-backends.mdx
@@ -19,6 +19,8 @@ agent = Agent(
 agent.start("Refactor utils.py")
 ```
 
+The user triggers a risky tool; the chosen approval backend prompts or routes the decision to a human.
+
 ```mermaid
 graph TB
     subgraph "pip install praisonai-code"

--- a/docs/features/approval.mdx
+++ b/docs/features/approval.mdx
@@ -19,7 +19,6 @@ agent = Agent(
 agent.start("Remove unused imports in utils.py")
 ```
 
-The user requests a code change; the agent pauses for approval before running dangerous tools.
 
 <Note>
 **Durability:** For chat bots, pending approvals can survive a gateway restart when you configure an [`ApprovalStore`](/docs/features/durable-approvals). Each `ApprovalRequest` includes `approval_id`, `agent_name`, and `session_id` for correlation.
@@ -44,6 +43,8 @@ The user requests a code change; the agent pauses for approval before running da
 <Note>
 **Sync and Async Parity**: Approval checks now work uniformly in both sync and async tool execution paths.
 </Note>
+
+The user requests a code change; the agent pauses for approval before running dangerous tools.
 
 ```mermaid
 graph LR

--- a/docs/features/async-agent-scheduler.mdx
+++ b/docs/features/async-agent-scheduler.mdx
@@ -16,12 +16,13 @@ agent = Agent(
 # Schedule via AsyncAgentScheduler (see Quick Start)
 ```
 
-The user sets a recurring schedule; the scheduler runs the agent asynchronously, retries on failure, and records stats without blocking the event loop.
 
 
 <Note>
 Since PraisonAI PR #1566, exceptions inside a scheduled run are caught and reported via `on_failure` without killing the scheduler loop. Use `await scheduler.get_stats_async()` for metrics from async code.
 </Note>
+
+The user sets a recurring schedule; the scheduler runs the agent asynchronously without blocking the event loop.
 
 ```mermaid
 graph LR

--- a/docs/features/async-db-hooks.mdx
+++ b/docs/features/async-db-hooks.mdx
@@ -21,7 +21,6 @@ agent = Agent(
 # In async code: await agent.achat("Remember my preferences")
 ```
 
-The user chats asynchronously; DB hooks persist messages without blocking the event loop.
 
 <Warning>
 **Breaking Change in PR #1829**: The `async_*` prefixed methods have been removed from async stores. The orchestrator now uses `isinstance(store, AsyncConversationStore)` for dispatch instead of runtime method introspection.
@@ -34,6 +33,8 @@ session = await store.async_get_session(session_id)
 session = await store.get_session(session_id)
 ```
 </Warning>
+
+The user chats asynchronously; DB hooks persist messages without blocking the event loop.
 
 ```mermaid
 graph LR

--- a/docs/features/async-jobs.mdx
+++ b/docs/features/async-jobs.mdx
@@ -18,10 +18,11 @@ async def main():
 asyncio.run(main())
 ```
 
-The user submits a long job; the agent runs asynchronously and returns when the job completes.
 
 
 Submit long-running agent tasks and recipes, then retrieve results asynchronously via a jobs server.
+
+The user submits a long job; the agent runs asynchronously and returns when the job completes.
 
 ```mermaid
 graph LR

--- a/docs/features/bot-command-access-control.mdx
+++ b/docs/features/bot-command-access-control.mdx
@@ -14,9 +14,10 @@ config = BotConfig(admin_users="123456789", user_allowed_commands={})
 agent.start("Restrict /learn to admins only")
 ```
 
-The user sends a restricted slash command; admins pass the policy check while other users only run commands on their allowlist.
 
 Per-command access control layers on top of user allowlists — admins run any command, regular users only run commands you explicitly permit. `CommandAccessPolicy` applies uniformly to **Telegram, Slack, and Discord** bots via the shared `CommandRegistry`.
+
+The user sends a restricted slash command; admins pass the policy check while other users only run commands on their allowlist.
 
 ```mermaid
 graph LR

--- a/docs/features/bot-lifecycle-hooks.mdx
+++ b/docs/features/bot-lifecycle-hooks.mdx
@@ -14,11 +14,12 @@ agent = Agent(name="assistant", instructions="You are a helpful messaging bot.")
 agent.start("Log when sessions start and end.")
 ```
 
-The user opens a chat session; lifecycle hooks fire on gateway start, session boundaries, and scheduled jobs without changing agent code.
 
 <Note>
 This page covers **in-process outbound lifecycle hooks** (GATEWAY_START, SESSION_START, SCHEDULE_TRIGGER) that fire inside the running gateway. For **HTTP inbound triggers** that let external services start agent runs via `POST /hooks/<path>`, see [Gateway Inbound Hooks](/docs/features/gateway-inbound-hooks).
 </Note>
+
+The user opens a chat session; lifecycle hooks fire on gateway start, session boundaries, and scheduled jobs.
 
 ```mermaid
 graph LR

--- a/docs/features/bot-platform-capabilities.mdx
+++ b/docs/features/bot-platform-capabilities.mdx
@@ -14,11 +14,12 @@ agent = Agent(name="assistant", instructions="Reply on Telegram with streaming w
 agent.start("Send a long answer with progressive updates.")
 ```
 
-The user receives a reply; platform capabilities tell PraisonAI how to chunk, stream, and rate-limit on that channel.
 
 <Info>
 Capabilities describe what a channel **can** render; [Display Policy](/docs/features/display-policy) controls what you **want** shown.
 </Info>
+
+The user receives a reply; platform capabilities tell PraisonAI how to chunk, stream, and rate-limit on that channel.
 
 ```mermaid
 graph LR

--- a/docs/features/bot-platform-plugins.mdx
+++ b/docs/features/bot-platform-plugins.mdx
@@ -12,11 +12,12 @@ agent = Agent(name="platform-bot", instructions="Use platform-specific bot plugi
 agent.start("Enable Telegram and Discord plugins for this bot.")
 ```
 
-The user installs a third-party bot package; entry points register new platforms alongside built-in channels.
 
 
 
 Third-party bot packages can register via Python entry points to extend PraisonAI with custom messaging platforms.
+
+The user installs a third-party bot package; entry points register new platforms alongside built-in channels.
 
 ```mermaid
 graph LR


### PR DESCRIPTION
## Summary
- Align 20 `docs/features/*.mdx` pages (a2a-tasks through bot-platform-plugins) with AGENTS hero pattern: agent-centric Python opener plus a "The user…" line immediately before the first mermaid diagram.
- No changes under `docs/concepts/`.

Refs #1351

## Test plan
- [x] Audit script: 20 edited pages pass hero + pre-mermaid user line checks
- [x] Remaining feature gaps: 119 (down from 139 pre-batch)


Made with [Cursor](https://cursor.com)