### PR TITLE
docs: AGENTS alignment batch 29 (features, #1351)

### DIFF
--- a/docs/features/cockroachdb.mdx
+++ b/docs/features/cockroachdb.mdx
@@ -7,6 +7,15 @@ icon: "bug"
 
 CockroachDB provides a distributed, PostgreSQL-compatible database that automatically scales and handles multi-region deployments for resilient AI agents.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="db-agent", instructions="Persist state in CockroachDB.")
+agent.start("Save this session and query it from another region.")
+```
+
+The user runs agents backed by CockroachDB; SQL requests route through distributed nodes with automatic replication.
+
 ```mermaid
 graph LR
     subgraph "CockroachDB Distributed Architecture"

--- a/docs/features/code-execution-with-tools.mdx
+++ b/docs/features/code-execution-with-tools.mdx
@@ -7,6 +7,19 @@ icon: "code-branch"
 
 Model-generated code can call your registered tools directly, collapsing multi-step tool pipelines into a single LLM turn.
 
+```python
+from praisonaiagents import Agent, ExecutionConfig
+
+agent = Agent(
+    name="bridge-agent",
+    instructions="Use code mode to chain tools in one turn.",
+    execution=ExecutionConfig(code_tools=True),
+)
+agent.start("Fetch weather and format a summary in one script.")
+```
+
+The user asks for a multi-step task; the agent emits code that calls registered tools through the in-process bridge.
+
 ```mermaid
 graph LR
     subgraph "Code Mode Tool Bridge"

--- a/docs/features/code.mdx
+++ b/docs/features/code.mdx
@@ -15,6 +15,8 @@ agent.start("Write a function to check if a number is prime.")
 
 PraisonAI Code provides AI agents with powerful tools to read, write, and modify code files with surgical precision. Inspired by Kilo Code's architecture, it uses a SEARCH/REPLACE diff strategy with fuzzy matching for reliable code modifications.
 
+The user asks the agent to edit project files; read, write, and SEARCH/REPLACE diffs apply changes safely.
+
 ```mermaid
 graph LR
     subgraph "AI Code Editing"

--- a/docs/features/codeagent.mdx
+++ b/docs/features/codeagent.mdx
@@ -6,6 +6,17 @@ icon: "code"
 ---
 
 
+Code agents run model-generated Python in a sandboxed interpreter so numeric and data tasks execute safely.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="code-runner", instructions="Write and execute Python to answer questions.")
+agent.start("Plot a sine wave and return the peak value.")
+```
+
+The user submits a task; the agent writes Python, runs it in the sandbox, and returns the result.
+
 ```mermaid
 flowchart LR
     In[Input] --> Agent[Agent]

--- a/docs/features/command-aware-permissions.mdx
+++ b/docs/features/command-aware-permissions.mdx
@@ -29,6 +29,8 @@ agent = Agent(
 agent.start("Tidy up /tmp")
 ```
 
+The user approves shell tools; compound commands are parsed so hidden `deny` rules still block unsafe operations.
+
 ```mermaid
 graph LR
     subgraph "Command-Aware Permission Check"

--- a/docs/features/concurrency.mdx
+++ b/docs/features/concurrency.mdx
@@ -7,6 +7,19 @@ icon: "gauge"
 
 Concurrency controls let you limit parallel agent execution and set timeouts for tool calls to prevent resource exhaustion.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="worker",
+    instructions="Respect concurrency limits across tool calls",
+)
+
+agent.start("Process these jobs without overloading APIs")
+```
+
+The user runs parallel work; concurrency controls cap simultaneous operations and tool timeouts.
+
 ```mermaid
 graph LR
     subgraph "Concurrency Control Flow"
@@ -34,18 +47,6 @@ graph LR
     class Error error
 ```
 
-```python
-from praisonaiagents import Agent
-
-agent = Agent(
-    name="worker",
-    instructions="Respect concurrency limits across tool calls",
-)
-
-agent.start("Process these jobs without overloading APIs")
-```
-
-The user runs parallel work; concurrency controls cap simultaneous operations.
 
 ## Quick Start
 

--- a/docs/features/conditional-branching.mdx
+++ b/docs/features/conditional-branching.mdx
@@ -7,6 +7,16 @@ icon: "code-branch"
 
 Conditional branching lets you create dynamic workflows that take different paths based on runtime conditions. Use the `if:` pattern to evaluate variables and route execution accordingly.
 
+```python
+from praisonaiagents import Agent, when
+
+agent = Agent(name="router", instructions="Branch based on runtime variables")
+branch = when(condition="{{tier}} == 'pro'", then_steps=["pro_handler"], else_steps=["standard"])
+agent.start("Route this customer request")
+```
+
+The user triggers a flow; conditions pick the next step from runtime values.
+
 ```mermaid
 flowchart TD
     A[Start] --> B{Condition}
@@ -14,30 +24,12 @@ flowchart TD
     B -->|False| D[Else Branch]
     C --> E[Continue]
     D --> E
-    
-    style A fill:#8B0000,color:#fff
-    style B fill:#189AB4,color:#fff
-    style C fill:#8B0000,color:#fff
-    style D fill:#8B0000,color:#fff
-    style E fill:#8B0000,color:#fff
+
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
-    class A,B agent
-    class C tool
-
+    class A,C,D,E agent
+    class B tool
 ```
-    classDef agent fill:#8B0000,color:#fff
-    classDef tool fill:#189AB4,color:#fff
-
-```python
-from praisonaiagents import Agent, when
-
-agent = Agent(name="router", instructions="Branch based on runtime variables")
-branch = when(condition="{{tier}} == "pro"", then_steps=["pro_handler"], else_steps=["standard"])
-agent.start("Route this customer request")
-```
-
-The user triggers a flow; conditions pick the next step from runtime values.
 
 ## Quick Start
 

--- a/docs/features/conditions.mdx
+++ b/docs/features/conditions.mdx
@@ -10,6 +10,15 @@ PraisonAI now provides a **unified condition syntax** that works the same way in
 </Info>
 
 
+```python
+from praisonaiagents import Agent, Task, when
+
+agent = Agent(name="conditional", instructions="Run tasks only when conditions match.")
+agent.start("Execute the follow-up step if the score is above 0.8.")
+```
+
+The user defines workflows; `when` expressions gate tasks and AgentFlow steps on runtime variables.
+
 ```mermaid
 flowchart LR
     In[Input] --> Agent[Agent]

--- a/docs/features/config-file.mdx
+++ b/docs/features/config-file.mdx
@@ -7,6 +7,15 @@ icon: "gear"
 
 Set default values for all Agent parameters using a configuration file. When you pass `True` to a feature, it uses your configured defaults.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="configured", instructions="Use defaults from config.toml.")
+agent.start("Hello — apply my saved model and memory settings.")
+```
+
+The user sets defaults in `.praisonai/config.toml`; explicit Agent parameters still override the file.
+
 ```mermaid
 graph LR
     subgraph "Configuration Sources"

--- a/docs/features/configurable-model.mdx
+++ b/docs/features/configurable-model.mdx
@@ -7,6 +7,15 @@ icon: "sliders"
 
 One agent, many models — override the LLM for a single call with `config=`, or permanently swap it with `switch_model()`, all while keeping your conversation history intact.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="flex", instructions="Answer with the best model for each task.", llm="gpt-4o-mini")
+agent.start("Draft a short poem, then switch to a stronger model for critique.")
+```
+
+The user keeps one agent; per-call `config=` or `switch_model()` changes the LLM without losing history.
+
 ```mermaid
 graph TB
     A[Agent] --> B{Which model?}

--- a/docs/features/context-api.mdx
+++ b/docs/features/context-api.mdx
@@ -22,6 +22,8 @@ agent.start("What did we discuss in the previous session?")
 Complete reference for CLI commands, flags, environment variables, and configuration options.
 
 
+The user inspects or trims context via CLI and config; the agent stays within the configured window.
+
 ```mermaid
 flowchart LR
     In[Input] --> Agent[Agent]

--- a/docs/features/context-budgeter-cli.mdx
+++ b/docs/features/context-budgeter-cli.mdx
@@ -7,6 +7,15 @@ icon: "gauge"
 
 Reserve output tokens and inspect per-segment budgets so long agent runs don't exhaust context before the model can reply.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="budget-cli", instructions="Respect output token reserves.")
+agent.start("Run a long task without exhausting the context budget.")
+```
+
+The user runs the agent from the CLI and checks `/context budget` to see segment allocation.
+
 ```mermaid
 graph LR
     M[Model Limit] --> B[Budget Allocator]

--- a/docs/features/context-budgeter.mdx
+++ b/docs/features/context-budgeter.mdx
@@ -10,6 +10,19 @@ icon: "coins"
 The Context Budgeter allocates token budgets across context segments based on model limits and configurable priorities.
 
 
+```python
+from praisonaiagents import Agent, ManagerConfig
+
+agent = Agent(
+    name="budget-agent",
+    instructions="Stay within token budgets.",
+    context=ManagerConfig(output_reserve=16000),
+)
+agent.start("Summarise this thread without using the full window.")
+```
+
+The user configures segment priorities; the budgeter allocates tokens before each model call.
+
 ```mermaid
 flowchart LR
     In[Input] --> Agent[Agent]

--- a/docs/features/context-cli-reference.mdx
+++ b/docs/features/context-cli-reference.mdx
@@ -15,6 +15,8 @@ agent.start("Show the current context window usage and compression stats.")
 
 Complete reference for all context management CLI commands and flags.
 
+The user runs `/context` commands in the terminal to show, compact, or budget the active session.
+
 ```mermaid
 graph LR
     subgraph "Context Management CLI"

--- a/docs/features/context-compaction-policy.mdx
+++ b/docs/features/context-compaction-policy.mdx
@@ -7,6 +7,19 @@ icon: "shield-check"
 
 Context Compaction Policy proactively routes long agent runs through token-budget checks before each LLM call, picking the right compaction strategy before context overflow happens.
 
+```python
+from praisonaiagents import Agent, ExecutionConfig
+
+agent = Agent(
+    name="LongRunner",
+    instructions="Handle long multi-turn research sessions.",
+    execution=ExecutionConfig(context_compaction=True),
+)
+agent.start("Continue our three-hour research thread.")
+```
+
+The user runs long sessions; policy checks token budgets before each LLM call and compacts when needed.
+
 ```mermaid
 graph LR
     subgraph "Policy Flow"

--- a/docs/features/context-compaction.mdx
+++ b/docs/features/context-compaction.mdx
@@ -9,6 +9,19 @@ icon: "compress"
 
 Context compaction automatically manages context window size while preventing models from treating summarized history as active instructions.
 
+```python
+from praisonaiagents import Agent, ExecutionConfig
+
+agent = Agent(
+    name="LongChat",
+    instructions="You are a helpful assistant.",
+    execution=ExecutionConfig(context_compaction=True),
+)
+agent.start("Pick up where we left off yesterday.")
+```
+
+The user continues a long chat; compaction summarises older turns with anti-injection framing when the window fills.
+
 ```mermaid
 graph LR
     subgraph "Context Compaction Flow"

--- a/docs/features/context-compression.mdx
+++ b/docs/features/context-compression.mdx
@@ -26,6 +26,8 @@ This page documents `praisonaiagents.rag.ContextCompressor` for compressing retr
 Context compression reduces retrieved content to fit within token budgets while preserving query-relevant information.
 
 
+The user retrieves large knowledge chunks; compression deduplicates and trims text to fit the token budget.
+
 ```mermaid
 flowchart LR
     In[Input] --> Agent[Agent]

--- a/docs/features/context-estimation-validation.mdx
+++ b/docs/features/context-estimation-validation.mdx
@@ -16,6 +16,8 @@ agent.start("How many tokens will this 5000-word document use?")
 Token estimation validation compares heuristic estimates against accurate counts, logging mismatches for debugging.
 
 
+The user monitors context size; validated estimation compares heuristics to accurate counts and logs mismatches.
+
 ```mermaid
 flowchart LR
     In[Input] --> Agent[Agent]

--- a/docs/features/context-files.mdx
+++ b/docs/features/context-files.mdx
@@ -7,6 +7,15 @@ icon: "file-text"
 
 Context files automatically inject markdown content into your agent's instructions — drop an `AGENTS.md` in your project root and every run sees it, no config needed.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="project-agent", instructions="Follow project AGENTS.md guidelines.")
+agent.start("Implement the feature using our team conventions.")
+```
+
+The user adds `AGENTS.md` or `CLAUDE.md`; discovery merges layered markdown into the agent instructions.
+
 ```mermaid
 graph LR
     subgraph "Context Injection Flow"

--- a/docs/features/context-ledger.mdx
+++ b/docs/features/context-ledger.mdx
@@ -18,6 +18,8 @@ agent.start("Show me the token usage ledger for today.")
 The Context Ledger tracks token usage across different context segments, enabling precise budget monitoring and optimization decisions.
 
 
+The user tracks token spend; the ledger records per-segment usage for budget decisions.
+
 ```mermaid
 flowchart LR
     In[Input] --> Agent[Agent]


### PR DESCRIPTION
## Summary
- Adds hero agent-centric Python examples and **The user…** interaction lines immediately before the first mermaid on 20 `docs/features/` pages (cockroachdb → context-ledger), per #1351 / AGENTS.md §1.1.
- Fixes conditional-branching hero mermaid markup and reorders concurrency hero (agent example + user flow before diagram).
- Does **not** touch `docs/concepts/`.

## Test plan
- [x] Gap audit: 45 → 25 remaining in `docs/features/*.mdx` (missing "The user" before first mermaid)
- [ ] Mintlify build (if CI runs)

Refs #1351

Made with [Cursor](https://cursor.com)