### PR TITLE
docs(tools): AGENTS alignment batch 2 (#1351)

### DIFF
--- a/docs/features/industry-templates/agriculture.mdx
+++ b/docs/features/industry-templates/agriculture.mdx
@@ -7,6 +7,17 @@ icon: "wheat"
 
 Analyse drone or satellite imagery, detect crop stress and pests before they spread, and receive actionable treatment plans — all from a single workflow call.
 
+Analyse drone or satellite imagery, detect crop stress and pests before they spread, and receive actionable treatment plans — all from a single workflow call.
+
+```python
+from examples.cookbooks.Industry_Templates.agriculture_template import precision_agriculture_workflow
+
+result = precision_agriculture_workflow("Field 12 multispectral scan — NDVI drop in north quadrant")
+print(result)
+```
+
+The user uploads crop imagery; agents detect stress, pests, and irrigation recommendations per field.
+
 ```mermaid
 graph LR
     subgraph "Precision Agriculture Workflow"
@@ -25,6 +36,8 @@ graph LR
     class MA,DI,SR,YP agent
     class OUT output
 
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/industry-templates/energy.mdx
+++ b/docs/features/industry-templates/energy.mdx
@@ -7,6 +7,17 @@ icon: "bolt"
 
 Monitor an entire wind farm, detect mechanical faults early, forecast 24-hour power output, and schedule maintenance — all in one workflow call.
 
+Monitor an entire wind farm, detect mechanical faults early, forecast 24-hour power output, and schedule maintenance — all in one workflow call.
+
+```python
+from examples.cookbooks.Industry_Templates.energy_template import energy_monitoring_workflow
+
+result = energy_monitoring_workflow("Wind farm sector 7 — vibration spike on turbine T-12")
+print(result)
+```
+
+The user sends a SCADA alert; agents monitor assets, forecast output, and recommend maintenance actions.
+
 ```mermaid
 graph LR
     subgraph "Energy Monitoring Workflow"
@@ -25,6 +36,8 @@ graph LR
     class SR,VA,PF,MS agent
     class OUT output
 
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/industry-templates/healthcare.mdx
+++ b/docs/features/industry-templates/healthcare.mdx
@@ -7,6 +7,17 @@ icon: "stethoscope"
 
 From patient arrival to bed assignment in four coordinated agents — with built-in HIPAA-compliant data handling and safety red-flag detection at every step.
 
+From patient arrival to bed assignment in four coordinated agents — with built-in HIPAA-compliant data handling and safety red-flag detection at every step.
+
+```python
+from examples.cookbooks.Industry_Templates.healthcare_template import emergency_triage_workflow
+
+result = emergency_triage_workflow("Patient arrival: chest pain, BP 180/110, SpO2 94%")
+print(result)
+```
+
+The user describes a patient presentation; agents triage vitals, suggest orders, and assign bed priority.
+
 ```mermaid
 graph LR
     subgraph "Emergency Triage Workflow"
@@ -25,6 +36,8 @@ graph LR
     class VS,EM,TR,RA agent
     class OUT output
 
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/industry-templates/manufacturing.mdx
+++ b/docs/features/industry-templates/manufacturing.mdx
@@ -7,6 +7,19 @@ icon: "factory"
 
 Turn an unstructured order (email, PDF, API payload) into a quality-checked production schedule with a single function call.
 
+Turn an unstructured order (email, PDF, API payload) into a quality-checked production schedule with a single function call.
+
+```python
+from examples.cookbooks.Industry_Templates.manufacturing_template import manufacturing_workflow
+
+result = manufacturing_workflow(
+    "Customer ABC needs 100 units of Product-XYZ by March 15th, high priority"
+)
+print(result)
+```
+
+The user submits unstructured order text; four agents parse inventory, schedule production, and return a quality report.
+
 ```mermaid
 graph LR
     subgraph "Manufacturing Workflow"
@@ -25,6 +38,8 @@ graph LR
     class PO,CI,OS,DD agent
     class OUT output
 
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/industry-templates/overview.mdx
+++ b/docs/features/industry-templates/overview.mdx
@@ -7,6 +7,21 @@ icon: "building-2"
 
 Five production-ready agent pipelines built on the SRAO Framework, each targeting a specific industry with typed I/O schemas, SLA targets, and graceful fallback strategies.
 
+Five production-ready agent pipelines built on the SRAO Framework, each targeting a specific industry with typed I/O schemas, SLA targets, and graceful fallback strategies.
+
+```python
+from praisonaiagents import Agent
+from examples.cookbooks.Industry_Templates.manufacturing_template import manufacturing_workflow
+
+agent = Agent(name="ops-lead", instructions="Route industry template workflows.")
+result = manufacturing_workflow(
+    "Customer ABC needs 100 units of Product-XYZ by March 15th, high priority"
+)
+print(result)
+```
+
+The user picks an industry template; agents parse the request and return a structured operations report.
+
 ```mermaid
 graph LR
     subgraph "Industry Templates"
@@ -23,6 +38,8 @@ graph LR
     class SRAO hub
     class MFG,ENG,HC,AG,TR industry
 
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/industry-templates/transportation.mdx
+++ b/docs/features/industry-templates/transportation.mdx
@@ -7,6 +7,17 @@ icon: "truck"
 
 Process LiDAR scans of tunnels and bridges, calculate structural displacement in millimetres, generate safety heatmaps, and schedule maintenance — all in one workflow call.
 
+Process LiDAR scans of tunnels and bridges, calculate structural displacement in millimetres, generate safety heatmaps, and schedule maintenance — all in one workflow call.
+
+```python
+from examples.cookbooks.Industry_Templates.transportation_template import infrastructure_safety_workflow
+
+result = infrastructure_safety_workflow("Tunnel scan TS-401 — displacement 3.2mm at chainage 1200")
+print(result)
+```
+
+The user submits LiDAR scan data; agents fuse sensors, score structural risk, and flag safety actions.
+
 ```mermaid
 graph LR
     subgraph "Infrastructure Monitoring Workflow"
@@ -25,6 +36,8 @@ graph LR
     class LF,DC,HG,MP agent
     class OUT output
 
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/activity-log.mdx
+++ b/docs/features/platform/activity-log.mdx
@@ -7,6 +7,17 @@ icon: "clock"
 
 Activity Log provides comprehensive audit trail and event tracking for all workspace activities, enabling team transparency, debugging, and compliance monitoring.
 
+Activity Log provides comprehensive audit trail and event tracking for all workspace activities, enabling team transparency, debugging, and compliance monitoring.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="auditor", instructions="Explain recent workspace activity.")
+agent.start("Summarise activity on this workspace in the last hour.")
+```
+
+The user reviews the audit trail to see who changed issues, agents, or membership and when.
+
 ```mermaid
 graph LR
     subgraph "Activity Tracking"
@@ -22,6 +33,8 @@ graph LR
     class Event event
     class Capture capture
     class Store,View view
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 <Note>

--- a/docs/features/platform/agents.mdx
+++ b/docs/features/platform/agents.mdx
@@ -7,6 +7,17 @@ icon: "user"
 
 Platform agents are AI workers registered in a workspace that can be assigned to issues and create comments automatically.
 
+Platform agents are AI workers registered in a workspace that can be assigned to issues and create comments automatically.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="CodeReviewBot", instructions="Review pull requests in this workspace.")
+agent.start("Register me as a workspace agent for code review.")
+```
+
+The user registers AI agents in a workspace and assigns them to issues so they can comment automatically.
+
 ```mermaid
 graph LR
     subgraph "Agent Management Flow"
@@ -23,6 +34,8 @@ graph LR
     class Register register
     class List,Assign manage  
     class Work,Comment result
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/auth-configuration.mdx
+++ b/docs/features/platform/auth-configuration.mdx
@@ -7,6 +7,19 @@ icon: "key"
 
 Platform authentication requires proper JWT secret configuration for security in production environments.
 
+Platform authentication requires proper JWT secret configuration for security in production environments.
+
+```python
+import os
+from praisonaiagents import Agent
+
+agent = Agent(name="platform-admin", instructions="Configure JWT secrets for the platform.")
+os.environ.setdefault("PLATFORM_JWT_SECRET", "change-me-in-production")
+agent.start("Verify JWT settings before go-live.")
+```
+
+The user sets JWT secrets and token lifetimes so issued tokens validate correctly in every environment.
+
 ```mermaid
 graph LR
     A[🔐 PLATFORM_JWT_SECRET] --> B{🌍 PLATFORM_ENV}
@@ -24,6 +37,8 @@ graph LR
     class B,D process
     class C,E success
     class F error
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/auth-me-endpoint-fix.mdx
+++ b/docs/features/platform/auth-me-endpoint-fix.mdx
@@ -1,5 +1,3 @@
-from datetime import datetime, timezone
-
 ---
 title: "Platform /me Endpoint Bugfix"
 sidebarTitle: "Auth /me Fix"
@@ -8,6 +6,16 @@ icon: "bug-slash"
 ---
 
 Platform Authentication /me endpoint now returns complete user data by querying the database instead of using incomplete token data.
+
+```python
+from datetime import datetime, timezone
+from praisonaiagents import Agent
+
+agent = Agent(name="auth-debugger", instructions="Validate /auth/me profile responses.")
+agent.start("Fetch my profile and confirm created_at is populated.")
+```
+
+The user calls GET /auth/me; the platform loads the full user row so created_at and profile fields are complete.
 
 ```mermaid
 graph LR
@@ -28,6 +36,8 @@ graph LR
     
     class Token1,Auth1,Null1 broken
     class Token2,Auth2,DB,Full fixed
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/authentication.mdx
+++ b/docs/features/platform/authentication.mdx
@@ -7,6 +7,17 @@ icon: "shield-check"
 
 Platform Authentication enables secure access to the PraisonAI Platform using JWT tokens for API authentication.
 
+Platform Authentication enables secure access to the PraisonAI Platform using JWT tokens for API authentication.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="secure-assistant", instructions="Use JWT-authenticated platform APIs.")
+agent.start("Call the platform with my bearer token.")
+```
+
+The user registers, logs in, and sends JWT bearer tokens on each API request for authorised access.
+
 ```mermaid
 graph LR
     subgraph "Authentication Flow"
@@ -22,6 +33,8 @@ graph LR
     class Register register
     class Login,Token auth
     class API api
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/cli.mdx
+++ b/docs/features/platform/cli.mdx
@@ -7,6 +7,17 @@ icon: "terminal"
 
 Start the PraisonAI platform server with `python -m praisonai_platform` for local development and production deployment.
 
+Start the PraisonAI platform server with `python -m praisonai_platform` for local development and production deployment.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="dev-assistant", instructions="Run the local platform server.")
+agent.start("Start the platform on port 8000 for local testing.")
+```
+
+The user runs `python -m praisonai_platform`; the CLI boots the API server for development or production.
+
 ```mermaid
 graph LR
     subgraph "Platform CLI"
@@ -21,6 +32,8 @@ graph LR
     class A input
     class B process
     class C output
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/comments.mdx
+++ b/docs/features/platform/comments.mdx
@@ -7,6 +7,17 @@ icon: "comments"
 
 Comments enable users and agents to discuss issues through a structured messaging system that supports threading for organized conversations.
 
+Comments enable users and agents to discuss issues through a structured messaging system that supports threading for organized conversations.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="collab-bot", instructions="Discuss issues via platform comments.")
+agent.start("Add a summary comment on issue ISS-42.")
+```
+
+The user or agent posts threaded comments on issues to capture decisions and hand-offs.
+
 ```mermaid
 graph LR
     subgraph "Comments System"
@@ -23,6 +34,8 @@ graph LR
     class A issue
     class B,C comment
     class D,E thread
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/data-model.mdx
+++ b/docs/features/platform/data-model.mdx
@@ -11,6 +11,17 @@ Every workspace, issue, agent, and comment you create is stored in these tables.
 Updated for **PraisonAI Platform PR #1591**: issues support `parent_issue_id`, workspace-scoped `number`/`identifier`, and kanban `position`; comments support `parent_id` threading; projects use `title`, `icon`, `status` (default `planned`), and `lead_type`/`lead_id`; agents use `owner_type`/`owner_id`, `runtime_mode`/`runtime_config`, and default status `offline`.
 </Note>
 
+Every workspace, issue, agent, and comment you create is stored in these tables.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="architect", instructions="Explain platform entities and relationships.")
+agent.start("How do workspaces, projects, and issues relate?")
+```
+
+The user maps product concepts to tables; workspaces contain projects, issues, agents, and comments.
+
 ```mermaid
 graph LR
     subgraph "Core Entities"
@@ -33,6 +44,8 @@ graph LR
     class B workspace
     class C,D,E,F,G,H entity
     class I system
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/dependencies.mdx
+++ b/docs/features/platform/dependencies.mdx
@@ -7,6 +7,17 @@ icon: "link"
 
 Issue dependencies express relationships between issues to track blocking, related, and duplicate connections in your project.
 
+Issue dependencies express relationships between issues to track blocking, related, and duplicate connections in your project.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="planner", instructions="Link blocking dependencies between issues.")
+agent.start("Mark ISS-10 blocked by ISS-7.")
+```
+
+The user links issues as blockers or related work so schedules reflect real delivery order.
+
 ```mermaid
 graph LR
     subgraph "Issue Dependencies"
@@ -23,6 +34,8 @@ graph LR
     class A,C issue
     class B,D relationship
     class E,F result
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/exceptions.mdx
+++ b/docs/features/platform/exceptions.mdx
@@ -7,6 +7,17 @@ icon: "triangle-exclamation"
 
 Platform custom exceptions provide domain-specific error handling for services instead of generic Python exceptions.
 
+Platform custom exceptions provide domain-specific error handling for services instead of generic Python exceptions.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="support-bot", instructions="Handle platform API errors clearly.")
+agent.start("Explain a NotFoundError when an issue ID is missing.")
+```
+
+The user catches typed platform exceptions to return actionable errors instead of generic HTTP failures.
+
 ```mermaid
 graph LR
     subgraph "Exception Hierarchy"
@@ -22,6 +33,8 @@ graph LR
     
     class A base
     class B,C,D,E,F specific
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/issue-ids.mdx
+++ b/docs/features/platform/issue-ids.mdx
@@ -7,6 +7,17 @@ icon: "hashtag"
 
 Issues are automatically assigned sequential identifiers like `ISS-1`, `ISS-2` within each workspace for easy reference and tracking.
 
+Issues are automatically assigned sequential identifiers like `ISS-1`, `ISS-2` within each workspace for easy reference and tracking.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="tracker", instructions="Reference issues by stable IDs.")
+agent.start("What is the status of ISS-3?")
+```
+
+The user references sequential IDs like ISS-1; the platform assigns them automatically per workspace.
+
 ```mermaid
 graph LR
     subgraph "Issue ID Generation"
@@ -22,6 +33,8 @@ graph LR
     class Create create
     class Counter,Generate process
     class Store result
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/issues.mdx
+++ b/docs/features/platform/issues.mdx
@@ -7,6 +7,17 @@ icon: "list-check"
 
 Issues are the core work items in the PraisonAI Platform, supporting comprehensive project management with status workflows, priority levels, agent assignment, and hierarchical organization.
 
+Issues are the core work items in the PraisonAI Platform, supporting comprehensive project management with status workflows, priority levels, agent assignment, and hierarchical organization.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="issue-bot", instructions="Track platform issues and status.")
+agent.start("Create a high-priority bug for login timeouts.")
+```
+
+The user describes work to track; the platform records issues with status, priority, and assignees.
+
 ```mermaid
 graph LR
     subgraph "Issue Lifecycle"
@@ -25,6 +36,8 @@ graph LR
     class Assign assign
     class Process process
     class Track,Complete complete
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/labels.mdx
+++ b/docs/features/platform/labels.mdx
@@ -7,6 +7,17 @@ icon: "tags"
 
 Labels provide a flexible tagging system for organizing issues by categories, priorities, teams, or any custom classification system.
 
+Labels provide a flexible tagging system for organizing issues by categories, priorities, teams, or any custom classification system.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="triage-bot", instructions="Label and categorise issues.")
+agent.start("Tag urgent customer bugs with label customer-escalation.")
+```
+
+The user applies colour-coded labels so boards and filters stay organised across many issues.
+
 ```mermaid
 graph LR
     subgraph "Label Management"
@@ -22,6 +33,8 @@ graph LR
     class Create create
     class Apply apply
     class Filter,Organize organize
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/members.mdx
+++ b/docs/features/platform/members.mdx
@@ -7,6 +7,17 @@ icon: "users"
 
 Team members and role-based access control (RBAC) enables workspace collaboration with granular permission management.
 
+Team members and role-based access control (RBAC) enables workspace collaboration with granular permission management.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="admin-assistant", instructions="Manage workspace membership and roles.")
+agent.start("Invite Alex as editor on this workspace.")
+```
+
+The user invites teammates; RBAC roles control who can read or change workspace resources.
+
 ```mermaid
 graph LR
     subgraph "Workspace Team Management"
@@ -24,6 +35,8 @@ graph LR
     class B role
     class C permission
     class D monitor
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/pagination.mdx
+++ b/docs/features/platform/pagination.mdx
@@ -7,6 +7,17 @@ icon: "list"
 
 Platform pagination enables efficient retrieval of large datasets through standardized `limit` and `offset` query parameters across all list endpoints.
 
+Platform pagination enables efficient retrieval of large datasets through standardized `limit` and `offset` query parameters across all list endpoints.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="api-helper", instructions="Fetch large issue lists safely.")
+agent.start("List the next page of open issues after the first 50.")
+```
+
+The user pages through large API result sets with limit and offset without loading entire tables at once.
+
 ```mermaid
 graph LR
     subgraph "Pagination Flow"
@@ -23,6 +34,8 @@ graph LR
     class A request
     class B,C process
     class D,E result
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/projects.mdx
+++ b/docs/features/platform/projects.mdx
@@ -7,6 +7,17 @@ icon: "folder-tree"
 
 Projects organize issues within a workspace, providing structure for team collaboration and progress tracking.
 
+Projects organize issues within a workspace, providing structure for team collaboration and progress tracking.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="pm-bot", instructions="Manage platform projects inside a workspace.")
+agent.start("Open a project for the mobile app release.")
+```
+
+The user groups issues into a project; the platform stores milestones, leads, and linked work items.
+
 ```mermaid
 graph LR
     subgraph "Project Management Flow"
@@ -24,6 +35,8 @@ graph LR
     class B manage
     class C track
     class D complete
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/rbac-enforcement.mdx
+++ b/docs/features/platform/rbac-enforcement.mdx
@@ -7,6 +7,17 @@ icon: "shield-check"
 
 API Route RBAC Enforcement protects workspace-scoped resources by requiring valid membership before allowing access to any workspace endpoints.
 
+API Route RBAC Enforcement protects workspace-scoped resources by requiring valid membership before allowing access to any workspace endpoints.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="security-bot", instructions="Respect workspace RBAC on API routes.")
+agent.start("Can this token delete issues in workspace WS-1?")
+```
+
+The user calls workspace-scoped routes; middleware checks membership and role before any mutation runs.
+
 ```mermaid
 graph LR
     subgraph "RBAC Request Flow"
@@ -25,6 +36,8 @@ graph LR
     class B,C auth
     class D check
     class E response
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/sdk-client.mdx
+++ b/docs/features/platform/sdk-client.mdx
@@ -7,6 +7,19 @@ icon: "plug"
 
 PlatformClient is an async Python SDK that wraps all platform API calls, providing authenticated access to workspaces, projects, issues, and agents.
 
+PlatformClient is an async Python SDK that wraps all platform API calls, providing authenticated access to workspaces, projects, issues, and agents.
+
+```python
+import os
+from praisonaiagents import Agent
+from praisonai_platform import PlatformClient
+
+agent = Agent(name="integrator", instructions="Automate platform APIs from Python.")
+agent.start("List workspaces I can access.")
+```
+
+The user drives PlatformClient from async code; authenticated HTTP calls wrap workspaces, issues, and agents.
+
 ```mermaid
 graph LR
     subgraph "Platform SDK Client"
@@ -24,6 +37,8 @@ graph LR
     class B auth
     class C client
     class D response
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/platform/workspaces.mdx
+++ b/docs/features/platform/workspaces.mdx
@@ -7,6 +7,19 @@ icon: "building"
 
 Workspaces are the top-level organizational containers in PraisonAI Platform that hold projects, issues, agents, and team members.
 
+Workspaces are the top-level organizational containers in PraisonAI Platform that hold projects, issues, agents, and team members.
+
+```python
+import os
+from praisonaiagents import Agent
+from praisonai_platform import PlatformClient
+
+agent = Agent(name="platform-assistant", instructions="Organise team workspaces.")
+agent.start("Create a workspace for the Q3 product launch.")
+```
+
+The user asks the agent to organise work; PlatformClient creates workspaces that hold projects, issues, and members.
+
 ```mermaid
 graph LR
     subgraph "Workspace Management"
@@ -31,6 +44,8 @@ graph LR
     class Create,List,Update action
     class WS workspace
     class Projects,Issues,Agents,Members content
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
 ```
 
 ## Quick Start

--- a/docs/features/tui/commands.mdx
+++ b/docs/features/tui/commands.mdx
@@ -5,6 +5,17 @@ icon: "command"
 ---
 
 
+Slash commands and CLI flags control models, sessions, and layout inside the TUI.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="tui-assistant", instructions="Use TUI slash commands effectively.")
+agent.start("Which /model should I pick for fast replies?")
+```
+
+The user types slash commands such as `/help` and `/model` while the agent streams responses in the TUI.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/features/tui/overview.mdx
+++ b/docs/features/tui/overview.mdx
@@ -5,6 +5,17 @@ icon: "terminal"
 ---
 
 
+An interactive terminal UI runs PraisonAI agents with streaming output, queues, and session persistence.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="tui-assistant", instructions="Help via the PraisonAI terminal UI.")
+agent.start("Summarise what is in my TUI queue.")
+```
+
+The user runs `praisonai tui launch` and chats with the agent in a full-screen Textual session.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/features/tui/queue.mdx
+++ b/docs/features/tui/queue.mdx
@@ -5,6 +5,17 @@ icon: "list-check"
 ---
 
 
+The TUI queue holds multiple agent tasks with priority, cancel, and retry controls.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="tui-assistant", instructions="Manage queued TUI jobs.")
+agent.start("Run these three research tasks in order.")
+```
+
+The user submits several prompts; the queue runs them sequentially without blocking the input pane.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/features/tui/simulation.mdx
+++ b/docs/features/tui/simulation.mdx
@@ -5,6 +5,17 @@ icon: "flask-vial"
 ---
 
 
+Headless simulation replays TUI sessions for CI and automated UI testing.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="tui-tester", instructions="Validate TUI flows in simulation mode.")
+agent.start("Replay the last session and assert on tool output.")
+```
+
+The user runs headless simulation to script keyboard input and assert on TUI behaviour without a display.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/guides/rag/knowledge-base.mdx
+++ b/docs/guides/rag/knowledge-base.mdx
@@ -3,9 +3,21 @@ title: "Knowledge Base Setup"
 description: "Create and configure knowledge bases for your agents"
 icon: "database"
 ---
+Attach file and URL sources so agents answer from your organisation's documents.
 
-# Knowledge Base Setup
+```python
+from praisonaiagents import Agent, Knowledge
 
+knowledge = Knowledge(sources=["docs/", "faq.pdf"])
+agent = Agent(
+    name="Support Agent",
+    instructions="Answer using the knowledge base only.",
+    knowledge=knowledge,
+)
+agent.start("What is our refund policy?")
+```
+
+The user asks a question; the agent retrieves relevant chunks and returns a grounded answer.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]
@@ -17,7 +29,6 @@ graph LR
     class A agent
     class U,O tool
 ```
-
 
 Add domain-specific knowledge to your agents using knowledge bases.
 

--- a/docs/guides/rag/retrieval.mdx
+++ b/docs/guides/rag/retrieval.mdx
@@ -3,8 +3,20 @@ title: "Retrieval Methods"
 description: "Configure retrieval strategies for knowledge bases"
 icon: "magnifying-glass"
 ---
+Tune top-k, similarity thresholds, and reranking so retrieval quality matches your use case.
 
+```python
+from praisonaiagents import Agent, KnowledgeConfig
 
+agent = Agent(
+    name="Researcher",
+    instructions="Cite retrieved passages in every answer.",
+    knowledge=KnowledgeConfig(sources=["docs/"], top_k=5, similarity_threshold=0.7),
+)
+agent.start("Summarise the security section of our handbook.")
+```
+
+The user submits a query; the agent pulls the best-matching passages before composing a reply.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]
@@ -16,8 +28,6 @@ graph LR
     class A agent
     class U,O tool
 ```
-
-# Retrieval Methods
 
 Configure how your agents retrieve information from knowledge bases.
 

--- a/docs/guides/recipes/decision-guide.mdx
+++ b/docs/guides/recipes/decision-guide.mdx
@@ -3,8 +3,30 @@ title: "Decision Guide"
 description: "When to use which integration model"
 icon: "compass"
 ---
+Pick the integration model that fits your stack, latency budget, and operational constraints.
 
-# Decision Guide
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Integration Advisor",
+    instructions="Recommend a PraisonAI recipe integration model for the described app.",
+)
+agent.start("We need recipes from a Node.js microservice on one machine.")
+```
+
+The user describes their environment; you map it to the right recipe integration pattern below.
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
 
 This guide helps you choose the right integration model for your use case.
 

--- a/docs/guides/recipes/index.mdx
+++ b/docs/guides/recipes/index.mdx
@@ -3,8 +3,19 @@ title: "Recipe Integration Guide"
 description: "Complete guide to integrating PraisonAI recipes into your applications"
 icon: "book"
 ---
+Navigate personas, integration models, and use cases for shipping PraisonAI recipes in production.
 
+```python
+from praisonaiagents import Agent
 
+agent = Agent(
+    name="Recipe Guide",
+    instructions="Point developers to the right recipe integration docs.",
+)
+agent.start("Where should I start integrating a customer-support recipe?")
+```
+
+The user picks a path below—models, personas, or use cases—to implement recipes in their app.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]
@@ -16,8 +27,6 @@ graph LR
     class A agent
     class U,O tool
 ```
-
-# Recipe Integration Guide
 
 This comprehensive guide covers everything you need to know about integrating PraisonAI recipes into your applications, including personas, integration models, and real-world use cases.
 

--- a/docs/guides/recipes/integration-models.mdx
+++ b/docs/guides/recipes/integration-models.mdx
@@ -3,8 +3,30 @@ title: "Integration Models"
 description: "6 ways to integrate PraisonAI recipes into your applications"
 icon: "diagram-project"
 ---
+Compare six ways to run PraisonAI recipes—from in-process Python to remote managed runners.
 
-# Integration Models
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Recipe Integrator",
+    instructions="Explain trade-offs between recipe integration models.",
+)
+agent.start("We need the lowest latency inside a Django app.")
+```
+
+The user chooses a model from the overview table, then follows the linked deep-dive page.
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
 
 PraisonAI recipes can be integrated into your applications using six distinct models. Each model has specific use cases, trade-offs, and implementation patterns.
 

--- a/docs/guides/recipes/integration-models/cli-invocation.mdx
+++ b/docs/guides/recipes/integration-models/cli-invocation.mdx
@@ -3,8 +3,30 @@ title: "Model 2: CLI Invocation"
 description: "Language-agnostic recipe execution via subprocess"
 icon: "terminal"
 ---
+Invoke recipes from any language by shelling out to the PraisonAI CLI and parsing JSON stdout.
 
-# Model 2: CLI Invocation (Subprocess)
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="CLI Orchestrator",
+    instructions="Describe when subprocess CLI recipe runs fit CI/CD.",
+)
+agent.start("How do I run a recipe from a GitHub Actions job?")
+```
+
+The user spawns praisonai recipe run; stdout JSON carries the result back to the caller.
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
 
 <Callout type="info">
 **When to Use**: Shell scripts, CI/CD pipelines, batch processing, or when you need language-agnostic recipe invocation without running a server.

--- a/docs/guides/recipes/integration-models/embedded-sdk.mdx
+++ b/docs/guides/recipes/integration-models/embedded-sdk.mdx
@@ -3,8 +3,30 @@ title: "Model 1: Embedded SDK"
 description: "Direct Python integration with zero network overhead"
 icon: "python"
 ---
+Run recipes inside your Python process for the lowest latency and direct access to results.
 
-# Model 1: Embedded SDK (In-Process)
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="In-Process Runner",
+    instructions="Execute recipe logic in-process for a notebook workflow.",
+)
+agent.start("Run the summarisation recipe on this paragraph.")
+```
+
+The user calls the SDK from application code; results return in memory with no network hop.
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
 
 <Callout type="info">
 **When to Use**: Python applications, Jupyter notebooks, data pipelines, or any scenario where you need the lowest possible latency and direct memory access to results.

--- a/docs/guides/recipes/integration-models/event-driven.mdx
+++ b/docs/guides/recipes/integration-models/event-driven.mdx
@@ -3,8 +3,30 @@ title: "Model 5: Event-Driven"
 description: "Queue-based async processing for high-volume workloads"
 icon: "bolt"
 ---
+Publish recipe jobs to a queue and scale workers for async, high-volume workloads.
 
-# Model 5: Event-Driven
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Queue Producer",
+    instructions="Explain event-driven recipe execution with retries.",
+)
+agent.start("Process 10k support tickets overnight via a queue.")
+```
+
+The user enqueues work; workers pull messages, run recipes, and ack or retry on failure.
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
 
 <Callout type="info">
 **When to Use**: High-volume batch processing, decoupled architectures, or when you need async recipe execution with guaranteed delivery and retry semantics.

--- a/docs/guides/recipes/integration-models/index.mdx
+++ b/docs/guides/recipes/integration-models/index.mdx
@@ -3,8 +3,30 @@ title: "Integration Models Overview"
 description: "6 ways to integrate PraisonAI recipes into your applications"
 icon: "diagram-project"
 ---
+Six integration models cover embedded SDK, CLI, sidecar HTTP, remote runner, events, and plugins.
 
-# Integration Models Overview
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Model Picker",
+    instructions="Summarise PraisonAI recipe integration options.",
+)
+agent.start("Compare CLI versus embedded SDK for our CI pipeline.")
+```
+
+The user selects a tab or card below to compare latency, complexity, and setup time.
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
 
 PraisonAI recipes can be integrated into your applications using six distinct models. Each model has specific use cases, trade-offs, and implementation patterns.
 

--- a/docs/guides/recipes/integration-models/local-http-sidecar.mdx
+++ b/docs/guides/recipes/integration-models/local-http-sidecar.mdx
@@ -3,8 +3,30 @@ title: "Model 3: Local HTTP Sidecar"
 description: "HTTP API running locally for polyglot microservices"
 icon: "server"
 ---
+Expose recipes over localhost HTTP so polyglot services call the same sidecar process.
 
-# Model 3: Local HTTP Sidecar
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Sidecar Client",
+    instructions="Explain local HTTP sidecar integration for microservices.",
+)
+agent.start("Call a recipe from Go via localhost.")
+```
+
+The user POSTs to the sidecar; the agent runtime executes the recipe and returns JSON.
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
 
 <Callout type="info">
 **When to Use**: Microservices architectures, non-Python applications, or when you need HTTP-based integration without deploying to the cloud.

--- a/docs/guides/recipes/integration-models/plugin-mode.mdx
+++ b/docs/guides/recipes/integration-models/plugin-mode.mdx
@@ -3,8 +3,30 @@ title: "Model 6: Plugin Mode"
 description: "Embed recipes into IDEs, CMS platforms, and chat applications"
 icon: "puzzle-piece"
 ---
+Embed recipes inside IDEs, CMS platforms, or chat apps with native host UX.
 
-# Model 6: Plugin Mode
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Plugin Host",
+    instructions="Describe plugin-mode recipe integration for editor extensions.",
+)
+agent.start("Expose a recipe as a VS Code command.")
+```
+
+The user triggers the plugin; the host forwards context to a local or remote recipe runner.
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
 
 <Callout type="info">
 **When to Use**: Building IDE extensions, CMS plugins, chat integrations, or any scenario where recipes need to be embedded into an existing platform with native UX.

--- a/docs/guides/recipes/integration-models/remote-managed-runner.mdx
+++ b/docs/guides/recipes/integration-models/remote-managed-runner.mdx
@@ -3,8 +3,30 @@ title: "Model 4: Remote Managed Runner"
 description: "Centralized, authenticated recipe execution for production"
 icon: "cloud"
 ---
+Centralise recipe execution behind authenticated, observable runner clusters in production.
 
-# Model 4: Remote Managed Runner
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Remote Client",
+    instructions="Outline remote managed runner integration for multi-tenant SaaS.",
+)
+agent.start("Secure recipe calls from our web tier to a shared runner.")
+```
+
+The user sends HTTPS requests to the managed runner; auth, limits, and traces apply at the edge.
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
 
 <Callout type="info">
 **When to Use**: Multi-tenant production environments, cloud deployments, or when you need centralized recipe management with authentication, rate limiting, and observability.

--- a/docs/guides/recipes/personas.mdx
+++ b/docs/guides/recipes/personas.mdx
@@ -3,8 +3,19 @@ title: "Personas"
 description: "Who uses PraisonAI recipes and how"
 icon: "users"
 ---
+App developers, platform engineers, and recipe authors each follow different integration paths.
 
+```python
+from praisonaiagents import Agent
 
+agent = Agent(
+    name="Persona Router",
+    instructions="Direct readers to the right recipe persona guide.",
+)
+agent.start("I deploy recipe infrastructure—where do I start?")
+```
+
+The user identifies their role below and opens the matching persona workflow.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]
@@ -16,8 +27,6 @@ graph LR
     class A agent
     class U,O tool
 ```
-
-# Personas
 
 This guide describes the three primary personas who work with PraisonAI recipes, their responsibilities, and recommended workflows.
 

--- a/docs/guides/recipes/personas/app-developer.mdx
+++ b/docs/guides/recipes/personas/app-developer.mdx
@@ -3,8 +3,19 @@ title: "App Developer Persona"
 description: "Build applications that integrate PraisonAI recipes"
 icon: "code"
 ---
+Integrate recipes into applications with solid error handling, latency, and UX patterns.
 
+```python
+from praisonaiagents import Agent
 
+agent = Agent(
+    name="App Integrator",
+    instructions="Follow app-developer best practices for recipe calls.",
+)
+agent.start("Handle recipe timeouts gracefully in our FastAPI service.")
+```
+
+The user embeds recipe calls in product code and ships features end users interact with.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]
@@ -16,8 +27,6 @@ graph LR
     class A agent
     class U,O tool
 ```
-
-# App Developer Persona
 
 <Callout type="info">
 **Role**: Build applications that use PraisonAI recipes to deliver AI-powered features to end users.

--- a/docs/guides/recipes/personas/index.mdx
+++ b/docs/guides/recipes/personas/index.mdx
@@ -3,8 +3,30 @@ title: "Personas Overview"
 description: "Role-specific guidance for integrating PraisonAI recipes"
 icon: "users"
 ---
+Role-specific docs cover building apps, operating infrastructure, and authoring recipes.
 
-# Personas Overview
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Role Guide",
+    instructions="Match the reader to app developer, platform, or author docs.",
+)
+agent.start("I am writing a new customer-support recipe.")
+```
+
+The user picks a persona card to see responsibilities, checklists, and linked guides.
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
 
 Different roles interact with PraisonAI recipes in different ways. This guide helps you find the right documentation based on your role and responsibilities.
 

--- a/docs/guides/recipes/personas/platform-devops.mdx
+++ b/docs/guides/recipes/personas/platform-devops.mdx
@@ -3,8 +3,19 @@ title: "Platform/DevOps Persona"
 description: "Deploy and operate PraisonAI recipe infrastructure"
 icon: "server"
 ---
+Deploy, scale, secure, and observe recipe runners and sidecars in production.
 
+```python
+from praisonaiagents import Agent
 
+agent = Agent(
+    name="Platform Engineer",
+    instructions="Advise on operating PraisonAI recipe infrastructure.",
+)
+agent.start("Roll out a new recipe runner with zero downtime.")
+```
+
+The user owns uptime, auth, and capacity for recipe endpoints the organisation relies on.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]
@@ -16,8 +27,6 @@ graph LR
     class A agent
     class U,O tool
 ```
-
-# Platform/DevOps Persona
 
 <Callout type="info">
 **Role**: Deploy, scale, secure, and monitor PraisonAI recipe infrastructure for production workloads.

--- a/docs/guides/recipes/personas/recipe-author.mdx
+++ b/docs/guides/recipes/personas/recipe-author.mdx
@@ -3,8 +3,19 @@ title: "Recipe Author Persona"
 description: "Create and maintain PraisonAI recipes"
 icon: "wand-magic-sparkles"
 ---
+Design, test, and document recipes with clear inputs, outputs, and agent instructions.
 
+```python
+from praisonaiagents import Agent
 
+agent = Agent(
+    name="Recipe Author",
+    instructions="Draft a support-reply recipe with eval-friendly outputs.",
+)
+agent.start("Define inputs and success criteria for a refund FAQ recipe.")
+```
+
+The user publishes recipes that app teams consume through SDK, CLI, or HTTP integrations.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]
@@ -16,8 +27,6 @@ graph LR
     class A agent
     class U,O tool
 ```
-
-# Recipe Author Persona
 
 <Callout type="info">
 **Role**: Design, build, test, and document recipes that solve real-world problems for App Developers and end users.

--- a/docs/guides/recipes/use-cases.mdx
+++ b/docs/guides/recipes/use-cases.mdx
@@ -3,8 +3,19 @@ title: "Use Cases"
 description: "12 real-world implementation patterns for PraisonAI recipes"
 icon: "lightbulb"
 ---
+Twelve production patterns show which integration model fits each recipe scenario.
 
+```python
+from praisonaiagents import Agent
 
+agent = Agent(
+    name="Use Case Mapper",
+    instructions="Map business scenarios to PraisonAI recipe patterns.",
+)
+agent.start("Automate draft replies for SaaS support tickets.")
+```
+
+The user finds a scenario below and copies the recommended model plus implementation steps.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]
@@ -16,8 +27,6 @@ graph LR
     class A agent
     class U,O tool
 ```
-
-# Recipe Use Cases
 
 This guide covers 12 real-world use cases for PraisonAI recipes, including recommended integration models, implementation steps, and security considerations.
 

--- a/docs/guides/single-agent.mdx
+++ b/docs/guides/single-agent.mdx
@@ -4,8 +4,19 @@ sidebarTitle: "Building a Single Agent"
 description: "Learn how to create and configure a single AI agent"
 icon: "user"
 ---
+Create one focused agent with instructions, tools, and memory—then iterate from a single prompt.
 
+```python
+from praisonaiagents import Agent
 
+agent = Agent(
+    name="Assistant",
+    instructions="You are a helpful assistant.",
+)
+agent.start("Say hello in one sentence.")
+```
+
+The user sends a prompt; the agent calls the model (and tools if configured) and returns text.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]
@@ -17,8 +28,6 @@ graph LR
     class A agent
     class U,O tool
 ```
-
-# Building a Single Agent
 
 This guide walks you through creating your first AI agent with PraisonAI.
 
@@ -220,4 +229,3 @@ print(result)
     Extend your agent with tools
   </Card>
 </CardGroup>
-

--- a/docs/guides/templates/add-tools-to-templates.mdx
+++ b/docs/guides/templates/add-tools-to-templates.mdx
@@ -3,8 +3,21 @@ title: "Add Tools to Recipes"
 description: "Step-by-step guide to adding and configuring tools in recipes"
 icon: "wrench"
 ---
+Register built-in or custom tools on recipe agents so templates can act on real data.
 
+```python
+from praisonaiagents import Agent, tool
 
+@tool
+def lookup_order(order_id: str) -> str:
+    """Look up order status."""
+    return f"Order {order_id} is shipped."
+
+agent = Agent(name="Support", tools=[lookup_order])
+agent.start("Check order 12345.")
+```
+
+The user adds tools to YAML or Python templates, then runs the recipe with those capabilities enabled.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/api-keys.mdx
+++ b/docs/tools/api-keys.mdx
@@ -5,6 +5,18 @@ description: "Complete reference for all API keys and environment variables used
 icon: "key"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Integrator",
+    instructions="Use tools that rely on configured API keys.",
+    tools=["web_search"],
+)
+agent.start("What needs to be set in the environment before this run?")
+```
+
+The user wires up provider and tool keys once, then the agent calls integrations without hard-coding secrets.
 
 ```mermaid
 graph LR

--- a/docs/tools/arxiv_tools.mdx
+++ b/docs/tools/arxiv_tools.mdx
@@ -13,6 +13,15 @@ icon: "book-open"
   - `arxiv` package installed
 </Note>
 
+```python
+from praisonaiagents import Agent
+from praisonai_tools import search_arxiv
+
+agent = Agent(name="Researcher", tools=[search_arxiv])
+agent.start("Find recent papers on retrieval-augmented generation")
+```
+
+The user asks for literature; the agent searches arXiv and returns relevant papers.
 
 ```mermaid
 graph LR

--- a/docs/tools/asqav-compliance.mdx
+++ b/docs/tools/asqav-compliance.mdx
@@ -5,6 +5,17 @@ description: "CI GitHub Action that scans PraisonAI agent code for governance ga
 icon: "shield-check"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="GovernedAssistant",
+    instructions="Follow audit, policy, and human-oversight requirements.",
+)
+agent.start("Review this agent module for compliance gaps")
+```
+
+The user opens a pull request; CI runs Asqav to scan PraisonAI imports for governance patterns before merge.
 
 ```mermaid
 graph LR

--- a/docs/tools/ast-grep-tools.mdx
+++ b/docs/tools/ast-grep-tools.mdx
@@ -57,6 +57,7 @@ Unlike regex, AST patterns understand code structure — they won't match patter
 </Steps>
 
 ## How It Works
+The user describes a refactor or search; the agent runs AST-grep search, rewrite, or scan tools on the codebase.
 
 ```mermaid
 flowchart LR

--- a/docs/tools/calculator_tools.mdx
+++ b/docs/tools/calculator_tools.mdx
@@ -13,6 +13,15 @@ icon: "calculator"
   - `sympy` and `pint` packages installed
 </Note>
 
+```python
+from praisonaiagents import Agent
+from praisonai_tools import evaluate
+
+agent = Agent(name="MathAssistant", tools=[evaluate])
+agent.start("What is the area of a circle with radius 5?")
+```
+
+The user asks a maths question; the agent evaluates expressions and returns a precise answer.
 
 ```mermaid
 graph LR

--- a/docs/tools/chain-of-thought.mdx
+++ b/docs/tools/chain-of-thought.mdx
@@ -5,6 +5,17 @@ description: "Generate step-by-step reasoning paths and synthetic training data 
 icon: "brain"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Reasoner",
+    instructions="Show step-by-step reasoning before the final answer.",
+)
+agent.start("If a train travels 60 mph for 2.5 hours, how far does it go?")
+```
+
+The user poses a multi-step problem; the agent records chain-of-thought steps before answering.
 
 ```mermaid
 graph LR

--- a/docs/tools/channels.mdx
+++ b/docs/tools/channels.mdx
@@ -9,6 +9,16 @@ icon: "message"
 PraisonAI supports **7+ messaging channels** including Telegram, Discord, Slack, Signal, LINE, iMessage, and WhatsApp.
 </Info>
 
+```python
+from praisonaiagents import Agent
+from praisonai_tools import SignalTool
+
+agent = Agent(name="Messenger", tools=[SignalTool()])
+agent.start("Send a Signal message to +1234567890 saying hello")
+```
+
+The user sends a message through a channel; the agent delivers it via the configured messaging tool.
+
 ```mermaid
 graph LR
     A[Agent]:::agent --> B[Channel Tool]:::tool

--- a/docs/tools/chrome-extension.mdx
+++ b/docs/tools/chrome-extension.mdx
@@ -36,6 +36,7 @@ agent.start("Navigate to example.com and extract the main heading")
 ## Architecture Overview
 
 The extension uses a **multi-layer architecture** to ensure reliable browser automation:
+The user asks for a browser task; the Chrome extension and agent automate the page via CDP.
 
 ```mermaid
 graph TB

--- a/docs/tools/composio.mdx
+++ b/docs/tools/composio.mdx
@@ -5,6 +5,18 @@ description: "Guide for integrating Composio's extensive tool ecosystem with Pra
 icon: "puzzle-piece"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="ComposioAgent",
+    instructions="Use Composio-connected apps when needed.",
+    tools=["composio"],
+)
+agent.start("Search for the latest AI news")
+```
+
+The user names an app action; Composio tools let the agent read mail, post updates, or query SaaS APIs.
 
 ```mermaid
 graph LR

--- a/docs/tools/crawl4ai.mdx
+++ b/docs/tools/crawl4ai.mdx
@@ -12,6 +12,14 @@ icon: "spider"
   - `crawl4ai` package installed and set up
 </Note>
 
+```python
+from praisonaiagents import Agent, crawl4ai_sync
+
+agent = Agent(name="Researcher", tools=[crawl4ai_sync])
+agent.start("Summarize the content at https://example.com")
+```
+
+The user shares a URL; the agent crawls the page and returns a concise summary.
 
 ```mermaid
 graph LR

--- a/docs/tools/csv_tools.mdx
+++ b/docs/tools/csv_tools.mdx
@@ -13,6 +13,15 @@ icon: "file-csv"
   - `pandas` package installed
 </Note>
 
+```python
+from praisonaiagents import Agent
+from praisonai_tools import read_csv, write_csv
+
+agent = Agent(name="Analyst", tools=[read_csv, write_csv])
+agent.start("Summarise column totals in data/sales.csv")
+```
+
+The user points at a CSV; the agent reads, transforms, and writes results with CSV tools.
 
 ```mermaid
 graph LR

--- a/docs/tools/custom.mdx
+++ b/docs/tools/custom.mdx
@@ -5,6 +5,19 @@ description: "Step-by-step guide for creating and implementing custom tools in P
 icon: "wrench"
 ---
 
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def weather(city: str) -> str:
+    """Return a short weather summary for a city."""
+    return f"Sunny in {city}"
+
+agent = Agent(name="Assistant", tools=[weather])
+agent.start("What is the weather in London?")
+```
+
+The user asks in plain language; custom tools extend what the agent can do beyond built-ins.
 
 ```mermaid
 graph LR

--- a/docs/tools/duckdb_tools.mdx
+++ b/docs/tools/duckdb_tools.mdx
@@ -13,6 +13,15 @@ icon: "database"
   - `duckdb` package installed
 </Note>
 
+```python
+from praisonaiagents import Agent
+from praisonai_tools import execute_query
+
+agent = Agent(name="Analyst", tools=[execute_query])
+agent.start("How many rows are in the orders table?")
+```
+
+The user asks an analytics question; the agent runs DuckDB queries and returns results.
 
 ```mermaid
 graph LR

--- a/docs/tools/duckduckgo.mdx
+++ b/docs/tools/duckduckgo.mdx
@@ -5,6 +5,14 @@ description: "Guide for integrating DuckDuckGo search capabilities with PraisonA
 icon: "duck"
 ---
 
+```python
+from praisonaiagents import Agent, duckduckgo
+
+agent = Agent(name="Researcher", tools=[duckduckgo])
+agent.start("What are the latest AI developments?")
+```
+
+The user asks for current information; the agent searches the web with DuckDuckGo and cites findings.
 
 ```mermaid
 graph LR

--- a/docs/tools/duckduckgo_tools.mdx
+++ b/docs/tools/duckduckgo_tools.mdx
@@ -12,6 +12,15 @@ icon: "magnifying-glass"
   - `duckduckgo-search` package installed
 </Note>
 
+```python
+from praisonaiagents import Agent
+from praisonaiagents import duckduckgo
+
+agent = Agent(name="Researcher", tools=[duckduckgo])
+agent.start("Find recent news about open-source LLMs")
+```
+
+The user needs fresh web results; DuckDuckGo tools fetch answers without a separate search API key.
 
 ```mermaid
 graph LR

--- a/docs/tools/exa.mdx
+++ b/docs/tools/exa.mdx
@@ -13,6 +13,14 @@ icon: "magnifying-glass-chart"
   - `EXA_API_KEY` environment variable set
 </Note>
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="Researcher", tools=["exa_search"])
+agent.start("Find recent papers on transformer architectures")
+```
+
+The user describes a research topic; Exa search returns high-quality web and paper results.
 
 ```mermaid
 graph LR

--- a/docs/tools/excel_tools.mdx
+++ b/docs/tools/excel_tools.mdx
@@ -13,6 +13,15 @@ icon: "file-excel"
   - `openpyxl` package installed
 </Note>
 
+```python
+from praisonaiagents import Agent
+from praisonai_tools import read_excel, write_excel
+
+agent = Agent(name="Analyst", tools=[read_excel, write_excel])
+agent.start("Total revenue in Q1 from reports/sales.xlsx")
+```
+
+The user references a spreadsheet; the agent reads and updates Excel workbooks via tools.
 
 ```mermaid
 graph LR

--- a/docs/tools/external/email.mdx
+++ b/docs/tools/external/email.mdx
@@ -6,6 +6,16 @@ icon: "envelope"
 
 Give your agents email superpowers. Just set env vars — tools auto-detect the right backend.
 
+```python
+from praisonaiagents import Agent
+from praisonai_tools import EmailTool
+
+agent = Agent(name="InboxAssistant", tools=[EmailTool()])
+agent.start("Check my inbox for unread messages from Bob")
+```
+
+The user asks about mail; the agent reads or sends email through the configured inbox tool.
+
 ```mermaid
 graph LR
     subgraph "Auto-Detect Backend"

--- a/docs/tools/external/surrealdb.mdx
+++ b/docs/tools/external/surrealdb.mdx
@@ -7,6 +7,16 @@ icon: "database"
 
 SurrealDB tool enables agents to interact with multi-model databases, supporting document, graph, and relational data through native SurrealQL queries.
 
+```python
+from praisonaiagents import Agent
+from praisonai_tools import SurrealDBTool
+
+agent = Agent(name="DataAgent", tools=[SurrealDBTool()])
+agent.start("List the ten most recent users in the database")
+```
+
+The user asks a data question; SurrealDB tools let the agent query and update records safely.
+
 ```mermaid
 graph LR
     subgraph "SurrealDB Agent Integration"

--- a/docs/tools/external/x.mdx
+++ b/docs/tools/external/x.mdx
@@ -7,6 +7,16 @@ icon: "wrench"
 
 X Tool enables agents to post content, reply to posts, create quote posts, manage polls, upload media, and interact with X (formerly Twitter) using the official X API v2.
 
+```python
+from praisonaiagents import Agent
+from praisonai_tools import XTool
+
+agent = Agent(name="SocialAgent", tools=[XTool()])
+agent.start('Post on X: "Just deployed our latest feature!"')
+```
+
+The user drafts a post; the agent publishes or reads timelines through the X tool.
+
 ```mermaid
 graph LR
     subgraph "X Tool OAuth Flow"

--- a/docs/tools/file_tools.mdx
+++ b/docs/tools/file_tools.mdx
@@ -5,6 +5,19 @@ description: "File system operation tools for AI agents."
 icon: "folder"
 ---
 
+```python
+from praisonaiagents import Agent
+from praisonaiagents import read_file, write_file, list_files
+
+agent = Agent(
+    name="File Assistant",
+    instructions="Read, write, and organise files safely.",
+    tools=[read_file, write_file, list_files],
+)
+agent.start("List files in ./src and summarise README.md")
+```
+
+The user describes a file task; the agent uses file tools to read paths and return a concise answer.
 <Note>
   **Prerequisites**
   - Python 3.10 or higher

--- a/docs/tools/gemini-internal-tools.mdx
+++ b/docs/tools/gemini-internal-tools.mdx
@@ -5,6 +5,19 @@ description: "Use Google Gemini's built-in internal tools (Google Search, URL Co
 icon: "google"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Gemini Researcher",
+    llm="gemini/gemini-2.0-flash",
+    instructions="Use Gemini built-in search when facts are needed.",
+    tools=[{"googleSearch": {}}],
+)
+agent.start("What changed in Python 3.13 release highlights?")
+```
+
+The user asks a factual question; the agent invokes Gemini Google Search and summarises grounded results.
 <Note>
   **Prerequisites**
   - Python 3.10 or higher

--- a/docs/tools/github_tools.mdx
+++ b/docs/tools/github_tools.mdx
@@ -27,6 +27,8 @@ agent.start(
 )
 ```
 
+The user describes a git workflow; the agent runs GitHub tools to branch, commit, push, and open a pull request.
+
 ```mermaid
 graph LR
     subgraph "GitHub Tools Flow"

--- a/docs/tools/googlecalendar.mdx
+++ b/docs/tools/googlecalendar.mdx
@@ -5,6 +5,18 @@ description: "Comprehensive guide for integrating Google Calendar functionality 
 icon: "calendar"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Calendar Assistant",
+    instructions="Create and list Google Calendar events.",
+    tools=["google_calendar"],
+)
+agent.start("Schedule a 30-minute sync tomorrow at 10:00 with the team")
+```
+
+The user states scheduling intent; the agent creates or updates calendar events via Google Calendar tools.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/gpt.mdx
+++ b/docs/tools/gpt.mdx
@@ -5,6 +5,19 @@ description: "Guide for using the PraisonAI Tools Creator GPT to quickly develop
 icon: "wand-magic-sparkles"
 ---
 
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def hello(name: str) -> str:
+    """Greet someone by name."""
+    return f"Hello, {name}!"
+
+agent = Agent(name="Demo", tools=[hello])
+agent.start("Say hello to Alex using the hello tool")
+```
+
+The user prototypes a custom tool with the Tools Creator GPT, then runs it through a PraisonAI agent.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/jira.mdx
+++ b/docs/tools/jira.mdx
@@ -5,6 +5,19 @@ description: "Manage Jira issues and Kanban boards with AI agents"
 icon: "list-check"
 ---
 
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools import jira_search, jira_create_task
+
+agent = Agent(
+    name="Jira Assistant",
+    instructions="Search and create Jira issues from natural language.",
+    tools=[jira_search, jira_create_task],
+)
+agent.start("Find open bugs in PROJ and create a task for the login timeout")
+```
+
+The user describes backlog work; the agent searches Jira and creates or updates issues.
 <Note>
   **Prerequisites**
   - Python 3.10 or higher

--- a/docs/tools/joy-trust-network.mdx
+++ b/docs/tools/joy-trust-network.mdx
@@ -4,6 +4,16 @@ sidebarTitle: "Joy Trust Network"
 description: Trust verification layer for secure AI agent interactions
 ---
 
+```python
+from praisonaiagents import Agent, PraisonAIAgents
+
+planner = Agent(name="Planner", instructions="Plan and delegate to a trusted executor.")
+executor = Agent(name="Executor", instructions="Execute delegated work.")
+agents = PraisonAIAgents(agents=[planner, executor], process="sequential")
+agents.start("Research AI trends and summarise for the team")
+```
+
+The user kicks off a multi-agent run; Joy Trust Network verifies reputation before agents delegate work.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/json_tools.mdx
+++ b/docs/tools/json_tools.mdx
@@ -5,6 +5,19 @@ description: "JSON data processing tools for AI agents."
 icon: "brackets-curly"
 ---
 
+```python
+from praisonaiagents import Agent
+from praisonaiagents import read_json, validate_json
+
+agent = Agent(
+    name="JSON Assistant",
+    instructions="Validate and summarise JSON payloads.",
+    tools=[read_json, validate_json],
+)
+agent.start("Validate config.json and list any schema errors")
+```
+
+The user points at JSON data; the agent validates structure and reports issues in plain language.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/langchain.mdx
+++ b/docs/tools/langchain.mdx
@@ -5,6 +5,19 @@ description: "Guide for integrating Langchain tools and utilities with PraisonAI
 icon: "link"
 ---
 
+```python
+from praisonaiagents import Agent
+from langchain_community.tools import WikipediaQueryRun
+
+agent = Agent(
+    name="LangChain Wrapper",
+    instructions="Use wrapped LangChain tools when helpful.",
+    tools=[WikipediaQueryRun()],
+)
+agent.start("Summarise the Wikipedia article on transformer models")
+```
+
+The user asks a research question; the agent calls a LangChain tool wrapped for PraisonAI.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/langchain_tools.mdx
+++ b/docs/tools/langchain_tools.mdx
@@ -5,6 +5,19 @@ description: "Learn how to use LangChain tools and utilities with PraisonAI agen
 icon: "link-simple"
 ---
 
+```python
+from praisonaiagents import Agent
+from langchain_community.tools import WikipediaQueryRun
+
+agent = Agent(
+    name="LangChain Agent",
+    instructions="Answer using LangChain community tools.",
+    tools=[WikipediaQueryRun()],
+)
+agent.start("Give a short overview of reinforcement learning from Wikipedia")
+```
+
+The user requests external knowledge; the agent queries LangChain tools and returns a summary.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/mem0.mdx
+++ b/docs/tools/mem0.mdx
@@ -5,6 +5,18 @@ description: "Guide for integrating Mem0 (formerly EmbedChain) memory management
 icon: "memory"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Memory Assistant",
+    instructions="Remember user preferences across turns.",
+    memory=True,
+)
+agent.start("Remember that I prefer concise bullet answers")
+```
+
+The user shares a preference; the agent stores it with Mem0-backed memory for later sessions.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/newspaper_tools.mdx
+++ b/docs/tools/newspaper_tools.mdx
@@ -5,6 +5,19 @@ description: "News article extraction tools for AI agents."
 icon: "newspaper"
 ---
 
+```python
+from praisonaiagents import Agent
+from praisonaiagents import extract_article
+
+agent = Agent(
+    name="News Reader",
+    instructions="Extract and summarise news articles from URLs.",
+    tools=[extract_article],
+)
+agent.start("Summarise the main points from this article URL")
+```
+
+The user pastes a news link; the agent extracts article text and returns a brief summary.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/pandas_tools.mdx
+++ b/docs/tools/pandas_tools.mdx
@@ -5,6 +5,19 @@ description: "Pandas data manipulation tools for AI agents."
 icon: "table"
 ---
 
+```python
+from praisonaiagents import Agent
+from praisonaiagents import read_csv, get_summary
+
+agent = Agent(
+    name="Data Analyst",
+    instructions="Analyse tabular data with pandas tools.",
+    tools=[read_csv, get_summary],
+)
+agent.start("Describe the sales.csv dataset and highlight outliers")
+```
+
+The user names a dataset; the agent loads it with pandas tools and explains key statistics.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/python_tools.mdx
+++ b/docs/tools/python_tools.mdx
@@ -5,6 +5,18 @@ description: "Python code execution tools for AI agents."
 icon: "code"
 ---
 
+```python
+from praisonaiagents import Agent, ExecutionConfig
+
+agent = Agent(
+    name="Python Runner",
+    instructions="Run short Python snippets safely to answer questions.",
+    execution=ExecutionConfig(code_execution=True, code_mode="safe"),
+)
+agent.start("Compute the first ten Fibonacci numbers and show the list")
+```
+
+The user asks for a computed result; the agent executes vetted Python and returns the output.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/reddit.mdx
+++ b/docs/tools/reddit.mdx
@@ -5,6 +5,19 @@ description: "Guide for integrating Reddit search capabilities with PraisonAI ag
 icon: "reddit"
 ---
 
+```python
+from praisonaiagents import Agent
+from praisonaiagents import reddit_search
+
+agent = Agent(
+    name="Reddit Researcher",
+    instructions="Search Reddit for community discussions.",
+    tools=[reddit_search],
+)
+agent.start("What are people saying about PraisonAI on Reddit this week?")
+```
+
+The user asks about community sentiment; the agent searches Reddit and summarises top threads.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/reliability.mdx
+++ b/docs/tools/reliability.mdx
@@ -5,6 +5,15 @@ description: "How PraisonAI tools handle errors, retries, and edge cases"
 icon: "shield-check"
 ---
 
+```python
+from praisonaiagents import Agent, duckduckgo
+
+agent = Agent(name="Researcher", tools=[duckduckgo])
+agent.start("Find recent news about tool reliability in AI agents")
+```
+
+The user relies on search tools; PraisonAI retries and fallbacks keep the agent run stable when a provider fails.
+
 PraisonAI tools are designed with **reliability-first** principles.
 
 ```mermaid

--- a/docs/tools/schedule-tools.mdx
+++ b/docs/tools/schedule-tools.mdx
@@ -5,6 +5,19 @@ description: "Agent-centric scheduling — let agents add, list, and remove sche
 icon: "clock"
 ---
 
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools import schedule_add, schedule_list, schedule_remove
+
+agent = Agent(
+    name="Scheduler",
+    instructions="Add and list scheduled reminders for the user.",
+    tools=[schedule_add, schedule_list, schedule_remove],
+)
+agent.start("Remind me daily at 9:00 to review the inbox")
+```
+
+The user describes a recurring reminder; the agent registers a schedule job via schedule tools.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/search-tools.mdx
+++ b/docs/tools/search-tools.mdx
@@ -5,8 +5,21 @@ description: "Fast, capped grep and glob built-ins for code-searching agents"
 icon: "magnifying-glass"
 ---
 
-Give your agent two zero-config primitives — `grep` to find text, `glob` to find files — bounded, path-safe, and ripgrep-accelerated when available.
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools import grep, glob
 
+agent = Agent(
+    name="Code Search",
+    instructions="Find symbols and files in the repository.",
+    tools=[grep, glob],
+)
+agent.start("Find all TODO comments under src/")
+```
+
+The user describes what to locate in the codebase; the agent runs grep and glob with safe caps.
+
+Give your agent two zero-config primitives — `grep` to find text, `glob` to find files — bounded, path-safe, and ripgrep-accelerated when available.
 ```mermaid
 graph LR
     subgraph "Search Tools"

--- a/docs/tools/searxng.mdx
+++ b/docs/tools/searxng.mdx
@@ -5,6 +5,18 @@ description: "Search the web using your local SearxNG instance for privacy-focus
 icon: "magnifying-glass"
 ---
 
+```python
+from praisonaiagents import Agent, search_web
+
+agent = Agent(
+    name="Private Search",
+    instructions="Search the web via the local SearxNG instance.",
+    tools=[search_web],
+)
+agent.start("Search for privacy-focused search engines and summarise")
+```
+
+The user asks for web results; the agent queries SearxNG instead of a commercial search API.
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/shell_tools.mdx
+++ b/docs/tools/shell_tools.mdx
@@ -5,8 +5,21 @@ description: "Shell command execution tools for AI agents."
 icon: "terminal"
 ---
 
-Shell tools let AI agents execute commands, manage processes, and monitor system resources.
+```python
+from praisonaiagents import Agent
+from praisonaiagents import execute_command
 
+agent = Agent(
+    name="Shell Assistant",
+    instructions="Run approved shell commands and report output.",
+    tools=[execute_command],
+)
+agent.start("Show disk usage for the current project directory")
+```
+
+The user requests a system check; the agent runs bounded shell commands and returns stdout safely.
+
+Shell tools let AI agents execute commands, manage processes, and monitor system resources.
 ```mermaid
 graph LR
     U[Input] --> A[Shell Agent]


### PR DESCRIPTION
## Summary
- Add agent-centric hero Python openers and **The user…** interaction lines before the first hero Mermaid on 20 `docs/tools` pages (alphabetical batch: `file_tools` through `shell_tools`).
- Part of #1351 tools sweep; does not touch `docs/concepts/`.

## Test plan
- [x] Verified 20 pages include python hero and The user text before first mermaid
- [x] docs.json valid JSON

Refs #1351

Made with [Cursor](https://cursor.com)