### PR TITLE
docs(tools): #1351 batch 3 final hero alignment

### DIFF
--- a/docs/guides/deployment/docker.mdx
+++ b/docs/guides/deployment/docker.mdx
@@ -16,7 +16,7 @@ agent = Agent(
 agent.start("Health check: confirm the service is ready.")
 ```
 
-You build a Docker image, run the container, and users reach the agent through your exposed port.
+The user builds a Docker image, runs the container, and reaches the agent through the exposed port.
 
 ```mermaid
 graph LR

--- a/docs/guides/deployment/index.mdx
+++ b/docs/guides/deployment/index.mdx
@@ -17,7 +17,7 @@ agent = Agent(
 agent.start("Process the next customer message.")
 ```
 
-Pick a deployment guide, ship the agent, then route real traffic to it.
+The user picks a deployment guide, ships the agent, then routes real traffic to it.
 
 ```mermaid
 graph LR

--- a/docs/guides/deployment/overview.mdx
+++ b/docs/guides/deployment/overview.mdx
@@ -17,7 +17,7 @@ agent = Agent(
 agent.start("Ready for production deployment")
 ```
 
-Choose a hosting pattern, configure secrets and scaling, then point users at the running agent.
+The user chooses a hosting pattern, configures secrets and scaling, then points clients at the running agent.
 
 ```mermaid
 graph LR

--- a/docs/guides/deployment/production-minimal.mdx
+++ b/docs/guides/deployment/production-minimal.mdx
@@ -17,7 +17,7 @@ agent = Agent(
 agent.start("Deploy for production")
 ```
 
-Supervisor restarts the process if it exits; users keep sending prompts while the agent stays online.
+The user deploys with Supervisor so the process restarts on exit and keeps handling prompts..
 
 ```mermaid
 graph LR

--- a/docs/guides/documentation-style-guide.mdx
+++ b/docs/guides/documentation-style-guide.mdx
@@ -17,7 +17,7 @@ agent = Agent(
 agent.start("What is agentic AI?")
 ```
 
-Readers copy the opening example, run the agent, then follow the page structure below.
+The user copies the opening example, runs the agent, then follows the page structure below.
 
 ```mermaid
 graph LR

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -17,7 +17,7 @@ agent = Agent(
 agent.start("Hello! What can you help me with?")
 ```
 
-Start with a guide that matches your goal, run the sample agent, then extend it step by step.
+The user starts with a guide that matches their goal, runs the sample agent, then extends it step by step.
 
 ```mermaid
 graph LR

--- a/docs/guides/integrating-praisonaiui.mdx
+++ b/docs/guides/integrating-praisonaiui.mdx
@@ -16,7 +16,7 @@ agent = Agent(
 agent.start("Summarise today's agent activity.")
 ```
 
-Install packages, launch `praisonai dashboard --aiui`, and interact with the agent in the browser.
+The user installs packages, launches `praisonai dashboard --aiui`, and interacts with the agent in the browser.
 
 ```mermaid
 graph LR

--- a/docs/guides/persistence/databases.mdx
+++ b/docs/guides/persistence/databases.mdx
@@ -14,7 +14,7 @@ agent = Agent(name="Assistant", session=session)
 agent.start("Remember this preference for next time.")
 ```
 
-Sessions write to your chosen database so the same user can reconnect after a restart.
+The user saves sessions to a database so the same person can reconnect after a restart.
 
 ```mermaid
 graph LR

--- a/docs/guides/persistence/index.mdx
+++ b/docs/guides/persistence/index.mdx
@@ -14,7 +14,7 @@ agent = Agent(name="Assistant", session=session)
 agent.start("Continue our conversation.")
 ```
 
-Open a persistence guide, wire a session store, then resume work without losing context.
+The user opens a persistence guide, wires a session store, then resumes work without losing context.
 
 ```mermaid
 graph LR

--- a/docs/guides/persistence/overview.mdx
+++ b/docs/guides/persistence/overview.mdx
@@ -14,7 +14,7 @@ agent = Agent(name="Assistant", session=session)
 agent.start("Pick up where we left off.")
 ```
 
-Each run loads stored memory and checkpoints so users do not repeat earlier steps.
+The user runs the agent again; stored memory and checkpoints avoid repeating earlier steps.
 
 ```mermaid
 graph LR

--- a/docs/guides/persistence/session-resume.mdx
+++ b/docs/guides/persistence/session-resume.mdx
@@ -14,7 +14,7 @@ agent = Agent(name="Worker", session=session)
 agent.resume()
 ```
 
-After a crash or deploy, reopen the same session ID and the agent continues the in-flight task.
+The user reopens the same session ID after a crash or deploy and the agent continues the in-flight task.
 
 ```mermaid
 graph LR

--- a/docs/guides/platform/assign-agents.mdx
+++ b/docs/guides/platform/assign-agents.mdx
@@ -17,7 +17,7 @@ agent = Agent(
 agent.start("Review issue #42 and propose a fix.")
 ```
 
-Register the agent on the platform, assign an issue, and review its automated output in the workspace.
+The user registers the agent on the platform, assigns an issue, and reviews its output in the workspace.
 
 ```mermaid
 graph LR

--- a/docs/guides/platform/getting-started.mdx
+++ b/docs/guides/platform/getting-started.mdx
@@ -17,7 +17,7 @@ agent = Agent(
 agent.start("Create a sample issue for my new project.")
 ```
 
-Install the platform, authenticate, then drive workspaces and issues from the API or SDK.
+The user installs the platform, authenticates, then drives workspaces and issues from the API or SDK.
 
 ```mermaid
 graph LR

--- a/docs/guides/platform/index.mdx
+++ b/docs/guides/platform/index.mdx
@@ -17,7 +17,7 @@ agent = Agent(
 agent.start("List open tasks in my workspace.")
 ```
 
-Run the platform locally, open a guide, and connect agents to issues your team creates.
+The user runs the platform locally, opens a guide, and connects agents to team issues.
 
 ```mermaid
 graph LR

--- a/docs/guides/platform/organize-issues.mdx
+++ b/docs/guides/platform/organize-issues.mdx
@@ -17,7 +17,7 @@ agent = Agent(
 agent.start("Apply labels to the latest bug reports.")
 ```
 
-Create labels and dependencies in the UI or API, then agents use them to route and order work.
+The user creates labels and dependencies in the UI or API, then agents use them to route and order work.
 
 ```mermaid
 graph LR

--- a/docs/guides/platform/quick-tutorial.mdx
+++ b/docs/guides/platform/quick-tutorial.mdx
@@ -17,7 +17,7 @@ agent = Agent(
 agent.start("Register my workspace and first issue.")
 ```
 
-Follow each step—register, create a workspace, add issues, assign the agent, and review activity.
+The user follows each step—register, create a workspace, add issues, assign the agent, and review activity.
 
 ```mermaid
 graph LR

--- a/docs/guides/praisonai-code-migration.mdx
+++ b/docs/guides/praisonai-code-migration.mdx
@@ -17,7 +17,7 @@ agent = Agent(
 agent.start("Say hello from praisonai run")
 ```
 
-Keep using `pip install praisonai`; the extracted `praisonai-code` package powers the same CLI entry points.
+The user keeps using `pip install praisonai`; the extracted `praisonai-code` package powers the same CLI entry points.
 
 ```mermaid
 graph LR

--- a/docs/guides/rag/chunking.mdx
+++ b/docs/guides/rag/chunking.mdx
@@ -17,7 +17,7 @@ agent = Agent(
 agent.start("What does our deployment guide say about Docker?")
 ```
 
-Documents are split into chunks, embedded, and the agent retrieves the best slices for each user question.
+The user uploads documents; they are chunked and embedded, and the agent retrieves the best slices for each question.
 
 ```mermaid
 graph LR

--- a/docs/guides/rag/index.mdx
+++ b/docs/guides/rag/index.mdx
@@ -17,7 +17,7 @@ agent = Agent(
 agent.start("Find the section about session persistence.")
 ```
 
-Attach a knowledge source, ask a question, and the agent grounds its reply in retrieved passages.
+The user attaches a knowledge source, asks a question, and the agent grounds its reply in retrieved passages.
 
 ```mermaid
 graph LR

--- a/docs/guides/templates/create-custom-templates.mdx
+++ b/docs/guides/templates/create-custom-templates.mdx
@@ -4,6 +4,20 @@ description: "Step-by-step guide to creating your own PraisonAI recipes"
 icon: "plus"
 ---
 
+Define roles and tasks in `agents.yaml`, then run the recipe from the CLI.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Recipe Author",
+    instructions="Design multi-step recipe roles and validate outputs.",
+)
+agent.start("Outline a two-agent research recipe.")
+```
+
+The user authors `agents.yaml`, runs `praisonai recipe run`, and receives output from each role.
+
 
 ```mermaid
 graph LR

--- a/docs/guides/templates/debug-templates.mdx
+++ b/docs/guides/templates/debug-templates.mdx
@@ -4,6 +4,17 @@ description: "Step-by-step guide to debugging and troubleshooting recipes"
 icon: "bug"
 ---
 
+Run validation and verbose recipe commands when a template fails in production.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="Recipe Debugger", instructions="Explain recipe validation errors clearly.")
+agent.start("Why did my recipe fail tool resolution?")
+```
+
+The user enables verbose mode, validates the recipe folder, and fixes configuration before re-running.
+
 
 ```mermaid
 graph LR

--- a/docs/guides/templates/different-ways-to-create-templates.mdx
+++ b/docs/guides/templates/different-ways-to-create-templates.mdx
@@ -4,6 +4,17 @@ description: "Explore all methods for creating PraisonAI recipes"
 icon: "layer-group"
 ---
 
+Create recipes with the CLI, by hand, or from existing examples—pick the path that fits your team.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="Recipe Planner", instructions="Compare recipe creation approaches.")
+agent.start("Should I use recipe init or a manual folder?")
+```
+
+The user picks a creation method, scaffolds files, and runs the recipe with the same CLI entry point.
+
 
 ```mermaid
 graph LR

--- a/docs/guides/templates/index.mdx
+++ b/docs/guides/templates/index.mdx
@@ -4,6 +4,17 @@ description: "Complete guide to working with PraisonAI recipes"
 icon: "book-open"
 ---
 
+Recipes package agents, tasks, and tools so you can run repeatable workflows from YAML.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="Recipe Runner", instructions="Summarise what PraisonAI recipes provide.")
+agent.start("What can I do with recipes?")
+```
+
+The user opens a recipe guide, configures roles, and runs `praisonai recipe run` with variables.
+
 
 ```mermaid
 graph LR

--- a/docs/guides/templates/manage-templates.mdx
+++ b/docs/guides/templates/manage-templates.mdx
@@ -4,6 +4,17 @@ description: "Step-by-step guide to updating, editing, and deleting recipes"
 icon: "gear"
 ---
 
+Update recipe versions, validate changes, and retire old templates safely.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="Recipe Maintainer", instructions="Guide safe recipe updates and rollbacks.")
+agent.start("How do I version my recipe changes?")
+```
+
+The user edits `agents.yaml`, validates the folder, and re-runs the recipe with updated variables.
+
 
 ```mermaid
 graph LR

--- a/docs/guides/templates/use-existing-templates.mdx
+++ b/docs/guides/templates/use-existing-templates.mdx
@@ -4,6 +4,17 @@ description: "Step-by-step guide to running and using existing PraisonAI recipes
 icon: "play"
 ---
 
+Discover community or built-in recipes and run them with your own inputs.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="Recipe Operator", instructions="Help run existing PraisonAI recipes.")
+agent.start("List steps to run an existing recipe with custom variables.")
+```
+
+The user lists recipes, passes `--var` flags, and collects outputs from each task.
+
 
 ```mermaid
 graph LR

--- a/docs/guides/tools/assign-tools-to-templates.mdx
+++ b/docs/guides/tools/assign-tools-to-templates.mdx
@@ -4,6 +4,22 @@ description: "Step-by-step guide to assigning and configuring tools in templates
 icon: "link"
 ---
 
+Wire built-in or custom tools into template manifests so agents can call them at runtime.
+
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def status_lookup(id: str) -> str:
+    """Return item status."""
+    return f"Status for {id}: ready"
+
+agent = Agent(name="Template Agent", tools=[status_lookup])
+agent.start("Check status for item 99.")
+```
+
+The user declares tools in YAML, assigns them to roles, and runs the template with those capabilities.
+
 
 ```mermaid
 graph LR

--- a/docs/guides/tools/create-custom-tools.mdx
+++ b/docs/guides/tools/create-custom-tools.mdx
@@ -4,6 +4,22 @@ description: "Step-by-step guide to creating custom tools for PraisonAI agents"
 icon: "plus"
 ---
 
+Turn Python functions into agent-callable tools with clear parameters and docstrings.
+
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def echo(query: str) -> str:
+    """Return the query uppercased."""
+    return query.upper()
+
+agent = Agent(name="Tool Demo", tools=[echo])
+agent.start("Use echo on hello world.")
+```
+
+The user defines a tool, registers it on an agent, and verifies the model invokes it correctly.
+
 
 ```mermaid
 graph LR

--- a/docs/guides/tools/debug-tools.mdx
+++ b/docs/guides/tools/debug-tools.mdx
@@ -4,6 +4,22 @@ description: "Step-by-step guide to debugging and troubleshooting tools"
 icon: "bug"
 ---
 
+Use doctor commands and targeted logs when tools fail to import or execute.
+
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def flaky() -> str:
+    """Simulate a tool for debugging."""
+    return "ok"
+
+agent = Agent(name="Tool Debugger", tools=[flaky])
+agent.start("Call flaky and report errors if any.")
+```
+
+The user runs `praisonai tools doctor`, fixes dependencies, and retries the agent call.
+
 
 ```mermaid
 graph LR

--- a/docs/guides/tools/different-ways-to-create-tools.mdx
+++ b/docs/guides/tools/different-ways-to-create-tools.mdx
@@ -4,6 +4,22 @@ description: "Explore all methods for creating tools in PraisonAI"
 icon: "layer-group"
 ---
 
+Choose between functions, classes, remote sources, or packages when extending agent capabilities.
+
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def add(a: int, b: int) -> int:
+    """Add two integers."""
+    return a + b
+
+agent = Agent(name="Toolkit", tools=[add])
+agent.start("What is 2 plus 3?")
+```
+
+The user picks a tool style, registers it, and confirms the agent selects the right tool.
+
 
 ```mermaid
 graph LR

--- a/docs/guides/tools/index.mdx
+++ b/docs/guides/tools/index.mdx
@@ -4,6 +4,22 @@ description: "Complete guide to working with PraisonAI tools"
 icon: "book-open"
 ---
 
+Tools let agents read data, call APIs, and run code—this hub links every tools how-to.
+
+```python
+from praisonaiagents import Agent, tool
+
+@tool
+def ping() -> str:
+    """Health check tool."""
+    return "pong"
+
+agent = Agent(name="Tools Intro", tools=[ping])
+agent.start("Run the ping tool.")
+```
+
+The user follows a tools guide, attaches capabilities to agents, and validates behaviour with doctor.
+
 
 ```mermaid
 graph LR

--- a/docs/guides/tools/remote-tools-github.mdx
+++ b/docs/guides/tools/remote-tools-github.mdx
@@ -4,6 +4,17 @@ description: "Step-by-step guide to using tools from GitHub and remote URLs"
 icon: "github"
 ---
 
+Pull tool implementations from GitHub URLs and reference them in template manifests.
+
+```python
+from praisonaiagents import Agent, tool
+
+agent = Agent(name="Remote Tools", instructions="Use tools loaded from remote sources.")
+agent.start("Which remote tool sources are configured?")
+```
+
+The user adds `tools_sources` entries, lists tools in `agents.yaml`, and runs the template.
+
 
 ```mermaid
 graph LR

--- a/docs/guides/troubleshoot-gateway.mdx
+++ b/docs/guides/troubleshoot-gateway.mdx
@@ -7,6 +7,30 @@ icon: "wrench"
 
 Common issues with the PraisonAI Gateway daemon and server, with step-by-step troubleshooting guides.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Gateway Helper",
+    instructions="Diagnose PraisonAI Gateway connectivity issues.",
+)
+agent.start("Gateway health check: is the daemon reachable?")
+```
+
+The user checks gateway status, reads logs, and restarts the daemon until channels respond again.
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
 ```mermaid
 graph TB
     subgraph "Troubleshooting Flow"

--- a/docs/guides/workflows/index.mdx
+++ b/docs/guides/workflows/index.mdx
@@ -4,6 +4,32 @@ description: "Understanding workflow patterns for multi-agent systems"
 icon: "diagram-project"
 ---
 
+Pick a workflow pattern and connect agents so they share context across steps.
+
+```python
+from praisonaiagents import Agent, AgentFlow
+
+researcher = Agent(name="Researcher", instructions="Research topics.")
+writer = Agent(name="Writer", instructions="Write clear summaries.")
+flow = AgentFlow(steps=[researcher, writer])
+flow.start("Explain workflow patterns in one paragraph.")
+```
+
+The user chooses a pattern, configures agents, and submits a task that flows through the team.
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
 # Workflows
 
 Workflows define **how multiple agents work together** to complete a task. Just like a team of people in an office, agents can collaborate in different ways depending on the task.

--- a/docs/guides/workflows/orchestrator.mdx
+++ b/docs/guides/workflows/orchestrator.mdx
@@ -4,6 +4,33 @@ description: "A manager agent that delegates work to specialists"
 icon: "sitemap"
 ---
 
+Let a manager agent delegate subtasks to specialists for complex, open-ended work.
+
+```python
+from praisonaiagents import Agent, Task, AgentTeam
+
+researcher = Agent(name="Researcher", instructions="Research topics")
+writer = Agent(name="Writer", instructions="Write content")
+task = Task(description="Report on AI trends", expected_output="A detailed report")
+team = AgentTeam(agents=[researcher, writer], tasks=[task], process="hierarchical", manager_llm="gpt-4o")
+team.start()
+```
+
+The user starts a hierarchical team; the manager assigns work and returns a consolidated result.
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
 # Orchestrator Pattern
 
 Like a **project manager** who assigns work to team members.

--- a/docs/guides/workflows/parallel.mdx
+++ b/docs/guides/workflows/parallel.mdx
@@ -4,6 +4,33 @@ description: "Execute multiple agents simultaneously for faster results"
 icon: "arrows-split-up-and-left"
 ---
 
+Run independent agents at the same time, then merge their outputs in a final step.
+
+```python
+from praisonaiagents import Agent, AgentFlow, parallel
+
+ai = Agent(name="AI", instructions="Research AI trends")
+ml = Agent(name="ML", instructions="Research ML trends")
+summary = Agent(name="Summary", instructions="Combine research")
+flow = AgentFlow(steps=[parallel([ai, ml]), summary])
+flow.start("Research latest developments")
+```
+
+The user runs parallel steps for speed, then lets a summariser agent combine the results.
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
 # Parallel Workflow
 
 Run multiple agents **at the same time** instead of waiting for each one.

--- a/docs/guides/workflows/routing.mdx
+++ b/docs/guides/workflows/routing.mdx
@@ -4,6 +4,30 @@ description: "Send requests to the right specialist agent"
 icon: "route"
 ---
 
+Classify each request and hand it to the specialist agent best suited to answer.
+
+```python
+from praisonaiagents import Agent
+
+router = Agent(name="Classifier", instructions="Route requests to billing, tech, or general support.")
+router.start("My API key returns 401—who should handle this?")
+```
+
+The user defines routing rules, maps intents to agents, and returns the specialist response.
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
 # Routing Workflow
 
 Like a **receptionist** directing calls to the right department.

--- a/docs/guides/workflows/sequential.mdx
+++ b/docs/guides/workflows/sequential.mdx
@@ -4,6 +4,33 @@ description: "Chain agents one after another like an assembly line"
 icon: "arrow-right"
 ---
 
+Pass work from one agent to the next when each step depends on the previous output.
+
+```python
+from praisonaiagents import Agent, AgentFlow
+
+researcher = Agent(name="Researcher", instructions="Research topics")
+analyst = Agent(name="Analyst", instructions="Analyze research findings")
+writer = Agent(name="Writer", instructions="Write based on analysis")
+flow = AgentFlow(steps=[researcher, analyst, writer])
+flow.start("AI trends in 2024")
+```
+
+The user chains agents in order; each step receives the prior output until the final result is ready.
+
+```mermaid
+graph LR
+    U[Input] --> A[Agent]
+    A --> O[Output]
+
+    classDef agent fill:#8B0000,color:#fff
+    classDef tool fill:#189AB4,color:#fff
+
+    class A agent
+    class U,O tool
+```
+
+
 # Sequential Workflow
 
 Pass work from one agent to the next, like an **assembly line**.

--- a/docs/tools/single-file-plugins.mdx
+++ b/docs/tools/single-file-plugins.mdx
@@ -5,6 +5,18 @@ description: "Create simple, WordPress-style plugins with just a Python file"
 icon: "puzzle-piece"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Assistant",
+    tools=["get_weather"],
+)
+agent.start("What is the weather in London?")
+```
+
+The user drops a single-file plugin into the plugins folder; the agent loads its tools and answers with plugin-backed actions.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/spider_tools.mdx
+++ b/docs/tools/spider_tools.mdx
@@ -5,6 +5,19 @@ description: "Web scraping tools for AI agents."
 icon: "spider"
 ---
 
+```python
+from praisonaiagents import Agent
+from praisonaiagents import scrape_page, extract_links, crawl, extract_text
+
+agent = Agent(
+    name="Spider",
+    tools=[scrape_page, extract_links, crawl, extract_text],
+)
+agent.start("Scrape the homepage and list outbound links")
+```
+
+The user names a URL or crawl task; the agent uses spider tools to fetch and summarise page content.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/tavily.mdx
+++ b/docs/tools/tavily.mdx
@@ -5,6 +5,15 @@ description: "Built-in Tavily search tools for AI agents - web search, content e
 icon: "magnifying-glass"
 ---
 
+```python
+from praisonaiagents import Agent, tavily
+
+agent = Agent(name="Researcher", tools=[tavily])
+agent.start("Search for the latest on agent frameworks")
+```
+
+The user describes a research question; the agent calls Tavily search and returns concise findings.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/tools.mdx
+++ b/docs/tools/tools.mdx
@@ -5,6 +5,18 @@ description: "Learn how to create AI agents that can use tools to interact with 
 icon: "screwdriver-wrench"
 ---
 
+```python
+from praisonaiagents import Agent
+
+def search(query: str) -> str:
+    return f"Results for {query}"
+
+agent = Agent(name="Assistant", tools=[search])
+agent.start("Search for Python 3.13 release notes")
+```
+
+The user assigns tools to an agent; the model chooses tool calls to complete the task.
+
 ```mermaid
 flowchart TB
     subgraph Tools

--- a/docs/tools/tools_class.mdx
+++ b/docs/tools/tools_class.mdx
@@ -5,6 +5,20 @@ description: "Learn how to create and use class-based tools with AI agents for e
 icon: "toolbox"
 ---
 
+```python
+from praisonaiagents import Agent
+from pydantic import BaseModel
+
+class CustomTool(BaseModel):
+    def run(self, query: str) -> str:
+        return f"Processed: {query}"
+
+agent = Agent(name="CustomAgent", tools=[CustomTool])
+agent.start("Run the custom tool on sample data")
+```
+
+The user wraps behaviour in a class-based tool; the agent invokes it like any other capability.
+
 ```mermaid
 flowchart LR
     In[In] --> Agent[AI Agent]

--- a/docs/tools/trafilatura.mdx
+++ b/docs/tools/trafilatura.mdx
@@ -5,6 +5,23 @@ description: "Extract clean, structured content from web pages with advanced tex
 icon: "file-export"
 ---
 
+```python
+import trafilatura
+from praisonaiagents import Agent
+
+def extract_article(url: str) -> str:
+    downloaded = trafilatura.fetch_url(url)
+    return trafilatura.extract(downloaded) or "Could not extract content"
+
+agent = Agent(
+    name="ExtractAgent",
+    tools=[extract_article],
+)
+agent.start("Extract and summarise https://example.com/article")
+```
+
+The user shares a URL; the agent extracts clean article text with Trafilatura and summarises it.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/web-search.mdx
+++ b/docs/tools/web-search.mdx
@@ -5,6 +5,15 @@ description: "Built-in unified web search tool with automatic fallback across mu
 icon: "magnifying-glass-plus"
 ---
 
+```python
+from praisonaiagents import Agent, search_web
+
+agent = Agent(name="Researcher", tools=[search_web])
+agent.start("Find recent news about renewable energy")
+```
+
+The user asks an open web question; the agent runs built-in web search and synthesises results.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/wikipedia.mdx
+++ b/docs/tools/wikipedia.mdx
@@ -5,6 +5,18 @@ description: "Guide for integrating Wikipedia search capabilities with PraisonAI
 icon: "book"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="WikiAgent",
+    instructions="Search Wikipedia for factual information.",
+)
+agent.start("Explain the history of the internet")
+```
+
+The user asks for encyclopaedic facts; the agent searches Wikipedia and returns a grounded summary.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/wikipedia_tools.mdx
+++ b/docs/tools/wikipedia_tools.mdx
@@ -5,6 +5,19 @@ description: "Wikipedia data retrieval tools for AI agents."
 icon: "book"
 ---
 
+```python
+from praisonaiagents import Agent
+from praisonai_tools import wiki_search, wiki_summary, wiki_page
+
+agent = Agent(
+    name="WikiResearcher",
+    tools=[wiki_search, wiki_summary, wiki_page],
+)
+agent.start("Summarise the Wikipedia article on machine learning")
+```
+
+The user requests a topic; the agent uses Wikipedia tools to search, fetch, and summarise articles.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/xml_tools.mdx
+++ b/docs/tools/xml_tools.mdx
@@ -5,6 +5,19 @@ description: "XML data processing tools for AI agents."
 icon: "code"
 ---
 
+```python
+from praisonaiagents import Agent
+from praisonaiagents import read_xml, write_xml, validate_xml
+
+agent = Agent(
+    name="XMLAgent",
+    tools=[read_xml, write_xml, validate_xml],
+)
+agent.start("Validate config.xml against our schema")
+```
+
+The user describes an XML task; the agent reads, validates, or transforms documents with XML tools.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/xquik.mdx
+++ b/docs/tools/xquik.mdx
@@ -7,6 +7,16 @@ icon: "magnifying-glass"
 
 Search recent public posts on X (Twitter) in agent workflows with a single function call.
 
+```python
+from praisonaiagents import Agent
+from praisonaiagents.tools import search_x_posts
+
+agent = Agent(name="SocialResearcher", tools=[search_x_posts])
+agent.start("Find recent posts about PraisonAI on X")
+```
+
+The user describes a topic; the agent searches recent public X posts via Xquik and summarises highlights.
+
 ```mermaid
 graph LR
     subgraph "Xquik Tweet Search"

--- a/docs/tools/yaml-tools.mdx
+++ b/docs/tools/yaml-tools.mdx
@@ -13,6 +13,15 @@ Tools can now be referenced by name directly in YAML files without creating a lo
 
 When you specify tools in your YAML configuration, PraisonAI automatically resolves them from multiple sources. Only tools you list under `tools:` in your YAML (under each role and each task) are loaded. Misspelled or unknown tool names now produce a `warning` log line, not a silent skip.
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="Researcher", tools=["tavily_search"])
+agent.start("Summarise today's AI headlines")
+```
+
+The user lists tools in agents.yaml; PraisonAI resolves built-ins and runs the configured agent.
+
 ```mermaid
 flowchart LR
     subgraph YAML["agents.yaml"]

--- a/docs/tools/yaml_tools.mdx
+++ b/docs/tools/yaml_tools.mdx
@@ -5,6 +5,19 @@ description: "YAML data processing tools for AI agents."
 icon: "code"
 ---
 
+```python
+from praisonaiagents import Agent
+from praisonaiagents import read_yaml, write_yaml, validate_yaml
+
+agent = Agent(
+    name="YAMLAgent",
+    tools=[read_yaml, write_yaml, validate_yaml],
+)
+agent.start("Validate and merge these two YAML configs")
+```
+
+The user describes a YAML change; the agent reads, validates, and updates structured config files.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/yfinance_tools.mdx
+++ b/docs/tools/yfinance_tools.mdx
@@ -5,6 +5,19 @@ description: "Yahoo Finance data retrieval tools for AI agents."
 icon: "chart-line"
 ---
 
+```python
+from praisonaiagents import Agent
+from praisonaiagents import get_stock_price, get_stock_info
+
+agent = Agent(
+    name="MarketAnalyst",
+    tools=[get_stock_price, get_stock_info],
+)
+agent.start("What is NVDA trading at and what is its market cap?")
+```
+
+The user asks about a ticker; the agent pulls live quotes and fundamentals with yfinance tools.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/you.com.mdx
+++ b/docs/tools/you.com.mdx
@@ -5,6 +5,15 @@ description: "Built-in You.com search tools for AI agents - web search, news, co
 icon: "magnifying-glass-plus"
 ---
 
+```python
+from praisonaiagents import Agent, search_web
+
+agent = Agent(name="Researcher", tools=[search_web])
+agent.start("Compare cloud GPU pricing for fine-tuning")
+```
+
+The user asks a research question; the agent uses You.com-backed search and returns a concise answer.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]

--- a/docs/tools/youtube.mdx
+++ b/docs/tools/youtube.mdx
@@ -5,6 +5,18 @@ description: "Guide for integrating YouTube search capabilities with PraisonAI a
 icon: "youtube"
 ---
 
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="YouTubeAgent",
+    instructions="Extract and analyse YouTube video content.",
+)
+agent.start("Summarise the key points from this video: https://www.youtube.com/watch?v=example")
+```
+
+The user shares a video link or search topic; the agent finds content and summarises transcripts or metadata.
+
 ```mermaid
 graph LR
     U[Input] --> A[Agent]


### PR DESCRIPTION
## Summary
- Add agent-centric hero Python openers and **The user…** interaction lines before the first hero Mermaid on the remaining 16  pages ( through ).
- Completes the tools portion of #1351 hero alignment for pages that include Mermaid; does not touch .

## Test plan
- [x] Hero audit: **0** gaps in  (agent opener + The user within 800 chars before first mermaid)
- [x]  valid JSON

Refs #1351