### PR TITLE
docs: update max_iter step-limit wrap-up behaviour

### DIFF
--- a/docs/configuration/execution-config.mdx
+++ b/docs/configuration/execution-config.mdx
@@ -105,7 +105,7 @@ config = ExecutionConfig(
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `max_iter` | `int` | `20` | Maximum tool-calling iterations. Now propagated to the `LLM` instance, so it controls every internal loop (previously some loops were hardcoded to 5/10/20/50). Both the `ExecutionConfig` default and the `LLM`-direct-construction default are `20` (aligned as of PR #1898). |
+| `max_iter` | `int` | `20` | Maximum tool-calling iterations. Now propagated to the `LLM` instance, so it controls every internal loop (previously some loops were hardcoded to 5/10/20/50). Both the `ExecutionConfig` default and the `LLM`-direct-construction default are `20` (aligned as of PR #1898). When the loop reaches this cap, the agent performs one bounded LLM call with tools disabled to synthesise a wrap-up summary instead of returning the old `"Task completed."` placeholder (as of PR #2577). |
 | `max_rpm` | `int \| None` | `None` | Max requests per minute (rate limit) |
 | `max_execution_time` | `int \| None` | `None` | Max execution time in seconds |
 | `max_retry_limit` | `int` | `2` | Max retries for retryable tool failures and guardrail validation failures. Total attempts = `1 + max_retry_limit`. Retries use exponential backoff with jitter (see `retry_initial_delay`, `retry_backoff_factor`, `retry_jitter`). |
@@ -176,6 +176,14 @@ agent = Agent(
 )
 # The agent's LLM will respect 15 iterations in all internal loops
 ```
+
+### When the limit is reached
+
+When the tool-calling loop reaches `max_iter`, the agent performs one final LLM call with `tool_choice="none"` and every advertised tool stripped, asking the model to summarise **what it accomplished, what remains unfinished, and any suggested next steps** using the tool results already in context. That synthesised text becomes the final answer.
+
+The extra call is bounded to exactly one non-tool completion and is routed through the same retry / failover wrappers as every other completion, so a transient rate-limit error doesn't drop straight to a placeholder. If the call still fails, the agent falls back to the last-turn text, then to `"Reached the step limit before finishing this task."` — behaviour never regresses.
+
+There is no opt-out. To avoid truncation, increase `max_iter` so the agent can finish normally.
 
 ---
 

--- a/docs/features/error-handling.mdx
+++ b/docs/features/error-handling.mdx
@@ -140,6 +140,12 @@ Raised errors stop the run; some callbacks record failures on the output instead
 
 ---
 
+## Reaching the Step Limit
+
+When the tool-calling loop hits `ExecutionConfig.max_iter`, the agent no longer returns the canned `"Task completed."` placeholder. It runs one bounded LLM call with tools disabled, asks the model to summarise what it accomplished and what remains, and returns that as the final answer. Detect truncation by monitoring iteration counts, or match the fallback string `"Reached the step limit before finishing this task."` as a last-resort signal.
+
+---
+
 ## Best Practices
 
 <AccordionGroup>

--- a/docs/features/execution.mdx
+++ b/docs/features/execution.mdx
@@ -97,6 +97,7 @@ sequenceDiagram
     participant User
     participant Agent
     participant Execution
+    participant LLM
 
     User->>Agent: Request
     Agent->>Execution: Check iteration budget
@@ -105,7 +106,9 @@ sequenceDiagram
         Execution->>Execution: Check limits (iter, time, RPM)
     end
     alt Budget exceeded
-        Execution-->>Agent: Stop signal
+        Execution->>LLM: One final call, tools disabled
+        LLM-->>Execution: Wrap-up summary
+        Execution-->>Agent: Wrap-up as final answer
     else Completed
         Execution-->>Agent: Done signal
     end
@@ -118,6 +121,7 @@ sequenceDiagram
 | 2. Rate limit | Enforces `max_rpm` requests-per-minute |
 | 3. Time limit | Stops if `max_execution_time` seconds elapsed |
 | 4. Retry | Retries failed steps up to `max_retry_limit` times |
+| 5. Step-limit wrap-up | If `max_iter` is reached mid-tool-loop, one final LLM call runs with tools disabled (`tool_choice="none"`) to synthesise a summary from accumulated tool results, so the user gets a useful final message instead of a placeholder. |
 
 ---
 
@@ -129,7 +133,7 @@ sequenceDiagram
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `max_iter` | `int` | `20` | Maximum iterations/tool calls per run |
+| `max_iter` | `int` | `20` | Maximum iterations/tool calls per run. When the loop reaches this cap, the agent makes one final LLM call with tools disabled and returns a wrap-up summary of what it accomplished, what remains unfinished, and suggested next steps — instead of the old canned `"Task completed."` placeholder. |
 | `max_rpm` | `int \| None` | `None` | Max requests per minute |
 | `max_execution_time` | `int \| None` | `None` | Max seconds per run |
 | `max_retry_limit` | `int` | `2` | Max retries on failure |
@@ -209,6 +213,10 @@ When your agent calls multiple independent tools per turn (e.g., search + fetch 
 
 <Accordion title="Code execution safety">
 Always use `code_mode="safe"` and `code_sandbox_mode="sandbox"` when enabling code execution. Only switch to `"unsafe"` or `"direct"` in fully isolated environments you control.
+</Accordion>
+
+<Accordion title="Detecting truncated runs">
+When `max_iter` is reached, the returned text is a real LLM-authored wrap-up ("Here's what I accomplished… here's what remains…"), not the old `"Task completed."` placeholder. If the extra call fails, the agent falls back to the last-turn text and finally to `"Reached the step limit before finishing this task."`. To detect truncation programmatically, raise `max_iter` and monitor iteration counts, or match the fallback string as a last-resort signal.
 </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary

Documents the behaviour change shipped in MervinPraison/PraisonAI#2577: when the tool-calling loop reaches `max_iter`, the agent now performs one bounded LLM call with tools disabled to synthesise a wrap-up summary instead of returning the old canned `"Task completed."` placeholder.

### Changes

- **`docs/features/execution.mdx`**: Extended sequence diagram with tools-disabled finalisation step; added "Step-limit wrap-up" row to How It Works table; updated `max_iter` config row description; added "Detecting truncated runs" accordion to Best Practices.
- **`docs/configuration/execution-config.mdx`**: Updated `max_iter` row to reference PR #2577 wrap-up behaviour (preserving existing PR #1898 wording); added "When the limit is reached" subsection under the Iteration Propagation section.
- **`docs/features/error-handling.mdx`**: Added "Reaching the Step Limit" section describing the new graceful-degradation path and how callers can detect truncation.

### Not modified (intentional)
- `docs/concepts/execution.mdx` — human-approved only per AGENTS.md §1.9
- `docs.json` — no new pages added

Fixes #1450

Generated with [Claude Code](https://claude.ai/code)