### PR TITLE
docs: add Inbound Message Gate page and update hook docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -920,6 +920,7 @@
                   "docs/features/hook-events",
                   "docs/features/hooks-before-tool-definitions",
                   "docs/features/bot-lifecycle-hooks",
+                  "docs/features/inbound-message-gate",
                   "docs/features/kanban",
                   "docs/features/dynamic-variables",
                   "docs/features/variable-substitution",

--- a/docs/features/bot-lifecycle-hooks.mdx
+++ b/docs/features/bot-lifecycle-hooks.mdx
@@ -283,7 +283,7 @@ Returning `HookResult.deny("reason")` from gateway or session lifecycle hooks is
 For policy enforcement on agent internals (e.g. blocking tool calls or LLM requests), use `BEFORE_TOOL` or `BEFORE_LLM` hooks.
 
 <Note>
-**Exception — `MESSAGE_RECEIVED` is now a real gate.** Since PR #2589, returning `HookResult.deny(...)` from `MESSAGE_RECEIVED` drops the inbound message, and `HookResult.modified_data(content=…)` rewrites it in place before the agent sees it. See [Inbound Message Gate](/docs/features/inbound-message-gate).
+**Exception — `MESSAGE_RECEIVED` is now a real gate.** Since PR #2589, returning `HookResult.deny(...)` from `MESSAGE_RECEIVED` drops the inbound message, and `HookResult(decision="allow", modified_input={"content": "…"})` rewrites it in place before the agent sees it. See [Inbound Message Gate](/docs/features/inbound-message-gate).
 </Note>
 
 ---

--- a/docs/features/bot-lifecycle-hooks.mdx
+++ b/docs/features/bot-lifecycle-hooks.mdx
@@ -282,6 +282,10 @@ Returning `HookResult.deny("reason")` from gateway or session lifecycle hooks is
 
 For policy enforcement on agent internals (e.g. blocking tool calls or LLM requests), use `BEFORE_TOOL` or `BEFORE_LLM` hooks.
 
+<Note>
+**Exception — `MESSAGE_RECEIVED` is now a real gate.** Since PR #2589, returning `HookResult.deny(...)` from `MESSAGE_RECEIVED` drops the inbound message, and `HookResult.modified_data(content=…)` rewrites it in place before the agent sees it. See [Inbound Message Gate](/docs/features/inbound-message-gate).
+</Note>
+
 ---
 
 ## Best Practices
@@ -311,6 +315,9 @@ Platform user IDs differ between Telegram, Discord, Slack, and WhatsApp. Use `se
 ## Related
 
 <CardGroup cols={2}>
+  <Card title="Inbound Message Gate" icon="shield-check" href="/docs/features/inbound-message-gate">
+    Drop or redact incoming messages before the agent sees them
+  </Card>
   <Card title="Hook Events Reference" icon="list" href="/docs/features/hook-events">
     Complete event reference with all input types and fields
   </Card>

--- a/docs/features/hook-events.mdx
+++ b/docs/features/hook-events.mdx
@@ -501,7 +501,7 @@ When multiple `MESSAGE_RECEIVED` hooks run, the **last matching modification** w
 ```python
 @registry.on(HookEvent.MESSAGE_SENDING)
 def on_message_sending(event_data):
-    print(f"Sending: {event_data.message}")
+    print(f"Sending: {event_data.content}")
     return HookResult.allow()
 ```
 

--- a/docs/features/hook-events.mdx
+++ b/docs/features/hook-events.mdx
@@ -505,6 +505,10 @@ def on_message_sending(event_data):
     return HookResult.allow()
 ```
 
+Since PraisonAI PR #2589, every messaging adapter (Telegram, Slack, Discord, WhatsApp, email, agentmail) honours these decisions. Hook exceptions are non-fatal — the message passes through.
+
+See [Inbound Message Gate](/docs/features/inbound-message-gate) for patterns and failure semantics.
+
 ### Gateway Events
 
 | Event | Trigger | Input Type | Key Fields | Use Case |
@@ -642,7 +646,7 @@ def on_auto_promotion(event_data):
 | `SETUP` | System | Initialization |
 | `BEFORE_COMPACTION` | Context | Before compaction |
 | `AFTER_COMPACTION` | Context | After compaction |
-| `MESSAGE_RECEIVED` | Message | Inbound gate — drop (deny) or redact/rewrite before agent dispatch |
+| `MESSAGE_RECEIVED` | Message | Inbound gate — drop (deny) or redact/rewrite before agent dispatch (see [Inbound Message Gate](/docs/features/inbound-message-gate)) |
 | `MESSAGE_SENDING` | Message | Outbound gate — cancel or rewrite before sending |
 | `MESSAGE_SENT` | Message | After message sent |
 | `GATEWAY_START` | Gateway | Gateway starts |
@@ -702,6 +706,9 @@ Wrap hook logic in try/except to prevent breaking agent execution.
 ## Related
 
 <CardGroup cols={2}>
+  <Card title="Inbound Message Gate" icon="shield-check" href="/docs/features/inbound-message-gate">
+    Drop or redact incoming messages before the agent sees them
+  </Card>
   <Card title="Hooks" icon="link" href="/docs/features/hooks">
     Hook system overview
   </Card>

--- a/docs/features/inbound-message-gate.mdx
+++ b/docs/features/inbound-message-gate.mdx
@@ -1,0 +1,312 @@
+---
+title: "Inbound Message Gate"
+sidebarTitle: "Inbound Message Gate"
+description: "Drop or redact incoming chat messages before they reach your agent"
+icon: "shield-check"
+---
+
+Filter, redact, or reject messages from Telegram, Slack, Discord, WhatsApp, and email before your agent sees them.
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.hooks import HookRegistry, HookEvent, HookResult
+from praisonai.bots import TelegramBot
+
+registry = HookRegistry()
+ALLOWED = {"12345", "67890"}
+
+@registry.on(HookEvent.MESSAGE_RECEIVED)
+def gate(event_data):
+    if event_data.sender_id not in ALLOWED:
+        return HookResult.deny("not on allowlist")
+    return HookResult.allow()
+
+agent = Agent(name="GatedBot", instructions="Be helpful.", hooks=registry)
+bot = TelegramBot(token="...", agent=agent)
+
+import asyncio
+asyncio.run(bot.start())
+```
+
+```mermaid
+graph LR
+    subgraph "Inbound Message Gate"
+        M[📨 Incoming Message] --> H[🔍 MESSAGE_RECEIVED Hook]
+        H -->|allow| A[🤖 Agent]
+        H -->|deny| D[🚫 Dropped]
+        H -->|modified_data| R[✏️ Redacted → Agent]
+    end
+
+    classDef message fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef hook fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef agent fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef drop fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class M message
+    class H hook
+    class A,R agent
+    class D drop
+```
+
+## Quick Start
+
+<Steps>
+
+<Step title="Allowlist — drop messages from unknown senders">
+```python
+from praisonaiagents import Agent
+from praisonaiagents.hooks import HookRegistry, HookEvent, HookResult
+
+ALLOWED = {"12345", "67890"}
+registry = HookRegistry()
+
+@registry.on(HookEvent.MESSAGE_RECEIVED)
+def gate(event_data):
+    if event_data.sender_id not in ALLOWED:
+        return HookResult.deny("not on allowlist")
+    return HookResult.allow()
+
+agent = Agent(name="GatedBot", instructions="Be helpful.", hooks=registry)
+agent.start("Hello")
+```
+</Step>
+
+<Step title="PII redaction — rewrite content before the LLM sees it">
+```python
+import re
+from praisonaiagents import Agent
+from praisonaiagents.hooks import HookRegistry, HookEvent, HookResult
+
+SSN = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+registry = HookRegistry()
+
+@registry.on(HookEvent.MESSAGE_RECEIVED)
+def redact(event_data):
+    cleaned = SSN.sub("[SSN]", event_data.content)
+    if cleaned != event_data.content:
+        return HookResult.modified_data(content=cleaned)
+    return HookResult.allow()
+
+agent = Agent(name="SafeBot", instructions="Be helpful.", hooks=registry)
+agent.start("My SSN is 123-45-6789")
+```
+</Step>
+
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Adapter
+    participant HookRunner
+    participant Agent
+
+    User->>Adapter: Send message
+    Adapter->>HookRunner: fire_message_received(message)
+    alt HookResult.allow()
+        HookRunner-->>Adapter: {drop: false, content: original}
+        Adapter->>Agent: dispatch with original content
+    else HookResult.deny(...)
+        HookRunner-->>Adapter: {drop: true, content: original}
+        Adapter-->>User: (silent — no reply sent)
+    else HookResult.modified_data(content=...)
+        HookRunner-->>Adapter: {drop: false, content: redacted}
+        Adapter->>Agent: dispatch with redacted content
+    else Hook raises exception
+        HookRunner-->>Adapter: {drop: false, content: original}
+        Adapter->>Agent: dispatch (fail-open)
+    end
+```
+
+---
+
+## Decision Table
+
+| Hook returns | `drop` | `content` sent to agent | Effect |
+|---|---|---|---|
+| `HookResult.allow()` (or no hook) | `false` | original | Message flows unchanged |
+| `HookResult.deny("...")` | `true` | — | Adapter skips dispatch — bot stays silent |
+| `HookResult.modified_data(content="…")` | `false` | redacted text | LLM sees rewritten content |
+| Hook raises exception | `false` | original | Non-fatal — message passes through |
+
+<Warning>
+Hook exceptions are **non-fatal**. Raising an exception does **not** drop the message — the message passes through to the agent. Use `HookResult.deny(...)` to explicitly block.
+</Warning>
+
+---
+
+## Supported Adapters
+
+Every built-in messaging adapter honours the gate decision:
+
+| Adapter | Module |
+|---------|--------|
+| Telegram | `praisonai.bots.telegram` |
+| Slack | `praisonai.bots.slack` |
+| Discord | `praisonai.bots.discord` |
+| WhatsApp | `praisonai.bots.whatsapp` (regular + status paths) |
+| Email | `praisonai.bots.email` |
+| AgentMail | `praisonai.bots.agentmail` |
+
+<Note>
+Custom adapters must call `fire_message_received` and check the returned `drop` / `content` fields to participate in the gate.
+</Note>
+
+---
+
+## Common Patterns
+
+### Allowlist
+
+```python
+from praisonaiagents.hooks import HookRegistry, HookEvent, HookResult
+
+ALLOWED = {"user_id_1", "user_id_2"}
+registry = HookRegistry()
+
+@registry.on(HookEvent.MESSAGE_RECEIVED)
+def allowlist(event_data):
+    if event_data.sender_id not in ALLOWED:
+        return HookResult.deny("sender not allowed")
+    return HookResult.allow()
+```
+
+### Rate Limiter
+
+```python
+import time
+from collections import defaultdict
+from praisonaiagents.hooks import HookRegistry, HookEvent, HookResult
+
+registry = HookRegistry()
+_counts: dict = defaultdict(list)
+LIMIT = 5
+WINDOW = 60
+
+@registry.on(HookEvent.MESSAGE_RECEIVED)
+def rate_limit(event_data):
+    now = time.time()
+    timestamps = [t for t in _counts[event_data.sender_id] if now - t < WINDOW]
+    if len(timestamps) >= LIMIT:
+        return HookResult.deny("rate limit exceeded")
+    timestamps.append(now)
+    _counts[event_data.sender_id] = timestamps
+    return HookResult.allow()
+```
+
+### Keyword Ban
+
+```python
+from praisonaiagents.hooks import HookRegistry, HookEvent, HookResult
+
+BANNED = {"spam", "scam"}
+registry = HookRegistry()
+
+@registry.on(HookEvent.MESSAGE_RECEIVED)
+def keyword_ban(event_data):
+    for word in BANNED:
+        if word in event_data.content.lower():
+            return HookResult.deny("banned keyword")
+    return HookResult.allow()
+```
+
+### Combined Gate + Redaction
+
+```python
+import re
+from praisonaiagents import Agent
+from praisonaiagents.hooks import HookRegistry, HookEvent, HookResult
+from praisonai.bots import TelegramBot
+
+registry = HookRegistry()
+BLOCKED = {"1234567"}
+SSN = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+
+@registry.on(HookEvent.MESSAGE_RECEIVED)
+def gate(event_data):
+    if event_data.sender_id in BLOCKED:
+        return HookResult.deny("blocked sender")
+    scrubbed = SSN.sub("[SSN]", event_data.content)
+    if scrubbed != event_data.content:
+        return HookResult.modified_data(content=scrubbed)
+    return HookResult.allow()
+
+agent = Agent(name="SafeBot", instructions="Be helpful.", hooks=registry)
+bot = TelegramBot(token="...", agent=agent)
+
+import asyncio
+asyncio.run(bot.start())
+```
+
+**Behaviour:**
+- Blocked user's messages: agent stays silent, no reply sent.
+- Messages containing an SSN pattern: LLM sees `[SSN]` instead of the digits.
+- All other messages: unchanged.
+
+---
+
+## User Interaction Flow
+
+A Telegram user sends a message. The gate runs before the agent responds:
+
+| Message | `sender_id` | Hook result | Agent sees | Bot reply |
+|---------|-------------|-------------|------------|-----------|
+| "Hello!" | `12345` (allowed) | `allow` | "Hello!" | Normal response |
+| "ping" | `99999` (blocked) | `deny` | — | *(silent)* |
+| "SSN: 123-45-6789" | `12345` (allowed) | `modified_data` | "SSN: [SSN]" | Answers without digits |
+
+---
+
+## Symmetry with Outbound
+
+`MESSAGE_RECEIVED` (inbound) and `MESSAGE_SENDING` (outbound) share the same `deny` / `modified_data` contract. Use the same pattern for both directions:
+
+```python
+@registry.on(HookEvent.MESSAGE_SENDING)
+def redact_outbound(event_data):
+    cleaned = SSN.sub("[SSN]", event_data.content)
+    if cleaned != event_data.content:
+        return HookResult.modified_data(content=cleaned)
+    return HookResult.allow()
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Keep the gate cheap">
+The hook runs on every inbound message. Avoid blocking I/O or heavy computation — use in-memory lookups and pre-compiled regex patterns.
+</Accordion>
+
+<Accordion title="Fail-open, not fail-closed">
+Raising an exception lets the message through. Explicitly call `HookResult.deny(...)` if you mean to block.
+</Accordion>
+
+<Accordion title="Mutate content only for redaction">
+The LLM will see `modified_data` content and may quote it back in replies. Only rewrite when necessary (e.g. PII scrubbing).
+</Accordion>
+
+<Accordion title="Use deny for hard blocks, not redaction">
+`deny` prevents agent dispatch entirely. `modified_data` still dispatches — use it only when you want the agent to respond to the sanitised content.
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Hook Events" icon="webhook" href="/docs/features/hook-events">
+    Complete reference for all hook events and input types
+  </Card>
+  <Card title="Bot Lifecycle Hooks" icon="robot" href="/docs/features/bot-lifecycle-hooks">
+    Gateway, session, and schedule lifecycle hooks
+  </Card>
+</CardGroup>

--- a/docs/features/inbound-message-gate.mdx
+++ b/docs/features/inbound-message-gate.mdx
@@ -34,7 +34,7 @@ graph LR
         M[📨 Incoming Message] --> H[🔍 MESSAGE_RECEIVED Hook]
         H -->|allow| A[🤖 Agent]
         H -->|deny| D[🚫 Dropped]
-        H -->|modified_data| R[✏️ Redacted → Agent]
+        H -->|modified_input| R[✏️ Redacted → Agent]
     end
 
     classDef message fill:#8B0000,stroke:#7C90A0,color:#fff
@@ -84,7 +84,7 @@ registry = HookRegistry()
 def redact(event_data):
     cleaned = SSN.sub("[SSN]", event_data.content)
     if cleaned != event_data.content:
-        return HookResult.modified_data(content=cleaned)
+        return HookResult(decision="allow", modified_input={"content": cleaned})
     return HookResult.allow()
 
 agent = Agent(name="SafeBot", instructions="Be helpful.", hooks=registry)
@@ -113,7 +113,7 @@ sequenceDiagram
     else HookResult.deny(...)
         HookRunner-->>Adapter: {drop: true, content: original}
         Adapter-->>User: (silent — no reply sent)
-    else HookResult.modified_data(content=...)
+    else HookResult(decision="allow", modified_input={"content": ...})
         HookRunner-->>Adapter: {drop: false, content: redacted}
         Adapter->>Agent: dispatch with redacted content
     else Hook raises exception
@@ -130,7 +130,7 @@ sequenceDiagram
 |---|---|---|---|
 | `HookResult.allow()` (or no hook) | `false` | original | Message flows unchanged |
 | `HookResult.deny("...")` | `true` | — | Adapter skips dispatch — bot stays silent |
-| `HookResult.modified_data(content="…")` | `false` | redacted text | LLM sees rewritten content |
+| `HookResult(decision="allow", modified_input={"content": "…"})` | `false` | redacted text | LLM sees rewritten content |
 | Hook raises exception | `false` | original | Non-fatal — message passes through |
 
 <Warning>
@@ -232,7 +232,7 @@ def gate(event_data):
         return HookResult.deny("blocked sender")
     scrubbed = SSN.sub("[SSN]", event_data.content)
     if scrubbed != event_data.content:
-        return HookResult.modified_data(content=scrubbed)
+        return HookResult(decision="allow", modified_input={"content": scrubbed})
     return HookResult.allow()
 
 agent = Agent(name="SafeBot", instructions="Be helpful.", hooks=registry)
@@ -257,20 +257,20 @@ A Telegram user sends a message. The gate runs before the agent responds:
 |---------|-------------|-------------|------------|-----------|
 | "Hello!" | `12345` (allowed) | `allow` | "Hello!" | Normal response |
 | "ping" | `99999` (blocked) | `deny` | — | *(silent)* |
-| "SSN: 123-45-6789" | `12345` (allowed) | `modified_data` | "SSN: [SSN]" | Answers without digits |
+| "SSN: 123-45-6789" | `12345` (allowed) | `modified_input` | "SSN: [SSN]" | Answers without digits |
 
 ---
 
 ## Symmetry with Outbound
 
-`MESSAGE_RECEIVED` (inbound) and `MESSAGE_SENDING` (outbound) share the same `deny` / `modified_data` contract. Use the same pattern for both directions:
+`MESSAGE_RECEIVED` (inbound) and `MESSAGE_SENDING` (outbound) share the same `deny` / `modified_input` contract. Use the same pattern for both directions:
 
 ```python
 @registry.on(HookEvent.MESSAGE_SENDING)
 def redact_outbound(event_data):
     cleaned = SSN.sub("[SSN]", event_data.content)
     if cleaned != event_data.content:
-        return HookResult.modified_data(content=cleaned)
+        return HookResult(decision="allow", modified_input={"content": cleaned})
     return HookResult.allow()
 ```
 
@@ -289,11 +289,11 @@ Raising an exception lets the message through. Explicitly call `HookResult.deny(
 </Accordion>
 
 <Accordion title="Mutate content only for redaction">
-The LLM will see `modified_data` content and may quote it back in replies. Only rewrite when necessary (e.g. PII scrubbing).
+The LLM will see the `modified_input` content and may quote it back in replies. Only rewrite when necessary (e.g. PII scrubbing).
 </Accordion>
 
 <Accordion title="Use deny for hard blocks, not redaction">
-`deny` prevents agent dispatch entirely. `modified_data` still dispatches — use it only when you want the agent to respond to the sanitised content.
+`deny` prevents agent dispatch entirely. `modified_input` still dispatches — use it only when you want the agent to respond to the sanitised content.
 </Accordion>
 
 </AccordionGroup>


### PR DESCRIPTION
## Summary

- Creates `docs/features/inbound-message-gate.mdx`: a new focused feature page for the `MESSAGE_RECEIVED` inbound gate capability added in PraisonAI PR #2589
- Updates `docs/features/hook-events.mdx`: expands the Message Events table entry and code sample to show all three hook return shapes (`allow`, `deny`, `modified_data`); adds cross-link to the new page
- Updates `docs/features/bot-lifecycle-hooks.mdx`: adds an inline `<Note>` callout to the Configuration/HookResult section clarifying that `MESSAGE_RECEIVED` is now a real gate (exception to the "best-effort" guidance)
- Updates `docs.json`: adds `inbound-message-gate` to the Features group right after `bot-lifecycle-hooks`

## What the new page covers

- Hero Mermaid diagram (inbound flow with allow/deny/redact branches)
- Quick Start with `<Steps>`: allowlist drop example + PII redaction example
- Sequence diagram showing all four decision outcomes
- Decision table mapping `HookResult` return to adapter behaviour
- Supported adapters (Telegram, Slack, Discord, WhatsApp, email, agentmail)
- Common patterns: allowlist, rate-limiter, keyword ban, combined gate + redaction
- User interaction flow table
- Symmetry callout linking `MESSAGE_SENDING` outbound counterpart
- Failure semantics: fail-open on exception
- Best Practices `<AccordionGroup>`

Fixes #1454

Generated with [Claude Code](https://claude.ai/code)