### PR TITLE
docs: document MESSAGE_RECEIVED as inbound gate (fixes #1458)

### DIFF
--- a/docs/features/bot-lifecycle-hooks.mdx
+++ b/docs/features/bot-lifecycle-hooks.mdx
@@ -131,8 +131,8 @@ sequenceDiagram
 | `SESSION_START` | First message per user (once per session lifetime) | `SessionStartInput` | `session_id`, `agent_name`, `source`, `session_name` |
 | `SESSION_END` | `/new` reset, policy auto-reset, stale reap, `reset_all` | `SessionEndInput` | `session_id`, `agent_name`, `reason` |
 | `SCHEDULE_TRIGGER` | Scheduled job runs in `BotOS._execute_schedule_job` | `ScheduleTriggerInput` | `job_name`, `job_id`, `message` |
-| `MESSAGE_RECEIVED` | Incoming message from platform | `MessageReceivedInput` | `platform`, `content`, `sender_id` |
-| `MESSAGE_SENDING` | Before bot sends a reply | `MessageSendingInput` | `platform`, `content`, `channel_id` |
+| `MESSAGE_RECEIVED` | Incoming message from platform, **before** agent dispatch — **inbound gate**: `deny` drops the message, `modified_input["content"]` rewrites it | `MessageReceivedInput` | `platform`, `content`, `sender_id` |
+| `MESSAGE_SENDING` | Before bot sends a reply — **outbound gate**: `deny` cancels sending, `modified_input["content"]` rewrites it | `MessageSendingInput` | `platform`, `content`, `channel_id` |
 | `MESSAGE_SENT` | After bot successfully sends a reply | `MessageSentInput` | `platform`, `content`, `message_id` |
 
 **`SESSION_END` reason values:**
@@ -272,9 +272,15 @@ asyncio.run(botos.start())
 
 ## Configuration / HookResult
 
-Returning `HookResult.deny("reason")` from a gateway or session lifecycle hook is **best-effort** for these events: `BotOS` emits them but does not gate startup or shutdown on the result.
+**Two events that DO gate:** `MESSAGE_RECEIVED` and `MESSAGE_SENDING` are real policy control points — `HookResult.deny("reason")` drops the message and the agent is never invoked; `HookResult(decision="allow", modified_input={"content": "..."})` rewrites the content before the agent sees it.
 
-Treat lifecycle hooks as observability points, not policy gates. For policy enforcement (e.g. blocking tool calls or LLM requests), use `BEFORE_TOOL` or `BEFORE_LLM` hooks and link to your guardrail logic.
+Returning `HookResult.deny("reason")` from gateway or session lifecycle hooks is **best-effort** for those specific events (`GATEWAY_START`, `GATEWAY_STOP`, `SESSION_START`, `SESSION_END`): `BotOS` emits them but does not gate startup or shutdown on the result.
+
+<Note>
+`MESSAGE_RECEIVED` is now an inbound gate, symmetric with `MESSAGE_SENDING` on the outbound side. A hook can drop (deny) or redact (rewrite content via `modified_input`) an inbound message before agent dispatch. This works consistently across sync and async adapters (Telegram, Slack, Discord, WhatsApp, Email, AgentMail) — no `async def` required. See [Hook Events → Message Events](/docs/features/hook-events#message-events).
+</Note>
+
+For policy enforcement on agent internals (e.g. blocking tool calls or LLM requests), use `BEFORE_TOOL` or `BEFORE_LLM` hooks.
 
 ---
 

--- a/docs/features/hook-events.mdx
+++ b/docs/features/hook-events.mdx
@@ -422,18 +422,83 @@ def after_compaction(event_data):
 
 ### Message Events
 
-| Event | Trigger | Use Case |
-|-------|---------|----------|
-| `MESSAGE_RECEIVED` | Message received | Preprocessing |
-| `MESSAGE_SENDING` | Before message sent | Modification |
-| `MESSAGE_SENT` | After message sent | Confirmation |
+| Event | Trigger | Input Type | Use Case |
+|-------|---------|------------|----------|
+| `MESSAGE_RECEIVED` | Inbound message from a bot channel, before agent dispatch | `MessageReceivedInput` | **Inbound gate** — drop (deny), redact/rewrite content, authorise sender, rate-limit |
+| `MESSAGE_SENDING` | Before message sent | `MessageSendingInput` | Outbound gate — cancel or rewrite outbound text |
+| `MESSAGE_SENT` | After message sent | `MessageSentInput` | Confirmation |
+
+`MESSAGE_RECEIVED` is a **first-class control point**: hooks can drop an inbound message so the agent never runs, or rewrite the message content before the agent (or memory) sees it. This is symmetric with `MESSAGE_SENDING` on the outbound side.
+
+<Note>
+`MESSAGE_RECEIVED` and `MESSAGE_SENDING` are the two message-lifecycle events that **do gate** — `deny` drops the message entirely, `modified_input["content"]` rewrites it. The gate is safe from both sync and async adapters (Telegram, Slack, Discord, WhatsApp, Email, AgentMail) — no `async def` required in your hook. See [PraisonAI #2589](https://github.com/MervinPraison/PraisonAI/pull/2589).
+</Note>
+
+#### Drop / block an inbound message
 
 ```python
+from praisonaiagents import Agent
+from praisonaiagents.hooks import HookRegistry, HookEvent, HookResult
+
+registry = HookRegistry()
+
 @registry.on(HookEvent.MESSAGE_RECEIVED)
-def on_message_received(event_data):
-    print(f"Received: {event_data.message}")
+def block_bots(event_data):
+    if event_data.sender_id.endswith("bot"):
+        return HookResult.deny("no bots")
     return HookResult.allow()
 
+agent = Agent(name="Concierge", instructions="Be helpful.", hooks=registry)
+```
+
+#### Redact PII before the agent sees it
+
+```python
+import re
+from praisonaiagents import Agent
+from praisonaiagents.hooks import HookRegistry, HookEvent, HookResult
+
+registry = HookRegistry()
+
+@registry.on(HookEvent.MESSAGE_RECEIVED)
+def redact_pii(event_data):
+    cleaned = re.sub(r"\b\d{3}-\d{2}-\d{4}\b", "[SSN]", event_data.content)
+    return HookResult(decision="allow", modified_input={"content": cleaned})
+
+agent = Agent(name="SafeAgent", instructions="Be helpful.", hooks=registry)
+```
+
+#### Authorise sender against an allowlist
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.hooks import HookRegistry, HookEvent, HookResult
+
+registry = HookRegistry()
+ALLOWED = {"U123", "U456"}
+
+@registry.on(HookEvent.MESSAGE_RECEIVED)
+def only_allowed_users(event_data):
+    if event_data.sender_id not in ALLOWED:
+        return HookResult.deny("unauthorised")
+    return HookResult.allow()
+
+agent = Agent(name="PrivateAgent", instructions="Be helpful.", hooks=registry)
+```
+
+#### How the gate applies decisions
+
+| Decision | Effect |
+|----------|--------|
+| `HookResult.deny("reason")` | Message is dropped; the agent is never invoked; the adapter returns immediately |
+| `HookResult(decision="allow", modified_input={"content": "..."})` | Content is rewritten in place; agent, memory, and command parser all see the new text |
+| `HookResult.allow()` | Message passes through unchanged |
+
+<Note>
+When multiple `MESSAGE_RECEIVED` hooks run, the **last matching modification** wins. Hook errors are non-fatal — the message passes through unchanged.
+</Note>
+
+```python
 @registry.on(HookEvent.MESSAGE_SENDING)
 def on_message_sending(event_data):
     print(f"Sending: {event_data.message}")
@@ -577,8 +642,8 @@ def on_auto_promotion(event_data):
 | `SETUP` | System | Initialization |
 | `BEFORE_COMPACTION` | Context | Before compaction |
 | `AFTER_COMPACTION` | Context | After compaction |
-| `MESSAGE_RECEIVED` | Message | Message received |
-| `MESSAGE_SENDING` | Message | Before message sent |
+| `MESSAGE_RECEIVED` | Message | Inbound gate — drop (deny) or redact/rewrite before agent dispatch |
+| `MESSAGE_SENDING` | Message | Outbound gate — cancel or rewrite before sending |
 | `MESSAGE_SENT` | Message | After message sent |
 | `GATEWAY_START` | Gateway | Gateway starts |
 | `GATEWAY_STOP` | Gateway | Gateway stops |
@@ -603,6 +668,10 @@ Gateway and session hooks are emitted by `BotOS` and `BotSessionManager` — no 
 - All emission is **best-effort** and a **no-op when no hooks are registered** (zero overhead)
 - `BEFORE_AGENT` / `AFTER_AGENT` are fired by `agent.chat()` itself — they are **not** re-fired at the gateway boundary to avoid double-dispatch
 - In async contexts (e.g. inside `BotSessionManager.chat`), emission is fire-and-forget; in sync contexts it is blocking
+
+<Note>
+**`MESSAGE_RECEIVED` and `MESSAGE_SENDING` are policy gates, not passive observers.** `deny` drops the message; `modified_input["content"]` rewrites it. Gateway/session lifecycle events (`GATEWAY_START`, `GATEWAY_STOP`, `SESSION_START`, `SESSION_END`) remain best-effort observability points and do not gate startup or shutdown.
+</Note>
 
 ---
 


### PR DESCRIPTION
## Summary

- **`docs/features/hook-events.mdx`**: Updated Message Events section to document `MESSAGE_RECEIVED` as a first-class inbound gate (not just a passive listener). Added three copy-paste recipes: drop/deny, redact PII, and authorise sender. Added a decision table explaining how each return type is applied. Updated the Complete Event Reference table and Bot Runtime Lifecycle section to clarify that `MESSAGE_RECEIVED`/`MESSAGE_SENDING` are policy gates while gateway/session events remain best-effort.
- **`docs/features/bot-lifecycle-hooks.mdx`**: Fixed the stale "does not gate" caveat that incorrectly swept `MESSAGE_RECEIVED` into the best-effort-only bucket. Updated the events table to label `MESSAGE_RECEIVED` and `MESSAGE_SENDING` as inbound/outbound gates. Added a Note callout explaining the gate works across all six adapters (Telegram, Slack, Discord, WhatsApp, Email, AgentMail) without requiring `async def`.

Fixes #1458

## Verification checklist

- [x] `MESSAGE_RECEIVED` table row updated to describe it as an inbound gate
- [x] deny (drop) example present
- [x] `modified_input={"content": ...}` (redact) example present
- [x] sender-authorisation example present
- [x] Note: gate works from async adapters (loop-safe) — no `async def` required
- [x] Note: hook errors are non-fatal (message passes through)
- [x] Note: last matching modification wins
- [x] `bot-lifecycle-hooks.mdx` — `MESSAGE_RECEIVED` re-labelled as a control point
- [x] `bot-lifecycle-hooks.mdx` — stale "does not gate" caveat corrected
- [x] `docs.json` valid JSON (no changes needed)
- [x] All code snippets copy-paste runnable with only `praisonaiagents` installed

Generated with [Claude Code](https://claude.ai/code)