### PR TITLE
docs: add allowed_approvers allowlist documentation for text-keyword approval backends

### DIFF
--- a/docs/features/approval-protocol.mdx
+++ b/docs/features/approval-protocol.mdx
@@ -17,7 +17,7 @@ agent.start("List files in the current directory.")
 <Note>
 **Button-based approvals are now available.** On channels that implement the [`SupportsPresentation`](/docs/features/bot-presentations) protocol (Telegram, Slack, Discord), approval prompts can render as inline buttons instead of relying on `yes`/`no` text replies. Use `MessagePresentation.approval(...)` to build the prompt. The text-keyword backends documented on this page continue to work unchanged — they are the recommended fallback for channels that do not yet support presentations. See [Interactive Bot Messages](/docs/features/bot-presentations).
 
-Approvals in shared chats are now actor-bound by default — only the requester and configured admins can resolve them. See [Interactive Callback Authorization](/docs/features/interactive-callback-authorization).
+**Button-based approvals** (via `MessagePresentation.approval(...)`) are actor-bound by default in shared chats. **Text-keyword backends** (`TelegramApproval`, `SlackApproval`, `DiscordApproval`) require an explicit `allowed_approvers=[...]` allowlist (or `TELEGRAM_APPROVERS` / `SLACK_APPROVERS` / `DISCORD_APPROVERS` env var) to lock down who may resolve an approval — added in [PR #2582](https://github.com/MervinPraison/PraisonAI/pull/2582). Without an allowlist, any responder in the group can approve. See [Interactive Callback Authorization](/docs/features/interactive-callback-authorization).
 </Note>
 
 > For unified ApprovalSpec configuration (YAML/CLI/Python), see the [Approval documentation](/features/approval). Backend selection uses the same string values in `--approval` and YAML `backend:` fields.
@@ -288,6 +288,7 @@ agent.start("Delete old log files")
 | `channel` | Bot's own DM | Channel ID, name, or user ID |
 | `timeout` | `300` (5 min) | Seconds to wait for response |
 | `poll_interval` | `3.0` | Seconds between polls |
+| `allowed_approvers` | `SLACK_APPROVERS` env, else `None` | Iterable of Slack user IDs (or comma-separated string) permitted to approve/deny. `None` = any responder (legacy). Set this for shared channels. |
 
 ### Approval Keywords
 
@@ -346,12 +347,38 @@ agent = Agent(
 )
 ```
 
+<Tip>
+**Group chat security:** Use `allowed_approvers` to restrict who can tap the Approve/Deny buttons. Without it, any group member can resolve the approval.
+
+```python
+agent = Agent(
+    name="ops",
+    instructions="Run destructive commands only after approval.",
+    approval=TelegramApproval(
+        chat_id="-100999888",
+        allowed_approvers=["999", "111"],  # only these Telegram user IDs may resolve
+    ),
+)
+```
+
+Or via environment variable (useful for containerised deployments):
+
+```bash
+export TELEGRAM_APPROVERS=999,111
+```
+</Tip>
+
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `token` | `TELEGRAM_BOT_TOKEN` env | Telegram bot token |
 | `chat_id` | _(required)_ | Chat ID to send approvals to |
 | `timeout` | `300` (5 min) | Seconds to wait for response |
 | `poll_interval` | `2.0` | Seconds between polls |
+| `allowed_approvers` | `TELEGRAM_APPROVERS` env, else `None` | Iterable of Telegram user IDs (or comma-separated string) permitted to tap Approve/Deny or reply with keywords. `None` = any responder (legacy). Set this for group chats. |
+
+<Note>
+Since [PR #2582](https://github.com/MervinPraison/PraisonAI/pull/2582), callback taps are bound to both `message_id` **and** `chat_id`, so a same-`message_id` button in a different chat cannot resolve this approval. An unauthorised tap shows the presser a *"You are not authorized to approve this action."* alert.
+</Note>
 
 ---
 
@@ -376,6 +403,7 @@ agent = Agent(
 | `channel_id` | _(required)_ | Channel ID to send approvals to |
 | `timeout` | `300` (5 min) | Seconds to wait for response |
 | `poll_interval` | `3.0` | Seconds between polls |
+| `allowed_approvers` | `DISCORD_APPROVERS` env, else `None` | Iterable of Discord user IDs (or comma-separated string) permitted to reply Approve/Deny. `None` = any responder (legacy). Set this for shared channels. |
 
 ---
 

--- a/docs/features/interactive-callback-authorization.mdx
+++ b/docs/features/interactive-callback-authorization.mdx
@@ -337,7 +337,7 @@ The in-memory log is bounded by `history_limit` (default 1000). For compliance o
   <Card title="Bot Command Access Control" icon="lock" href="/docs/features/bot-command-access-control">
     Restrict which users can run which bot commands
   </Card>
-  <Card icon="shield-check" href="/docs/features/approval-protocol#slack-approval">
+  <Card title="Text-keyword Backends" icon="shield-check" href="/docs/features/approval-protocol#slack-approval">
     Text-keyword backends and their allowed_approvers allowlist
   </Card>
 </CardGroup>

--- a/docs/features/interactive-callback-authorization.mdx
+++ b/docs/features/interactive-callback-authorization.mdx
@@ -256,6 +256,45 @@ if handler.is_authorized(approval_id, actor="telegram:12345"):
 
 ---
 
+## Text-keyword fallback backends
+
+`TelegramApproval`, `SlackApproval`, and `DiscordApproval` are separate from the `_presentation_approval` wrapper documented above. They poll for text keyword replies (or inline button taps on Telegram) and have their **own** actor allowlist added in [PR #2582](https://github.com/MervinPraison/PraisonAI/pull/2582).
+
+Set `allowed_approvers` on the constructor (or via env var) to restrict who can resolve an approval from these backends:
+
+```python
+from praisonaiagents import Agent
+from praisonai.bots import TelegramApproval
+
+agent = Agent(
+    name="ops",
+    instructions="Run approved changes only.",
+    approval=TelegramApproval(
+        chat_id="-100999888",
+        allowed_approvers=["11111", "22222"],  # only these users may resolve
+    ),
+)
+agent.start("Deploy the release")
+```
+
+| Situation | Effect |
+|-----------|--------|
+| No `allowed_approvers` configured | Any responder can resolve (legacy — unsafe in shared chats) |
+| Authorised user taps Approve / replies "yes" | Approval resolved (`approved=True`) |
+| Authorised user taps Deny / replies "no" | Approval resolved (`approved=False`) |
+| **Unauthorised user taps Telegram inline button** | Telegram shows *"You are not authorized to approve this action."* alert; poll continues |
+| Unauthorised user replies with keyword (any channel) | Warning logged; reply ignored; poll continues |
+| Unauthorised user's message from a different Telegram chat with same `message_id` | Ignored (chat-id binding added in PR #2582) |
+| Approval times out | `ApprovalDecision(approved=False, reason="timed out")` |
+
+<Note>
+With `allowed_approvers=None` (the default), legacy "any responder" behaviour is preserved for backward compatibility. You **must** set `allowed_approvers` explicitly to secure approvals in shared group chats.
+</Note>
+
+The env var equivalents are `TELEGRAM_APPROVERS`, `SLACK_APPROVERS`, and `DISCORD_APPROVERS` (comma-separated user IDs). See the [Approval Protocol](/docs/features/approval-protocol) page for full configuration tables.
+
+---
+
 ## Best Practices
 
 <AccordionGroup>
@@ -297,5 +336,8 @@ The in-memory log is bounded by `history_limit` (default 1000). For compliance o
   </Card>
   <Card title="Bot Command Access Control" icon="lock" href="/docs/features/bot-command-access-control">
     Restrict which users can run which bot commands
+  </Card>
+  <Card icon="shield-check" href="/docs/features/approval-protocol#slack-approval">
+    Text-keyword backends and their allowed_approvers allowlist
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

Documents the `allowed_approvers` allowlist added in [PraisonAI PR #2582](https://github.com/MervinPraison/PraisonAI/pull/2582) for `TelegramApproval`, `SlackApproval`, and `DiscordApproval` backends — a security-critical change that was not previously documented.

### Changes

**`docs/features/approval-protocol.mdx`**
- Updated the top `<Note>` block to clarify the security distinction between button-based approvals (actor-bound by default) and text-keyword backends (require explicit `allowed_approvers` to be safe in group chats)
- Added `allowed_approvers` row to the Slack Approval configuration table (with `SLACK_APPROVERS` env var)
- Added `allowed_approvers` row + `<Tip>` with usage example to the Telegram Approval section (with `TELEGRAM_APPROVERS` env var and env var usage example)
- Added `<Note>` about chat-id binding fix (PR #2582) to Telegram section
- Added `allowed_approvers` row to the Discord Approval configuration table (with `DISCORD_APPROVERS` env var)

**`docs/features/interactive-callback-authorization.mdx`**
- Added new "Text-keyword fallback backends" section documenting the `allowed_approvers` constructor kwarg, behavior table (authorized/unauthorized/timeout scenarios), and backward-compat note
- Added a Related card pointing to the text-keyword backends section on the approval-protocol page

Fixes #1461

Generated with [Claude Code](https://claude.ai/code)