### PR TITLE
docs: add reusable approval scopes + 4 doc updates (fixes #1456)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -576,6 +576,7 @@
                   "docs/features/agent-max-budget",
                   "docs/features/subscription-auth",
                   "docs/features/approval",
+                  "docs/features/reusable-approval-scopes",
                   "docs/features/approval-backends",
                   "docs/features/approval-secure-backend",
                   "docs/features/durable-approvals",

--- a/docs/features/bot-platform-capabilities.mdx
+++ b/docs/features/bot-platform-capabilities.mdx
@@ -146,6 +146,25 @@ def default_capabilities(cls) -> PlatformCapabilities:
     return PlatformCapabilities(max_message_length=2000, supports_edit=True)
 ```
 
+Entry-point registrations (via `praisonai.channels`) get default capabilities unless the adapter class exposes a `default_capabilities()` classmethod. This keeps zero-config connectors functional while letting polished adapters declare exact limits:
+
+```toml
+# pyproject.toml
+[project.entry-points."praisonai.channels"]
+myplatform = "mypackage.bot:MyPlatformBot"
+```
+
+```python
+class MyPlatformBot:
+    @classmethod
+    def default_capabilities(cls):
+        from praisonaiagents.bots import PlatformCapabilities
+        return PlatformCapabilities(max_message_length=1000, supports_edit=False)
+    
+    async def start(self): ...
+    async def stop(self): ...
+```
+
 **Serialise for config files:**
 
 ```python

--- a/docs/features/bot-platform-capabilities.mdx
+++ b/docs/features/bot-platform-capabilities.mdx
@@ -32,8 +32,8 @@ graph LR
     E --> G
     F --> G
 
-    classDef agent fill:#8B0000,color:#fff
-    classDef tool fill:#189AB4,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
 
     class G agent
     class A,B,C,D,E,F tool

--- a/docs/features/bot-platform-plugins.mdx
+++ b/docs/features/bot-platform-plugins.mdx
@@ -63,7 +63,7 @@ Create a pip-installable plugin using `pyproject.toml`:
 
 ```toml
 # pyproject.toml
-[project.entry-points."praisonai.bots"]
+[project.entry-points."praisonai.channels"]
 mybot = "my_pkg.bot:MyBot"
 ```
 
@@ -72,7 +72,7 @@ After installation, use the bot platform:
 ```python
 from praisonai.bots import Bot
 
-bot = Bot("mybot", agent=my_agent, token="...")
+bot = Bot("mybot", agent=my_agent)
 await bot.start()
 ```
 

--- a/docs/features/bot-platform-plugins.mdx
+++ b/docs/features/bot-platform-plugins.mdx
@@ -25,8 +25,8 @@ graph LR
     B --> C[📝 BotPlatformRegistry]
     C --> D[💬 Bot - mattermost - agent=...]
 
-    classDef agent fill:#8B0000,color:#fff
-    classDef tool fill:#189AB4,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
 
     class D agent
     class A,B,C tool

--- a/docs/features/bot-platform-plugins.mdx
+++ b/docs/features/bot-platform-plugins.mdx
@@ -134,7 +134,52 @@ PraisonAI includes these built-in bot platforms:
 - `email` - Email bot integration
 - `agentmail` - AgentMail integration
 
-**Entry-point group**: `praisonai.bots`
+### Entry-point Groups
+
+| Group | Purpose |
+|-------|---------|
+| `praisonai.channels` | **Recommended** for new packaged connectors — idiomatic, zero-config auto-registration |
+| `praisonai.bots` | Legacy group — still scanned for backward compatibility |
+
+Both groups are scanned by `BotPlatformRegistry` on startup. A connector that would shadow a built-in platform is skipped with a warning.
+
+### Discovery via entry points (`praisonai.channels`)
+
+The `praisonai.channels` entry-point group is the idiomatic way to distribute a bot connector as a pip-installable package. Once installed, the platform is available with no extra Python code:
+
+```toml
+# pyproject.toml of your connector package
+[project.entry-points."praisonai.channels"]
+irc = "praisonai_irc:IRCBot"
+```
+
+After `pip install praisonai-irc`:
+
+```python
+from praisonai.bots import Bot
+
+bot = Bot("irc", agent=my_agent, server="irc.libera.chat")
+await bot.start()
+```
+
+List all registered platforms — built-in, entry-point, and custom — with the CLI:
+
+```bash
+praisonai gateway channels --available
+# => telegram, discord, slack, whatsapp, linear, email, agentmail, irc
+```
+
+Or in Python:
+
+```python
+from praisonai.bots._registry import list_platforms
+
+print(sorted(list_platforms()))
+```
+
+<Note>
+`praisonai.channels` is preferred over `praisonai.bots` for new packages. Both entry-point groups continue to work.
+</Note>
 
 ---
 

--- a/docs/features/botos.mdx
+++ b/docs/features/botos.mdx
@@ -136,7 +136,7 @@ flowchart LR
   - **Protocol-driven**: `BotOSProtocol` lives in the lightweight core SDK; heavy implementations live in the wrapper
   - **Lazy loading**: Platform libraries (telegram, discord, etc.) are only imported when `start()` is called
   - **Agent-centric**: Every bot is powered by an Agent, AgentTeam, or AgentFlow
-  - **Extensible**: Register custom platforms at runtime with `register_platform()`
+  - **Extensible**: Register custom platforms at runtime with `register_platform()`, or distribute packaged connectors via the `praisonai.channels` entry-point group for zero-code auto-registration
 </Accordion>
 
 ## Token Setup

--- a/docs/features/hook-events.mdx
+++ b/docs/features/hook-events.mdx
@@ -430,6 +430,13 @@ def after_compaction(event_data):
 
 `MESSAGE_RECEIVED` is a **first-class control point**: hooks can drop an inbound message so the agent never runs, or rewrite the message content before the agent (or memory) sees it. This is symmetric with `MESSAGE_SENDING` on the outbound side.
 
+The hook now returns a decision that every platform adapter (Telegram, Slack, Discord, WhatsApp, Email, AgentMail) honours:
+
+- `HookResult.deny(reason=...)` → the message is **dropped**; agent dispatch is skipped entirely.
+- `HookResult(modified_input={"content": "..."})` → the inbound message content is **rewritten** before dispatch.
+- `None` or `HookResult.allow()` → message passes through unchanged (default).
+- Hook errors are **non-fatal** — a raising hook logs the error and lets the message through.
+
 <Note>
 `MESSAGE_RECEIVED` and `MESSAGE_SENDING` are the two message-lifecycle events that **do gate** — `deny` drops the message entirely, `modified_input["content"]` rewrites it. The gate is safe from both sync and async adapters (Telegram, Slack, Discord, WhatsApp, Email, AgentMail) — no `async def` required in your hook. See [PraisonAI #2589](https://github.com/MervinPraison/PraisonAI/pull/2589).
 </Note>

--- a/docs/features/messaging-channels-strategy.mdx
+++ b/docs/features/messaging-channels-strategy.mdx
@@ -59,7 +59,7 @@ botos = BotOS(
     }
 )
 
-await botos.run()
+botos.run()
 ```
 
 </Step>

--- a/docs/features/messaging-channels-strategy.mdx
+++ b/docs/features/messaging-channels-strategy.mdx
@@ -321,11 +321,11 @@ bot = Bot("mattermost", agent=my_agent, server_url="https://chat.company.com")
 
 ### Distribute as a pip-installable plugin
 
-For better distribution, use Python entry points to auto-register your platform:
+For packaged connectors, use the `praisonai.channels` entry-point group — the idiomatic path for new connectors that self-register with zero Python code:
 
 ```toml
 # pyproject.toml of your community bot package
-[project.entry-points."praisonai.bots"]
+[project.entry-points."praisonai.channels"]
 mattermost = "praisonai_mattermost.bot:MattermostBot"
 ```
 
@@ -336,7 +336,25 @@ from praisonai.bots import Bot
 bot = Bot("mattermost", agent=my_agent, server_url="https://chat.company.com")
 ```
 
+And it appears in the gateway's `--available` list:
+
+```bash
+praisonai gateway channels --available
+# => agentmail, discord, email, linear, mattermost, slack, telegram, whatsapp
+```
+
+You can also accept it in `gateway.yaml`:
+
+```yaml
+channels:
+  team-chat:
+    platform: mattermost
+    token: ${MATTERMOST_TOKEN}
+    server_url: https://chat.company.com
+```
+
 <Note>
+`praisonai.channels` is preferred over `praisonai.bots` for new packages. Both groups are scanned for backward compatibility.
 See [Bot Platform Plugins](/docs/features/bot-platform-plugins) for complete documentation on creating distributable bot platform plugins.
 </Note>
 

--- a/docs/features/messaging-channels-strategy.mdx
+++ b/docs/features/messaging-channels-strategy.mdx
@@ -63,14 +63,16 @@ botos.run()
 <Step title="Add Microsoft Teams">
 
 ```python
+import os
+
 # Add Teams to existing setup
 botos = BotOS(
     agent=agent,
     platforms={
-        "telegram": {"token": telegram_token},
+        "telegram": {"token": os.environ["TELEGRAM_BOT_TOKEN"]},
         "teams": {
-            "app_id": teams_app_id,
-            "app_password": teams_password
+            "app_id": os.environ["TEAMS_APP_ID"],
+            "app_password": os.environ["TEAMS_APP_PASSWORD"]
         }
     }
 )

--- a/docs/features/messaging-channels-strategy.mdx
+++ b/docs/features/messaging-channels-strategy.mdx
@@ -52,11 +52,7 @@ agent = Agent(
 # Enable multi-platform messaging
 botos = BotOS(
     agent=agent,
-    platforms={
-        "telegram": {"token": "your-token"},
-        "discord": {"token": "your-token"},
-        "slack": {"token": "your-token"}
-    }
+    platforms=["telegram", "discord", "slack"]
 )
 
 botos.run()

--- a/docs/features/reusable-approval-scopes.mdx
+++ b/docs/features/reusable-approval-scopes.mdx
@@ -63,6 +63,7 @@ print(suggested)
 
 mgr.approve(
     target="bash:git status -s",
+    approved=True,
     scope="always",
     reusable_scope=True,
 )
@@ -200,12 +201,14 @@ mgr = PermissionManager()
 
 mgr.approve(
     target="bash:npm run build",
+    approved=True,
     scope="session",
     reusable_scope=True,
 )
 
 mgr.approve(
     target="bash:git status -s",
+    approved=True,
     scope="always",
     reusable_scope=True,
 )
@@ -272,7 +275,7 @@ print(f"This will auto-approve: {pattern}")
 A bad derived pattern that uses `always` persists across all future sessions. Use `session` by default for reusable scopes — if the pattern turns out to be safe, upgrade it to `always` deliberately:
 
 ```python
-mgr.approve(target="bash:git status -s", scope="session", reusable_scope=True)
+mgr.approve(target="bash:git status -s", approved=True, scope="session", reusable_scope=True)
 ```
 
 </Accordion>

--- a/docs/features/reusable-approval-scopes.mdx
+++ b/docs/features/reusable-approval-scopes.mdx
@@ -53,7 +53,7 @@ The first time the agent runs `git status -s`, the user sees the prompt once. Ev
 For advanced workflows — CLIs, approval UIs, or testing — call the `PermissionManager` API directly:
 
 ```python
-from praisonaiagents.permissions import PermissionManager, derive_pattern
+from praisonaiagents.permissions import PermissionManager
 
 mgr = PermissionManager()
 

--- a/docs/features/reusable-approval-scopes.mdx
+++ b/docs/features/reusable-approval-scopes.mdx
@@ -159,11 +159,12 @@ The arity table tells PraisonAI how many tokens to include in the prefix. A comm
 |---------|-------|-----------------|---------------|
 | `git` | 2 | `git status -s` | `bash:git status *` |
 | `npm` | 2 | `npm run build` | `bash:npm run *` |
-| `docker` | 2 | `docker compose up -d` | `bash:docker compose *` |
+| `docker` | 2 | `docker pull ubuntu` | `bash:docker pull *` |
+| `docker compose` | 2 | `docker compose up -d` | `bash:docker compose *` |
 | `ls` | 1 | `ls -la` | `bash:ls *` |
 | `cat` | 1 | `cat file.txt` | `bash:cat *` |
 | `echo` | 1 | `echo hello` | `bash:echo *` |
-| `python` | 1 | `python script.py` | `bash:python *` |
+| `python` | 2 | `python -m pytest` | `bash:python -m *` |
 | `go` | 2 | `go test ./...` | `bash:go test *` |
 | `cargo` | 2 | `cargo build --release` | `bash:cargo build *` |
 | `kubectl` | 2 | `kubectl get pods` | `bash:kubectl get *` |
@@ -171,7 +172,7 @@ The arity table tells PraisonAI how many tokens to include in the prefix. A comm
 | `pip` | 2 | `pip install requests` | `bash:pip install *` |
 
 <Note>
-Multi-word keys in the arity table win over single-word keys. `docker compose` (arity 2 for the subcommand) overrides `docker` (arity 1), so `docker compose up -d` derives `bash:docker compose *` rather than `bash:docker *`.
+Multi-word keys win over single-word keys. `docker compose` (a 2-word key, arity 2) takes precedence over `docker` (arity 2), so `docker compose up -d` derives `bash:docker compose *`. Commands not in the table (e.g. `ls`, `cat`) default to arity 1 — only the first token is kept.
 </Note>
 
 ### Extend the arity table for your own tools

--- a/docs/features/reusable-approval-scopes.mdx
+++ b/docs/features/reusable-approval-scopes.mdx
@@ -1,0 +1,323 @@
+---
+title: "Reusable Approval Scopes"
+sidebarTitle: "Reusable Approval Scopes"
+description: "Approve a shell command once and cover its variants"
+icon: "shield-check"
+---
+
+Approve `git status` once and it also covers `git status -s`, `git status .`, and every other flag — without granting all of `git`.
+
+```mermaid
+graph LR
+    subgraph "Reusable Approval Scope"
+        Cmd[📝 git status -s] --> Prefix[🔍 Detect prefix<br/>git status]
+        Prefix --> Rule[💾 Store<br/>bash:git status *]
+        Rule --> Next[✅ Auto-allow<br/>git status .]
+    end
+
+    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Cmd input
+    class Prefix,Rule process
+    class Next output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Enable reusable scopes on your Agent">
+
+Add one line to opt in — approval fatigue drops immediately:
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Shell Assistant",
+    instructions="Run git commands the user asks for",
+    tools=["shell"],
+    approval={"reusable_scope": True},
+)
+
+agent.start("Show me the status and then the last five commits")
+```
+
+The first time the agent runs `git status -s`, the user sees the prompt once. Every subsequent `git status <flags>` variant is auto-approved for the session.
+
+</Step>
+
+<Step title="Preview and store scopes programmatically">
+
+For advanced workflows — CLIs, approval UIs, or testing — call the `PermissionManager` API directly:
+
+```python
+from praisonaiagents.permissions import PermissionManager, derive_pattern
+
+mgr = PermissionManager()
+
+suggested = mgr.suggest_scope_pattern("bash:git status -s")
+print(suggested)
+# => "bash:git status *"
+
+mgr.approve(
+    target="bash:git status -s",
+    scope="always",
+    reusable_scope=True,
+)
+```
+
+`suggest_scope_pattern()` lets you surface the derived pattern in your UI before committing it, so users can review what `always` will cover.
+
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Approval as Approval Manager
+
+    Agent->>Approval: run `git status -s`
+    Approval->>User: Approve `git status -s`?<br/>(suggested scope: bash:git status *)
+    User-->>Approval: Approve · always · reusable
+    Approval->>Approval: store bash:git status *
+    Agent->>Approval: run `git status .`
+    Approval-->>Agent: auto-approved ✅
+    Agent->>Approval: run `git commit -m ...`
+    Approval->>User: Approve? (different prefix)
+```
+
+When the user approves with `reusable_scope=True`, PraisonAI:
+
+1. Parses the command into tokens
+2. Looks up the top-level command name (`git`) in the built-in arity table
+3. Takes the first N tokens where N is the arity for that command (e.g. `git` → arity 2, so `git status`)
+4. Stores the pattern as `bash:git status *`
+
+A later `git status .` matches `bash:git status *` via prefix — no second prompt.
+
+| Phase | What Happens |
+|-------|-------------|
+| **Derive** | `derive_pattern("bash:git status -s")` → `"bash:git status *"` |
+| **Store** | Pattern saved as a `PersistentApproval` with `derived=True` flag |
+| **Match** | `rules.PersistentApproval.matches("bash:git status .")` → `True` |
+| **Skip prompt** | Agent proceeds without user interaction |
+
+---
+
+## When Does a Pattern Stay Literal?
+
+Not every approval becomes a prefix glob. The derivation is intentionally conservative:
+
+```mermaid
+graph TB
+    Start{Target starts with<br/>bash: or shell:?}
+    Start -->|no| Literal1[Stored literal]
+    Start -->|yes| Glob{Already contains<br/>* or ?}
+    Glob -->|yes| Literal2[Stored literal]
+    Glob -->|no| Op{Contains shell<br/>operator?}
+    Op -->|yes| Literal3[Stored literal]
+    Op -->|no| Bare{Single token &amp;<br/>equals full command?}
+    Bare -->|yes| Literal4[Stored literal]
+    Bare -->|no| Derived[Stored as prefix *]
+
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef literal fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef derived fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Start,Glob,Op,Bare check
+    class Literal1,Literal2,Literal3,Literal4 literal
+    class Derived derived
+```
+
+**Escape hatches — these always stay literal:**
+
+| Condition | Example target | Stored as |
+|-----------|---------------|-----------|
+| Non-shell target | `read:/etc/hosts` | `read:/etc/hosts` |
+| Already globbed | `bash:git status *` | `bash:git status *` |
+| Contains `&&`, `\|\|`, `\|`, `;`, `&` | `bash:cd /tmp && rm -rf x` | exact string |
+| Contains `$(`, backtick, `>`, `<`, newline | `bash:echo $(whoami)` | exact string |
+| Bare single token equals the full command | `bash:git` | `bash:git` |
+
+The bare-single-token rule is the most important: approving `bash:git` stays literal — it never automatically covers `bash:git push --force`.
+
+---
+
+## Configuration — Arity Table
+
+The arity table tells PraisonAI how many tokens to include in the prefix. A command with arity 2 means "take the first two tokens as the stable prefix":
+
+| Command | Arity | Example approved | Pattern stored |
+|---------|-------|-----------------|---------------|
+| `git` | 2 | `git status -s` | `bash:git status *` |
+| `npm` | 2 | `npm run build` | `bash:npm run *` |
+| `docker` | 2 | `docker compose up -d` | `bash:docker compose *` |
+| `ls` | 1 | `ls -la` | `bash:ls *` |
+| `cat` | 1 | `cat file.txt` | `bash:cat *` |
+| `echo` | 1 | `echo hello` | `bash:echo *` |
+| `python` | 1 | `python script.py` | `bash:python *` |
+| `go` | 2 | `go test ./...` | `bash:go test *` |
+| `cargo` | 2 | `cargo build --release` | `bash:cargo build *` |
+| `kubectl` | 2 | `kubectl get pods` | `bash:kubectl get *` |
+| `yarn` | 2 | `yarn add lodash` | `bash:yarn add *` |
+| `pip` | 2 | `pip install requests` | `bash:pip install *` |
+
+<Note>
+Multi-word keys in the arity table win over single-word keys. `docker compose` (arity 2 for the subcommand) overrides `docker` (arity 1), so `docker compose up -d` derives `bash:docker compose *` rather than `bash:docker *`.
+</Note>
+
+### Extend the arity table for your own tools
+
+Pass a custom `arity_map` to `derive_pattern()` to add commands not in the built-in table:
+
+```python
+from praisonaiagents.permissions import derive_pattern
+
+my_tools = {"mytool": 2, "mytool sub": 3}
+
+pattern = derive_pattern("bash:mytool sub action --flag", arity_map=my_tools)
+print(pattern)
+# => "bash:mytool sub action *"
+```
+
+---
+
+## Common Patterns
+
+### Session vs Always scope
+
+```python
+from praisonaiagents.permissions import PermissionManager
+
+mgr = PermissionManager()
+
+mgr.approve(
+    target="bash:npm run build",
+    scope="session",
+    reusable_scope=True,
+)
+
+mgr.approve(
+    target="bash:git status -s",
+    scope="always",
+    reusable_scope=True,
+)
+```
+
+Use `session` for exploratory work and `always` only for commands you trust unconditionally across all future sessions.
+
+### Preview before storing
+
+```python
+from praisonaiagents.permissions import PermissionManager
+
+mgr = PermissionManager()
+
+targets = [
+    "bash:git log --oneline",
+    "bash:npm run test",
+    "bash:docker ps",
+]
+
+for t in targets:
+    print(f"{t!r}  →  {mgr.suggest_scope_pattern(t)!r}")
+```
+
+```
+'bash:git log --oneline'  →  'bash:git log *'
+'bash:npm run test'       →  'bash:npm run *'
+'bash:docker ps'          →  'bash:docker *'
+```
+
+### Non-shell targets stay literal
+
+Path-based approvals are never globbed — `read:/etc/hosts` only covers that exact file:
+
+```python
+from praisonaiagents.permissions import derive_pattern
+
+print(derive_pattern("read:/etc/hosts"))
+# => "read:/etc/hosts"   (unchanged — non-bash target)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Preview the scope before storing">
+
+Call `suggest_scope_pattern()` in your CLI or approval UI so users can see exactly what `always` will cover before confirming. A pattern like `bash:rm *` deserves a careful second look:
+
+```python
+from praisonaiagents.permissions import PermissionManager
+
+mgr = PermissionManager()
+pattern = mgr.suggest_scope_pattern("bash:rm -rf /tmp/build")
+print(f"This will auto-approve: {pattern}")
+```
+
+</Accordion>
+
+<Accordion title="Prefer session over always for reusable scopes">
+
+A bad derived pattern that uses `always` persists across all future sessions. Use `session` by default for reusable scopes — if the pattern turns out to be safe, upgrade it to `always` deliberately:
+
+```python
+mgr.approve(target="bash:git status -s", scope="session", reusable_scope=True)
+```
+
+</Accordion>
+
+<Accordion title="Non-shell targets stay literal — that is intentional">
+
+Path approvals such as `read:/etc/hosts` or `write:/tmp/report.txt` must remain exact. File paths that look like prefixes (`read:/etc/`) would grant access to all files under `/etc/`, which is a security anti-pattern. The literal-only behaviour for non-shell targets is by design.
+
+</Accordion>
+
+<Accordion title="Extend ARITY for your own CLI tools">
+
+If your agent uses an internal tool (`mytool`) or a domain-specific CLI (`kubectl`), pass a custom `arity_map` to `derive_pattern()` so the prefix is derived correctly:
+
+```python
+from praisonaiagents.permissions import derive_pattern
+
+corp_tools = {
+    "deploy": 2,
+    "deploy rollback": 2,
+}
+
+pattern = derive_pattern("bash:deploy rollback service-a --dry-run", arity_map=corp_tools)
+# => "bash:deploy rollback *"
+```
+
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Approval" icon="shield" href="/docs/features/approval">
+  How PraisonAI approvals work end-to-end
+</Card>
+<Card title="Security" icon="lock" href="/docs/security">
+  Security model and best practices
+</Card>
+<Card title="Approval Backends" icon="server" href="/docs/features/approval-backends">
+  Store approvals in Redis, PostgreSQL, or custom backends
+</Card>
+<Card title="Durable Approvals" icon="database" href="/docs/features/durable-approvals">
+  Persist approvals across process restarts
+</Card>
+</CardGroup>

--- a/docs/gateway.mdx
+++ b/docs/gateway.mdx
@@ -157,6 +157,74 @@ New WebSocket clients should send a `hello` frame to negotiate protocol version,
 
 ---
 
+## Gateway YAML Configuration
+
+The `gateway.yaml` schema accepts three optional top-level blocks alongside `channels` and `agents`. All three are optional and ignored when not present.
+
+### `gateway:` block
+
+Global gateway settings — reliability preset, drain timeout, health monitor:
+
+```yaml
+gateway:
+  reliability: production    # "production" | "default" | "off"
+  drain_timeout: 15          # seconds to wait for in-flight turns on shutdown
+
+channels:
+  telegram:
+    platform: telegram
+    token: ${TELEGRAM_BOT_TOKEN}
+  discord:
+    platform: discord
+    token: ${DISCORD_BOT_TOKEN}
+```
+
+### `hooks:` block
+
+Register shell-command hooks that fire at gateway and message lifecycle events:
+
+```yaml
+hooks:
+  - event: message_received
+    command: /usr/local/bin/rate-check.sh
+  - event: gateway_start
+    command: "curl -s https://monitoring.example.com/ping"
+```
+
+### `BotOS.from_config` and tool names
+
+`BotOS.from_config("botos.yaml")` now routes tool names through the standard `ToolResolver` chain:
+
+1. Local `tools.py` in the working directory
+2. Wrapper `ToolRegistry`
+3. `praisonaiagents` built-in tools
+4. `praisonai-tools` package
+5. Installed plugins
+
+This means a YAML bot referencing a `praisonai-tools` symbol or a local `tools.py` function just works — no ad-hoc `importlib` lookup required:
+
+```yaml
+# botos.yaml
+agent:
+  name: assistant
+  instructions: You are a helpful assistant.
+  tools:
+    - web_search          # resolved via praisonai-tools
+    - my_custom_tool      # resolved from local tools.py
+platforms:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+```
+
+```python
+from praisonai.bots import BotOS
+
+botos = BotOS.from_config("botos.yaml")
+botos.run()
+```
+
+---
+
 ## Gateway Agent Defaults
 
 Gateway agents loaded from YAML use chat-optimised defaults that differ from the Python SDK.


### PR DESCRIPTION
Fixes #1456. Four documentation deliverables from PraisonAI PRs #2576, #2587, #2588, #2589 (v4.6.109). NEW: docs/features/reusable-approval-scopes.mdx with agent-centric Quick Start, Mermaid diagrams, arity table, best practices. UPDATED: hook-events.mdx (MESSAGE_RECEIVED drop/redact), bot-platform-plugins.mdx + botos.mdx + bot-platform-capabilities.mdx + messaging-channels-strategy.mdx (praisonai.channels entry-point), gateway.mdx (gateway:/hooks: blocks + ToolResolver chain). docs.json updated, valid JSON confirmed. Generated with Claude Code.