### PR TITLE
docs: AGENTS.md compliance audit fixes — frontmatter, Steps, AccordionGroup, learn-config page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -934,6 +934,7 @@
                   "docs/features/skill-manage",
                   "docs/features/skill-lifecycle",
                   "docs/features/learn-skill",
+                  "docs/features/learn-config",
                   "docs/features/self-improve",
                   "docs/features/agent-learn-skill",
                   "docs/features/bot-default-tools",

--- a/docs/features/interactive-approval.mdx
+++ b/docs/features/interactive-approval.mdx
@@ -66,7 +66,7 @@ agent.start("Refactor utils.py")
 praisonai --approval console run "Refactor utils.py"
 ```
 
-You will see a prompt like:
+A prompt appears:
 
 ```
 ⚠ Tool Approval Required

--- a/docs/features/learn-config.mdx
+++ b/docs/features/learn-config.mdx
@@ -5,8 +5,6 @@ description: "Configure continuous learning to capture patterns and preferences 
 icon: "graduation-cap"
 ---
 
-Agents learn from every interaction — capturing user preferences, insights, and patterns to improve future responses automatically.
-
 ```python
 from praisonaiagents import Agent, LearnConfig
 
@@ -22,6 +20,8 @@ agent = Agent(
 
 agent.start("I prefer concise answers with bullet points")
 ```
+
+Agents learn from every interaction — capturing user preferences, insights, and patterns to improve future responses automatically.
 
 The user interacts with the agent; learnings are extracted and stored, then recalled in future sessions.
 
@@ -173,7 +173,7 @@ graph TB
 
 ## Configuration Options
 
-<Card title="LearnConfig Python Reference" icon="code" href="/docs/sdk/reference/python/classes/LearnConfig">
+<Card title="LearnConfig Python Reference" icon="code" href="/docs/sdk/reference/praisonaiagents/classes/LearnConfig">
   Full parameter reference for LearnConfig
 </Card>
 

--- a/docs/features/learn-config.mdx
+++ b/docs/features/learn-config.mdx
@@ -1,0 +1,278 @@
+---
+title: "Learn Config"
+sidebarTitle: "Learn Config"
+description: "Configure continuous learning to capture patterns and preferences from agent interactions using LearnConfig"
+icon: "graduation-cap"
+---
+
+Agents learn from every interaction — capturing user preferences, insights, and patterns to improve future responses automatically.
+
+```python
+from praisonaiagents import Agent, LearnConfig
+
+agent = Agent(
+    name="Personal Assistant",
+    instructions="You are a helpful assistant that remembers user preferences.",
+    learn=LearnConfig(
+        persona=True,
+        insights=True,
+        mode="agentic",
+    )
+)
+
+agent.start("I prefer concise answers with bullet points")
+```
+
+The user interacts with the agent; learnings are extracted and stored, then recalled in future sessions.
+
+```mermaid
+graph LR
+    subgraph "Continuous Learning"
+        U[👤 User] --> A[🤖 Agent]
+        A --> L[🧠 Learn]
+        L --> S[💾 Store]
+        S --> R[🔄 Recall]
+        R --> A
+    end
+
+    classDef user fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef agent fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef learn fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef store fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class U user
+    class A agent
+    class L learn
+    class S store
+    class R result
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Enable Learning with Defaults">
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Learning Agent",
+    instructions="You are a helpful assistant",
+    learn=True
+)
+
+agent.start("I work in Python and prefer type hints")
+```
+
+</Step>
+
+<Step title="Configure Learning Capabilities">
+
+```python
+from praisonaiagents import Agent, LearnConfig
+
+agent = Agent(
+    name="Smart Assistant",
+    instructions="Remember my preferences and insights.",
+    learn=LearnConfig(
+        persona=True,
+        insights=True,
+        patterns=True,
+        mode="agentic",
+    )
+)
+
+agent.start("Always format code examples with type annotations")
+```
+
+</Step>
+
+<Step title="Use a Database Backend">
+
+```python
+from praisonaiagents import Agent, LearnConfig
+
+agent = Agent(
+    name="Persistent Learner",
+    instructions="Store learnings in a database.",
+    learn=LearnConfig(
+        backend="sqlite",
+        db_url="sqlite:///learn.db",
+        persona=True,
+        insights=True,
+    )
+)
+
+agent.start("My timezone is UTC+5:30")
+```
+
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant LearnEngine
+    participant Storage
+
+    User->>Agent: Send message
+    Agent->>Agent: Process and respond
+    Agent->>LearnEngine: Extract learnings (mode=agentic)
+    LearnEngine->>Storage: Store persona, insights, patterns
+    Storage-->>Agent: Recalled on next session
+    Agent-->>User: Personalized response
+```
+
+---
+
+## Choose a Learning Mode
+
+```mermaid
+graph TB
+    Q{What should happen\nafter each interaction?} -->|Nothing automatic| D[mode: disabled\nManual capture only]
+    Q -->|Auto-extract learnings| AG[mode: agentic\nAgent extracts & stores]
+    Q -->|Propose for review| PR[mode: propose\nFuture — behaves as disabled now]
+
+    classDef decision fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef disabled fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef agentic fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef propose fill:#189AB4,stroke:#7C90A0,color:#fff
+
+    class Q decision
+    class D disabled
+    class AG agentic
+    class PR propose
+```
+
+## Choose a Storage Backend
+
+```mermaid
+graph TB
+    B{Where to store\nlearning data?} -->|Simple, no deps| FILE[backend: file\nJSON files in ~/.praison]
+    B -->|Local database| SQ[backend: sqlite\nSQLite file]
+    B -->|Fast in-memory| RE[backend: redis\nRequires redis package]
+    B -->|Scale out| MG[backend: mongodb\nRequires pymongo]
+
+    classDef decision fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef file fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef db fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef remote fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class B decision
+    class FILE file
+    class SQ,RE,MG db
+```
+
+---
+
+## Configuration Options
+
+<Card title="LearnConfig Python Reference" icon="code" href="/docs/sdk/reference/python/classes/LearnConfig">
+  Full parameter reference for LearnConfig
+</Card>
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `persona` | `bool` | `True` | Capture user preferences and profile |
+| `insights` | `bool` | `True` | Capture observations and learnings |
+| `thread` | `bool` | `True` | Capture session/conversation context |
+| `patterns` | `bool` | `False` | Capture reusable knowledge patterns |
+| `decisions` | `bool` | `False` | Log decision history |
+| `feedback` | `bool` | `False` | Capture outcome signals |
+| `improvements` | `bool` | `False` | Self-improvement proposals |
+| `mode` | `str` | `"disabled"` | `"disabled"`, `"agentic"`, or `"propose"` |
+| `backend` | `str` | `"file"` | `"file"`, `"sqlite"`, `"redis"`, or `"mongodb"` |
+| `db_url` | `str \| None` | `None` | Database connection URL (non-file backends) |
+| `store_path` | `str \| None` | `None` | Custom path for file backend |
+| `max_entries` | `int` | `0` | Max entries per store (0 = unbounded) |
+| `retention_days` | `int` | `0` | Archive entries unused for N days (0 = keep forever) |
+| `llm` | `str \| None` | `None` | LLM for learning extraction (defaults to agent's LLM) |
+| `scope` | `str` | `"private"` | `"private"` or `"shared"` |
+| `nudge_interval` | `int` | `0` | Nudge agent every N turns (0 = disabled) |
+
+---
+
+## Common Patterns
+
+**Self-improving assistant with retention governance:**
+
+```python
+from praisonaiagents import Agent, LearnConfig
+
+agent = Agent(
+    name="Adaptive Assistant",
+    instructions="Adapt to user preferences over time.",
+    learn=LearnConfig(
+        persona=True,
+        insights=True,
+        patterns=True,
+        mode="agentic",
+        max_entries=500,
+        retention_days=90,
+    )
+)
+```
+
+**Shared learnings across a team of agents:**
+
+```python
+from praisonaiagents import Agent, LearnConfig
+
+shared_learn = LearnConfig(
+    scope="shared",
+    backend="sqlite",
+    db_url="sqlite:///team_learnings.db",
+    persona=True,
+    insights=True,
+)
+
+researcher = Agent(name="Researcher", instructions="Research topics.", learn=shared_learn)
+writer = Agent(name="Writer", instructions="Write content.", learn=shared_learn)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Start with learn=True before tuning">
+Enable learning with defaults first. Once you understand what gets captured, switch to `LearnConfig` to enable only the capabilities you need (`persona`, `insights`, `patterns`).
+</Accordion>
+
+<Accordion title="Use agentic mode for hands-off learning">
+Set `mode="agentic"` to have the agent automatically extract and store learnings after each conversation. This requires no manual action from users or developers.
+</Accordion>
+
+<Accordion title="Set retention limits in production">
+Use `max_entries` and `retention_days` to prevent unbounded growth. A limit of `max_entries=1000` with `retention_days=180` keeps the learning store manageable.
+</Accordion>
+
+<Accordion title="Use sqlite or redis for persistence across restarts">
+The default `file` backend stores JSON in `~/.praison`. For production or multi-instance setups, use `backend="sqlite"` or `backend="redis"` with a `db_url`.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Memory Config" icon="brain" href="/docs/configuration/memory-config">
+    Session and persistent memory configuration
+  </Card>
+  <Card title="Agent Learning" icon="graduation-cap" href="/docs/features/learn">
+    Agent learn feature overview
+  </Card>
+  <Card title="Learning Retention" icon="clock" href="/docs/features/learning-retention">
+    Govern how long learnings are kept
+  </Card>
+  <Card title="Learn Skill" icon="star" href="/docs/features/learn-skill">
+    Teach agents new skills dynamically
+  </Card>
+</CardGroup>

--- a/docs/features/learn-config.mdx
+++ b/docs/features/learn-config.mdx
@@ -195,6 +195,8 @@ graph TB
 | `llm` | `str \| None` | `None` | LLM for learning extraction (defaults to agent's LLM) |
 | `scope` | `str` | `"private"` | `"private"` or `"shared"` |
 | `nudge_interval` | `int` | `0` | Nudge agent every N turns (0 = disabled) |
+| `nudge_min_tool_iters` | `int` | `3` | Minimum tool iterations before a nudge fires |
+| `propose_skills` | `bool` | `False` | Enable `skill_manage` tool in propose mode |
 
 ---
 

--- a/docs/features/mini.mdx
+++ b/docs/features/mini.mdx
@@ -1,4 +1,11 @@
---Mini agents run multi-step workflows in a few lines — one `Agent` per role, coordinated by `AgentTeam`.
+---
+title: "Mini Agents"
+sidebarTitle: "Mini Agents"
+description: "Multi-step multi-agent workflows in a few lines using AgentTeam"
+icon: "users"
+---
+
+Mini agents run multi-step workflows in a few lines — one `Agent` per role, coordinated by `AgentTeam`.
 
 ```python
 from praisonaiagents import Agent, AgentTeam

--- a/docs/features/modular-recipes.mdx
+++ b/docs/features/modular-recipes.mdx
@@ -1,4 +1,11 @@
---Build complex workflows by composing smaller, reusable recipes with the `include:` pattern.
+---
+title: "Modular Recipes"
+sidebarTitle: "Modular Recipes"
+description: "Compose complex workflows from smaller, reusable recipes with the include: pattern"
+icon: "layer-group"
+---
+
+Build complex workflows by composing smaller, reusable recipes with the `include:` pattern.
 
 ```python
 from praisonaiagents import Agent

--- a/docs/features/standalone-llm-modules.mdx
+++ b/docs/features/standalone-llm-modules.mdx
@@ -61,6 +61,64 @@ graph TB
 
 ---
 
+## Quick Start
+
+<Steps>
+<Step title="Install the Package">
+
+```bash
+pip install praisonai-code
+```
+
+</Step>
+
+<Step title="Discover Available Models">
+
+```python
+from praisonai_code.llm.catalogue import ModelCatalogue
+
+catalogue = ModelCatalogue()
+models = catalogue.list_models(provider="openai")
+print(f"{len(models)} OpenAI models available")
+```
+
+</Step>
+
+<Step title="Check Credentials and Resolve Endpoint">
+
+```python
+from praisonai_code.llm.credentials import is_configured, inject_credentials_into_env
+from praisonai_code.llm.env import resolve_llm_endpoint
+
+if is_configured():
+    inject_credentials_into_env()
+    ep = resolve_llm_endpoint()
+    print(f"Using: {ep.model} at {ep.base_url}")
+```
+
+</Step>
+
+<Step title="Build an Agent with Catalogue Info">
+
+```python
+from praisonaiagents import Agent
+from praisonai_code.llm.catalogue import ModelCatalogue
+
+catalogue = ModelCatalogue()
+models = catalogue.list_models(provider="openai")
+
+agent = Agent(
+    name="LLM Info Agent",
+    instructions=f"You have access to {len(models)} OpenAI models.",
+)
+agent.start("Which OpenAI model supports vision and tool calling?")
+```
+
+</Step>
+</Steps>
+
+---
+
 ## The Four Modules
 
 | Module | Public exports | Purpose |
@@ -225,6 +283,17 @@ inject_credentials_into_env()
 ```
 </Accordion>
 </AccordionGroup>
+
+---
+
+## Configuration Options
+
+<Card title="ModelCatalogue Python Reference" icon="code" href="/docs/sdk/reference/python/classes/ModelCatalogue">
+  Python configuration options for ModelCatalogue
+</Card>
+<Card title="LLMEndpoint Python Reference" icon="code" href="/docs/sdk/reference/python/classes/LLMEndpoint">
+  Python configuration options for LLMEndpoint
+</Card>
 
 ---
 

--- a/docs/features/tool-discovery-order.mdx
+++ b/docs/features/tool-discovery-order.mdx
@@ -51,6 +51,31 @@ graph LR
 
 ## Quick Start
 
+<Steps>
+<Step title="Enable Local Tools">
+
+Set the environment variable to allow loading local tool files:
+
+```bash
+export PRAISONAI_ALLOW_LOCAL_TOOLS=true
+```
+
+</Step>
+
+<Step title="Create a Local Tool">
+
+Create `tools.py` in your project directory:
+
+```python
+def read_notes(query: str) -> str:
+    """Read local notes matching the query."""
+    return f"Notes about: {query}"
+```
+
+</Step>
+
+<Step title="Use Tools by Name in Agent">
+
 ```python
 from praisonaiagents import Agent
 import os
@@ -65,7 +90,10 @@ agent = Agent(
 agent.start("What did I write about caching and what's new in the news?")
 ```
 
-PraisonAI will find `read_notes` from your local `tools.py` and `internet_search` from the built-in SDK — no extra configuration needed.
+PraisonAI finds `read_notes` from your local `tools.py` and `internet_search` from the built-in SDK.
+
+</Step>
+</Steps>
 
 ---
 
@@ -142,6 +170,36 @@ sys.modules[__name__] = _impl
 ```
 
 This means `praisonai.tool_resolver is praisonai_code.tool_resolver` — both names point at the same object. The same identity holds for `_framework_availability`, `_safe_loader`, and `tool_registry`, as asserted in `test_c5_backward_compat.py::test_module_identity`.
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Enable local tools only when needed">
+Set `PRAISONAI_ALLOW_LOCAL_TOOLS=true` only in environments where you trust the local `tools.py`. This opt-in prevents accidental execution of untrusted code.
+</Accordion>
+
+<Accordion title="Avoid naming conflicts between tiers">
+If you define a function with the same name as a built-in (e.g., `search`), the local version wins at Tier 1. Choose unique names or use `LOGLEVEL=INFO` to confirm which tier resolved each tool.
+</Accordion>
+
+<Accordion title="Register third-party tools via entry_points">
+Plugins should register under the `praisonai.tool_sources` group in their `pyproject.toml`. This makes them discoverable at Tier 4 without modifying agent code.
+</Accordion>
+
+<Accordion title="Debug discovery order with LOGLEVEL=INFO">
+Run with `LOGLEVEL=INFO` to see exactly which tier resolved each tool name. Look for log lines like `Resolved 'tool_name' from source 'local-tools.py'`.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Configuration Options
+
+<Card title="Tool Resolver Python Reference" icon="code" href="/docs/sdk/reference/python/modules/tool_resolver">
+  Python reference for the tool resolver module
+</Card>
 
 ---
 

--- a/docs/features/tool-discovery-order.mdx
+++ b/docs/features/tool-discovery-order.mdx
@@ -197,6 +197,11 @@ Run with `LOGLEVEL=INFO` to see exactly which tier resolved each tool name. Look
 
 ## Configuration Options
 
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `PRAISONAI_ALLOW_LOCAL_TOOLS` | env var (`bool`-like string) | `false` | Opt-in flag that enables loading local `tools.py` or `tools/` directory (Tier 1). |
+| `LOGLEVEL` | env var (`string`) | unset | Set to `INFO` to log which tier resolved each tool name. |
+
 <Card title="Tool Resolver Python Reference" icon="code" href="/docs/sdk/reference/python/modules/tool_resolver">
   Python reference for the tool resolver module
 </Card>


### PR DESCRIPTION
Fixes all P0 and P1 issues, plus P2 style violations from the AGENTS.md compliance audit (fixes #1473). Changes: fix broken frontmatter in mini.mdx and modular-recipes.mdx; add Steps to standalone-llm-modules.mdx and tool-discovery-order.mdx; add AccordionGroup Best Practices to tool-discovery-order.mdx; create docs/features/learn-config.mdx with agent-centric example, decision diagrams for LearnMode and LearnBackend, full config table; add Configuration Options SDK cards to priority pages; fix forbidden phrase in interactive-approval.mdx. Generated with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Learn Config” guide covering continuous learning setup, options, patterns, and best practices.
  * Expanded the standalone LLM modules guide with a quick start and configuration reference.
  * Improved guidance for tool discovery order with step-by-step instructions, best practices, and configuration links.
  * Added or updated page metadata for several docs pages, including mini agents and modular recipes.
  * Refined wording in the interactive approval guide for smoother reading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->