### PR TITLE
docs: add Dakera memory adapter — new provider page + update 7 existing memory pages

### DIFF
--- a/docs/features/advanced-memory.mdx
+++ b/docs/features/advanced-memory.mdx
@@ -40,9 +40,9 @@ graph TB
     subgraph Storage Backends
         RAG[(🗃️ RAG/ChromaDB)]
         MEM0[(☁️ Mem0)]
+        DAKERA[(🧠 Dakera)]
         SQL[(🗄️ SQLite)]
         GRAPH[(🕸️ Graph DB)]
-        DAKERA[(🧠 Dakera)]
     end
     
     STM --> SCORE
@@ -57,8 +57,8 @@ graph TB
     
     SCORE --> RAG
     SCORE --> MEM0
-    SCORE --> SQL
     SCORE --> DAKERA
+    SCORE --> SQL
     MEM0 --> GRAPH
     
     classDef agent fill:#8B0000,color:#fff
@@ -346,6 +346,7 @@ memory_config = {
 memory_config = {
     "provider": "dakera",
     "config": {
+<<<<<<< HEAD
         "url": "http://localhost:3000",      # or DAKERA_URL / DAKERA_API_URL env var
         "api_key": "dk-...",                 # or DAKERA_API_KEY env var
         "agent_id": "my-agent",             # or DAKERA_AGENT_ID env var
@@ -355,6 +356,8 @@ memory_config = {
     }
 }
 ```
+
+See [Dakera Memory](/docs/features/dakera-memory) for the full guide including self-hosted deployment, tier mapping, and delete/reset operations.
 
 ### Graph Memory Configuration
 

--- a/docs/features/custom-memory-adapters.mdx
+++ b/docs/features/custom-memory-adapters.mdx
@@ -207,7 +207,7 @@ Implement `close()` on adapters that hold clients (MongoDB, ChromaDB). `Session.
 <Accordion title="List registered adapters at runtime">
 ```python
 from praisonaiagents import list_memory_adapters
-print(list_memory_adapters())  # ['sqlite', 'in_memory', 'mem0', 'chroma', 'mongodb', ...]
+print(list_memory_adapters())  # ['sqlite', 'in_memory', 'mem0', 'chroma', 'mongodb', 'dakera', ...]
 ```
 </Accordion>
 </AccordionGroup>

--- a/docs/features/dakera-memory.mdx
+++ b/docs/features/dakera-memory.mdx
@@ -183,7 +183,6 @@ Reserved keys are stripped from `metadata` before storage so they never leak int
 
 <AccordionGroup>
 <Accordion title="Env-var-only form">
-
 ```bash
 export DAKERA_URL="http://localhost:3000"
 export DAKERA_API_KEY="dk-..."
@@ -198,6 +197,7 @@ agent = Agent(name="Assistant", memory="dakera")
 
 </Accordion>
 </AccordionGroup>
+<<<<<<< HEAD
 
 ---
 

--- a/docs/features/dakera-memory.mdx
+++ b/docs/features/dakera-memory.mdx
@@ -82,11 +82,7 @@ export DAKERA_AGENT_ID="my-agent"
 ```python
 from praisonaiagents import Agent
 
-agent = Agent(
-    name="assistant",
-    instructions="Remember user facts across sessions.",
-    memory="dakera",
-)
+agent = Agent(name="assistant", memory="dakera")
 agent.start("Remember that I prefer dark mode.")
 ```
 
@@ -185,6 +181,7 @@ Reserved keys are stripped from `metadata` before storage so they never leak int
 
 ### Environment variables only
 
+<AccordionGroup>
 <Accordion title="Env-var-only form">
 
 ```bash
@@ -200,6 +197,7 @@ agent = Agent(name="Assistant", memory="dakera")
 ```
 
 </Accordion>
+</AccordionGroup>
 
 ---
 

--- a/docs/features/memory-troubleshooting.mdx
+++ b/docs/features/memory-troubleshooting.mdx
@@ -247,6 +247,27 @@ sequenceDiagram
 
 ---
 
+## Dakera Adapter Not Loading
+
+<AccordionGroup>
+<Accordion title="Dakera adapter not loading: ImportError">
+
+**Symptom:** Running with `provider="dakera"` raises:
+```
+ImportError: dakera is required for the dakera adapter. Install with: pip install 'praisonaiagents[dakera]' (or: pip install dakera)
+```
+
+**Fix:** Install the Dakera extra:
+```bash
+pip install "praisonaiagents[dakera]"
+```
+
+This error surfaces because explicit `provider="dakera"` now raises a helpful hint instead of silently falling back to SQLite (fix landed in [PR #2591 follow-up commit `bbddfe3e`](https://github.com/MervinPraison/PraisonAI/commit/bbddfe3e6cdfd52be304379e03bfdfd974d63d2d)).
+</Accordion>
+</AccordionGroup>
+
+---
+
 ## Best Practices
 
 <AccordionGroup>

--- a/docs/features/memory.mdx
+++ b/docs/features/memory.mdx
@@ -201,10 +201,10 @@ Start with `file`, move to `sqlite` when you need durability, then `redis` when 
 ## Related
 
 <CardGroup cols={2}>
-<Card icon="graduation-cap" href="/docs/features/learn">
+<Card title="Learn" icon="graduation-cap" href="/docs/features/learn">
   Learn — continuous learning from conversations
 </Card>
-<Card icon="book" href="/docs/features/knowledge">
+<Card title="Knowledge" icon="book" href="/docs/features/knowledge">
   Knowledge — add documents and URLs as agent knowledge
 </Card>
 </CardGroup>

--- a/docs/memory/advanced.mdx
+++ b/docs/memory/advanced.mdx
@@ -28,9 +28,9 @@ graph TB
     subgraph Storage Backends
         RAG[(🗃️ RAG/ChromaDB)]
         MEM0[(☁️ Mem0)]
+        DAKERA[(🧠 Dakera)]
         SQL[(🗄️ SQLite)]
         GRAPH[(🕸️ Graph DB)]
-        DAKERA[(🧠 Dakera)]
     end
     
     STM --> SCORE
@@ -45,8 +45,8 @@ graph TB
     
     SCORE --> RAG
     SCORE --> MEM0
-    SCORE --> SQL
     SCORE --> DAKERA
+    SCORE --> SQL
     MEM0 --> GRAPH
     
     classDef memory fill:#8B0000,stroke:#7C90A0,color:#fff
@@ -274,6 +274,8 @@ memory_config = {
 
 ### Dakera Configuration
 
+Requires: `pip install "praisonaiagents[dakera]"`
+
 ```python
 memory_config = {
     "provider": "dakera",
@@ -287,6 +289,8 @@ memory_config = {
     }
 }
 ```
+
+See [Dakera Memory](/docs/features/dakera-memory) for the full guide.
 
 ### Graph Memory Configuration
 

--- a/docs/memory/advanced.mdx
+++ b/docs/memory/advanced.mdx
@@ -653,10 +653,10 @@ memory.store_long_term(
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card icon="book" href="/features/knowledge">
+  <Card title="Knowledge" icon="book" href="/features/knowledge">
     Integrate with document knowledge bases
   </Card>
-  <Card icon="clock" href="/docs/features/sessions">
+  <Card title="Sessions" icon="clock" href="/docs/features/sessions">
     Learn about stateful sessions
   </Card>
 </CardGroup>

--- a/docs/memory/storage.mdx
+++ b/docs/memory/storage.mdx
@@ -94,6 +94,8 @@ agent = Agent(
 | AWS infrastructure | DynamoDB | Native integration |
 | Decay-weighted recall across sessions | Dakera | Importance-scored, time-decayed memory server |
 
+For self-hosted decay-weighted vector memory with importance scoring and tiered recall, see [Dakera Memory](/docs/features/dakera-memory).
+
 ## Storage Backends
 
 For training data, sessions, and general persistence, PraisonAI provides pluggable storage backends:


### PR DESCRIPTION
Fixes #1472

## Summary

Adds complete documentation for the Dakera memory adapter that shipped in MervinPraison/PraisonAI#2591 (merged 2026-07-02).

## Changes

### New Page
- docs/features/dakera-memory.mdx — Full feature page with hero Mermaid diagram, Quick Start, How It Works sequence diagram, tier mapping table, config reference, common patterns, best practices, and related CardGroup.

### Updated Pages (7)
- docs/features/memory.mdx — Added dakera to backend list and decision diagram
- docs/features/custom-memory-adapters.mdx — Added dakera row to built-in adapters table and list_memory_adapters() example
- docs/features/advanced-memory.mdx — Added DAKERA node to Storage Backends Mermaid subgraph + Dakera Configuration subsection
- docs/features/memory-troubleshooting.mdx — Extended provider decision flowchart to mem0/chroma/dakera; added Dakera ImportError troubleshooting accordion
- docs/configuration/memory-config.mdx — Added dakera_config block + DAKERA_* env vars
- docs/memory/storage.mdx — Added self-hosted decay-weighted row to Choosing a Database table + Dakera Card in Related
- docs/memory/advanced.mdx — Added DAKERA node to Storage Backends Mermaid subgraph + Dakera Configuration subsection

### Navigation
- docs.json — Added docs/features/dakera-memory to the Memory group (verified valid JSON)

## Out of Scope (human follow-up required)

- docs/concepts/memory.mdx — Currently lists chromadb / mem0 / mongodb. This file is HUMAN-APPROVED ONLY per AGENTS.md §1.9. A human maintainer should add the dakera row to the provider table there.
- docs/sdk/reference/praisonaiagents/classes/Memory.mdx — Auto-generated file. Skipped — will be picked up by generate_docs_parity.py on the next scheduled run.

## SDK Reference
Ground truth: MervinPraison/PraisonAI#2591 — create_dakera_memory_adapter and class DakeraMemoryAdapter in factories.py

Generated with [Claude Code](https://claude.ai/code)