### PR TITLE
docs(memory): add Dakera memory adapter documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1123,7 +1123,8 @@
               "docs/memory/advanced-search",
               "docs/features/memory-lifecycle-hooks",
               "docs/features/custom-memory-adapters",
-              "docs/features/mongodb-memory"
+              "docs/features/mongodb-memory",
+              "docs/features/dakera-memory"
             ]
           },
           {

--- a/docs/configuration/memory-config.mdx
+++ b/docs/configuration/memory-config.mdx
@@ -512,8 +512,9 @@ memory_agent = Agent(
 export PRAISONAI_MEMORY_PROVIDER="rag"
 export PRAISONAI_MEMORY_PATH="./memory"
 
-# Dakera memory provider
+# Dakera memory provider (DAKERA_URL and DAKERA_API_URL are both accepted)
 export DAKERA_URL="http://localhost:3000"
+# export DAKERA_API_URL="http://localhost:3000"  # alias for DAKERA_URL
 export DAKERA_API_KEY="dk-..."
 export DAKERA_AGENT_ID="my-agent"
 

--- a/docs/configuration/memory-config.mdx
+++ b/docs/configuration/memory-config.mdx
@@ -74,6 +74,20 @@ mem0_config = {
     "organization_id": "org-456"
 }
 
+# Dakera Provider
+# Requires: pip install "praisonaiagents[dakera]"
+dakera_config = {
+    "provider": "dakera",
+    "config": {
+        "url": "http://localhost:3000",
+        "api_key": "dk-...",
+        "agent_id": "my-agent",
+        "short_term_type": "working",
+        "long_term_type": "episodic",
+        "default_importance": 0.5,
+    }
+}
+
 # Custom Provider
 custom_config = {
     "provider": "custom",
@@ -497,6 +511,11 @@ memory_agent = Agent(
 # Memory provider
 export PRAISONAI_MEMORY_PROVIDER="rag"
 export PRAISONAI_MEMORY_PATH="./memory"
+
+# Dakera memory provider
+export DAKERA_URL="http://localhost:3000"
+export DAKERA_API_KEY="dk-..."
+export DAKERA_AGENT_ID="my-agent"
 
 # Graph database
 export PRAISONAI_GRAPH_ENABLED="true"

--- a/docs/features/advanced-memory.mdx
+++ b/docs/features/advanced-memory.mdx
@@ -42,6 +42,7 @@ graph TB
         MEM0[(☁️ Mem0)]
         SQL[(🗄️ SQLite)]
         GRAPH[(🕸️ Graph DB)]
+        DAKERA[(🧠 Dakera)]
     end
     
     STM --> SCORE
@@ -57,13 +58,14 @@ graph TB
     SCORE --> RAG
     SCORE --> MEM0
     SCORE --> SQL
+    SCORE --> DAKERA
     MEM0 --> GRAPH
     
     classDef agent fill:#8B0000,color:#fff
     classDef tool fill:#189AB4,color:#fff
     
     class STM,LTM,ENT,USR agent
-    class SCORE,COMP,REL,CLR,ACC,RAG,MEM0,SQL,GRAPH tool
+    class SCORE,COMP,REL,CLR,ACC,RAG,MEM0,SQL,GRAPH,DAKERA tool
 ```
 
 ## Key Features
@@ -276,6 +278,7 @@ user_context = memory.search_user_memory(
 | Postgres | `"postgres"` | PostgreSQL |
 | Mem0 | `"mem0"` | Mem0 cloud service (requires `mem0ai`) |
 | MongoDB | `"mongodb"` | MongoDB |
+| Dakera | `"dakera"` | Self-hosted decay-weighted memory server (requires `praisonaiagents[dakera]`) |
 
 **MemoryConfig parameters:**
 
@@ -324,6 +327,31 @@ memory_config = {
         "api_key": "your-mem0-api-key",
         "org_id": "your-org-id",
         "project_id": "your-project-id"
+    }
+}
+```
+
+### Dakera Configuration
+
+> Requires the optional Dakera extra:
+> ```bash
+> pip install "praisonaiagents[dakera]"
+> ```
+> If the package is missing, configuring `"provider": "dakera"` raises:
+> ```
+> ImportError: dakera is required for the dakera adapter. Install with: pip install 'praisonaiagents[dakera]' (or: pip install dakera)
+> ```
+
+```python
+memory_config = {
+    "provider": "dakera",
+    "config": {
+        "url": "http://localhost:3000",
+        "api_key": "dk-...",
+        "agent_id": "my-agent",
+        "short_term_type": "working",
+        "long_term_type": "episodic",
+        "default_importance": 0.5,
     }
 }
 ```

--- a/docs/features/advanced-memory.mdx
+++ b/docs/features/advanced-memory.mdx
@@ -346,9 +346,9 @@ memory_config = {
 memory_config = {
     "provider": "dakera",
     "config": {
-        "url": "http://localhost:3000",
-        "api_key": "dk-...",
-        "agent_id": "my-agent",
+        "url": "http://localhost:3000",      # or DAKERA_URL / DAKERA_API_URL env var
+        "api_key": "dk-...",                 # or DAKERA_API_KEY env var
+        "agent_id": "my-agent",             # or DAKERA_AGENT_ID env var
         "short_term_type": "working",
         "long_term_type": "episodic",
         "default_importance": 0.5,

--- a/docs/features/custom-memory-adapters.mdx
+++ b/docs/features/custom-memory-adapters.mdx
@@ -135,6 +135,7 @@ sequenceDiagram
 | Factory | `"chroma"` | ChromaDB (lazy) | Vector search, local RAG |
 | Factory | `"mongodb"` | MongoDB (lazy) | Document store, Atlas Vector Search |
 | Factory | `"mem0"` | Mem0 cloud (lazy) | Managed graph / cloud memory |
+| Factory | `"dakera"` | Dakera (lazy) | Self-hosted decay-weighted vector memory |
 
 Heavy backends register as **factories** in `praisonaiagents.memory.adapters.factories` so optional dependencies load only when requested.
 
@@ -185,7 +186,7 @@ from praisonaiagents import has_memory_adapter, list_memory_adapters, add_memory
 if not has_memory_adapter("redis"):
     add_memory_adapter("redis", RedisMemoryAdapter)
 
-print(list_memory_adapters())  # ['sqlite', 'in_memory', 'mem0', 'chroma', 'mongodb', 'redis']
+print(list_memory_adapters())  # ['sqlite', 'in_memory', 'mem0', 'chroma', 'mongodb', 'dakera', 'redis']
 ```
 
 ## Best Practices

--- a/docs/features/dakera-memory.mdx
+++ b/docs/features/dakera-memory.mdx
@@ -1,0 +1,396 @@
+---
+title: "Dakera Memory"
+sidebarTitle: "Dakera Memory"
+description: "Self-hosted, decay-weighted memory server for agent recall"
+icon: "brain"
+---
+
+Dakera gives your agent decay-weighted memory that fades stale context and keeps fresh, important facts on top.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="assistant",
+    instructions="Remember what the user tells you across sessions.",
+    memory={
+        "provider": "dakera",
+        "config": {
+            "url": "http://localhost:3000",
+            "api_key": "dk-...",
+            "agent_id": "my-agent",
+        },
+    },
+)
+agent.start("Remember that my favourite colour is teal")
+```
+
+Later chats can recall the fact — Dakera weights it by importance and decays older memories.
+
+```mermaid
+graph LR
+    subgraph "Dakera Memory"
+        A[🤖 Agent] --> B[🧠 Memory Adapter]
+        B --> C[(working\nshort-term)]
+        B --> D[(episodic\nlong-term)]
+        C --> E[⏱️ Decay / Importance]
+        D --> E
+        E --> F[✅ Recall Result]
+    end
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef adapter fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef store fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef decay fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A agent
+    class B adapter
+    class C,D store
+    class E decay
+    class F result
+```
+
+## Quick Start
+
+<Steps>
+
+<Step title="Install">
+
+```bash
+pip install "praisonaiagents[dakera]"
+```
+
+Equivalent:
+
+```bash
+pip install dakera
+```
+
+Run the Dakera server locally with Docker Compose — see [`dakera-ai/dakera-deploy`](https://github.com/dakera-ai/dakera-deploy) for the compose file. The default port is `3000`, matching the adapter default.
+
+</Step>
+
+<Step title="Configure with environment variables">
+
+```bash
+export DAKERA_URL="http://localhost:3000"
+export DAKERA_API_KEY="dk-..."
+export DAKERA_AGENT_ID="my-agent"
+```
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="assistant",
+    instructions="Remember user facts across sessions.",
+    memory="dakera",
+)
+agent.start("Remember that I prefer dark mode.")
+```
+
+</Step>
+
+<Step title="Configure with a dict">
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="assistant",
+    instructions="Remember user facts across sessions.",
+    memory={
+        "provider": "dakera",
+        "config": {
+            "url": "http://localhost:3000",
+            "api_key": "dk-...",
+            "agent_id": "my-agent",
+            "default_importance": 0.6,
+        },
+    },
+)
+agent.start("I work in software engineering.")
+```
+
+</Step>
+
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Dakera
+
+    User->>Agent: "My favourite colour is teal"
+    Agent->>Dakera: store_long_term(text, importance=0.9)
+    Dakera->>Dakera: score by importance, timestamp for decay
+
+    Note over Dakera: ...next session...
+
+    User->>Agent: "What's my favourite colour?"
+    Agent->>Dakera: recall(query, top_k=5, memory_type="episodic")
+    Dakera-->>Agent: [{text, score, memory_type}]
+    Agent-->>User: "Teal."
+```
+
+Dakera stores memories with an importance score and timestamps them. Over time, memories decay — so stale context stops competing with fresh, relevant facts.
+
+---
+
+## Memory Tiers
+
+PraisonAI maps its two memory tiers onto distinct Dakera `memory_type` values:
+
+| PraisonAI tier | Default Dakera `memory_type` | Override config key | Description |
+|---|---|---|---|
+| short-term (`store_short_term` / `search_short_term`) | `"working"` | `short_term_type` | Recency-heavy scratch context, reset frequently |
+| long-term (`store_long_term` / `search_long_term`) | `"episodic"` | `long_term_type` | Durable knowledge, persists across sessions |
+
+Unlike Mem0 or ChromaDB, Dakera has a first-class `memory_type` field — so the two tiers never collapse.
+
+---
+
+## Configuration Options
+
+| Option | Type | Default | Env fallback | Description |
+|---|---|---|---|---|
+| `url` (alias `base_url`) | `str` | `"http://localhost:3000"` | `DAKERA_URL` → `DAKERA_API_URL` | Dakera server URL |
+| `api_key` | `str` | `None` | `DAKERA_API_KEY` | API key for the Dakera server |
+| `agent_id` | `str` | `"praisonai"` | `DAKERA_AGENT_ID` | Namespaces this agent's memories |
+| `short_term_type` | `str` | `"working"` | — | Dakera `memory_type` for the short-term tier |
+| `long_term_type` | `str` | `"episodic"` | — | Dakera `memory_type` for the long-term tier |
+| `default_importance` | `float` | `0.5` | — | Importance score when a store call does not supply one |
+
+**Env fallback chain for URL:** `DAKERA_URL` → `DAKERA_API_URL` → `"http://localhost:3000"`.
+
+**Precedence:** config dict > env var > hard default. Config dict values always win.
+
+### Reserved metadata keys
+
+These keys are lifted out of `metadata` and promoted to Dakera fields. Explicit `kwargs` win over metadata values:
+
+| Key | Dakera field |
+|---|---|
+| `importance` | Importance score |
+| `session_id` | Session scope |
+| `tags` | Memory tags |
+
+Reserved keys are stripped from `metadata` before storage so they never leak into the payload.
+
+### Environment variables only
+
+<Accordion title="Env-var-only form">
+
+```bash
+export DAKERA_URL="http://localhost:3000"
+export DAKERA_API_KEY="dk-..."
+export DAKERA_AGENT_ID="my-agent"
+```
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(name="Assistant", memory="dakera")
+```
+
+</Accordion>
+
+---
+
+## Precedence Ladder
+
+```python
+# Level 1: String (simplest — uses env vars for URL/key/agent_id)
+agent = Agent(memory="dakera")
+
+# Level 2: Dict (recommended — inline config)
+agent = Agent(
+    memory={
+        "provider": "dakera",
+        "config": {
+            "url": "http://localhost:3000",
+            "api_key": "dk-...",
+            "agent_id": "my-agent",
+        },
+    }
+)
+```
+
+<Warning>
+Do not invent a `DakeraConfig` dataclass, a `Dakera(...)` instance form, or a `Bool` / `Array` level — none exist in the SDK. Only `memory="dakera"` and `memory={"provider": "dakera", "config": {...}}` are supported.
+</Warning>
+
+---
+
+## Store, Search, Delete & Reset
+
+### Storing memories
+
+```python
+from praisonaiagents.memory import Memory
+
+memory = Memory(config={"provider": "dakera", "config": {"agent_id": "my-agent"}})
+
+# Short-term (working memory)
+memory.store_short_term(
+    "User is asking about Python today",
+    metadata={"session_id": "sess-1"},
+)
+
+# Long-term with explicit importance
+memory.store_long_term(
+    "User prefers dark mode",
+    importance=0.9,
+    tags=["preference", "ui"],
+)
+```
+
+`metadata`, `importance`, `session_id`, and `tags` can be passed as kwargs or inside `metadata`. Kwargs always win.
+
+### Searching memories
+
+```python
+# Search short-term
+results = memory.search_short_term("Python", limit=5)
+
+# Search long-term, filtering by importance
+results = memory.search_long_term("colour preference", limit=5, min_importance=0.7)
+
+# Each result has this shape:
+# {"id": str, "text": str, "metadata": dict, "score": float | None, "memory_type": str | None}
+```
+
+### Retrieving all memories
+
+```python
+# Uses Dakera's batch_recall — no embedding required
+all_memories = memory.get_all_memories(limit=1000)
+```
+
+### Deleting memories
+
+<Note>
+Dakera is one of the only providers that supports `DeletableMemoryProtocol` and `ResettableMemoryProtocol` — mem0, ChromaDB, and MongoDB do not implement these optional protocols.
+</Note>
+
+```python
+# Delete by id — returns True on success, False on failure (logs warning)
+deleted = memory.delete_memory("mem-id-123")
+
+# Delete multiple — returns count deleted
+count = memory.delete_memories(["mem-id-1", "mem-id-2", "mem-id-3"])
+```
+
+### Resetting tiers
+
+```python
+# Clear all working (short-term) memory for this agent — scoped by memory_type
+memory.reset_short_term()
+
+# Clear all episodic (long-term) memory for this agent
+# Does NOT wipe short-term memory
+memory.reset_long_term()
+```
+
+---
+
+## Common Patterns
+
+### Namespace per user / tenant
+
+```python
+from praisonaiagents import Agent
+
+user_agent = Agent(
+    name="assistant",
+    memory={
+        "provider": "dakera",
+        "config": {
+            "url": "http://localhost:3000",
+            "agent_id": "user-alice",
+        },
+    },
+)
+```
+
+Different `agent_id`s on the same Dakera server keep memories fully isolated.
+
+### Boost recall for high-signal facts
+
+```python
+from praisonaiagents.memory import Memory
+
+memory = Memory(config={"provider": "dakera"})
+
+memory.store_long_term(
+    "User's payment method is Visa ending 4242",
+    importance=0.9,
+)
+```
+
+Higher importance scores surface this fact ahead of lower-scored memories when Dakera ranks results.
+
+### Filter recall by minimum importance
+
+```python
+results = memory.search_long_term(
+    "payment details",
+    limit=5,
+    min_importance=0.7,
+)
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+
+<Accordion title="Set agent_id per agent (or per user)">
+Each agent or user should have a unique `agent_id` so memories don't cross-read. One Dakera server can host many namespaced agents.
+</Accordion>
+
+<Accordion title="Use default_importance to bias new stores">
+Set `default_importance` in config to bias all new stores without repeating it on every call. Pass explicit `importance` only on the highest-signal facts.
+</Accordion>
+
+<Accordion title="Keep working resets frequent, episodic resets rare">
+Reset `working` (short-term) memory at the end of each session or task. Avoid resetting `episodic` (long-term) memory unless you intentionally want to wipe all durable knowledge — this matches how Dakera's decay is tuned.
+</Accordion>
+
+<Accordion title="Prefer env vars in production">
+Use `DAKERA_URL`, `DAKERA_API_KEY`, and `DAKERA_AGENT_ID` so credentials don't appear in source code or version control.
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Deploying Dakera
+
+Dakera is a self-hosted memory server. The quickest way to run it is with Docker Compose via [`dakera-ai/dakera-deploy`](https://github.com/dakera-ai/dakera-deploy). The default compose port is `3000`, which matches the adapter's default `http://localhost:3000`, so no URL config is needed for local development.
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Memory Configuration" icon="brain" href="/docs/features/memory">
+  Provider strings, MemoryConfig, and backend overview.
+</Card>
+<Card title="Custom Memory Adapters" icon="puzzle-piece" href="/docs/features/custom-memory-adapters">
+  Register your own memory backend with the adapter registry.
+</Card>
+<Card title="MongoDB Memory" icon="database" href="/docs/features/mongodb-memory">
+  Document-backed memory with optional Atlas Vector Search.
+</Card>
+<Card title="Memory Overview" icon="book" href="/docs/memory/overview">
+  Memory system overview and quickstart.
+</Card>
+</CardGroup>

--- a/docs/features/dakera-memory.mdx
+++ b/docs/features/dakera-memory.mdx
@@ -223,7 +223,7 @@ agent = Agent(
 ```
 
 <Warning>
-Do not invent a `DakeraConfig` dataclass, a `Dakera(...)` instance form, or a `Bool` / `Array` level — none exist in the SDK. Only `memory="dakera"` and `memory={"provider": "dakera", "config": {...}}` are supported.
+Do not invent a `DakeraConfig` dataclass, a `Dakera(...)` instance form, or a `Bool` / `Array` level — none exist in the SDK. The supported forms are: `memory="dakera"` (env-var driven), `memory={"provider": "dakera", "config": {...}}` (nested), or a flat dict of config keys (`memory={"url": "...", "api_key": "..."}`).
 </Warning>
 
 ---
@@ -251,7 +251,7 @@ memory.store_long_term(
 )
 ```
 
-`metadata`, `importance`, `session_id`, and `tags` can be passed as kwargs or inside `metadata`. Kwargs always win.
+`importance`, `session_id`, and `tags` can be passed as top-level kwargs or inside the `metadata` dict — kwargs always win. `metadata` is the container, not a promoted field.
 
 ### Searching memories
 

--- a/docs/features/memory-troubleshooting.mdx
+++ b/docs/features/memory-troubleshooting.mdx
@@ -34,7 +34,7 @@ graph TB
     end
     
     START --> EXPLICIT
-    EXPLICIT -->|Yes mem0/chroma| INSTALLED
+    EXPLICIT -->|Yes mem0/chroma/dakera| INSTALLED
     EXPLICIT -->|No/default| FALLBACK
     INSTALLED -->|No| IMPORT
     INSTALLED -->|Yes| APIKEY
@@ -189,6 +189,37 @@ sequenceDiagram
 4. **User re-runs** the agent code — either works or shows next error (missing API key)
 5. **User sets** `MEM0_API_KEY` environment variable
 6. **Agent works** successfully
+
+---
+
+## Dakera adapter not loading
+
+<AccordionGroup>
+  <Accordion title="Dakera adapter not loading">
+    **Symptom:** `ImportError` when using `memory="dakera"` or `memory={"provider": "dakera", ...}`.
+
+    **Install the extra:**
+
+    ```bash
+    pip install "praisonaiagents[dakera]"
+    ```
+
+    Or equivalently:
+
+    ```bash
+    pip install dakera
+    ```
+
+    The exact error message when the package is missing:
+    ```
+    dakera is required for the dakera adapter. Install with: pip install 'praisonaiagents[dakera]' (or: pip install dakera)
+    ```
+
+    **Explicit provider now raises immediately:** Since the fix in commit `bbddfe3`, using `provider="dakera"` raises this `ImportError` with the install hint instead of silently falling back to SQLite.
+
+    **If the server is unreachable:** Ensure Dakera is running at the configured URL (default `http://localhost:3000`). See [`dakera-ai/dakera-deploy`](https://github.com/dakera-ai/dakera-deploy) for Docker Compose setup.
+  </Accordion>
+</AccordionGroup>
 
 ---
 

--- a/docs/features/memory-troubleshooting.mdx
+++ b/docs/features/memory-troubleshooting.mdx
@@ -215,7 +215,7 @@ sequenceDiagram
     dakera is required for the dakera adapter. Install with: pip install 'praisonaiagents[dakera]' (or: pip install dakera)
     ```
 
-    **Explicit provider now raises immediately:** Since the fix in commit `bbddfe3`, using `provider="dakera"` raises this `ImportError` with the install hint instead of silently falling back to SQLite.
+    **Explicit provider now raises immediately:** Using `provider="dakera"` raises this `ImportError` with the install hint instead of silently falling back to SQLite.
 
     **If the server is unreachable:** Ensure Dakera is running at the configured URL (default `http://localhost:3000`). See [`dakera-ai/dakera-deploy`](https://github.com/dakera-ai/dakera-deploy) for Docker Compose setup.
   </Accordion>

--- a/docs/features/memory.mdx
+++ b/docs/features/memory.mdx
@@ -116,13 +116,14 @@ graph TB
     Q -->|Single server, persistent| S[sqlite backend\nnpm install...]
     Q -->|Multi-instance / production| R[redis or valkey]
     Q -->|Multi-agent shared memory| M[mem0 or mongodb]
+    Q -->|Self-hosted decay-weighted memory| D[dakera]
     Q -->|Anthropic model with long context| C[claude_memory=True]
 
     classDef decision fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef backend fill:#6366F1,stroke:#7C90A0,color:#fff
 
     class Q decision
-    class F,S,R,M,C backend
+    class F,S,R,M,D,C backend
 ```
 
 ---
@@ -135,7 +136,7 @@ graph TB
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `backend` | `str` | `"file"` | Storage backend: `file`, `sqlite`, `redis`, `valkey`, `postgres`, `mem0`, `mongodb` |
+| `backend` | `str` | `"file"` | Storage backend: `file`, `sqlite`, `redis`, `valkey`, `postgres`, `mem0`, `mongodb`, `dakera` |
 | `user_id` | `str \| None` | `None` | User identifier for scoped memory |
 | `session_id` | `str \| None` | `None` | Session identifier |
 | `auto_memory` | `bool` | `False` | Auto-extract and store key facts |

--- a/docs/memory/advanced.mdx
+++ b/docs/memory/advanced.mdx
@@ -278,9 +278,9 @@ memory_config = {
 memory_config = {
     "provider": "dakera",
     "config": {
-        "url": "http://localhost:3000",
-        "api_key": "dk-...",
-        "agent_id": "my-agent",
+        "url": "http://localhost:3000",      # or DAKERA_URL / DAKERA_API_URL env var
+        "api_key": "dk-...",                 # or DAKERA_API_KEY env var
+        "agent_id": "my-agent",             # or DAKERA_AGENT_ID env var
         "short_term_type": "working",
         "long_term_type": "episodic",
         "default_importance": 0.5,

--- a/docs/memory/advanced.mdx
+++ b/docs/memory/advanced.mdx
@@ -30,6 +30,7 @@ graph TB
         MEM0[(☁️ Mem0)]
         SQL[(🗄️ SQLite)]
         GRAPH[(🕸️ Graph DB)]
+        DAKERA[(🧠 Dakera)]
     end
     
     STM --> SCORE
@@ -45,6 +46,7 @@ graph TB
     SCORE --> RAG
     SCORE --> MEM0
     SCORE --> SQL
+    SCORE --> DAKERA
     MEM0 --> GRAPH
     
     classDef memory fill:#8B0000,stroke:#7C90A0,color:#fff
@@ -53,7 +55,7 @@ graph TB
     
     class STM,LTM,ENT,USR memory
     class SCORE,COMP,REL,CLR,ACC quality
-    class RAG,MEM0,SQL,GRAPH storage
+    class RAG,MEM0,SQL,GRAPH,DAKERA storage
 ```
 
 ## Key Features
@@ -266,6 +268,22 @@ memory_config = {
         "api_key": "your-mem0-api-key",
         "org_id": "your-org-id",
         "project_id": "your-project-id"
+    }
+}
+```
+
+### Dakera Configuration
+
+```python
+memory_config = {
+    "provider": "dakera",
+    "config": {
+        "url": "http://localhost:3000",
+        "api_key": "dk-...",
+        "agent_id": "my-agent",
+        "short_term_type": "working",
+        "long_term_type": "episodic",
+        "default_importance": 0.5,
     }
 }
 ```

--- a/docs/memory/storage.mdx
+++ b/docs/memory/storage.mdx
@@ -92,6 +92,7 @@ agent = Agent(
 | High-speed caching | Redis | Sub-ms latency |
 | Serverless | Neon/Upstash | No server management |
 | AWS infrastructure | DynamoDB | Native integration |
+| Decay-weighted recall across sessions | Dakera | Importance-scored, time-decayed memory server |
 
 ## Storage Backends
 
@@ -133,5 +134,8 @@ See [Storage Backends](/docs/storage/backends) for detailed usage with all compo
   </Card>
   <Card title="Storage Backends" icon="hard-drive" href="/docs/storage/backends">
     Pluggable storage backends
+  </Card>
+  <Card icon="brain" href="/docs/features/dakera-memory">
+    Self-hosted decay-weighted vector memory
   </Card>
 </CardGroup>

--- a/docs/memory/storage.mdx
+++ b/docs/memory/storage.mdx
@@ -135,7 +135,7 @@ See [Storage Backends](/docs/storage/backends) for detailed usage with all compo
   <Card title="Storage Backends" icon="hard-drive" href="/docs/storage/backends">
     Pluggable storage backends
   </Card>
-  <Card icon="brain" href="/docs/features/dakera-memory">
+  <Card title="Dakera Memory" icon="brain" href="/docs/features/dakera-memory">
     Self-hosted decay-weighted vector memory
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

- Adds `docs/features/dakera-memory.mdx` — full feature page for the Dakera self-hosted, decay-weighted memory adapter introduced in MervinPraison/PraisonAI#2591
- Updates 7 existing files to include `dakera` in all provider lists, decision diagrams, configuration sections, and troubleshooting guides
- Updates `docs.json` navigation (Memory group)

## Changes

**New file:**
- `docs/features/dakera-memory.mdx` — agent-centric first code block, hero Mermaid diagram, sequenceDiagram, Quick Start Steps, tier-mapping table, config options table (6 options, 4 env fallbacks), reserved metadata keys, precedence ladder, store/search/delete/reset docs, common patterns, best practices, deploying Dakera, related CardGroup

**Updated files:**
- `docs/features/memory.mdx` — add `dakera` to backend list and decision diagram
- `docs/features/custom-memory-adapters.mdx` — add dakera row to built-in adapters table; update `list_memory_adapters()` output comment
- `docs/features/advanced-memory.mdx` — add `DAKERA` node to Storage Backends Mermaid; add Dakera Configuration section
- `docs/features/memory-troubleshooting.mdx` — extend flowchart; add "Dakera adapter not loading" AccordionGroup with exact `ImportError` and `bbddfe3` fix note
- `docs/configuration/memory-config.mdx` — add `dakera_config` block; add `DAKERA_*` env vars
- `docs/memory/storage.mdx` — add Dakera row to Choosing a Database table; add Dakera Card to Related
- `docs/memory/advanced.mdx` — add `DAKERA` node to Mermaid; add Dakera Configuration section
- `docs.json` — add `docs/features/dakera-memory` to Memory group

## References

- Feature PR: MervinPraison/PraisonAI#2591 — `feat(memory): add Dakera memory adapter` (merged 2026-07-02, commit `afcf09b`)
- Follow-up fix: `bbddfe3e6c` — surface install hint on explicit provider path
- Closes #1480
- Consolidates #1472 and #1474

## Human follow-up required

`docs/concepts/memory.mdx` has a provider table that still lists `chromadb / mem0 / mongodb`. Per `AGENTS.md` §1.9, `docs/concepts/` is **HUMAN-APPROVED ONLY** — an AI agent must not edit it. A human maintainer should add `dakera` to that list as a follow-up.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Dakera memory option across the docs, including setup, configuration, and usage examples.
  * Expanded the memory documentation to show Dakera as a supported backend and recommended choice for decay-weighted recall.
  * Added a dedicated Dakera Memory guide and linked it from related memory pages.

* **Bug Fixes**
  * Updated the memory troubleshooting guide to clarify installation requirements and expected behavior when the Dakera provider is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->