### PR TITLE
docs: add Dakera memory adapter page (fixes #1482)

### DIFF
--- a/docs/features/custom-memory-adapters.mdx
+++ b/docs/features/custom-memory-adapters.mdx
@@ -224,6 +224,9 @@ print(list_memory_adapters())  # ['sqlite', 'in_memory', 'mem0', 'chroma', 'mong
 <Card title="MongoDB Memory" icon="database" href="/docs/features/mongodb-memory">
   Atlas Vector Search and `use_vector_search` configuration.
 </Card>
+<Card title="Dakera Memory" icon="database" href="/docs/features/dakera-memory">
+  Self-hosted, decay-weighted vector recall via the Dakera server.
+</Card>
 <Card title="Memory Troubleshooting" icon="triangle-exclamation" href="/docs/features/memory-troubleshooting">
   ImportError and fallback behaviour when providers are missing.
 </Card>

--- a/docs/features/memory-troubleshooting.mdx
+++ b/docs/features/memory-troubleshooting.mdx
@@ -278,4 +278,7 @@ sequenceDiagram
   <Card title="Advanced Memory" icon="gear" href="/docs/features/advanced-memory">
     Multi-tiered memory with quality scoring and graph support
   </Card>
+  <Card title="Dakera Memory" icon="database" href="/docs/features/dakera-memory">
+    Self-hosted, decay-weighted vector recall via the Dakera server.
+  </Card>
 </CardGroup>

--- a/docs/features/mongodb-memory.mdx
+++ b/docs/features/mongodb-memory.mdx
@@ -168,4 +168,7 @@ As of PraisonAI PR #2060, `use_vector_search` is always initialised on the `Memo
 <Card title="Memory Advanced Search" icon="magnifying-glass-plus" href="/docs/features/memory-advanced-search">
   Reranking, relevance cutoffs, and quality filtering.
 </Card>
+<Card title="Dakera Memory" icon="database" href="/docs/features/dakera-memory">
+  Self-hosted, decay-weighted vector recall via the Dakera server.
+</Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

- Creates `docs/features/dakera-memory.mdx` — a full documentation page for the new `dakera` memory provider shipped in `praisonaiagents` 1.6.116
- Updates `docs/features/memory.mdx` to list `dakera` in the backend options table and decision diagram
- Registers `docs/features/dakera-memory` in the **Memory** group of `docs.json` (after `mongodb-memory`)
- Adds Dakera cross-link cards to `custom-memory-adapters.mdx`, `mongodb-memory.mdx`, and `memory-troubleshooting.mdx`

All config keys, defaults, and env-var fallbacks verified against `praisonaiagents/memory/adapters/factories.py`.

Fixes #1482

Generated with [Claude Code](https://claude.ai/code)