### PR TITLE
docs: fix broken init command hints + provider-aware model defaults

### DIFF
--- a/docs/cli/init.mdx
+++ b/docs/cli/init.mdx
@@ -42,7 +42,7 @@ This writes three files under `.praisonai/` — skipping any that already exist.
 <Step title="Run the scaffolded agent">
 
 ```bash
-praisonai agent run assistant "hello"
+praisonai run --agent assistant "hello"
 ```
 
 </Step>
@@ -50,7 +50,7 @@ praisonai agent run assistant "hello"
 <Step title="Run the scaffolded command">
 
 ```bash
-praisonai command run review "src/foo.py"
+praisonai run --command review "src/foo.py"
 ```
 
 </Step>
@@ -77,7 +77,7 @@ sequenceDiagram
 | Resolve target | Walks up to the git root (or uses cwd) and sets `.praisonai/` as the base |
 | Write files | Creates `config.yaml`, `agents/assistant.md`, `commands/review.md` |
 | Report | Prints `Created <path>` or `Skipped (already exists, use --force): <path>` per file |
-| Next steps | Prints the exact `agent run` and `command run` commands you can copy |
+| Next steps | Prints the exact `praisonai run --agent` and `praisonai run --command` commands you can copy |
 
 ## Project vs global
 
@@ -107,7 +107,17 @@ graph TB
 
 ## Scaffolded files
 
+### Scaffolded model is provider-aware
+
+`praisonai init` reads your available provider credentials (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`, `COHERE_API_KEY`, `OLLAMA_HOST`) and writes the matching default model into both `config.yaml` and `agents/assistant.md`. Falls back to `gpt-4o-mini` when no credential is detected. This choice is **not persisted** as your recent model — subsequent `praisonai run` invocations resolve independently.
+
+See [Models → Default Model Resolution](/docs/models#provider-auto-detection-no-config-first-run) for the full credential-to-model precedence table.
+
 **`config.yaml`** — project-wide defaults:
+
+<Note>
+The `model:` value shown below (`gpt-4o-mini`) is the terminal fallback. With only `ANTHROPIC_API_KEY` set, the scaffolded `model:` is `anthropic/claude-3-5-sonnet-latest`; with only `GEMINI_API_KEY`, it is `gemini/gemini-1.5-flash`. See [Models → Default Model Resolution](/docs/models#provider-auto-detection-no-config-first-run) for the full precedence.
+</Note>
 
 ```yaml
 # yaml-language-server: $schema=https://raw.githubusercontent.com/MervinPraison/PraisonAI/main/src/praisonai/praisonai/cli/configuration/config.schema.json
@@ -123,6 +133,10 @@ output:
 The `# yaml-language-server:` line enables editor autocomplete and inline error highlighting in VS Code (YAML extension) and other LSP-aware editors. The nested `agent:` / `output:` shape is exactly what `ConfigResolver` reads — flat top-level `model:` / `output:` keys will now produce a warning.
 
 **`agents/assistant.md`** — ready-to-run starter agent:
+
+<Note>
+The `model:` field is written with the provider-detected default (same logic as `config.yaml` above). The value shown here is the terminal fallback.
+</Note>
 
 ```markdown
 ---
@@ -160,7 +174,7 @@ If a file path is provided, here are its contents:
 
 ```bash
 praisonai init
-praisonai agent run assistant "hello"
+praisonai run --agent assistant "hello"
 ```
 
 ### Re-init after editing a file

--- a/docs/cli/init.mdx
+++ b/docs/cli/init.mdx
@@ -109,14 +109,14 @@ graph TB
 
 ### Scaffolded model is provider-aware
 
-`praisonai init` reads your available provider credentials (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`, `COHERE_API_KEY`, `OLLAMA_HOST`) and writes the matching default model into both `config.yaml` and `agents/assistant.md`. Falls back to `gpt-4o-mini` when no credential is detected. This choice is **not persisted** as your recent model — subsequent `praisonai run` invocations resolve independently.
+`praisonai init` reads your available provider credentials (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`, `COHERE_API_KEY`, `OLLAMA_HOST`) and writes the matching default model into both `config.yaml` and `agents/assistant.md`. Falls back to `gpt-4o-mini` when no credential is detected. This choice is **not persisted** as your recent model — subsequent `praisonai run` invocations resolve independently.
 
-See [Models → Default Model Resolution](/docs/models#provider-auto-detection-no-config-first-run) for the full credential-to-model precedence table.
+See [Models → Provider Auto-Detection](/docs/models#provider-auto-detection-no-config-first-run) for the full credential-to-model precedence table.
 
 **`config.yaml`** — project-wide defaults:
 
 <Note>
-The `model:` value shown below (`gpt-4o-mini`) is the terminal fallback. With only `ANTHROPIC_API_KEY` set, the scaffolded `model:` is `anthropic/claude-3-5-sonnet-latest`; with only `GEMINI_API_KEY`, it is `gemini/gemini-1.5-flash`. See [Models → Default Model Resolution](/docs/models#provider-auto-detection-no-config-first-run) for the full precedence.
+The `model:` value shown below (`gpt-4o-mini`) is the terminal fallback. With only `ANTHROPIC_API_KEY` set, the scaffolded `model:` is `anthropic/claude-3-5-sonnet-latest`; with only `GEMINI_API_KEY`, it is `gemini/gemini-1.5-flash`. See [Models → Provider Auto-Detection](/docs/models#provider-auto-detection-no-config-first-run) for the full precedence.
 </Note>
 
 ```yaml

--- a/docs/cli/realworld-examples.mdx
+++ b/docs/cli/realworld-examples.mdx
@@ -28,7 +28,7 @@ This guide covers 10 real-world scenarios demonstrating these capabilities.
 
 | Flag | Description |
 |------|-------------|
-| `-m, --model` | LLM model to use (default: gpt-4o-mini) |
+| `-m, --model` | LLM model to use (default: provider-aware — falls back to `gpt-4o-mini` when no credential is set; see [Models → Default Model Resolution](/docs/models#provider-auto-detection-no-config-first-run)) |
 | `-w, --workspace` | Working directory for file operations |
 | `-f, --file` | Attach file(s) to prompt |
 | `-c, --continue` | Continue last session |
@@ -241,7 +241,7 @@ praisonai chat -w . -m gpt-4o-mini "Run pytest to see failing tests. Fix each on
 | Flag | Description |
 |------|-------------|
 | `-w, --workspace` | Set working directory for file operations |
-| `-m, --model` | LLM model to use (default: gpt-4o-mini) |
+| `-m, --model` | LLM model to use (default: provider-aware — falls back to `gpt-4o-mini` when no credential is set; see [Models → Default Model Resolution](/docs/models#provider-auto-detection-no-config-first-run)) |
 | `-c, --continue` | Continue previous session |
 | `-f, --file` | Attach file(s) to prompt |
 | `-s, --session` | Resume specific session ID |

--- a/docs/cli/realworld-examples.mdx
+++ b/docs/cli/realworld-examples.mdx
@@ -28,7 +28,7 @@ This guide covers 10 real-world scenarios demonstrating these capabilities.
 
 | Flag | Description |
 |------|-------------|
-| `-m, --model` | LLM model to use (default: provider-aware — falls back to `gpt-4o-mini` when no credential is set; see [Models → Default Model Resolution](/docs/models#provider-auto-detection-no-config-first-run)) |
+| `-m, --model` | LLM model to use (default: provider-aware — falls back to `gpt-4o-mini` when no credential is set; see [Models → Provider Auto-Detection](/docs/models#provider-auto-detection-no-config-first-run)) |
 | `-w, --workspace` | Working directory for file operations |
 | `-f, --file` | Attach file(s) to prompt |
 | `-c, --continue` | Continue last session |
@@ -241,7 +241,7 @@ praisonai chat -w . -m gpt-4o-mini "Run pytest to see failing tests. Fix each on
 | Flag | Description |
 |------|-------------|
 | `-w, --workspace` | Set working directory for file operations |
-| `-m, --model` | LLM model to use (default: provider-aware — falls back to `gpt-4o-mini` when no credential is set; see [Models → Default Model Resolution](/docs/models#provider-auto-detection-no-config-first-run)) |
+| `-m, --model` | LLM model to use (default: provider-aware — falls back to `gpt-4o-mini` when no credential is set; see [Models → Provider Auto-Detection](/docs/models#provider-auto-detection-no-config-first-run)) |
 | `-c, --continue` | Continue previous session |
 | `-f, --file` | Attach file(s) to prompt |
 | `-s, --session` | Resume specific session ID |

--- a/docs/cli/setup.mdx
+++ b/docs/cli/setup.mdx
@@ -184,7 +184,7 @@ graph TB
 | 2 | Most-recently-used model (`~/.praison/state/model.json`) | Only *user-chosen* values are remembered |
 | 3 | `MODEL_NAME` env var (then `OPENAI_MODEL_NAME` for backward compatibility) | Persisted on use |
 | 4 | First present provider credential (table below) | **Not** persisted — kept fresh per run |
-| 5 | `gpt-4o-mini` as ultimate fallback | **Not** persisted |
+| 5 | Terminal fallback (`DEFAULT_FALLBACK_MODEL` — currently `gpt-4o-mini`) | **Not** persisted |
 
 ### Credential → default-model map
 
@@ -206,7 +206,7 @@ The first time a provider-aware default is inferred, the CLI prints a one-line n
 No model set; using anthropic/claude-3-5-sonnet-latest because ANTHROPIC_API_KEY is present.
 ```
 
-Only *user-chosen* values (explicit `--model`, env overrides) are persisted as the recent model. Provider-inferred defaults and the `gpt-4o-mini` fallback are **deliberately not** persisted — this keeps model selection fresh if your available providers change between runs.
+Only *user-chosen* values (explicit `--model`, env overrides) are persisted as the recent model. Provider-inferred defaults and the terminal fallback (`DEFAULT_FALLBACK_MODEL`, currently `gpt-4o-mini`) are **deliberately not** persisted — this keeps model selection fresh if your available providers change between runs.
 
 <Note>
 The recency file lives at `~/.praison/state/model.json` (note: `.praison`, not `.praisonai`). It is created on demand; if it's missing or unreadable, resolution falls straight through to provider inference and works normally.

--- a/docs/models.mdx
+++ b/docs/models.mdx
@@ -241,6 +241,10 @@ When you run `praisonai run` without setting `--model` or a `model:` key in `con
 
 Precedence: the first credential in the table that is set wins. If multiple provider keys are set, the one listed first takes effect.
 
+<Note>
+The same resolver drives implicit defaults for `praisonai run`, `praisonai chat`, `praisonai init` scaffolding, `praisonai setup`, and the bare-`praisonai` TUI launch — not just `run`.
+</Note>
+
 ```mermaid
 graph TB
     Start([praisonai run — no model set]) --> A{OPENAI_API_KEY?}


### PR DESCRIPTION
## Summary

Fixes #1497 — three documentation files updated to reflect the behaviour changes from PraisonAI PR #2615.

### Changes

**`docs/cli/init.mdx`** (P0 + P1)
- Fixed 3 broken CLI command examples: `praisonai agent run assistant` → `praisonai run --agent assistant` and `praisonai command run review` → `praisonai run --command review`
- Added `<Note>` above the `config.yaml` scaffold snippet explaining the `model:` value is provider-detected (not always `gpt-4o-mini`)
- Added `<Note>` above the `agents/assistant.md` scaffold snippet with same provider-awareness caveat
- Added "Scaffolded model is provider-aware" subsection with credential → model mapping and link to Models docs

**`docs/cli/realworld-examples.mdx`** (P1)
- Updated both `-m, --model` flag table rows to describe provider-aware resolution with link to Default Model Resolution docs

**`docs/models.mdx`** (P1)
- Added `<Note>` above the mermaid resolver flow diagram naming all five entry points that share the same `resolve_default_model()` resolver: `run`, `chat`, `init` scaffold, `setup`, and bare TUI

**`docs/cli/setup.mdx`** (informational)
- Updated precedence table row 5 to reference `DEFAULT_FALLBACK_MODEL` by name
- Updated persistence-rule paragraph to reference `DEFAULT_FALLBACK_MODEL` by name

### Verification

- `grep -rn "praisonai agent run\|praisonai command run" docs/` returns zero hits
- All three `praisonai run --agent` / `praisonai run --command` invocations are present
- `<Note>` components added above both scaffold snippets in `init.mdx`
- "Scaffolded model is provider-aware" subsection added
- Both `-m/--model` rows in `realworld-examples.mdx` updated
- `models.mdx` flow diagram has scope note
- `setup.mdx` uses `DEFAULT_FALLBACK_MODEL` naming

Generated with [Claude Code](https://claude.ai/code)