### PR TITLE
docs: cover durable proactive delivery stack — rate limiter, whole-envelope idempotency, failed-send retry semantics (PraisonAI #2578 series)

### DIFF
--- a/docs/features/bot-rate-limiting.mdx
+++ b/docs/features/bot-rate-limiting.mdx
@@ -11,16 +11,11 @@ Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot se
 
 
 ```python
-from praisonaiagents import Agent, BotConfig
+from praisonai.bots._rate_limit import RateLimiter
 
-agent = Agent(name="rate-limited-bot", instructions="Respond to users within rate limits.")
-config = BotConfig(rate_limit_per_user=10)
-agent.start("Apply rate limiting: max 10 requests per user per minute.")
+limiter = RateLimiter.for_platform("telegram")
+await limiter.acquire(channel_id="telegram-chat-12345")
 ```
-
-The user sends many messages quickly; outbound replies are throttled so the platform does not return HTTP 429 errors.
-
-
 
 Bot Rate Limiting prevents messaging platform 429 errors by throttling outbound messages to channels, respecting platform-specific limits and per-channel delays.
 

--- a/docs/features/bot-rate-limiting.mdx
+++ b/docs/features/bot-rate-limiting.mdx
@@ -24,6 +24,13 @@ The user sends many messages quickly; outbound replies are throttled so the plat
 
 Bot Rate Limiting prevents messaging platform 429 errors by throttling outbound messages to channels, respecting platform-specific limits and per-channel delays.
 
+Since PraisonAI #2578, the limiter also covers the proactive path — scheduled and agent-initiated sends now share one bucket per platform with the reply path. `DeliveryRouter.deliver` reuses `adapter._rate_limiter` if the adapter already carries one; otherwise it lazily calls `RateLimiter.for_platform(platform)`.
+
+| Send path | Rate limiter used |
+|-----------|-------------------|
+| Reply path (`DurableDelivery.send`, `deliver_with_retry`) | Per-platform bucket on the adapter |
+| Proactive path (`BotOS.deliver` / `DeliveryRouter.deliver`) | Same per-platform bucket — reuses `adapter._rate_limiter` or lazily creates one |
+
 ```mermaid
 graph LR
     subgraph "Bot Rate Limiting Flow"

--- a/docs/features/dead-target-registry.mdx
+++ b/docs/features/dead-target-registry.mdx
@@ -274,6 +274,40 @@ registry = DeadTargetRegistry(
 
 ---
 
+## Adapter Return Conventions
+
+A channel adapter's `send_message()` can signal delivery outcome three ways:
+
+```mermaid
+graph TB
+    Send[send_message returns] --> None{None?}
+    None -->|Yes| OK[✅ Success — key recorded]
+    None -->|No| F{False?}
+    F -->|Yes| Retry[🔁 Transient failure — key NOT recorded]
+    F -->|No| Raise{Raised?}
+    Raise -->|Yes| Dead[💀 Dead-target counter++]
+
+    classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef warn fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef err fill:#8B0000,stroke:#7C90A0,color:#fff
+
+    class OK ok
+    class Retry warn
+    class Dead err
+```
+
+| Return value | Meaning | Dead-target effect |
+|---|---|---|
+| `None` / no value | **Success** (dominant convention) | Counter cleared on success |
+| `False` (explicit) | **Transient failure** — idempotency key NOT recorded, dead-target flag NOT tripped, safe to retry | No change |
+| Raises exception | **Failure** — exception flows to the failure path, dead-target counter increments if a permanent error is detected | Counter increments on permanent errors (403/404/410) |
+
+<Note>
+The `False` convention was formalised in PraisonAI #2578. Adapters that previously returned `False` silently to signal "send skipped" should now raise an exception or return `None` to avoid being misclassified as a transient failure.
+</Note>
+
+---
+
 ## Common Patterns
 
 ### Long-running broadcast gateway

--- a/docs/features/dead-target-registry.mdx
+++ b/docs/features/dead-target-registry.mdx
@@ -280,12 +280,11 @@ A channel adapter's `send_message()` can signal delivery outcome three ways:
 
 ```mermaid
 graph TB
-    Send[send_message returns] --> None{None?}
+    Send[send_message call] -->|Raises exception| Dead[💀 Dead-target counter++]
+    Send -->|Returns value| None{None?}
     None -->|Yes| OK[✅ Success — key recorded]
     None -->|No| F{False?}
     F -->|Yes| Retry[🔁 Transient failure — key NOT recorded]
-    F -->|No| Raise{Raised?}
-    Raise -->|Yes| Dead[💀 Dead-target counter++]
 
     classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
     classDef warn fill:#F59E0B,stroke:#7C90A0,color:#fff

--- a/docs/features/durable-delivery.mdx
+++ b/docs/features/durable-delivery.mdx
@@ -528,18 +528,18 @@ asyncio.create_task(delivery.drain_pending())
 
 ## Proactive Path
 
-The proactive path (`BotOS.deliver`) now honours `idempotency_key` too — but the guarantee is weaker than the reply-path outbox.
+The proactive path (`BotOS.deliver`) shares the reply-path rate limiter — but does not support idempotency deduplication. For durable, deduped sends use the reply-path outbox (`delivery.send`).
 
 | Property | Reply-path outbox (`delivery.send`) | Proactive path (`BotOS.deliver`) |
 |----------|------------------------------------|----------------------------------|
-| Persistence | SQLite outbox, survives restart | In-memory LRU, resets on restart |
-| Cross-worker dedup | Yes (`UNIQUE` on `idempotency_key`) | No — process-local, best-effort |
+| Persistence | SQLite outbox, survives restart | Not persisted — fire-and-forget |
+| Cross-worker dedup | Yes (`UNIQUE` on `idempotency_key`) | ❌ not supported |
+| Idempotency key | ✅ | ❌ not a parameter |
 | Rate limiter shared | ✅ same bucket | ✅ same bucket (post PraisonAI #2578) |
 | Adapter `was_delivered` reconciliation | ✅ | ❌ not applicable |
-| Bounded cache size | Unbounded (durable) | 4096 keys (LRU eviction) |
 
 <Note>
-Use `delivery.send(...)` when you need durability across restarts and workers. Use `BotOS.deliver(...)` when the send is agent-initiated and same-process dedup is enough.
+Use `delivery.send(...)` when you need durability across restarts, workers, or deduplication. Use `BotOS.deliver(...)` for simple agent-initiated sends where rate-limiting is enough.
 </Note>
 
 ---

--- a/docs/features/durable-delivery.mdx
+++ b/docs/features/durable-delivery.mdx
@@ -46,10 +46,6 @@ graph LR
     class Queue storage
     class Sent success
     class Later pending
-
-    classDef tool fill:#189AB4,color:#fff
-
-    classDef agent fill:#8B0000,color:#fff
 ```
 
 ## Quick Start
@@ -559,9 +555,6 @@ Use `delivery.send(...)` when you need durability across restarts and workers. U
 </Card>
 <Card title="Inbound DLQ" icon="inbox" href="/docs/features/inbound-dlq">
   Dead-letter queue for failed inbound message processing
-</Card>
-<Card title="Dead Target Registry" icon="x-circle" href="/docs/features/dead-target-registry">
-  Skip permanently-dead chat targets to prevent retry storms
 </Card>
 <Card title="Delivery Config" icon="settings" href="/docs/features/delivery-config">
   Configure outbound resilience for all six bot channels

--- a/docs/features/durable-delivery.mdx
+++ b/docs/features/durable-delivery.mdx
@@ -530,6 +530,24 @@ asyncio.create_task(delivery.drain_pending())
 
 ---
 
+## Proactive Path
+
+The proactive path (`BotOS.deliver`) now honours `idempotency_key` too — but the guarantee is weaker than the reply-path outbox.
+
+| Property | Reply-path outbox (`delivery.send`) | Proactive path (`BotOS.deliver`) |
+|----------|------------------------------------|----------------------------------|
+| Persistence | SQLite outbox, survives restart | In-memory LRU, resets on restart |
+| Cross-worker dedup | Yes (`UNIQUE` on `idempotency_key`) | No — process-local, best-effort |
+| Rate limiter shared | ✅ same bucket | ✅ same bucket (post PraisonAI #2578) |
+| Adapter `was_delivered` reconciliation | ✅ | ❌ not applicable |
+| Bounded cache size | Unbounded (durable) | 4096 keys (LRU eviction) |
+
+<Note>
+Use `delivery.send(...)` when you need durability across restarts and workers. Use `BotOS.deliver(...)` when the send is agent-initiated and same-process dedup is enough.
+</Note>
+
+---
+
 ## Related
 
 <CardGroup cols={2}>

--- a/docs/features/proactive-delivery.mdx
+++ b/docs/features/proactive-delivery.mdx
@@ -141,6 +141,59 @@ Call `botos.delivery_router.refresh_directory()` periodically so adapters enumer
 
 ---
 
+## Rate Limiting & Idempotency
+
+Scheduled and background sends now share the reply-path rate limiter and dedup guard automatically — no config change required.
+
+```mermaid
+graph LR
+    Agent[🤖 Agent] --> Msg[BotOutboundMessenger]
+    Msg --> Dup{🔍 is_duplicate_key?}
+    Dup -->|Hit| Skip[⏭ Skip envelope]
+    Dup -->|Miss| Rate{⚖️ Rate Limiter}
+    Rate --> Send[📤 Send text]
+    Send --> Media[📎 Send media]
+    Media --> Remember[💾 remember_key]
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef result fill:#10B981,stroke:#7C90A0,color:#fff
+    classDef config fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class Agent agent
+    class Msg,Rate,Send,Media process
+    class Dup,Skip config
+    class Remember result
+```
+
+| You call | What happens |
+|----------|--------------|
+| `botos.deliver("ops-alerts", "...")` with no `idempotency_key` | Rate-limited per platform. No dedup. |
+| `botos.deliver(..., idempotency_key="job-42")` | Rate-limited **and** dedup'd within this process (bounded LRU, 4096 keys). A retry with the same key returns success without re-sending. |
+| `botos.deliver(..., idempotency_key="job-42")` with attachments | Whole text + media envelope is deduped. Key is recorded only after both text and media succeed — a failed media upload leaves the key retryable. |
+| Adapter's `send_message()` returns `False` | Treated as a transient failure. Key not stored. Dead-target flag not tripped. Safe to retry. |
+
+```python
+# Scheduled daily digest — safe to retry from cron on transient failure
+await botos.deliver(
+    "ops-alerts",
+    "Nightly digest ready",
+    idempotency_key=f"digest-{today.isoformat()}",
+)
+```
+
+```python
+# Notification with attachment — media won't double-upload on retry
+await botos.deliver(
+    "ops-alerts",
+    "Build finished",
+    attachments=[BuildLog("/var/log/build.log")],
+    idempotency_key=f"build-{build_id}",
+)
+```
+
+---
+
 ## Best Practices
 
 <AccordionGroup>
@@ -155,6 +208,21 @@ Bare-platform targets fail without a configured home channel.
 </Accordion>
 <Accordion title="Handle the bool return">
 `deliver()` returns `False` on resolution or send failure — log and retry as needed.
+</Accordion>
+<Accordion title="Pick a stable idempotency_key for scheduled sends">
+Derive the key from the trigger — job ID, cron-timestamp, or inbound message ID. Never use `uuid.uuid4()` inside the retry loop; a new UUID on every call defeats deduplication.
+
+```python
+# ✅ Good: derived from a stable trigger
+idempotency_key=f"digest-{today.isoformat()}"
+
+# ❌ Bad: new UUID on every call — no dedup across retries
+import uuid
+idempotency_key=str(uuid.uuid4())
+```
+</Accordion>
+<Accordion title="In-process dedup is best-effort">
+The LRU dedup guard holds at most 4096 keys per process. If your cron re-fires the same job on a different worker, the in-memory LRU won't catch it. For cross-worker dedup, use the reply-path `delivery.send(...)` outbox (see [Durable Delivery](/docs/features/durable-delivery)) or an external idempotency store keyed off the same `idempotency_key`.
 </Accordion>
 </AccordionGroup>
 

--- a/docs/features/proactive-delivery.mdx
+++ b/docs/features/proactive-delivery.mdx
@@ -141,54 +141,46 @@ Call `botos.delivery_router.refresh_directory()` periodically so adapters enumer
 
 ---
 
-## Rate Limiting & Idempotency
+## Rate Limiting
 
-Scheduled and background sends now share the reply-path rate limiter and dedup guard automatically — no config change required.
+Scheduled and background sends share the reply-path rate limiter automatically — no config change required.
 
 ```mermaid
 graph LR
     Agent[🤖 Agent] --> Msg[BotOutboundMessenger]
-    Msg --> Dup{🔍 is_duplicate_key?}
-    Dup -->|Hit| Skip[⏭ Skip envelope]
-    Dup -->|Miss| Rate{⚖️ Rate Limiter}
+    Msg --> Rate{⚖️ Rate Limiter}
     Rate --> Send[📤 Send text]
-    Send --> Media[📎 Send media]
-    Media --> Remember[💾 remember_key]
+    Send --> Done[✅ Delivered]
 
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
     classDef result fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef config fill:#F59E0B,stroke:#7C90A0,color:#fff
 
     class Agent agent
-    class Msg,Rate,Send,Media process
-    class Dup,Skip config
-    class Remember result
+    class Msg,Rate,Send process
+    class Done result
 ```
 
 | You call | What happens |
 |----------|--------------|
-| `botos.deliver("ops-alerts", "...")` with no `idempotency_key` | Rate-limited per platform. No dedup. |
-| `botos.deliver(..., idempotency_key="job-42")` | Rate-limited **and** dedup'd within this process (bounded LRU, 4096 keys). A retry with the same key returns success without re-sending. |
-| `botos.deliver(..., idempotency_key="job-42")` with attachments | Whole text + media envelope is deduped. Key is recorded only after both text and media succeed — a failed media upload leaves the key retryable. |
-| Adapter's `send_message()` returns `False` | Treated as a transient failure. Key not stored. Dead-target flag not tripped. Safe to retry. |
+| `botos.deliver("ops-alerts", "...")` | Rate-limited per platform via the shared reply-path rate limiter. |
+| `botos.deliver("ops-alerts", "...", origin=source)` | Rate-limited with origin context; used for targeted proactive replies. |
+| Adapter's `send_message()` returns `False` | Treated as a transient failure. Dead-target flag not tripped. Safe to retry. |
 
 ```python
-# Scheduled daily digest — safe to retry from cron on transient failure
+# Scheduled daily digest — proactive send to a named channel
 await botos.deliver(
     "ops-alerts",
     "Nightly digest ready",
-    idempotency_key=f"digest-{today.isoformat()}",
 )
 ```
 
 ```python
-# Notification with attachment — media won't double-upload on retry
+# Targeted proactive send with origin context
 await botos.deliver(
     "ops-alerts",
     "Build finished",
-    attachments=[BuildLog("/var/log/build.log")],
-    idempotency_key=f"build-{build_id}",
+    origin=source,
 )
 ```
 
@@ -209,20 +201,8 @@ Bare-platform targets fail without a configured home channel.
 <Accordion title="Handle the bool return">
 `deliver()` returns `False` on resolution or send failure — log and retry as needed.
 </Accordion>
-<Accordion title="Pick a stable idempotency_key for scheduled sends">
-Derive the key from the trigger — job ID, cron-timestamp, or inbound message ID. Never use `uuid.uuid4()` inside the retry loop; a new UUID on every call defeats deduplication.
-
-```python
-# ✅ Good: derived from a stable trigger
-idempotency_key=f"digest-{today.isoformat()}"
-
-# ❌ Bad: new UUID on every call — no dedup across retries
-import uuid
-idempotency_key=str(uuid.uuid4())
-```
-</Accordion>
-<Accordion title="In-process dedup is best-effort">
-The LRU dedup guard holds at most 4096 keys per process. If your cron re-fires the same job on a different worker, the in-memory LRU won't catch it. For cross-worker dedup, use the reply-path `delivery.send(...)` outbox (see [Durable Delivery](/docs/features/durable-delivery)) or an external idempotency store keyed off the same `idempotency_key`.
+<Accordion title="Use durable delivery for cross-worker dedup">
+`BotOS.deliver` rate-limits sends via the shared reply-path rate limiter, but does not support idempotency deduplication. For dedup across retries or workers, use the reply-path `delivery.send(...)` outbox (see [Durable Delivery](/docs/features/durable-delivery)).
 </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
Fixes #1459