### PR TITLE
docs: docs(features): new page — reusable command-prefix approval scopes (`reusable_scope`, `suggest_scope_pattern`, `arity`) — from PraisonAI PR #2576

### DIFF
--- a/docs/features/command-aware-permissions.mdx
+++ b/docs/features/command-aware-permissions.mdx
@@ -270,6 +270,8 @@ The command parser is lazy-imported: no parsing cost when permissions are not in
 
 ---
 
+Command-aware permissions decompose a compound command; [Reusable Approval Scopes](/docs/features/reusable-approval-scopes) generalise a single command's approval to a whole family.
+
 ## Related
 
 <CardGroup cols={2}>
@@ -287,6 +289,9 @@ The command parser is lazy-imported: no parsing cost when permissions are not in
 </Card>
 <Card title="Workspace Boundary" icon="shield-halved" href="/docs/features/workspace-boundary">
   Gate shell/file access outside a project root with <code>external_dir:*</code>
+</Card>
+<Card title="Reusable Approval Scopes" icon="recycle" href="/docs/features/reusable-approval-scopes">
+  Generalise one approval to cover a whole command family
 </Card>
 </CardGroup>
 

--- a/docs/features/durable-approvals.mdx
+++ b/docs/features/durable-approvals.mdx
@@ -96,6 +96,10 @@ sequenceDiagram
 
 Each `ApprovalRequest` carries a stable `approval_id` (UUID hex) used as the correlation key across restarts.
 
+<Note>
+Persisted approvals can be recorded as reusable command prefixes — see [Reusable Approval Scopes](/docs/features/reusable-approval-scopes) for the `reusable_scope=True` opt-in.
+</Note>
+
 ---
 
 ## ApprovalStore API

--- a/docs/features/permissions.mdx
+++ b/docs/features/permissions.mdx
@@ -271,7 +271,7 @@ manager.check("bash:cd /tmp && rm -rf x").is_denied  # True — rm in compound c
 Add high-priority deny rules for `bash:rm *`, `bash:sudo *`, and similar patterns before broader allow rules.
 </Accordion>
 <Accordion title="Use session scope for repeated tools">
-Approve with `scope="session"` so a tool call doesn't re-prompt every time in one run. For shell commands whose flags/args change (`git status -s` vs `git status .`), add `reusable_scope=True` so the approval covers the whole subcommand instead of just the literal string. See [Reusable command-prefix approvals](#reusable-command-prefix-approvals).
+Approve with `scope="session"` so a tool call doesn't re-prompt every time in one run. For shell commands whose flags/args change (`git status -s` vs `git status .`), add `reusable_scope=True` so the approval covers the whole subcommand instead of just the literal string. See [Reusable Approval Scopes](/docs/features/reusable-approval-scopes).
 </Accordion>
 <Accordion title="Set per-agent rules for teams">
 Use `agent_name` on rules when a coder agent may write but a reviewer agent must stay read-only.

--- a/docs/features/reusable-approval-scopes.mdx
+++ b/docs/features/reusable-approval-scopes.mdx
@@ -94,6 +94,28 @@ Pass `pattern=` to override the derived pattern with any string you prefer.
 
 </Step>
 
+<Step title="Persistence round-trip">
+
+```python
+import tempfile
+from praisonaiagents.permissions import PermissionManager
+
+with tempfile.TemporaryDirectory() as d:
+    mgr1 = PermissionManager(storage_dir=d)
+    mgr1.approve(
+        "bash:git log --oneline",
+        approved=True,
+        scope="always",
+        reusable_scope=True,
+    )
+
+    # Reload from disk
+    mgr2 = PermissionManager(storage_dir=d)
+    print(mgr2.check("bash:git log --oneline -5").is_allowed)  # True
+```
+
+</Step>
+
 </Steps>
 
 ---
@@ -212,6 +234,26 @@ approval = manager.check("bash:cd /tmp && rm x")
 print(approval.pattern)  # 'bash:cd /tmp && rm x'  — literal, not generalised
 ```
 
+**Preview and override before saving**
+
+```python
+from praisonaiagents.permissions import PermissionManager
+
+manager = PermissionManager()
+
+target = "bash:npm run build"
+preview = manager.suggest_scope_pattern(target)
+# preview = "bash:npm run *"
+
+# User narrows the scope — override with explicit pattern
+manager.approve(
+    target=target,
+    approved=True,
+    scope="session",
+    pattern="bash:npm run build",  # explicit override: stays literal
+)
+```
+
 ---
 
 ## Best Practices
@@ -232,6 +274,10 @@ A `cd /tmp && rm x` approval covers only that exact string. If you want to reuse
 
 <Accordion title="Non-shell targets stay literal">
 `read:`, `write:`, and `write_file:` patterns are never derived. Use explicit globs for those, e.g. `pattern="read:/tmp/*"`.
+</Accordion>
+
+<Accordion title="Not a replacement for deny rules">
+A `deny` rule on `bash:rm *` still wins. Reusable scopes only extend `allow` approvals — deny is enforced at the rule level. See [Command-Aware Permissions](/docs/features/command-aware-permissions).
 </Accordion>
 
 </AccordionGroup>

--- a/docs/features/reusable-approval-scopes.mdx
+++ b/docs/features/reusable-approval-scopes.mdx
@@ -23,27 +23,26 @@ manager.approve("bash:git status *", True, scope="always")
 ```mermaid
 graph LR
     subgraph "Reusable Approval Scope"
-        C[⌨️ git status -s] --> D{🧠 derive_pattern}
-        D --> P[📝 bash:git status *]
-        P --> S[💾 Persistent approval]
-        S --> M{🔍 Future call?}
-        M -->|git status| OK1[✅ Auto-allow bare]
-        M -->|git status --short| OK2[✅ Auto-allow variant]
-        M -->|git push| NEW[❓ New prompt]
+        A["🤖 Agent"] --> C["⚙️ approve reusable_scope=True"]
+        C --> D["🧩 derive_pattern"]
+        D --> P["💾 bash:git status *"]
+        P --> R{"Next call: bash:git status ."}
+        R --> OK["✅ Auto-allowed"]
     end
 
-    classDef input fill:#6366F1,stroke:#7C90A0,color:#fff
-    classDef process fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef config fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef derive fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef store fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef check fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef ok fill:#10B981,stroke:#7C90A0,color:#fff
-    classDef ask fill:#8B0000,stroke:#7C90A0,color:#fff
 
-    class C input
-    class D,P process
-    class S store
-    class M process
-    class OK1,OK2 ok
-    class NEW ask
+    class A agent
+    class C config
+    class D derive
+    class P store
+    class R check
+    class OK ok
 ```
 
 ## Quick Start
@@ -123,6 +122,16 @@ with tempfile.TemporaryDirectory() as d:
 ## How It Works
 
 When `reusable_scope=True` and `scope` is `"session"` or `"always"`, `PermissionManager.approve()` calls `suggest_scope_pattern()` internally. That delegates to `arity.derive_pattern()`, which looks up the command in a small arity table and builds a glob.
+
+| Situation | Behaviour |
+|-----------|-----------|
+| Bare command (`bash:git`) | Kept literal — approving `git` alone never auto-approves `git push`. |
+| Compound command (`bash:cd /tmp && rm x`) | Kept literal — second op never swallowed into the reusable scope. |
+| Pipe / redirect / substitution (&#124;, `>`, `$(...)`) | Kept literal. |
+| Non-shell target (`read:`, `write:`, `edit:`, …) | Unchanged — only `bash:`/`shell:` are generalised. |
+| Already-globbed target (`bash:git *`) | Unchanged. |
+| `scope="once"` | Always literal, even with `reusable_scope=True`. |
+| User-authored `bash:rm *` glob | Keeps exact `fnmatch` semantics — a bare `bash:rm` still does **not** match. |
 
 ```mermaid
 sequenceDiagram

--- a/docs/features/reusable-approval-scopes.mdx
+++ b/docs/features/reusable-approval-scopes.mdx
@@ -334,7 +334,7 @@ Exception-safe wrapper around `arity.derive_pattern`. Returns the derived glob p
   <Card title="Permissions" icon="shield" href="/docs/features/permissions">
     Full `PermissionManager` Python SDK reference
   </Card>
-  <Card title="Workspace Boundary" icon="folder-lock" href="/docs/features/workspace">
-    Restrict agent file access to the project directory
+  <Card title="Command-Aware Permissions" icon="shield-halved" href="/docs/features/command-aware-permissions">
+    How compound shell commands are evaluated
   </Card>
 </CardGroup>


### PR DESCRIPTION
Fixes #1448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for reusable approval scopes with clearer examples, diagrams, and a quick start for saving and reloading approvals.
  * Added details on how approval scopes are derived in different command scenarios, plus how to preview or override a scope before saving.
  * Updated related feature links across permissions docs for easier navigation.
  * Clarified that reusable scopes do not override deny rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->