### PR TITLE
Allow nav-only docs.json auto-merge; fix FINAL cooldown loop

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -88,6 +88,43 @@ assert('ci-only label not exempt mixed changes', mg.sensitivePathReasons(
 ).length === 1);
 assert('secret in patch', mg.secretScanReasons([{ filename: 'x.py', patch: '+key = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"' }]).length === 1);
 
+// Nav-only docs.json exempt from manual-review sensitive path
+const navOnlyPatch = [
+  '--- a/docs.json',
+  '+++ b/docs.json',
+  '@@ -10,6 +10,7 @@',
+  '     "pages": [',
+  '+      "docs/features/new-page",',
+  '     ]',
+].join('\n');
+assert('nav-only docs.json not sensitive', mg.sensitivePathReasons([{ filename: 'docs.json', patch: navOnlyPatch }]).length === 0);
+const themePatch = navOnlyPatch.replace('+      "docs/features/new-page",', '+  "theme": "dark",');
+assert('docs.json theme change still sensitive', mg.sensitivePathReasons([{ filename: 'docs.json', patch: themePatch }]).length === 1);
+
+// Stale-FINAL recovery guards (PraisonAI #2334 parity)
+const finalAt = '2026-07-03T10:00:00Z';
+const pushSoonAfter = '2026-07-03T10:05:00Z';
+const staleComments = [
+  { user: { login: 'MervinPraison' }, body: '@claude FINAL architecture reviewer', created_at: finalAt },
+  { user: { login: 'praisonai-triage-agent[bot]' }, body: 'Claude finished', created_at: '2026-07-03T10:04:00Z' },
+];
+assert(
+  'skip stale recovery when push soon after FINAL',
+  mg.shouldSkipStaleFinalRecovery(staleComments, pushSoonAfter, 'praisonai-triage-agent[bot]').skip
+);
+assert(
+  'automation pusher skips stale recovery',
+  mg.shouldSkipStaleFinalRecovery(staleComments, pushSoonAfter, 'praisonai-triage-agent[bot]').skip
+);
+assert('isClaudeAutomationLogin triage bot', mg.isClaudeAutomationLogin('praisonai-triage-agent[bot]'));
+
+// Cooldown: FINAL current on HEAD should not block merge gate
+const finalCompleteComments = [
+  { user: { login: 'MervinPraison' }, body: '@claude FINAL architecture reviewer', created_at: '2026-07-03T10:00:00Z' },
+];
+assert('final complete on head when not stale', mg.finalClaudeCompletedOnSha(finalCompleteComments, '2026-07-03T10:00:30Z'));
+assert('final not complete when head after final without re-trigger', !mg.finalClaudeCompletedOnSha(finalCompleteComments, '2026-07-03T10:07:00Z'));
+
 // Claude run scoping — other PR branches must not block
 assert('other branch claude does not block', !mg.hasBlockingClaudeRunForPr(
   [{ event: 'issue_comment', head_branch: 'other-branch' }],

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -7,6 +7,9 @@ const CLAUDE_TRIGGER_LOGINS = ['MervinPraison', 'github-actions[bot]'];
 const AUTO_ACTORS = CLAUDE_TRIGGER_LOGINS;
 const CONFLICT_COOLDOWN_MS = 12 * 60 * 60 * 1000;
 const CLAUDE_ACTIVE_MS = 35 * 60 * 1000;
+const STALE_FINAL_RECOVERY_WINDOW_MS = 60 * 60 * 1000;
+const STALE_FINAL_MAX_PER_WINDOW = 2;
+const PUSH_AFTER_FINAL_DEBOUNCE_MS = 15 * 60 * 1000;
 const ALLOWED_MERGE_STATES = new Set(['CLEAN', 'UNSTABLE']);
 const BLOAT_FILE_MAX_AUTO_LINES = 100;
 const PR_MAX_AUTO_ADDITIONS = 800;
@@ -23,6 +26,7 @@ const SENSITIVE_PATH_PATTERNS = [
   /\.env(\.|$)/,
   /credentials\.json$/i,
 ];
+const DOCS_JSON_CONFIG_KEYS = /"(theme|colors|favicon|name|icons|contextual|redirects|seo|integrations|navbar|footer|\$schema|analytics|topbar|search|logo)"/;
 const REQUIRED_SDK_CHECK_PATTERNS = [];
 const SECRET_PATTERNS = [
   /sk-[a-zA-Z0-9]{20,}/,
@@ -198,6 +202,71 @@ function shouldSkipFinalRecovery(comments, headPushedAt) {
   const isStale = isStaleFinalAfterPush(comments, headPushedAt);
   if (isStale) return false;
   return hasRecentClaudeTrigger(comments, 35);
+}
+
+function countFinalTriggersSince(comments, sinceMs) {
+  return comments.filter(
+    (c) => isFinalClaudeTriggerComment(c) && new Date(c.created_at).getTime() > sinceMs
+  ).length;
+}
+
+function isClaudeAutomationLogin(login) {
+  const lower = (login || '').toLowerCase();
+  return lower.includes('praisonai-triage') || lower === 'github-actions[bot]';
+}
+
+function isPushSoonAfterLatestFinal(comments, headPushedAt) {
+  if (!headPushedAt) return false;
+  const finals = comments.filter(isFinalClaudeTriggerComment);
+  if (finals.length === 0) return false;
+  const latestFinal = finals.reduce((a, b) =>
+    new Date(a.created_at) > new Date(b.created_at) ? a : b
+  );
+  const finalTime = new Date(latestFinal.created_at).getTime();
+  const headTime = new Date(headPushedAt).getTime();
+  if (headTime <= finalTime) return false;
+  return headTime - finalTime < PUSH_AFTER_FINAL_DEBOUNCE_MS;
+}
+
+/** Returns { skip: true, reason } when stale-FINAL recovery should not post. */
+function shouldSkipStaleFinalRecovery(comments, headPushedAt, headPusherLogin = null) {
+  if (!isStaleFinalAfterPush(comments, headPushedAt)) {
+    return { skip: true, reason: 'not stale' };
+  }
+  if (headPusherLogin && isClaudeAutomationLogin(headPusherLogin)) {
+    return { skip: true, reason: 'head pushed by Claude automation' };
+  }
+  if (isPushSoonAfterLatestFinal(comments, headPushedAt)) {
+    return {
+      skip: true,
+      reason: 'head pushed soon after FINAL (wait for CI / batched fixes)',
+    };
+  }
+  const windowStart = Date.now() - STALE_FINAL_RECOVERY_WINDOW_MS;
+  const finalsInWindow = countFinalTriggersSince(comments, windowStart);
+  if (finalsInWindow >= STALE_FINAL_MAX_PER_WINDOW) {
+    return {
+      skip: true,
+      reason: `stale-FINAL capped (${finalsInWindow} FINAL triggers in last hour)`,
+    };
+  }
+  return { skip: false, reason: '' };
+}
+
+function isNavOnlyDocsJsonPatch(patch) {
+  if (!patch) return false;
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('@@') || line.startsWith('+++') || line.startsWith('---')) continue;
+    if (!line.startsWith('+') && !line.startsWith('-')) continue;
+    if (DOCS_JSON_CONFIG_KEYS.test(line)) return false;
+    const content = line.slice(1).trim();
+    if (!content) continue;
+    if (line.startsWith('-')) {
+      if (/^"docs\//.test(content) || /"(group|tab|pages|icon)"/.test(content)) return false;
+      if (!/^[\]},]?$/.test(content)) return false;
+    }
+  }
+  return true;
 }
 
 function finalClaudeCompletedOnSha(comments, headPushedAt) {
@@ -501,6 +570,7 @@ function sensitivePathReasons(files, labels = []) {
   }
   const reasons = [];
   for (const f of files) {
+    if (f.filename === 'docs.json' && isNavOnlyDocsJsonPatch(f.patch)) continue;
     if (SENSITIVE_PATH_PATTERNS.some((p) => p.test(f.filename))) {
       reasons.push(`sensitive path: ${f.filename}`);
       break;
@@ -685,7 +755,8 @@ async function evaluatePipelineQuiescent(github, owner, repo, prNumber, core, op
   }
   if (!skipRecentClaudeCooldown && hasRecentClaudeTrigger(ctx.comments, 35)) {
     const verdictOnHead = findMergeGateVerdict(ctx.comments, null, ctx.headPushedAt) !== null;
-    if (!verdictOnHead) reasons.push('recent @claude within 35min');
+    const finalCurrent = finalClaudeCompletedOnSha(ctx.comments, ctx.headPushedAt);
+    if (!verdictOnHead && !finalCurrent) reasons.push('recent @claude within 35min');
   }
 
   if (!skipGlobalClaudeRunCheck && (await hasInProgressClaudeAssistant(github, owner, repo, prNumber))) {
@@ -808,6 +879,7 @@ module.exports = {
   touchesSdk,
   hasManualOnlyLabel,
   sensitivePathReasons,
+  isNavOnlyDocsJsonPatch,
   prSizeReasons,
   missingTestsReason,
   secretScanReasons,
@@ -817,6 +889,9 @@ module.exports = {
   isStaleFinalAfterPush,
   needsStaleFinalRecovery,
   shouldSkipFinalRecovery,
+  shouldSkipStaleFinalRecovery,
+  isClaudeAutomationLogin,
+  isPushSoonAfterLatestFinal,
   FINAL_CLAUDE_REVIEW_BODY,
   loadPrContext,
   evaluatePipelineQuiescent,

--- a/.github/workflows/auto-pr-comment.yml
+++ b/.github/workflows/auto-pr-comment.yml
@@ -135,9 +135,37 @@ jobs:
             const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
             const comments = await mergeGate.listAllComments(github, owner, repo, prNumber);
             const headPushedAt = (await mergeGate.getHeadCommitDate(github, owner, repo, prNumber)) || pr.updated_at;
+            const headPusher = context.payload.sender?.login || null;
             const hasFinal = mergeGate.hasFinalClaudeReviewTrigger(comments);
             const isStale = mergeGate.isStaleFinalAfterPush(comments, headPushedAt);
-            if (!hasFinal || isStale) {
+
+            if (mergeGate.shouldSkipFinalRecovery(comments, headPushedAt)) {
+              core.info('Recent @claude within 35min and FINAL not stale — skip recovery');
+              await ps.ensurePipelineLabels(github, owner, repo, core);
+              await ps.syncPipelineLabels(github, owner, repo, prNumber, core);
+              return;
+            }
+            if (await mergeGate.hasInProgressClaudeAssistant(github, owner, repo, prNumber)) {
+              core.info('Claude workflow in progress — skip recovery');
+              await ps.ensurePipelineLabels(github, owner, repo, core);
+              await ps.syncPipelineLabels(github, owner, repo, prNumber, core);
+              return;
+            }
+
+            if (hasFinal && isStale) {
+              const gate = mergeGate.shouldSkipStaleFinalRecovery(comments, headPushedAt, headPusher);
+              if (gate.skip) {
+                core.info(`Skip stale-FINAL recovery: ${gate.reason}`);
+                await ps.ensurePipelineLabels(github, owner, repo, core);
+                await ps.syncPipelineLabels(github, owner, repo, prNumber, core);
+                return;
+              }
+              await chain.maybeTriggerClaudeFinal(
+                github, owner, repo, prNumber,
+                mergeGate.FINAL_CLAUDE_REVIEW_BODY, core,
+                { skipCopilot: true, optionalWaitMs: 0, prCreatedAt: pr.created_at }
+              );
+            } else if (!hasFinal) {
               await chain.maybeTriggerClaudeFinal(
                 github, owner, repo, prNumber,
                 mergeGate.FINAL_CLAUDE_REVIEW_BODY, core,
@@ -193,6 +221,13 @@ jobs:
               if (hasFinal && !isStale) continue;
               if (mergeGate.hasRecentClaudeTrigger(comments, 10)) continue;
               if (await mergeGate.hasInProgressClaudeAssistant(github, owner, repo, pr.number)) continue;
+              if (hasFinal && isStale) {
+                const gate = mergeGate.shouldSkipStaleFinalRecovery(comments, headPushedAt);
+                if (gate.skip) {
+                  core.info(`PR #${pr.number}: skip stale — ${gate.reason}`);
+                  continue;
+                }
+              }
               const result = await chain.maybeTriggerClaudeFinal(
                 github, owner, repo, pr.number,
                 mergeGate.FINAL_CLAUDE_REVIEW_BODY, core,

--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -280,7 +280,7 @@ jobs:
             2. Read all PR comments and reviews (FINAL documentation reviewer / Lead Engineer must have run).
             3. Confirm documentation value: accurate, beginner-friendly, SDK-verified, Mintlify-compliant.
             4. New pages must be in `docs/features/` — block if `docs/concepts/` changed without approval.
-            5. BLOCK if labels security/breaking-change/needs-manual-review/release, sensitive paths (`mint.json`, `docs.json`, `.github/workflows/`), secrets in diff, or PR >800 lines or >30 files. Label `merge-gate-ci-only` exempts CI-only changes under `.github/workflows/`, `.github/actions/`, or merge-gate scripts.
+            5. BLOCK if labels security/breaking-change/needs-manual-review/release, sensitive paths (`.github/workflows/`, `mint.json`, non-nav-only `docs.json` edits), secrets in diff, or PR >800 lines or >30 files. Nav-only `docs.json` changes (adding pages/groups only) are allowed. Label `merge-gate-ci-only` exempts CI-only changes under `.github/workflows/`, `.github/actions/`, or merge-gate scripts.
             6. Confirm no CHANGES_REQUESTED reviews and any CI checks green on HEAD ${{ matrix.head_sha }} (docs-only PRs with no checks are OK).
             7. If ready to merge: MERGE_GATE_VERDICT: APPROVE. Otherwise: MERGE_GATE_VERDICT: BLOCK with reasons.
 


### PR DESCRIPTION
## Summary
- **Nav-only docs.json**: PRs that only add navigation entries (pages/groups) are no longer blocked as sensitive paths; theme/colours/name and nav deletions still require manual review.
- **Cooldown loop (#2334 parity)**: Port stale-FINAL guards — 15min push-after-FINAL debounce, 2 FINAL/hour cap, skip when Claude automation pushes HEAD, and skip merge-gate cooldown when FINAL is current on HEAD.
- **auto-pr-comment.yml**: claude-final-on-sync and scheduled recovery use shouldSkipStaleFinalRecovery instead of blindly re-posting FINAL.

## Test plan
- [x] node .github/scripts/merge-gate-selftest.js passes (36 tests)
- [ ] After merge: ~17 open bot PRs with nav-only docs.json should lose pipeline/blocked:manual-review once CI/FINAL are green
- [ ] Push after Claude fix should not double-post FINAL within 15min