### PR TITLE
docs: praisonai-bot package migration guide and four-tier stack

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -136,6 +136,7 @@
               "docs/guides/index",
               "docs/guides/documentation-style-guide",
               "docs/guides/praisonai-code-migration",
+              "docs/guides/praisonai-bot-migration",
               "docs/guides/single-agent",
               "docs/guides/multi-agent",
               {

--- a/docs/developers/wrapper.mdx
+++ b/docs/developers/wrapper.mdx
@@ -276,15 +276,83 @@ If you want PraisonAI to leave your application's logging untouched, just don't 
 
 ---
 
-## C8 Architecture: Wrapper–Code Boundary (Developer Reference)
+## C9 Architecture: Four-Tier Package Model (Developer Reference)
 
 <Note>
-This section covers the internal three-tier package architecture. It is relevant to contributors and maintainers, not end-users.
+This section covers the internal four-tier package architecture introduced in C9 (PR #2633). It is relevant to contributors and maintainers, not end-users.
 </Note>
 
-### Three-Tier Model
+### Sibling: praisonai-bot
 
-PraisonAI uses a strict three-tier package model with a one-way dependency rule:
+As of C9 (merged 2026-07-03), bots, gateway, and channel CLI live in a new sibling PyPI package **`praisonai-bot`** (module `praisonai_bot`). The `praisonai.bots`, `praisonai.gateway`, and `praisonai.daemon` paths remain as `alias_package` shims and are the stable public API.
+
+<CardGroup cols={2}>
+<Card title="praisonai-bot Migration Guide" icon="package" href="/docs/guides/praisonai-bot-migration">
+  Install options, CLI reference, backward-compat guarantees, and channel extension guide
+</Card>
+<Card title="Built-in Channels" icon="robot" href="/docs/features/messaging-bots">
+  Telegram, Discord, Slack, WhatsApp, Linear, Email, AgentMail
+</Card>
+</CardGroup>
+
+### Four-Tier Model
+
+PraisonAI uses a strict four-tier package model with a one-way dependency rule:
+
+```mermaid
+graph TB
+    subgraph tier1 ["Tier 1 — praisonaiagents (Core SDK)"]
+        PROTO[Protocols / Hooks / Base Classes]
+        CLI_PROTO[cli/protocols.py]
+    end
+
+    subgraph tier2a ["Tier 2 — praisonai-code (Terminal CLI)"]
+        RUN[run / chat / code / serve]
+        BRIDGE[_wrapper_bridge.py]
+    end
+
+    subgraph tier2b ["Tier 2 — praisonai-bot (Bots / Gateway)"]
+        BOTS[bots / gateway / daemon / claw]
+        WBRIDGE[_wrapper_bridge.py]
+    end
+
+    subgraph tier3 ["Tier 3 — praisonai (Wrapper)"]
+        CMDS[Repatriated Commands]
+        FEATS[Repatriated Features]
+        ADAPT[adapters/]
+        SHIMS[alias_package shims for bots/gateway/daemon]
+    end
+
+    PROTO --> RUN
+    PROTO --> BOTS
+    CLI_PROTO --> ADAPT
+    RUN -.->|"lazy bridge only — no PyPI dep"| CMDS
+    BRIDGE -.-> CMDS
+    BRIDGE -.-> FEATS
+    WBRIDGE -.->|"lazy bridge only — no PyPI dep"| CMDS
+
+    classDef core fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef code fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef wrapper fill:#4a5568,stroke:#7C90A0,color:#fff
+    classDef shim fill:#F59E0B,stroke:#7C90A0,color:#fff
+
+    class PROTO,CLI_PROTO core
+    class RUN,BRIDGE,BOTS,WBRIDGE code
+    class CMDS,FEATS,ADAPT wrapper
+    class SHIMS shim
+```
+
+**Invariant:** Both `praisonai-code` and `praisonai-bot` declare **no** PyPI dependency on `praisonai`. All cross-tier access goes through `_wrapper_bridge` only.
+
+### C8 Architecture: Wrapper–Code Boundary (Historical Reference)
+
+<Note>
+The following section documents the C8 three-tier model that preceded C9. The three-tier diagram and metrics are preserved for historical reference.
+</Note>
+
+#### Three-Tier Model (pre-C9 / C8)
+
+Before C9, PraisonAI used a three-tier package model:
 
 ```mermaid
 graph TB
@@ -391,7 +459,7 @@ The `praisonai.adapters` module lazily re-exports existing adapter classes (`Aut
 - `praisonai-code/cli/legacy/prompt_dispatch.py` — standalone-safe helpers.
 - `main.py` still contains the `PraisonAI` class body; wrapper access is normalised via the bridge. The physical 7k-line split is **deferred** (out of scope of C8).
 
-### Developer Tooling
+#### Developer Tooling (C8)
 
 | Script | Purpose |
 |--------|---------|
@@ -399,7 +467,7 @@ The `praisonai.adapters` module lazily re-exports existing adapter classes (`Aut
 | `scripts/c8_bridge_convert.py` | Converts direct `from praisonai …` imports to `_wrapper_bridge` calls |
 | `scripts/c8_repatriate.py` | Moves a command/feature implementation from `praisonai-code` → `praisonai` |
 
-### Deferred Work
+#### Deferred Work (C8)
 
 The physical extraction of the `PraisonAI` class (~7k lines in `main.py`) to `praisonai/cli/legacy/praison_class.py` was explicitly deferred from C8. The `docs/concepts/architecture.mdx` page (HUMAN-ONLY) also needs a maintainer update to reflect the C8 metrics.
 

--- a/docs/features/bot-command-access-control.mdx
+++ b/docs/features/bot-command-access-control.mdx
@@ -5,6 +5,11 @@ description: "Restrict who can run which bot commands with admin users and per-u
 icon: "shield-keyhole"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 from praisonaiagents.bots import BotConfig

--- a/docs/features/bot-commands.mdx
+++ b/docs/features/bot-commands.mdx
@@ -5,6 +5,11 @@ description: "Built-in chat commands — status, model switching, usage, context
 icon: "terminal"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/bot-default-tools.mdx
+++ b/docs/features/bot-default-tools.mdx
@@ -5,6 +5,11 @@ description: "The 20+ tools every bot gets automatically"
 icon: "toolbox"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Bot default tools provide instant superpowers to every bot deployment, automatically injecting 20+ safe and useful tools when agents have no explicit tool configuration.
 
 ```python

--- a/docs/features/bot-gateway.mdx
+++ b/docs/features/bot-gateway.mdx
@@ -5,6 +5,11 @@ description: "Run multiple bots (Telegram, Discord, Slack) from a single gateway
 icon: "server"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/bot-inbound-media.mdx
+++ b/docs/features/bot-inbound-media.mdx
@@ -5,6 +5,11 @@ description: "Forward user photos and documents to your agent's vision capabilit
 icon: "image"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Bot adapters forward inbound photos and documents to your agent's vision capability — validated, size-capped, and SSRF-safe.
 
 ```python

--- a/docs/features/bot-intentional-silence.mdx
+++ b/docs/features/bot-intentional-silence.mdx
@@ -5,6 +5,11 @@ description: "Let agents stay silent in group chats by returning NO_REPLY"
 icon: "volume-xmark"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 With `allow_silence: true`, an agent can return `NO_REPLY` (or a custom token) to send nothing — no message, no typing indicator, no error.
 
 ```python

--- a/docs/features/bot-lifecycle-hooks.mdx
+++ b/docs/features/bot-lifecycle-hooks.mdx
@@ -5,6 +5,11 @@ description: "Observe and control your messaging bot's gateway, session, and sch
 icon: "webhook"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Bot lifecycle hooks let you watch your bot start and stop, see every user session begin and end, and react when scheduled jobs fire — without changing your agent code.
 
 ```python

--- a/docs/features/bot-pairing.mdx
+++ b/docs/features/bot-pairing.mdx
@@ -5,6 +5,11 @@ description: "Secure unknown user onboarding with CLI-approved pairing codes"
 icon: "handshake"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Bot pairing lets unknown users self-request access to your bot with secure 8-character codes that you approve from the CLI.
 
 ```python

--- a/docs/features/bot-platform-capabilities.mdx
+++ b/docs/features/bot-platform-capabilities.mdx
@@ -5,6 +5,11 @@ description: "Declare what a messaging platform can do — Praison uses it for u
 icon: "sliders"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Platform capabilities tell PraisonAI what your bot's platform can do, so streaming, chunking, and rate limiting work the same way everywhere.
 
 ```python

--- a/docs/features/bot-platform-plugins.mdx
+++ b/docs/features/bot-platform-plugins.mdx
@@ -5,6 +5,11 @@ description: "Add custom messaging-platform bots to PraisonAI via Python entry p
 icon: "puzzle-piece"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/bot-presentations.mdx
+++ b/docs/features/bot-presentations.mdx
@@ -5,6 +5,11 @@ description: "Reply with buttons, dropdowns, and approval prompts that render as
 icon: "display"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Agents can reply with structured interactive messages — buttons, dropdowns, dividers, context text — and each channel adapter renders them as native widgets.
 
 ```python

--- a/docs/features/bot-rate-limiting.mdx
+++ b/docs/features/bot-rate-limiting.mdx
@@ -5,6 +5,11 @@ description: "Throttle outbound bot messages to messaging platforms like Telegra
 icon: "gauge"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent, BotConfig
 

--- a/docs/features/bot-routing.mdx
+++ b/docs/features/bot-routing.mdx
@@ -5,6 +5,11 @@ description: "Route messages from different chat contexts (DMs, groups, channels
 icon: "route"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/bot-run-control.mdx
+++ b/docs/features/bot-run-control.mdx
@@ -5,6 +5,11 @@ description: "Responsive UX for bots during long-running agent tasks — busy ac
 icon: "octagon-pause"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Bot run control provides responsive feedback during long-running agent tasks, eliminating silent blocking where follow-up messages queue invisibly.
 
 ```python

--- a/docs/features/bot-session-compaction.mdx
+++ b/docs/features/bot-session-compaction.mdx
@@ -5,6 +5,11 @@ description: "Summarise older turns in long-lived bot sessions instead of droppi
 icon: "compress"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Long-lived bot conversations get a compact summary of older turns instead of having them silently dropped.
 
 ```python

--- a/docs/features/bot-session-reset.mdx
+++ b/docs/features/bot-session-reset.mdx
@@ -5,6 +5,11 @@ description: "Automatically reset bot sessions based on idle time or daily sched
 icon: "rotate"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent, BotConfig
 

--- a/docs/features/bot-status-reactions.mdx
+++ b/docs/features/bot-status-reactions.mdx
@@ -5,6 +5,11 @@ description: "Show agent run progress as an emoji reaction on the user's message
 icon: "face-smile"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Status reactions update an emoji on the user's message to reflect run state — queued, thinking, tool execution, done, or error — at a glance without reading reply text.
 
 ```python

--- a/docs/features/bot-streaming-replies.mdx
+++ b/docs/features/bot-streaming-replies.mdx
@@ -5,6 +5,11 @@ description: "Show live draft replies on Telegram/Discord/Slack as your agent th
 icon: "message-pen"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Channel bots can post a quick placeholder message and progressively edit it in place as the agent's answer streams in — replacing the old "stare at a typing indicator for 45s, then a wall of text lands in one burst" experience.
 
 ```python

--- a/docs/features/bot-typing-indicators.mdx
+++ b/docs/features/bot-typing-indicators.mdx
@@ -5,6 +5,11 @@ description: "Show a typing indicator while the agent is working, with keepalive
 icon: "keyboard"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Typing indicators tell users the bot is working — with automatic keepalive resends, a circuit breaker on failures, and a safety TTL so a stuck indicator never hangs forever.
 
 ```python

--- a/docs/features/bot-unknown-user-pairing.mdx
+++ b/docs/features/bot-unknown-user-pairing.mdx
@@ -5,6 +5,11 @@ description: "Owner-DM inline-button approval for unknown users on Telegram, Dis
 icon: "user-check"
 ---
 
+<Note>
+Bot platform adapters now ship in the `praisonai-bot` package. `praisonai bot serve` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Bot pairing enables owner-approval for unknown users with inline Approve/Deny buttons sent directly to your DM.
 
 ```python

--- a/docs/features/gateway-admission-control.mdx
+++ b/docs/features/gateway-admission-control.mdx
@@ -4,6 +4,11 @@ sidebarTitle: "Admission Control"
 description: "Bound the number of concurrent inbound agent runs with a fair queue and explicit overflow policy"
 icon: "shield-check"
 ---
+
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
 <Note>
 For the composed one-switch experience, see [Reliability Preset](/docs/features/gateway-reliability). This page documents the admission-control knob in isolation.
 </Note>

--- a/docs/features/gateway-agent-defaults.mdx
+++ b/docs/features/gateway-agent-defaults.mdx
@@ -5,6 +5,11 @@ description: "Chat-optimised defaults for YAML agents behind the gateway"
 icon: "gauge-high"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-bind-aware-auth.mdx
+++ b/docs/features/gateway-bind-aware-auth.mdx
@@ -5,6 +5,11 @@ description: "Gateway and UI automatically enforce stricter auth when bound to e
 icon: "shield"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 The gateway and chat UI change security behaviour based on the interface they bind to — permissive on loopback, strict on external.
 
 ```python

--- a/docs/features/gateway-channel-supervision.mdx
+++ b/docs/features/gateway-channel-supervision.mdx
@@ -5,6 +5,11 @@ description: "Self-healing gateway channels with operator pause/resume/reconnect
 icon: "heart-pulse"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-cli.mdx
+++ b/docs/features/gateway-cli.mdx
@@ -5,6 +5,11 @@ description: "Command-line interface for managing the PraisonAI Gateway daemon a
 icon: "tower-broadcast"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-client.mdx
+++ b/docs/features/gateway-client.mdx
@@ -5,6 +5,11 @@ description: "Reconnecting WebSocket client with protocol negotiation, exponenti
 icon: "plug"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-code-skew-guard.mdx
+++ b/docs/features/gateway-code-skew-guard.mdx
@@ -4,6 +4,11 @@ sidebarTitle: "Code-Skew Guard"
 description: "Detect in-place updates (git pull, pip install -U) and refuse hot operations with a clear restart message instead of a cryptic ImportError"
 icon: "fingerprint"
 ---
+
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
 After an in-place update — `git pull`, `pip install -U`, or auto-update on a durable volume — a `/model` switch previously crashed with a cryptic `ImportError` from a lazy import loaded after startup. The code-skew guard detects the mismatch and refuses the operation with a clear message.
 
 ```python

--- a/docs/features/gateway-config-migration.mdx
+++ b/docs/features/gateway-config-migration.mdx
@@ -5,6 +5,11 @@ description: "Upgrade legacy bot.yaml and platforms: configs to the canonical sc
 icon: "arrows-rotate"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-config-reload.mdx
+++ b/docs/features/gateway-config-reload.mdx
@@ -4,6 +4,11 @@ sidebarTitle: "Config Reload"
 description: "Hot-reload gateway.yaml without dropping in-flight turns — SIGHUP, watchdog, drain-coordinated restart"
 icon: "arrows-rotate"
 ---
+
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
 Edit `gateway.yaml` and save — the running gateway diffs it and restarts only what changed, in-flight turns included.
 
 ```python

--- a/docs/features/gateway-drain-trigger.mdx
+++ b/docs/features/gateway-drain-trigger.mdx
@@ -5,6 +5,11 @@ description: "Port-less, restart-safe external drain signal for hosted / contain
 icon: "power-off"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-error-handling.mdx
+++ b/docs/features/gateway-error-handling.mdx
@@ -5,6 +5,11 @@ description: "Unicode-safe error handling for Gateway bot replies with root-caus
 icon: "shield-check"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Gateway error handling automatically sanitises exception text to prevent encoding crashes while preserving meaningful error information for users.
 
 ```python

--- a/docs/features/gateway-exit-codes.mdx
+++ b/docs/features/gateway-exit-codes.mdx
@@ -4,6 +4,11 @@ sidebarTitle: "Gateway Exit Codes"
 description: "Restart-intent exit codes that let systemd, Kubernetes, and s6 distinguish a recoverable blip from a fatal misconfiguration"
 icon: "circle-stop"
 ---
+
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
 `praisonai serve gateway` exits with a specific code to tell your supervisor whether to restart or stop — a misconfigured gateway should not crash-loop forever.
 
 ```python

--- a/docs/features/gateway-flow-control.mdx
+++ b/docs/features/gateway-flow-control.mdx
@@ -5,6 +5,11 @@ description: "Bounded inboxes and slow-consumer disconnect keep one misbehaving 
 icon: "gauge-high"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Flow control bounds per-session inboxes and disconnects slow consumers so a single misbehaving client can't degrade the whole gateway.
 
 ```python

--- a/docs/features/gateway-forensics.mdx
+++ b/docs/features/gateway-forensics.mdx
@@ -4,6 +4,11 @@ sidebarTitle: "Crash Forensics"
 description: "Capture why a gateway died — OOM, supervisor SIGKILL, or parent death — without blocking shutdown"
 icon: "triangle-exclamation"
 ---
+
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
 When the gateway dies unexpectedly, forensics writes one log line and one diagnostic file so the next boot can tell you *why*.
 
 ```python

--- a/docs/features/gateway-graceful-drain.mdx
+++ b/docs/features/gateway-graceful-drain.mdx
@@ -6,6 +6,11 @@ icon: "circle-stop"
 ---
 
 <Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
+<Note>
 For the composed one-switch experience, see [Reliability Preset](/docs/features/gateway-reliability). This page documents the drain-only knob.
 </Note>
 

--- a/docs/features/gateway-handshake-protocol.mdx
+++ b/docs/features/gateway-handshake-protocol.mdx
@@ -5,6 +5,11 @@ description: "Versioned WebSocket handshake with capability negotiation and stru
 icon: "handshake"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-hooks.mdx
+++ b/docs/features/gateway-hooks.mdx
@@ -5,6 +5,11 @@ description: "Trigger agents from external services via authenticated POST /hook
 icon: "webhook"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Inbound hooks expose a `POST /hooks/<path>` endpoint on the gateway — point any external service (GitHub Actions, Linear, Gmail push, Sentry alerts) at it and the gateway runs an agent and delivers the reply to a configured channel.
 
 ```python

--- a/docs/features/gateway-hot-reload.mdx
+++ b/docs/features/gateway-hot-reload.mdx
@@ -5,6 +5,11 @@ description: "Edit gateway.yaml live — restart only what changed"
 icon: "rotate"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-inbound-hooks.mdx
+++ b/docs/features/gateway-inbound-hooks.mdx
@@ -4,6 +4,11 @@ sidebarTitle: "Inbound Hooks"
 description: "Trigger agent runs from external HTTP events with POST /hooks/<path>"
 icon: "webhook"
 ---
+
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
 Trigger an agent run from any external HTTP event — Gmail, GitHub, Stripe, CI, forms, IoT — by POSTing JSON to `/hooks/<path>`.
 
 ```python

--- a/docs/features/gateway-metrics.mdx
+++ b/docs/features/gateway-metrics.mdx
@@ -5,6 +5,11 @@ description: "Prometheus-format message-flow metrics from the PraisonAI gateway"
 icon: "chart-line"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Scrape `GET /metrics` on the PraisonAI gateway to feed Prometheus — counters and gauges for every hop of the message flow, zero new dependencies.
 
 ```python

--- a/docs/features/gateway-operator-scopes.mdx
+++ b/docs/features/gateway-operator-scopes.mdx
@@ -5,6 +5,11 @@ description: "Least-privilege role-based access control for multi-operator Gatew
 icon: "shield-check"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Operator scopes grant teammates least-privilege access to a shared Gateway — read-only dashboards, send-but-not-approve operators, or full admins — without handing over the whole keys.
 
 ```python

--- a/docs/features/gateway-overview.mdx
+++ b/docs/features/gateway-overview.mdx
@@ -5,6 +5,11 @@ description: "WebSocket gateway for multi-channel agent coordination and communi
 icon: "broadcast-tower"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-rate-limit-policy.mdx
+++ b/docs/features/gateway-rate-limit-policy.mdx
@@ -5,6 +5,11 @@ description: "Inject a custom rate limiter into the core gateway via RateLimitPo
 icon: "gauge"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-rate-limit.mdx
+++ b/docs/features/gateway-rate-limit.mdx
@@ -5,6 +5,11 @@ description: "Bound inbound turns per identity/scope with a config-driven slidin
 icon: "gauge-high"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-rate-limiting.mdx
+++ b/docs/features/gateway-rate-limiting.mdx
@@ -5,6 +5,11 @@ description: "Bound inbound gateway requests per identity/scope — sliding-wind
 icon: "gauge"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-relay-transport.mdx
+++ b/docs/features/gateway-relay-transport.mdx
@@ -5,6 +5,11 @@ description: "Run bots behind NAT without public webhooks using an out-of-proces
 icon: "arrow-right-arrow-left"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-reliability-preset.mdx
+++ b/docs/features/gateway-reliability-preset.mdx
@@ -5,6 +5,11 @@ description: "One switch that composes graceful drain + admission control for th
 icon: "shield-check"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-reliability.mdx
+++ b/docs/features/gateway-reliability.mdx
@@ -5,6 +5,11 @@ description: "One switch that composes graceful drain + admission control for pr
 icon: "shield-check"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 One line makes your gateway production-grade — `reliability="production"` composes graceful drain and admission control automatically.
 
 ```python

--- a/docs/features/gateway-route-bindings.mdx
+++ b/docs/features/gateway-route-bindings.mdx
@@ -5,6 +5,11 @@ description: "Route inbound messages to the right agent by sender, role, channel
 icon: "route"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-scale-to-zero.mdx
+++ b/docs/features/gateway-scale-to-zero.mdx
@@ -5,6 +5,11 @@ description: "Suspend the gateway when nothing is happening and wake on the next
 icon: "moon"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-session-continuity.mdx
+++ b/docs/features/gateway-session-continuity.mdx
@@ -5,6 +5,11 @@ description: "Durable gateway sessions survive disconnects, restarts, and shutdo
 icon: "shield-check"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/features/gateway-session-persistence.mdx
+++ b/docs/features/gateway-session-persistence.mdx
@@ -5,6 +5,11 @@ description: "Persistent gateway sessions that survive restarts, with reconnect 
 icon: "database"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Persistent sessions keep conversation state alive across gateway restarts and let clients resume mid-conversation with event replay.
 
 <Note>

--- a/docs/features/gateway-telegram-multichannel.mdx
+++ b/docs/features/gateway-telegram-multichannel.mdx
@@ -5,6 +5,11 @@ description: "Deploy Hermes-style multi-agent workforce with multiple Telegram b
 icon: "paper-plane"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Deploy a Hermes-style AI workforce using PraisonAI Gateway with multiple specialized Telegram bots, each serving different business functions while sharing common knowledge.
 
 ```python

--- a/docs/features/gateway-tool-policy.mdx
+++ b/docs/features/gateway-tool-policy.mdx
@@ -5,6 +5,11 @@ description: "Scope the toolset advertised to the model per inbound route — tr
 icon: "shield-check"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 Untrusted inbound routes never even see dangerous tools — the model is offered a scoped subset for that turn, then the agent's original toolset is restored.
 
 ```python

--- a/docs/features/gateway-windows-deployment.mdx
+++ b/docs/features/gateway-windows-deployment.mdx
@@ -5,6 +5,11 @@ description: "Complete guide for deploying PraisonAI Gateway on Windows with mul
 icon: "windows"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
+
 ```python
 from praisonaiagents import Agent
 

--- a/docs/gateway.mdx
+++ b/docs/gateway.mdx
@@ -5,6 +5,10 @@ description: "Unified gateway and control plane architecture for PraisonAI integ
 icon: "gateway"
 ---
 
+<Note>
+The gateway now ships in the `praisonai-bot` package. `praisonai serve gateway` still works exactly as documented here; for a standalone install see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
+</Note>
+
 Agents can connect through a unified gateway providing single-entry access to multi-agent coordination, tools, and streaming events.
 
 ```mermaid

--- a/docs/guides/praisonai-bot-migration.mdx
+++ b/docs/guides/praisonai-bot-migration.mdx
@@ -1,0 +1,281 @@
+---
+title: "praisonai-bot Package Migration"
+sidebarTitle: "praisonai-bot Migration"
+description: "Where bots, gateway, and channel CLI live after the C9 extraction from the praisonai wrapper into a new sibling PyPI package"
+icon: "package"
+---
+
+`praisonai-bot` is a new sibling PyPI package holding the bots, gateway, and channel CLI — extracted from the `praisonai` wrapper — and every existing import still works via `alias_package` shims.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Support",
+    instructions="Answer support questions from users on Telegram, Slack, and Discord.",
+    llm="gpt-4o-mini",
+)
+agent.start("Hello — reply if you see this.")
+```
+
+A gateway process running `praisonai-bot gateway start` routes each Telegram/Slack/Discord message to this agent and posts the reply back.
+
+```mermaid
+graph LR
+    Agents[praisonaiagents<br/>Core SDK] --> Code[praisonai-code<br/>Terminal CLI]
+    Agents --> Bot[praisonai-bot<br/>Bots / Gateway / Channels]
+    Code --> Main[praisonai<br/>Wrapper + shims]
+    Bot --> Main
+
+    WB["_wrapper_bridge"] -.->|optional dep| Main
+    CB["_code_bridge"] -.->|optional dep| Code
+
+    classDef pkg fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef bridge fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef shim fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef core fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class Agents core
+    class Code,Bot,Main pkg
+    class WB,CB bridge
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Nothing changes if you install the wrapper">
+
+`pip install praisonai` pulls in `praisonai-bot` transitively. Every existing command still works:
+
+```bash
+pip install praisonai
+praisonai bot serve --config bot.yaml
+praisonai serve gateway --config gateway.yaml
+```
+
+</Step>
+
+<Step title="Standalone install for headless workers or containers">
+
+Install only what your container needs:
+
+```bash
+pip install praisonai-bot[gateway,bot]
+praisonai-bot gateway start --config gateway.yaml
+praisonai-bot bot start --config bot.yaml
+```
+
+</Step>
+
+<Step title="Agent-centric example — route messages from any channel">
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    name="Support",
+    instructions="Answer support questions from users on Telegram, Slack, and Discord.",
+    llm="gpt-4o-mini",
+)
+agent.start("Hello — reply if you see this.")
+```
+
+Run the gateway alongside it:
+
+```bash
+praisonai-bot gateway start --agents agents.yaml
+```
+
+Messages arrive from any configured channel, the agent replies, and the gateway posts the response back.
+
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant U as User (Telegram)
+    participant GW as praisonai-bot gateway
+    participant A as praisonaiagents.Agent
+
+    U->>GW: incoming message
+    GW->>A: Agent.run(message)
+    A-->>GW: reply text
+    GW-->>U: outbound message
+```
+
+The gateway is the only process that holds channel credentials. Agents never talk directly to Telegram, Slack, or Discord — they receive plain text and return plain text. The gateway handles platform-specific formatting, rate-limiting, and delivery guarantees.
+
+---
+
+## Which install shape is right for me?
+
+```mermaid
+graph TB
+    Start{What do I need?}
+
+    Start -->|Full CLI + all commands| Full["pip install praisonai<br/>→ praisonai bot serve<br/>→ praisonai serve gateway"]
+    Start -->|Small container — gateway only| GW["pip install praisonai-bot[gateway]<br/>→ praisonai-bot gateway start"]
+    Start -->|Small container — bots only| BotOnly["pip install praisonai-bot[bot]<br/>→ praisonai-bot bot telegram ..."]
+    Start -->|Existing code with praisonai.bots imports| Shim["No change required<br/>alias_package shims keep working"]
+    Start -->|Writing a new channel adapter| Plugin["Publish entry-point:<br/>praisonai.channels group<br/>(see Extending below)"]
+
+    classDef pkg fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef shim fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef plugin fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef start fill:#6366F1,stroke:#7C90A0,color:#fff
+
+    class Full,GW,BotOnly pkg
+    class Shim shim
+    class Plugin plugin
+    class Start start
+```
+
+---
+
+## Compatibility Guarantees
+
+Every existing import path continues to resolve. No code changes required.
+
+| Old path (still works) | Resolves to |
+|---|---|
+| `from praisonai.bots import Bot` | `praisonai_bot.bots.Bot` |
+| `from praisonai.bots.telegram import TelegramBot` | `praisonai_bot.bots.telegram.TelegramBot` |
+| `from praisonai.gateway import GatewayConfig` | `praisonai_bot.gateway.GatewayConfig` |
+| `from praisonai.gateway.server import GatewayServer` | `praisonai_bot.gateway.server.GatewayServer` |
+| `from praisonai.daemon import ...` | `praisonai_bot.daemon.*` |
+| CLI command modules (bot / gateway / channels) | `praisonai_bot.cli.commands.*` |
+
+- `pip install praisonai` remains the canonical user-facing install.
+- `praisonai.bots.*`, `praisonai.gateway.*`, `praisonai.daemon.*` are stable API — they are `alias_package` shims backed by `praisonai_bot.*`.
+- `praisonai-bot` has **no** hard PyPI dependency on `praisonai` — no import cycle.
+- Any access that `praisonai-bot` needs into the wrapper goes through `_wrapper_bridge` at call time, degrading gracefully when the wrapper is absent.
+
+---
+
+## New CLI: `praisonai-bot`
+
+The `praisonai-bot` binary is separate from the `praisonai` binary. It exposes:
+
+```
+praisonai-bot
+├── bot         Start messaging bots with full agent capabilities
+│   ├── start       Start a bot from a YAML config file (zero-code)
+│   ├── telegram    Start a Telegram bot
+│   ├── discord     Start a Discord bot
+│   ├── slack       Start a Slack bot
+│   └── ...
+├── gateway     Manage the PraisonAI gateway server
+│   ├── start       Start the gateway server
+│   ├── stop        Stop a running gateway instance
+│   └── status      Check gateway and daemon status
+├── pairing     Manage bot pairing
+├── identity    Manage bot identity
+├── onboard     Onboard a new bot
+├── kanban      Kanban integration
+├── claw        Channel-agnostic bot operations
+└── mint_link   Mint magic links
+```
+
+Examples:
+
+```bash
+praisonai-bot gateway start --config gateway.yaml
+praisonai-bot gateway start --agents agents.yaml --port 9000
+praisonai-bot gateway stop
+praisonai-bot gateway status
+
+praisonai-bot bot start --config bot.yaml
+praisonai-bot bot telegram --token $TELEGRAM_BOT_TOKEN --model gpt-4o-mini
+praisonai-bot bot slack --token $SLACK_BOT_TOKEN --memory
+```
+
+<Note>
+The existing `praisonai serve gateway` and `praisonai bot serve` wrapper commands still work and are the recommended entry point for users who installed via `pip install praisonai`.
+</Note>
+
+---
+
+## Extending: Register a New Channel
+
+`praisonai-bot` discovers channel adapters via the `praisonai.channels` entry-point group at startup. No changes to `praisonai-bot` itself are needed.
+
+To publish a third-party channel adapter, add an entry-point in your package's `pyproject.toml`:
+
+```toml
+[project.entry-points."praisonai.channels"]
+mattermost = "my_pkg.mattermost:MattermostBot"
+```
+
+The gateway/bot loader calls `entry_points(group="praisonai.channels")` on startup and registers every discovered adapter automatically.
+
+---
+
+## Built-in Channels
+
+| Entry-point key | Class |
+|---|---|
+| `telegram` | `praisonai_bot.bots.telegram:TelegramBot` |
+| `discord` | `praisonai_bot.bots.discord:DiscordBot` |
+| `slack` | `praisonai_bot.bots.slack:SlackBot` |
+| `whatsapp` | `praisonai_bot.bots.whatsapp:WhatsAppBot` |
+| `linear` | `praisonai_bot.bots.linear:LinearBot` |
+| `email` | `praisonai_bot.bots.email:EmailBot` |
+| `agentmail` | `praisonai_bot.bots.agentmail:AgentMailBot` |
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Keep using praisonai.bots / praisonai.gateway in library code">
+
+Application and library code should continue to import from `praisonai.bots`, `praisonai.gateway`, and `praisonai.daemon`. These paths are the stable public API backed by `alias_package` shims. `praisonai_bot.*` is an alternative available path, not a replacement — the shim layer allows the physical package layout to evolve without breaking callers.
+
+</Accordion>
+
+<Accordion title="Use praisonai-bot extras for headless workers">
+
+For containers or workers that don't need the full `praisonai` wrapper, install only the extras you need:
+
+- `pip install praisonai-bot[gateway]` — WebSocket gateway only (~200 MB fewer transitive deps than the full wrapper).
+- `pip install praisonai-bot[bot]` — messaging platform adapters only.
+- `pip install praisonai-bot[gateway,bot]` — full inbound-and-outbound flow.
+- `pip install praisonai-bot[all]` — shortcut for `[gateway,bot]`.
+
+</Accordion>
+
+<Accordion title="Extras are additive — install only what you need">
+
+`[gateway]` pulls in FastAPI, uvicorn, SSE-starlette, websockets, watchdog, and redis. `[bot]` pulls in python-telegram-bot, discord.py, slack_sdk, slack-bolt, and psutil. Installing both is safe and additive. `[bot-whatsapp-web]` adds neonize and qrcode for WhatsApp Web support.
+
+</Accordion>
+
+<Accordion title="Alias shims are load-bearing — do not remove them as cleanup">
+
+`praisonai.bots`, `praisonai.gateway`, and `praisonai.daemon` are `alias_package` shims in the wrapper. Removing or rewriting imports away from these paths in your own code is not a "cleanup" — they are the stable API. `praisonai_bot.*` is a new alternative surface for users who want the standalone install shape.
+
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="praisonai-code Migration" icon="package" href="/docs/guides/praisonai-code-migration">
+  The C0–C6 sibling extraction that moved the agentic terminal CLI into its own package
+</Card>
+<Card title="Python Wrapper" icon="box" href="/docs/developers/wrapper">
+  The praisonai wrapper — four-tier architecture reference for contributors
+</Card>
+<Card title="Gateway" icon="gateway" href="/docs/gateway">
+  Gateway and control plane — WebSocket server, config, and deployment
+</Card>
+<Card title="Messaging Bots" icon="robot" href="/docs/features/messaging-bots">
+  Bot platform documentation — Telegram, Discord, Slack, WhatsApp, and more
+</Card>
+</CardGroup>

--- a/docs/guides/praisonai-bot-migration.mdx
+++ b/docs/guides/praisonai-bot-migration.mdx
@@ -32,7 +32,6 @@ graph LR
 
     classDef pkg fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef bridge fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef shim fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef core fill:#6366F1,stroke:#7C90A0,color:#fff
 
     class Agents core

--- a/docs/guides/praisonai-code-migration.mdx
+++ b/docs/guides/praisonai-code-migration.mdx
@@ -63,7 +63,7 @@ python -c "import praisonai_code; print(praisonai_code.__version__)"
 
 ## How It Works
 
-Dependency flow is one-way: **`praisonai` → `praisonai-code` → `praisonaiagents`**. The `praisonai-code` package never declares a dependency on `praisonai`, which avoids a PyPI cycle. Bot, gateway, and daemon code stays in the main `praisonai` package throughout the migration.
+Dependency flow is one-way: **`praisonai` → `praisonai-code` → `praisonaiagents`**. The `praisonai-code` package never declares a dependency on `praisonai`, which avoids a PyPI cycle. Bot, gateway, and daemon code moved to `praisonai-bot` in C9.
 
 ```mermaid
 sequenceDiagram
@@ -85,7 +85,7 @@ sequenceDiagram
 |-------|---------|------|
 | SDK | `praisonaiagents` | Agents, tools, memory, workflows |
 | Terminal CLI | `praisonai-code` | `run`, `chat`, `code`, warm runtime, CLI backends |
-| User install | `praisonai` | `pip install praisonai`, bots/gateway/daemon, PEP 562 shims |
+| User install | `praisonai` | `pip install praisonai`, PEP 562 shims (bots/gateway/daemon moved to `praisonai-bot` in C9) |
 
 ---
 
@@ -96,7 +96,7 @@ graph TB
     Start{Who are you?}
     Start -->|End user| User[pip install praisonai<br/>No change]
     Start -->|Contributor on runtime / cli_backends| C1[After C1: praisonai_code.runtime<br/>praisonai_code.cli_backends]
-    Start -->|Contributor on bots / gateway / daemon| Main[Stay in praisonai.bots<br/>praisonai.gateway / daemon]
+    Start -->|Contributor on bots / gateway / daemon| Main[Use praisonai-bot package<br/>praisonai_bot.bots / gateway / daemon]
     Start -->|Library using PraisonAI class| Shim[from praisonai.cli.main import PraisonAI<br/>Keeps working via PEP 562 shim after C5]
 
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
@@ -134,7 +134,7 @@ Tracking issue: [PraisonAI#2512](https://github.com/MervinPraison/PraisonAI/issu
 - **Existing import paths keep working** — PEP 562 shims at old `praisonai.*` paths land as code moves in C1–C5. `from praisonai.cli.main import PraisonAI` continues unchanged (154+ tests depend on it).
 - **Console entry unchanged** — `praisonai = "praisonai.__main__:main"`.
 - **One-way dependencies** — `praisonai` → `praisonai-code` → `praisonaiagents`; `praisonai-code` never depends on `praisonai`.
-- **Scope split** — `praisonai-code` covers only the agentic terminal product; `bots/`, `gateway/`, and `daemon/` stay in `praisonai` throughout.
+- **Scope split** — `praisonai-code` covers only the agentic terminal product; `bots/`, `gateway/`, and `daemon/` moved to `praisonai-bot` in C9 (see [praisonai-bot Migration](/docs/guides/praisonai-bot-migration)).
 
 ---
 
@@ -147,11 +147,9 @@ Application and library code should keep using `import praisonai` and `from prai
 
 </Accordion>
 
-<Accordion title="Bot-channel modules stay in praisonai">
+<Accordion title="Bot-channel modules moved to praisonai-bot (C9)">
 
-These CLI commands never move: `gateway`, `bot`, `onboard`, `pairing`, `identity`, `kanban`, `mint_link`, `claw`, `dashboard`.
-
-These features never move: `gateway`, `bots_cli`, `onboard`, `approval`, `serve`.
+As of C9, the following CLI commands and features live in `praisonai-bot`, not `praisonai-code`: `gateway`, `bot`, `onboard`, `pairing`, `identity`, `kanban`, `mint_link`, `claw`. The `praisonai.bots`, `praisonai.gateway`, and `praisonai.daemon` paths remain as `alias_package` shims. See [praisonai-bot Migration](/docs/guides/praisonai-bot-migration).
 
 </Accordion>
 

--- a/docs/guides/praisonai-code-migration.mdx
+++ b/docs/guides/praisonai-code-migration.mdx
@@ -22,7 +22,7 @@ The user keeps using `pip install praisonai`; the extracted `praisonai-code` pac
 ```mermaid
 graph LR
     Agents[praisonaiagents<br/>SDK] --> Code[praisonai-code<br/>terminal CLI]
-    Code --> Main[praisonai<br/>wrapper + bots/gateway + shims]
+    Code --> Main[praisonai<br/>wrapper + shims]
 
     classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
     classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff

--- a/docs/guides/praisonai-code-migration.mdx
+++ b/docs/guides/praisonai-code-migration.mdx
@@ -179,4 +179,7 @@ Removing shims would break 154+ tests and every `from praisonai.cli.main import 
 <Card title="Development setup" icon="wrench" href="/docs/developers/development-setup">
   Clone the monorepo and install editable packages with uv
 </Card>
+<Card title="praisonai-bot Migration" icon="package" href="/docs/guides/praisonai-bot-migration">
+  The sibling extraction that moves bots/gateway/daemon out of the wrapper
+</Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

Closes #1516. Documents the C9 `praisonai-bot` package extraction (PraisonAI PR #2633).

### Changes

- **New page** `docs/guides/praisonai-bot-migration.mdx`:
  - Hero four-tier Mermaid diagram (`praisonaiagents → praisonai-code + praisonai-bot → praisonai`)
  - Agent-centric Quick Start with 3 steps (wrapper install / standalone install / agent example)
  - `sequenceDiagram` showing Telegram → gateway → Agent → gateway → User flow
  - Decision `graph TB` for install shape selection
  - Compatibility guarantees table (7 old import paths → new `praisonai_bot.*` targets)
  - `praisonai-bot` CLI reference (bot / gateway / pairing / identity / onboard / kanban / claw / mint_link)
  - "Extending: register a new channel" with `[project.entry-points."praisonai.channels"]` example
  - Built-in channels table (7 entries from `pyproject.toml`)
  - `<AccordionGroup>` best practices (4 items)
  - `<CardGroup>` related links

- **Updated** `docs/developers/wrapper.mdx`: refreshed from three-tier to four-tier, added "Sibling: praisonai-bot" subsection with card links

- **Updated** `docs/gateway.mdx` + **35** `docs/features/gateway-*.mdx` pages: `<Note>` callout linking to migration guide

- **Updated** **20** `docs/features/bot-*.mdx` pages: `<Note>` callout linking to migration guide

- **Updated** `docs/guides/praisonai-code-migration.mdx`: cross-link card in Related section

- **Updated** `docs.json`: `docs/guides/praisonai-bot-migration` registered under Guides group (valid JSON verified)

### References
- Source PR: MervinPraison/PraisonAI#2633
- Sibling guide: closes #1516

Generated with [Claude Code](https://claude.ai/code)