### PR TITLE
Unblock valid docs-primary PRs (comma-fix nav, CI stale checks)

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -101,6 +101,40 @@ assert('nav-only docs.json not sensitive', mg.sensitivePathReasons([{ filename: 
 const themePatch = navOnlyPatch.replace('+      "docs/features/new-page",', '+  "theme": "dark",');
 assert('docs.json theme change still sensitive', mg.sensitivePathReasons([{ filename: 'docs.json', patch: themePatch }]).length === 1);
 
+const commaFixPatch = [
+  '--- a/docs.json',
+  '+++ b/docs.json',
+  '@@ -1123,7 +1123,8 @@',
+  '-              "docs/features/mongodb-memory"',
+  '+              "docs/features/mongodb-memory",',
+  '+              "docs/features/dakera-memory"',
+].join('\n');
+assert('comma-fix nav docs.json not sensitive', mg.sensitivePathReasons([{ filename: 'docs.json', patch: commaFixPatch }]).length === 0);
+
+const navRemovalPatch = [
+  '--- a/docs.json',
+  '+++ b/docs.json',
+  '@@ -10,6 +10,5 @@',
+  '     "pages": [',
+  '-      "docs/cli/doctor",',
+  '     ]',
+].join('\n');
+assert('nav path removal still sensitive', mg.sensitivePathReasons([{ filename: 'docs.json', patch: navRemovalPatch }]).length === 1);
+
+const conflictMarkerPatch = navOnlyPatch.replace('+      "docs/features/new-page",', '+<<<<<<< HEAD');
+assert('conflict markers in docs.json blocked', !mg.isNavOnlyDocsJsonPatch(conflictMarkerPatch));
+
+const docsPrimaryFiles = [
+  { filename: 'docs/features/foo.mdx', additions: 840 },
+];
+assert('docs-primary allows larger audit file', mg.prSizeReasons(docsPrimaryFiles).length === 0);
+
+const sdkMirrorFiles = [
+  { filename: 'docs/features/toolsets.mdx', additions: 34 },
+  { filename: 'praisonaiagents/toolsets.py', additions: 8 },
+];
+assert('small SDK mirror sync ok without tests', mg.missingTestsReason(sdkMirrorFiles) === null);
+
 // Stale-FINAL recovery guards (PraisonAI #2334 parity)
 const finalAt = '2026-07-03T10:00:00Z';
 const pushSoonAfter = '2026-07-03T10:05:00Z';

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -14,6 +14,9 @@ const ALLOWED_MERGE_STATES = new Set(['CLEAN', 'UNSTABLE']);
 const BLOAT_FILE_MAX_AUTO_LINES = 100;
 const PR_MAX_AUTO_ADDITIONS = 800;
 const PR_MAX_AUTO_FILES = 30;
+const DOCS_PRIMARY_MAX_ADDITIONS = 1200;
+const DOCS_PRIMARY_MAX_FILES = 40;
+const DOCS_PRIMARY_MAX_SDK_ADDITIONS = 25;
 const MANUAL_ONLY_LABELS = new Set(['security', 'breaking-change', 'needs-manual-review', 'release']);
 const WORKFLOW_ONLY_LABEL = 'merge-gate-ci-only';
 const CI_ONLY_PATH_PREFIXES = ['.github/workflows/', '.github/actions/', '.github/scripts/merge-gate'];
@@ -253,18 +256,51 @@ function shouldSkipStaleFinalRecovery(comments, headPushedAt, headPusherLogin = 
   return { skip: false, reason: '' };
 }
 
+function extractDocsNavPath(line) {
+  const m = (line || '').match(/"(docs\/[^"]+)"/);
+  return m ? m[1] : null;
+}
+
+function isDocsPrimaryPullRequest(files) {
+  if (!files.length) return false;
+  const hasDocChange = files.some((f) => {
+    const name = f.filename || '';
+    return name.startsWith('docs/') || name === 'docs.json';
+  });
+  if (!hasDocChange) return false;
+  return files.every((f) => {
+    const name = f.filename || '';
+    return (
+      name.startsWith('docs/') ||
+      name === 'docs.json' ||
+      SDK_PATH_PREFIXES.some((p) => name.startsWith(p))
+    );
+  });
+}
+
 function isNavOnlyDocsJsonPatch(patch) {
-  if (!patch) return false;
+  if (!patch || /<<<<<<<|=======|>>>>>>>/.test(patch)) return false;
+  const removedPaths = [];
+  const addedPaths = [];
   for (const line of patch.split('\n')) {
     if (line.startsWith('@@') || line.startsWith('+++') || line.startsWith('---')) continue;
-    if (!line.startsWith('+') && !line.startsWith('-')) continue;
     if (DOCS_JSON_CONFIG_KEYS.test(line)) return false;
+    if (!line.startsWith('+') && !line.startsWith('-')) continue;
     const content = line.slice(1).trim();
     if (!content) continue;
+    const path = extractDocsNavPath(content);
     if (line.startsWith('-')) {
-      if (/^"docs\//.test(content) || /"(group|tab|pages|icon)"/.test(content)) return false;
-      if (!/^[\]},]?$/.test(content)) return false;
+      if (path) removedPaths.push(path);
+      else if (/"(group|tab|pages|icon)"/.test(content)) return false;
+      else if (!/^[\]},]?$/.test(content)) return false;
+    } else {
+      if (path) addedPaths.push(path);
+      else if (/"(group|tab|pages|icon)"/.test(content)) return false;
+      else if (!/^[\]},]?$/.test(content)) return false;
     }
+  }
+  for (const removed of removedPaths) {
+    if (!addedPaths.includes(removed)) return false;
   }
   return true;
 }
@@ -317,7 +353,9 @@ async function getMergeState(github, owner, repo, prNumber) {
   };
 }
 
-async function allChecksGreenOnSha(github, owner, repo, sha, core) {
+async function allChecksGreenOnSha(github, owner, repo, sha, core, options = {}) {
+  const mergeStateStatus = (options.mergeStateStatus || '').toUpperCase();
+  const ignoreWhenClean = new Set(['detect-and-trigger']);
   const { data } = await github.rest.checks.listForRef({
     owner,
     repo,
@@ -336,6 +374,10 @@ async function allChecksGreenOnSha(github, owner, repo, sha, core) {
     }
     const ok = ['success', 'neutral', 'skipped'].includes(run.conclusion);
     if (!ok) {
+      if (mergeStateStatus === 'CLEAN' && ignoreWhenClean.has(run.name || '')) {
+        core?.info?.(`Ignoring stale failed check on CLEAN PR: ${run.name}`);
+        continue;
+      }
       core?.info?.(`Check failed: ${run.name} (${run.conclusion})`);
       return false;
     }
@@ -581,12 +623,15 @@ function sensitivePathReasons(files, labels = []) {
 
 function prSizeReasons(files) {
   const reasons = [];
+  const docsPrimary = isDocsPrimaryPullRequest(files);
+  const maxAdditions = docsPrimary ? DOCS_PRIMARY_MAX_ADDITIONS : PR_MAX_AUTO_ADDITIONS;
+  const maxFiles = docsPrimary ? DOCS_PRIMARY_MAX_FILES : PR_MAX_AUTO_FILES;
   const totalAdditions = files.reduce((sum, f) => sum + (f.additions || 0), 0);
-  if (totalAdditions > PR_MAX_AUTO_ADDITIONS) {
-    reasons.push(`PR +${totalAdditions} lines (>${PR_MAX_AUTO_ADDITIONS}) requires manual review`);
+  if (totalAdditions > maxAdditions) {
+    reasons.push(`PR +${totalAdditions} lines (>${maxAdditions}) requires manual review`);
   }
-  if (files.length > PR_MAX_AUTO_FILES) {
-    reasons.push(`${files.length} files changed (>${PR_MAX_AUTO_FILES}) requires manual review`);
+  if (files.length > maxFiles) {
+    reasons.push(`${files.length} files changed (>${maxFiles}) requires manual review`);
   }
   return reasons;
 }
@@ -600,6 +645,10 @@ function missingTestsReason(files) {
       (f.additions || 0) > 0
   );
   if (sdkAdds.length === 0) return null;
+  if (isDocsPrimaryPullRequest(files)) {
+    const sdkAdditions = sdkAdds.reduce((sum, f) => sum + (f.additions || 0), 0);
+    if (sdkAdditions <= DOCS_PRIMARY_MAX_SDK_ADDITIONS) return null;
+  }
   const hasTestChange = files.some(
     (f) => /\/tests?\//.test(f.filename) || /test_.*\.py$/.test(f.filename) || /_test\.py$/.test(f.filename)
   );
@@ -763,7 +812,9 @@ async function evaluatePipelineQuiescent(github, owner, repo, prNumber, core, op
     reasons.push('claude.yml in progress');
   }
 
-  const checksOk = await allChecksGreenOnSha(github, owner, repo, ctx.headSha, core);
+  const checksOk = await allChecksGreenOnSha(github, owner, repo, ctx.headSha, core, {
+    mergeStateStatus: ctx.mergeState.status,
+  });
   if (!checksOk) reasons.push('CI not green on HEAD');
 
   if (!finalClaudeCompletedOnSha(ctx.comments, ctx.headPushedAt)) {
@@ -880,6 +931,8 @@ module.exports = {
   hasManualOnlyLabel,
   sensitivePathReasons,
   isNavOnlyDocsJsonPatch,
+  isDocsPrimaryPullRequest,
+  extractDocsNavPath,
   prSizeReasons,
   missingTestsReason,
   secretScanReasons,

--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -280,7 +280,7 @@ jobs:
             2. Read all PR comments and reviews (FINAL documentation reviewer / Lead Engineer must have run).
             3. Confirm documentation value: accurate, beginner-friendly, SDK-verified, Mintlify-compliant.
             4. New pages must be in `docs/features/` — block if `docs/concepts/` changed without approval.
-            5. BLOCK if labels security/breaking-change/needs-manual-review/release, sensitive paths (`.github/workflows/`, `mint.json`, non-nav-only `docs.json` edits), secrets in diff, or PR >800 lines or >30 files. Nav-only `docs.json` changes (adding pages/groups only) are allowed. Label `merge-gate-ci-only` exempts CI-only changes under `.github/workflows/`, `.github/actions/`, or merge-gate scripts.
+            5. BLOCK if labels security/breaking-change/needs-manual-review/release, sensitive paths (`.github/workflows/`, `mint.json`, non-nav-only `docs.json` edits including nav removals and conflict markers), secrets in diff, or PR exceeds size limits (800 lines / 30 files default; 1200 / 40 for docs-primary PRs). Nav-only `docs.json` changes (adding pages or comma-fix when appending to a list) are allowed. Label `merge-gate-ci-only` exempts CI-only changes under `.github/workflows/`, `.github/actions/`, or merge-gate scripts.
             6. Confirm no CHANGES_REQUESTED reviews and any CI checks green on HEAD ${{ matrix.head_sha }} (docs-only PRs with no checks are OK).
             7. If ready to merge: MERGE_GATE_VERDICT: APPROVE. Otherwise: MERGE_GATE_VERDICT: BLOCK with reasons.
 


### PR DESCRIPTION
## Summary
- **Comma-fix nav**: docs.json patches that re-add the same path with a trailing comma plus new entries (common when appending to a list) are treated as nav-only.
- **Docs-primary limits**: PRs touching only docs/ + optional synced SDK mirrors get 1200 lines / 40 files (was 800/30).
- **SDK mirror sync**: Small synced praisonaiagents/ changes (≤25 lines) in docs-primary PRs skip the “missing tests” manual block.
- **Stale CI**: Ignore failed detect-and-trigger on CLEAN PRs (leftover from when PR had conflicts).
- **Safety kept**: Nav removals, theme/config edits, conflict markers in docs.json, concepts-only PRs, and non-docs changes still blocked.

## Expected unblock (~12 PRs after merge + pipeline sync)
1481, 1483, 1478, 1508 (comma-fix nav), 1488 (SDK mirror), 1509 (audit size), 1517 (30-file bot migration), plus CI-only blockers on 1426/1443/1451/etc.

## Still needs Claude rebase (valid blocks)
Conflicts: 1352, 1375, 1419, 1442, 1457, 1468, 1510, 1511, 1514, 1519
Nav removal: 1518 (removed doctor-cli from nav)
Concepts/human: 1519

## Test plan
- [x] node .github/scripts/merge-gate-selftest.js (42 tests)
- [ ] Merge → workflow_dispatch pipeline-status-sync → verify manual-review count drops
- [ ] workflow_dispatch merge-conflict-claude for conflicting PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded merge-gate handling for docs-focused pull requests, allowing larger docs-primary updates to pass with higher size limits.
  * Improved navigation-only `docs.json` recognition so valid page additions and list fixes are accepted.

* **Bug Fixes**
  * Added stricter checks to block risky `docs.json` edits, including nav removals and conflict-marker content.
  * Prevented stale CI failure states from incorrectly blocking otherwise healthy pull requests.
  * Refined test requirements for small SDK mirror syncs so they no longer trigger unnecessary test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->