### PR TITLE
docs: add user-interaction sequenceDiagrams to top-10 feature pages

### DIFF
--- a/docs/features/callbacks.mdx
+++ b/docs/features/callbacks.mdx
@@ -180,6 +180,33 @@ praisonai agents.yaml
   - Generation progress
 </Card>
 
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Callback
+    participant LLM
+
+    User->>Agent: Message
+    Agent->>Callback: on_interaction (before)
+    Agent->>LLM: Send prompt
+    LLM-->>Agent: Response (or tool call)
+    Agent->>Callback: on_tool_call (if tool used)
+    Agent->>Callback: on_interaction (after) with response
+    Agent-->>User: Final response
+```
+
+| Phase | What happens |
+|---|---|
+| 1. Register | `register_display_callback("interaction", fn)` attaches your function to an event type |
+| 2. Trigger | Agent fires the registered callback at the appropriate lifecycle point |
+| 3. Observe | Callback receives `message`, `response`, and any extra kwargs for logging or side-effects |
+| 4. Continue | Agent execution continues; callbacks are non-blocking observers |
+
+---
+
 ## Features
 
 <CardGroup cols={2}>

--- a/docs/features/knowledge.mdx
+++ b/docs/features/knowledge.mdx
@@ -155,6 +155,35 @@ results = kb.search(
 
 </Steps>
 
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant Knowledge
+    participant VectorStore
+    participant LLM
+
+    User->>Agent: Question about documents
+    Agent->>Knowledge: search(query)
+    Knowledge->>VectorStore: Embed query + semantic search
+    VectorStore-->>Knowledge: Top-k chunks
+    Knowledge-->>Agent: Retrieved context
+    Agent->>LLM: Prompt + context
+    LLM-->>Agent: Grounded answer
+    Agent-->>User: Response
+```
+
+| Phase | What happens |
+|---|---|
+| 1. Add | Documents are chunked, embedded, and stored in the vector store via `knowledge.add()` |
+| 2. Search | `knowledge.search(query)` embeds the query and returns top-k similar chunks |
+| 3. Retrieve | Agent injects the chunks as context before calling the LLM |
+| 4. Generate | LLM answers using the retrieved knowledge; responses are grounded in your data |
+
+---
+
 ## Configuration Options
 
 <Card title="KnowledgeConfig SDK Reference" icon="code" href="/docs/sdk/reference/python/classes/KnowledgeConfig">

--- a/docs/features/parallelisation.mdx
+++ b/docs/features/parallelisation.mdx
@@ -97,6 +97,33 @@ result = asyncio.run(run())
 ## How It Works
 
 ```mermaid
+sequenceDiagram
+    participant User
+    participant AgentFlow
+    participant WorkerA
+    participant WorkerB
+    participant WorkerC
+    participant Aggregator
+
+    User->>AgentFlow: start("input")
+    AgentFlow->>WorkerA: Execute concurrently
+    AgentFlow->>WorkerB: Execute concurrently
+    AgentFlow->>WorkerC: Execute concurrently
+    WorkerA-->>AgentFlow: StepResult A
+    WorkerB-->>AgentFlow: StepResult B
+    WorkerC-->>AgentFlow: StepResult C
+    AgentFlow->>Aggregator: parallel_outputs list
+    Aggregator-->>AgentFlow: Merged result
+    AgentFlow-->>User: Final result
+```
+
+| Phase | What happens |
+|---|---|
+| 1. Fan-out | AgentFlow dispatches all workers in parallel (thread pool) |
+| 2. Collect | All `StepResult` objects gathered into `ctx.variables["parallel_outputs"]` |
+| 3. Aggregate | Next step (aggregator) receives the combined list and produces one response |
+
+```mermaid
 graph TB
     Q{Tasks independent?}
     Q -->|Yes| P[parallel step]

--- a/docs/features/rag.mdx
+++ b/docs/features/rag.mdx
@@ -92,9 +92,26 @@ agent.start("What is KAG in one line?")
 
 ## How It Works
 
-1. **Indexing** — documents are chunked and embedded into the vector store on first access
-2. **Retrieval** — each query embeds and searches for similar chunks
-3. **Generation** — retrieved context is injected before the LLM answers
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant KnowledgeStore
+    participant LLM
+
+    User->>Agent: Question
+    Agent->>KnowledgeStore: Embed query + search
+    KnowledgeStore-->>Agent: Relevant chunks (top-k)
+    Agent->>LLM: Prompt + retrieved context
+    LLM-->>Agent: Grounded answer
+    Agent-->>User: Response
+```
+
+| Phase | What happens |
+|---|---|
+| 1. Index | Documents are chunked and embedded into the vector store on first access |
+| 2. Retrieve | User query is embedded; top-k similar chunks are returned |
+| 3. Generate | Retrieved context is injected before the LLM prompt; LLM answers from your data |
 
 For pre-indexed stores, pass vector config via task context or call `agent.retrieve("query")` directly.
 

--- a/docs/features/routing.mdx
+++ b/docs/features/routing.mdx
@@ -104,6 +104,29 @@ workflow = AgentFlow(
 
 ---
 
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Classifier
+    participant Route
+    participant HandlerAgent
+
+    User->>Classifier: Request
+    Classifier-->>Route: Classification label
+    Route->>HandlerAgent: Dispatch to matched handler
+    HandlerAgent-->>User: Response
+```
+
+| Phase | What happens |
+|---|---|
+| 1. Classify | Classifier agent reads input and returns a label (e.g. `"technical"`) |
+| 2. Route | `route()` looks up the label in the routes dict; falls back to `"default"` if missing |
+| 3. Handle | The matched handler agent (or steps) runs and produces the final response |
+
+---
+
 ## Configuration Options
 
 | Pattern | Description |

--- a/docs/features/workflow-loop.mdx
+++ b/docs/features/workflow-loop.mdx
@@ -232,6 +232,34 @@ workflow = AgentFlow(steps=[
 | **Email Campaigns** | Send personalized emails to list |
 | **API Calls** | Call API for each item in list |
 
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant AgentFlow
+    participant Loop
+    participant StepHandler
+
+    User->>AgentFlow: start("input")
+    AgentFlow->>Loop: Resolve items list
+    loop For each item
+        Loop->>StepHandler: Execute with ctx.variables["item"]
+        StepHandler-->>Loop: StepResult
+    end
+    Loop-->>AgentFlow: All item results
+    AgentFlow-->>User: Final result
+```
+
+| Phase | What happens |
+|---|---|
+| 1. Resolve | `loop()` reads the `over` variable (list, CSV, or text file) from `ctx.variables` |
+| 2. Iterate | Handler is called once per item; `ctx.variables["item"]` holds the current value |
+| 3. Collect | All `StepResult` objects are gathered; `loop_index` tracks the current position |
+| 4. Return | AgentFlow returns after the last item completes |
+
+---
+
 ## Best Practices
 
 <AccordionGroup>

--- a/docs/features/workflow-parallel.mdx
+++ b/docs/features/workflow-parallel.mdx
@@ -199,6 +199,42 @@ Parallel execution uses Python's `ThreadPoolExecutor`:
 | **Validation** | Run multiple validators concurrently |
 | **A/B Comparison** | Run different approaches and compare |
 
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant AgentFlow
+    participant Parallel
+    participant TaskA
+    participant TaskB
+    participant TaskC
+
+    User->>AgentFlow: start("input")
+    AgentFlow->>Parallel: Execute parallel block
+    par Concurrent execution
+        Parallel->>TaskA: Execute (thread pool)
+    and
+        Parallel->>TaskB: Execute (thread pool)
+    and
+        Parallel->>TaskC: Execute (thread pool)
+    end
+    TaskA-->>Parallel: StepResult A
+    TaskB-->>Parallel: StepResult B
+    TaskC-->>Parallel: StepResult C
+    Parallel-->>AgentFlow: parallel_outputs list
+    AgentFlow-->>User: Final result
+```
+
+| Phase | What happens |
+|---|---|
+| 1. Fan-out | `parallel()` submits each step to a thread pool simultaneously |
+| 2. Execute | Steps run concurrently; each receives the same workflow context |
+| 3. Collect | All results gather into `ctx.variables["parallel_outputs"]` in completion order |
+| 4. Continue | Next workflow step (aggregator) receives the merged outputs |
+
+---
+
 ## Best Practices
 
 <AccordionGroup>

--- a/docs/features/workflow-repeat.mdx
+++ b/docs/features/workflow-repeat.mdx
@@ -228,6 +228,36 @@ workflow = AgentFlow(steps=[
 | **Data Collection** | Collect until enough data gathered |
 | **Self-Correction** | Agent corrects itself until correct |
 
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant AgentFlow
+    participant Repeat
+    participant Generator
+
+    User->>AgentFlow: start("input")
+    AgentFlow->>Repeat: Begin repeat block
+    loop Until condition met or max_iterations reached
+        Repeat->>Generator: Execute step
+        Generator-->>Repeat: StepResult + variables
+        Repeat->>Repeat: Evaluate until condition
+    end
+    Repeat-->>AgentFlow: Final StepResult
+    AgentFlow-->>User: Result
+```
+
+| Phase | What happens |
+|---|---|
+| 1. Start | `repeat()` records the initial `repeat_index = 0` in context variables |
+| 2. Generate | The wrapped step runs and returns a `StepResult` |
+| 3. Evaluate | The `until` callable receives the updated `WorkflowContext`; returns `True` to stop |
+| 4. Repeat | If `until` returns `False` and `max_iterations` not reached, the step runs again |
+| 5. Return | Final `StepResult` is passed to the next workflow step |
+
+---
+
 ## Best Practices
 
 <AccordionGroup>

--- a/docs/features/workflow-routing.mdx
+++ b/docs/features/workflow-routing.mdx
@@ -196,6 +196,34 @@ workflow = AgentFlow(steps=[
 | **A/B Testing** | Route to different processing pipelines |
 | **Error Handling** | Route based on success/failure status |
 
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant AgentFlow
+    participant Classifier
+    participant Route
+    participant HandlerAgent
+
+    User->>AgentFlow: start("input")
+    AgentFlow->>Classifier: Execute classifier step
+    Classifier-->>AgentFlow: Label (e.g. "high", "support")
+    AgentFlow->>Route: Look up label in routes dict
+    Route->>HandlerAgent: Dispatch to matched handler(s)
+    HandlerAgent-->>AgentFlow: StepResult
+    AgentFlow-->>User: Final result
+```
+
+| Phase | What happens |
+|---|---|
+| 1. Classify | A step (function or agent) returns a string label as its output |
+| 2. Match | `route()` looks up the label in the routes dict; uses `"default"` if no key matches |
+| 3. Execute | The matched handler list runs sequentially within the chosen branch |
+| 4. Continue | Execution resumes with the next workflow step after the route block |
+
+---
+
 ## Best Practices
 
 <AccordionGroup>

--- a/docs/features/workflows.mdx
+++ b/docs/features/workflows.mdx
@@ -148,6 +148,35 @@ result = workflow.start("Explain quantum computing")
 </Step>
 </Steps>
 
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant AgentFlow
+    participant StepAgent1
+    participant StepAgent2
+    participant StepAgentN
+
+    User->>AgentFlow: start("input")
+    AgentFlow->>StepAgent1: Execute step 1
+    StepAgent1-->>AgentFlow: StepResult (output)
+    AgentFlow->>StepAgent2: Execute step 2 + context
+    StepAgent2-->>AgentFlow: StepResult (output)
+    AgentFlow->>StepAgentN: Execute step N + context
+    StepAgentN-->>AgentFlow: StepResult (output)
+    AgentFlow-->>User: Final result dict
+```
+
+| Phase | What happens |
+|---|---|
+| 1. Start | User calls `workflow.start("input")` |
+| 2. Normalize | AgentFlow resolves each step (Agent, Task, or callable) |
+| 3. Execute | Steps run in order; output from step N becomes context for step N+1 |
+| 4. Return | Final `{"output": ..., "status": "completed"}` dict returned to user |
+
+---
+
 ## Workflow Class API
 
 The `Workflow` class provides a powerful programmatic API for creating workflows with functions, agents, and pattern helpers.


### PR DESCRIPTION
## Summary

Adds a `sequenceDiagram` block under `## How It Works` on each of the 10 highest-traffic feature pages, addressing AGENTS.md §1.1 rule 10 — "Include a user-interaction flow — show how users will actually interact with the feature in a real scenario."

### Pages updated

| Page | Feature | Sequence participants |
|------|---------|----------------------|
| `docs/features/workflows.mdx` | AgentFlow multi-step workflows | `User → AgentFlow → StepAgent1 → StepAgent2 → StepAgentN → User` |
| `docs/features/routing.mdx` | Classifier routing | `User → Classifier → Route → HandlerAgent → User` |
| `docs/features/parallelisation.mdx` | Parallel agent execution | `User → AgentFlow → WorkerA/B/C (concurrent) → Aggregator → User` |
| `docs/features/workflow-loop.mdx` | `loop()` primitive | `User → AgentFlow → Loop → StepHandler (per item) → User` |
| `docs/features/workflow-repeat.mdx` | `repeat()` primitive | `User → AgentFlow → Repeat → Generator (until condition) → User` |
| `docs/features/workflow-parallel.mdx` | `parallel()` primitive | `User → AgentFlow → Parallel → TaskA/B/C (concurrent) → User` |
| `docs/features/workflow-routing.mdx` | `route()` primitive | `User → AgentFlow → Classifier → Route → HandlerAgent → User` |
| `docs/features/rag.mdx` | RAG | `User → Agent → KnowledgeStore → LLM → User` |
| `docs/features/knowledge.mdx` | Knowledge base | `User → Agent → Knowledge → VectorStore → LLM → User` |
| `docs/features/callbacks.mdx` | Callbacks | `User → Agent → Callback → LLM → Callback → User` |

### Verification

- ✅ Each edited page has a `sequenceDiagram` under `## How It Works`
- ✅ Participants and message labels verified against `praisonaiagents/workflows/workflows.py` and `praisonaiagents/knowledge/knowledge.py`
- ✅ Surrounding `graph LR/TB` diagrams untouched and still use standard palette
- ✅ `docs.json` unchanged (`python3 -m json.tool docs.json` validates)
- ✅ No files under `docs/concepts/`, `docs/js/`, `docs/rust/` touched
- ✅ All imports in existing code snippets use friendly top-level imports

Fixes #1521

Generated with [Claude Code](https://claude.ai/code)