### PR TITLE
docs: cover user-visible fixes from PraisonAI#2634 (list-format YAML, retry_policy=None fallback, too many requests)

### DIFF
--- a/docs/features/tool-retry-policy.mdx
+++ b/docs/features/tool-retry-policy.mdx
@@ -146,24 +146,36 @@ sequenceDiagram
 | 4 | If `policy.should_retry(error_type, attempt)` is true, wait `policy.get_delay_ms(attempt)` ms and retry |
 | 5 | `HookEvent.ON_RETRY` fires before each retry with the new `OnRetryInput` fields |
 
+An error is tagged `rate_limit` when its message contains either `"rate…limit"` or `"too many requests"` — the latter catches HTTP 429 responses whose bodies use the standard phrasing without the word "limit":
+
+```python
+# Both of these classify as rate_limit and are retried by default:
+raise Exception("Rate limit exceeded")
+raise Exception("HTTP 429: Too Many Requests")
+```
+
 ---
 
 ## Precedence Ladder
 
 ```mermaid
 graph TB
-    A[🔧 @tool(retry_policy=...)] -->|Overrides| B[🤖 Agent(tool_config=ToolConfig(retry_policy=...))]
-    B -->|Overrides| C[📋 Default RetryPolicy()]
+    A["🔧 @tool(retry_policy=RetryPolicy(...))"] -->|Overrides| B["🤖 Agent(tool_config=ToolConfig(retry_policy=...))"]
+    AN["🔧 @tool(retry_policy=None)"] -->|"None → falls through"| B
+    B -->|Overrides| C["📋 Default RetryPolicy()"]
     
     classDef highest fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef none fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef agent fill:#189AB4,stroke:#7C90A0,color:#fff
-    classDef config fill:#F59E0B,stroke:#7C90A0,color:#fff
     classDef default fill:#10B981,stroke:#7C90A0,color:#fff
     
     class A highest
+    class AN none
     class B agent
     class C default
 ```
+
+`retry_policy=None` on `@tool(...)` means **use the fallback** — the tool-level slot is treated as empty, not as "no retries". To disable retries for a specific tool, pass an explicit `RetryPolicy(max_attempts=1)` instead.
 
 **Tool-level (highest priority):**
 ```python
@@ -171,6 +183,22 @@ graph TB
 def flaky_api():
     pass
 ```
+
+<Warning>
+**Do NOT pass `retry_policy=None` to disable retries.** `@tool(retry_policy=None)` is treated as *"no policy set here"* and falls through to the agent-level or default `RetryPolicy`. To actually disable retries for a specific tool, pass `RetryPolicy(max_attempts=1)`.
+
+```python
+# ✅ Disable retries for a specific tool
+@tool(retry_policy=RetryPolicy(max_attempts=1))
+def one_shot_only():
+    ...
+
+# ⚠️ retry_policy=None falls through to agent/default policy — NOT "no retries"
+@tool(retry_policy=None)
+def uses_agent_or_default():
+    ...
+```
+</Warning>
 
 **Agent-level (medium priority):**
 ```python
@@ -217,7 +245,7 @@ graph TB
 | `max_attempts` | `int` | `3` | Total attempts including the first try |
 | `initial_delay_ms` | `int` | `1000` | Delay before first retry, in milliseconds |
 | `backoff_factor` | `float` | `2.0` | Multiplier applied to delay per attempt |
-| `retry_on` | `set[str]` | `{"timeout","rate_limit","connection_error"}` | Error types that trigger a retry |
+| `retry_on` | `set[str]` | `{"timeout","rate_limit","connection_error"}` | Error types that trigger a retry. `rate_limit` matches messages containing `"rate…limit"` **or** `"too many requests"` |
 | `jitter` | `bool` | `False` | Add randomized jitter to delays |
 | `jitter_factor` | `float` | `0.25` | Jitter range as fraction of delay (±25%) |
 | `max_delay_ms` | `int` | `30000` | Maximum delay between retries |

--- a/docs/features/yaml-configuration-reference.mdx
+++ b/docs/features/yaml-configuration-reference.mdx
@@ -128,6 +128,45 @@ PraisonAI accepts both old and new field names. **Use canonical names for new pr
 
 <Note>
 The validator automatically normalises these aliases — `agents`↔`roles`, `topic`↔`input`, and `stream`↔`streaming` are all accepted and converted to their canonical form. You can mix old and new names freely.
+
+`instructions` is normalised to `backstory` at **two points**: once at YAML load (`_normalize_yaml_config`) and once at schema validation — so downstream code that reads `backstory` works correctly regardless of which input shape you use.
+</Note>
+
+---
+
+## List vs. Dict Shape
+
+PraisonAI auto-normalises list-form `agents`, `roles`, and `tasks` into dict form on load — you don't need to convert legacy configs by hand.
+
+<Tabs>
+  <Tab title="List form (e.g. imported from CrewAI-style YAML)">
+```yaml
+agents:
+  - name: researcher
+    role: Research Analyst
+    instructions: "Expert researcher"
+
+tasks:
+  - name: research_task
+    agent: researcher
+    description: "Research {{topic}}"
+```
+  </Tab>
+  <Tab title="Dict form (canonical — recommended for new projects)">
+```yaml
+agents:
+  researcher:
+    role: Research Analyst
+    instructions: "Expert researcher"
+    tasks:
+      research_task:
+        description: "Research {{topic}}"
+```
+  </Tab>
+</Tabs>
+
+<Note>
+When a top-level `tasks:` list is normalised, each task is attached to its named agent's `tasks:` map. A task whose `agent:` key doesn't match any defined agent is **logged as a warning and skipped** — the run continues rather than crashing.
 </Note>
 
 ---


### PR DESCRIPTION
## Summary

Documents three user-visible behaviour changes from PraisonAI#2634:

### Change 1 — List-format `agents`/`roles`/`tasks` YAML auto-normalisation
- Added new **"List vs. Dict Shape"** section to `docs/features/yaml-configuration-reference.mdx`
- Side-by-side Tabs block showing list form vs dict form (canonical)
- Note clarifying that unresolved `task.agent` keys warn-and-skip (do not crash)
- Added `instructions`→`backstory` dual-normalisation footnote to the Field Name Mapping `<Note>`

### Change 2 — `@tool(retry_policy=None)` no longer bypasses default policy
- Updated precedence ladder diagram in `docs/features/tool-retry-policy.mdx` with `None → falls through` edge
- Added prose clarification that `retry_policy=None` falls through to agent/default policy
- Added `<Warning>` block with correct pattern (`RetryPolicy(max_attempts=1)` to disable retries)

### Change 3 — "too many requests" now classifies as `rate_limit`
- Added classifier description with examples to the "How It Works" section
- Updated `retry_on` row in Configuration Options table to mention both `"rate…limit"` and `"too many requests"`

## Checklist
- [x] `docs/features/yaml-configuration-reference.mdx` documents list-form normalisation with Tabs example
- [x] `docs/features/yaml-configuration-reference.mdx` mentions that unresolved `task.agent` keys warn-and-skip
- [x] `docs/features/tool-retry-policy.mdx` `<Warning>` block clarifies `retry_policy=None` falls through
- [x] `docs/features/tool-retry-policy.mdx` shows `RetryPolicy(max_attempts=1)` as correct "disable retries" pattern
- [x] `docs/features/tool-retry-policy.mdx` classifier description includes `"too many requests"`
- [x] `docs.json` unchanged; `python3 -m json.tool docs.json` validates
- [x] No files under `docs/concepts/`, `docs/js/`, `docs/rust/` touched

Fixes #1522

Generated with [Claude Code](https://claude.ai/code)