### PR TITLE
Post-1520: auto pipeline sync on main push + docs-primary 80-file cap

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -124,6 +124,15 @@ assert('nav path removal still sensitive', mg.sensitivePathReasons([{ filename: 
 const conflictMarkerPatch = navOnlyPatch.replace('+      "docs/features/new-page",', '+<<<<<<< HEAD');
 assert('conflict markers in docs.json blocked', !mg.isNavOnlyDocsJsonPatch(conflictMarkerPatch));
 
+assert(
+  'docs.json additions-only without patch not sensitive',
+  mg.sensitivePathReasons([{ filename: 'docs.json', additions: 3, deletions: 0 }]).length === 0
+);
+assert(
+  'docs.json deletions without patch still sensitive',
+  mg.sensitivePathReasons([{ filename: 'docs.json', additions: 1, deletions: 2 }]).length === 1
+);
+
 const docsPrimaryFiles = [
   { filename: 'docs/features/foo.mdx', additions: 840 },
 ];

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -15,11 +15,16 @@ const BLOAT_FILE_MAX_AUTO_LINES = 100;
 const PR_MAX_AUTO_ADDITIONS = 800;
 const PR_MAX_AUTO_FILES = 30;
 const DOCS_PRIMARY_MAX_ADDITIONS = 1200;
-const DOCS_PRIMARY_MAX_FILES = 40;
+const DOCS_PRIMARY_MAX_FILES = 80;
 const DOCS_PRIMARY_MAX_SDK_ADDITIONS = 25;
 const MANUAL_ONLY_LABELS = new Set(['security', 'breaking-change', 'needs-manual-review', 'release']);
 const WORKFLOW_ONLY_LABEL = 'merge-gate-ci-only';
-const CI_ONLY_PATH_PREFIXES = ['.github/workflows/', '.github/actions/', '.github/scripts/merge-gate'];
+const CI_ONLY_PATH_PREFIXES = [
+  '.github/workflows/',
+  '.github/actions/',
+  '.github/scripts/merge-gate',
+  '.github/scripts/pipeline-status',
+];
 const SDK_PATH_PREFIXES = ['praisonaiagents/', 'praisonai/'];
 const BLOAT_FILES = [];
 const SENSITIVE_PATH_PATTERNS = [
@@ -606,13 +611,20 @@ function hasManualOnlyLabel(labels) {
   return labels.some((l) => MANUAL_ONLY_LABELS.has(l));
 }
 
+function isDocsJsonAdditionsOnly(file) {
+  if (file.filename !== 'docs.json') return false;
+  if (file.patch && isNavOnlyDocsJsonPatch(file.patch)) return true;
+  if (!file.patch && (file.deletions || 0) === 0 && (file.additions || 0) > 0) return true;
+  return false;
+}
+
 function sensitivePathReasons(files, labels = []) {
   if (labels.includes(WORKFLOW_ONLY_LABEL) && isCiOnlyChange(files)) {
     return [];
   }
   const reasons = [];
   for (const f of files) {
-    if (f.filename === 'docs.json' && isNavOnlyDocsJsonPatch(f.patch)) continue;
+    if (isDocsJsonAdditionsOnly(f)) continue;
     if (SENSITIVE_PATH_PATTERNS.some((p) => p.test(f.filename))) {
       reasons.push(`sensitive path: ${f.filename}`);
       break;
@@ -930,6 +942,7 @@ module.exports = {
   touchesSdk,
   hasManualOnlyLabel,
   sensitivePathReasons,
+  isDocsJsonAdditionsOnly,
   isNavOnlyDocsJsonPatch,
   isDocsPrimaryPullRequest,
   extractDocsNavPath,

--- a/.github/workflows/pipeline-status-sync.yml
+++ b/.github/workflows/pipeline-status-sync.yml
@@ -3,6 +3,14 @@ name: Pipeline Status Sync
 # Sync pipeline/* stage and blocker labels on open internal PRs.
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/merge-gate.js'
+      - '.github/scripts/merge-gate-selftest.js'
+      - '.github/scripts/pipeline-status.js'
+      - '.github/workflows/claude-merge-gate.yml'
+      - '.github/workflows/pipeline-status-sync.yml'
   schedule:
     - cron: '*/10 * * * *'
   workflow_dispatch:
@@ -29,5 +37,5 @@ jobs:
             const ps = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/pipeline-status.js'));
             await ps.syncOpenPullRequests(
               github, context.repo.owner, context.repo.repo,
-              { maxPrs: 30, dispatchMergeGate: true }, core
+              { maxPrs: 50, dispatchMergeGate: true }, core
             );


### PR DESCRIPTION
## Summary
- **80-file cap** for docs-primary PRs (unblocks #1517 bot migration sweep — 60 files)
- **docs.json without patch**: additions-only treated as nav-safe when GitHub omits diff
- **Auto label sync** on push to `main` when merge-gate / pipeline-status files change
- **Scan 50 PRs** per pipeline sync (was 30)

## Test plan
- [x] merge-gate-selftest.js (44 tests)
- [ ] After merge: #1517 should lose manual-review; pipeline sync runs automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of documentation-only changes so simple additions are less likely to trigger extra review, while deletions still receive the expected scrutiny.
  * Expanded automated status syncing so more open changes are processed in each run.
* **Chores**
  * Adjusted review thresholds for doc-heavy updates to reduce unnecessary manual checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->