### PR TITLE
docs: reflect ToolResolver delegation in tools doctor / dependency checker / tools list diagnostics

### DIFF
--- a/docs/cli/strict-tools.mdx
+++ b/docs/cli/strict-tools.mdx
@@ -4,8 +4,6 @@ description: "Fail-fast dependency checking for templates"
 icon: "shield-check"
 ---
 
-## Overview
-
 Strict tools mode provides fail-fast dependency checking before running templates. When enabled, the template will not execute if any required tool, package, or environment variable is missing.
 
 ## Python API
@@ -46,7 +44,7 @@ checker = DependencyChecker()
 # Check tool availability
 tool_status = checker.check_tool("internet_search")
 print(f"Available: {tool_status['available']}")
-print(f"Source: {tool_status['source']}")  # builtin, praisonai-tools, custom
+print(f"Source: {tool_status['source']}")  # local, builtin, external, registered, resolver, custom
 
 # Check package availability
 pkg_status = checker.check_package("pandas")
@@ -58,6 +56,26 @@ env_status = checker.check_env_var("OPENAI_API_KEY")
 print(f"Available: {env_status['available']}")
 print(f"Masked value: {env_status['masked_value']}")  # sk-****1234
 ```
+
+### Tool Source Values
+
+`check_tool()` delegates to `ToolResolver.list_available_sources()` — the same resolution chain used at agent run time. The `source` field reflects where the tool actually comes from:
+
+| Source | Where it comes from | Notes |
+|--------|---------------------|-------|
+| `local` | Your local `tools.py` (via `ToolResolver`) | Requires `PRAISONAI_ALLOW_LOCAL_TOOLS=true` |
+| `builtin` | `praisonaiagents.tools` (via `ToolResolver`) | No extra install needed |
+| `external` | `praisonai-tools` package (via `ToolResolver`) | Requires `pip install praisonai-tools` |
+| `registered` | Wrapper `ToolRegistry` or core SDK entry-point plugin (via `ToolResolver`) | Tools registered via `register_function()` |
+| `resolver` | Resolvable but not attributed to a bucket (rare) | Conservative fallback |
+| `custom` | Custom tool directories (`custom_tool_dirs=[...]`) | Always honored unconditionally |
+| `builtin` / `praisonai-tools` / `custom` | Legacy fallback path | Only appears when `ToolResolver` cannot be imported |
+
+<Note>
+**Tools registered via `ToolRegistry.register_function()` and core SDK entry-point plugins are now correctly reported as `available`.** Before [PR #2642](https://github.com/MervinPraison/PraisonAI/pull/2642), these tools resolved correctly at agent run time but were reported as "not installed" by the dependency checker. The checker now delegates to `ToolResolver` — the same source of truth used by `resolve()` — so diagnostic output matches runtime behaviour.
+
+If you are migrating from an earlier version and previously saw tools reported as missing in strict mode, verify those tools are registered via `ToolRegistry` or a `praisonai.tool_sources` entry-point plugin — they will now appear as `available` with `source: "registered"`.
+</Note>
 
 ### Getting Install Hints
 
@@ -77,6 +95,8 @@ for hint in hints:
 # • Package 'opencv-python': pip install opencv-python
 # • Environment variable 'YOUTUBE_API_KEY': export YOUTUBE_API_KEY=<value>
 ```
+
+Install hints are only generated for tools that are genuinely missing from all sources. Tools that resolve via `ToolRegistry` or entry-point plugins will not trigger install hints.
 
 ## StrictModeError
 
@@ -101,13 +121,29 @@ except StrictModeError as e:
 
 ## Custom Tool Directories
 
-The checker can search custom directories for tools:
+The checker always honors `custom_tool_dirs` on top of the resolver's chain:
 
 ```python
 checker = DependencyChecker(
     custom_tool_dirs=["~/.praisonai/tools", "./my-tools"]
 )
 
-# Tools in custom dirs will be found
+# Tools in custom dirs will be found (source: "custom:<dir>")
 result = checker.check_tool("my_custom_tool")
 ```
+
+Custom directories are not part of the `ToolResolver` chain — they are checked unconditionally so template-local tool directories always resolve regardless of resolver availability.
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Tools Doctor" icon="stethoscope" href="/docs/cli/tools-doctor">
+  Full tool availability diagnostics
+</Card>
+<Card title="Tool Resolver" icon="wrench" href="/docs/features/tool-resolver">
+  Resolution chain and source labels
+</Card>
+<Card title="Tools" icon="wrench" href="/docs/cli/tools">
+  Source label table and CLI reference
+</Card>
+</CardGroup>

--- a/docs/cli/strict-tools.mdx
+++ b/docs/cli/strict-tools.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Strict Tools Mode"
+sidebarTitle: "Strict Tools Mode"
 description: "Fail-fast dependency checking for templates"
 icon: "shield-check"
 ---

--- a/docs/cli/tools-discover.mdx
+++ b/docs/cli/tools-discover.mdx
@@ -99,6 +99,7 @@ graph LR
 
 ## Legacy Discovery (Pre-#2476)
 
+<AccordionGroup>
 <Accordion title="Raw importlib / TOOL_MAPPINGS pattern (deprecated)">
 Before `ToolResolver.list_available_sources()` was introduced in [PR #2476](https://github.com/MervinPraison/PraisonAI/pull/2476), each surface walked its own partial subset:
 
@@ -120,6 +121,7 @@ for name in dir(ext_tools):
 
 Use `ToolResolver.list_available_sources()` instead — it covers all four sources in a single call.
 </Accordion>
+</AccordionGroup>
 
 ## Related
 

--- a/docs/cli/tools-discover.mdx
+++ b/docs/cli/tools-discover.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tools Discover"
+sidebarTitle: "Tools Discover"
 description: "Discover tools from all available sources via ToolResolver"
 icon: "search"
 ---

--- a/docs/cli/tools-discover.mdx
+++ b/docs/cli/tools-discover.mdx
@@ -1,27 +1,109 @@
 ---
 title: "Tools Discover"
-description: "Discover tools from installed packages"
+description: "Discover tools from all available sources via ToolResolver"
+icon: "search"
 ---
 
-## Code Usage
+`ToolResolver.list_available_sources()` is the single entry point for discovering tools from every source — local `tools.py`, built-in agents tools, the `praisonai-tools` package, and registered or plugin tools.
+
+## Quick Start
 
 ```python
-import importlib
+from praisonai.tool_resolver import ToolResolver
 
-# Discover tools from praisonai_tools
-try:
-    import praisonai_tools.tools as ext_tools
-    for name in dir(ext_tools):
-        if not name.startswith('_'):
-            obj = getattr(ext_tools, name, None)
-            if callable(obj):
-                print(f"Found: {name}")
-except ImportError:
-    pass
+resolver = ToolResolver()
+sources = resolver.list_available_sources()
+
+# sources is a dict of {tool_name: source_label}
+print(f"Total tools available: {len(sources)}")
+for name, source in list(sources.items())[:10]:
+    print(f"  {name}: {source}")
 ```
 
+## Filter by Source Bucket
+
 ```python
-# Discover from praisonaiagents built-in tools
+from praisonai.tool_resolver import ToolResolver
+
+resolver = ToolResolver()
+sources = resolver.list_available_sources()
+
+local      = [n for n, s in sources.items() if s == "local"]
+builtin    = [n for n, s in sources.items() if s == "builtin"]
+external   = [n for n, s in sources.items() if s == "external"]
+registered = [n for n, s in sources.items() if s == "registered"]
+
+print(f"Local tools ({len(local)}):      {local}")
+print(f"Built-in tools ({len(builtin)}): {builtin[:5]}...")
+print(f"External tools ({len(external)}): {external[:5]}...")
+print(f"Registered tools ({len(registered)}): {registered}")
+```
+
+**Source bucket reference:**
+
+| Source | What it includes |
+|--------|-----------------|
+| `local` | Functions and classes from your local `tools.py` |
+| `builtin` | Tools shipped with `praisonaiagents.tools` |
+| `external` | Tools from the optional `praisonai-tools` package |
+| `registered` | Tools added via `ToolRegistry.register_function()` or a `praisonai.tool_sources` entry-point plugin |
+
+## Check a Single Tool
+
+```python
+from praisonai.tool_resolver import ToolResolver
+
+resolver = ToolResolver()
+
+# has_tool() uses the same chain without loading the callable
+if resolver.has_tool("internet_search"):
+    source = resolver.list_available_sources().get("internet_search")
+    print(f"internet_search is available from: {source}")
+```
+
+## CLI Equivalent
+
+```bash
+# Same resolver-backed enumeration from the command line
+praisonai tools list
+
+# Filter by bucket
+praisonai tools list --source registered
+praisonai tools list --source external
+praisonai tools list --source local
+praisonai tools list --source builtin
+
+# Full diagnostics (same source of truth)
+praisonai tools doctor
+```
+
+## How It Works
+
+```mermaid
+graph LR
+    subgraph "ToolResolver.list_available_sources()"
+        A["local\ntools.py"] --> OUT["Dict[name, source]"]
+        B["builtin\npraisonaiagents.tools"] --> OUT
+        C["external\npraisonai-tools"] --> OUT
+        D["registered\nToolRegistry / plugins"] --> OUT
+    end
+
+    classDef source fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A,B,C,D source
+    class OUT output
+```
+
+`list_available_sources()` reflects the same four-source chain that `resolve()` uses at run time. Every name returned can be passed to `resolve(name)` and will load successfully — no more "visible in list, fails at runtime" mismatches.
+
+## Legacy Discovery (Pre-#2476)
+
+<Accordion title="Raw importlib / TOOL_MAPPINGS pattern (deprecated)">
+Before `ToolResolver.list_available_sources()` was introduced in [PR #2476](https://github.com/MervinPraison/PraisonAI/pull/2476), each surface walked its own partial subset:
+
+```python
+# Old pattern — only sees TOOL_MAPPINGS, misses registered/plugin tools
 from praisonaiagents import TOOL_MAPPINGS
 
 for tool_name in list(TOOL_MAPPINGS.keys())[:10]:
@@ -29,11 +111,26 @@ for tool_name in list(TOOL_MAPPINGS.keys())[:10]:
 ```
 
 ```python
-# Discover from custom package
-import importlib
-
-pkg = "my_custom_tools"
-mod = importlib.import_module(pkg)
-tools = [n for n in dir(mod) if not n.startswith('_') and callable(getattr(mod, n, None))]
-print(f"Found {len(tools)} tools in {pkg}")
+# Old pattern — only sees praisonai_tools, misses builtin/registered
+import praisonai_tools.tools as ext_tools
+for name in dir(ext_tools):
+    if not name.startswith('_') and callable(getattr(ext_tools, name, None)):
+        print(f"Found: {name}")
 ```
+
+Use `ToolResolver.list_available_sources()` instead — it covers all four sources in a single call.
+</Accordion>
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Tools" icon="wrench" href="/docs/cli/tools">
+  Source label table and --source filter
+</Card>
+<Card title="Tool Resolver" icon="wrench" href="/docs/features/tool-resolver">
+  Full resolver API and source buckets
+</Card>
+<Card title="Tools Doctor" icon="stethoscope" href="/docs/cli/tools-doctor">
+  Diagnostic output backed by the resolver
+</Card>
+</CardGroup>

--- a/docs/cli/tools-doctor-cli.mdx
+++ b/docs/cli/tools-doctor-cli.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tools Doctor CLI"
+sidebarTitle: "Tools Doctor CLI"
 description: "CLI commands for diagnosing tool availability"
 icon: "terminal"
 ---

--- a/docs/cli/tools-doctor-cli.mdx
+++ b/docs/cli/tools-doctor-cli.mdx
@@ -4,6 +4,8 @@ description: "CLI commands for diagnosing tool availability"
 icon: "terminal"
 ---
 
+`praisonai tools doctor` uses the same `ToolResolver` source of truth as `praisonai tools list` — the counts and tool names you see are guaranteed to match what actually loads at agent run time.
+
 ```bash
 # Run full diagnostics (human-readable output)
 praisonai tools doctor
@@ -20,11 +22,21 @@ praisonai tools doctor --json
 #   ✓ praisonaiagents
 #   ✓ praisonai-tools (optional)
 #
-# Built-in Tools (15):
-#   • internet_search
+# Built-in Tools (15):            ← resolver "builtin" bucket, sorted A-Z
+#   • arxiv_search
 #   • calculator
-#   • read_file
+#   • internet_search
 #   ... and 12 more
+#
+# praisonai-tools (8):            ← resolver "external" bucket, sorted A-Z
+#   • csv_tool
+#   • excel_tool
+#   • pdf_tool
+#   ... and 5 more
+#
+# Registered Tools (2):           ← resolver "registered" bucket (new)
+#   • my_plugin_tool
+#   • my_registered_fn
 #
 # Custom Tool Directories:
 #   ✗ ~/.praisonai/tools
@@ -33,3 +45,19 @@ praisonai tools doctor --json
 # ✓ No issues found
 # ============================================================
 ```
+
+<Note>
+**Counts now match `praisonai tools list`.** As of [PR #2642](https://github.com/MervinPraison/PraisonAI/pull/2642), both commands read from `ToolResolver.list_available_sources()`. Previously the doctor and the list command walked different partial subsets of the tool chain, so their counts could disagree. They are now the same source of truth.
+
+A tool that resolves at run time is visible in both `tools doctor` and `tools list`. A tool that does not resolve is reported as missing in both.
+</Note>
+
+### Fallback mode
+
+When `ToolResolver` cannot be imported (e.g. the `praisonai` wrapper package is not installed), the doctor falls back to a direct `TOOL_MAPPINGS` / `praisonai_tools` scan. In this mode:
+
+- Built-in and praisonai-tools counts are shown (unsorted, in dict-iteration order)
+- The `Registered Tools` section is not shown
+- The `local` bucket is not reflected
+
+Install the `praisonai` wrapper package to get full resolver-backed output.

--- a/docs/cli/tools-doctor-cli.mdx
+++ b/docs/cli/tools-doctor-cli.mdx
@@ -39,7 +39,7 @@ praisonai tools doctor --json
 #   • my_registered_fn
 #
 # Custom Tool Directories:
-#   ✗ ~/.praisonai/tools
+#   ✗ ~/.praison/tools
 #   ✗ ~/.config/praison/tools
 #
 # ✓ No issues found

--- a/docs/cli/tools-doctor.mdx
+++ b/docs/cli/tools-doctor.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tools Doctor"
+sidebarTitle: "Tools Doctor"
 description: "Diagnose tool availability and dependencies"
 icon: "stethoscope"
 ---

--- a/docs/cli/tools-doctor.mdx
+++ b/docs/cli/tools-doctor.mdx
@@ -4,9 +4,73 @@ description: "Diagnose tool availability and dependencies"
 icon: "stethoscope"
 ---
 
-## Overview
+Tools Doctor diagnoses tool availability, checks dependencies, and reports issues with your PraisonAI tools setup — using the same `ToolResolver` source of truth as `praisonai tools list`.
 
-The Tools Doctor command diagnoses tool availability, checks dependencies, and reports issues with your PraisonAI tools setup.
+## Quick Start
+
+```python
+from praisonai.templates import ToolsDoctor
+
+doctor = ToolsDoctor()
+result = doctor.diagnose()
+
+print(f"praisonai-tools installed: {result['praisonai_tools_installed']}")
+print(f"Built-in tools: {len(result['builtin_tools'])}")
+print(f"Issues found: {len(result['issues'])}")
+
+# Human-readable output
+print(doctor.diagnose_human())
+```
+
+## How Tools Are Discovered
+
+`ToolsDoctor` delegates to `ToolResolver.list_available_sources()` — the same resolution chain that `praisonai tools list` and `resolve()` use at run time. This guarantees that the doctor's counts and listings match what actually loads when agents run.
+
+```mermaid
+graph TB
+    D["ToolsDoctor.diagnose()"] --> RS["_resolver_sources()"]
+    RS --> LAS["ToolResolver.list_available_sources()"]
+    LAS --> B["builtin bucket\n(praisonaiagents.tools)"]
+    LAS --> L["local bucket\n(tools.py)"]
+    LAS --> E["external bucket\n(praisonai-tools)"]
+    LAS --> R["registered bucket\n(ToolRegistry / plugins)"]
+    B --> OUT["Doctor output\nbuiltin_tools (sorted)"]
+    E --> OUT2["Doctor output\npraisonai_tools_available (sorted)"]
+    R --> OUT3["Doctor output\nregistered tools listed"]
+
+    classDef entry fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef resolver fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef bucket fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class D entry
+    class RS,LAS resolver
+    class B,L,E,R bucket
+    class OUT,OUT2,OUT3 output
+```
+
+**Bucket mapping:**
+
+| Doctor field | Resolver bucket | What's included |
+|---|---|---|
+| `builtin_tools` | `builtin` | Tools from `praisonaiagents.tools`, sorted alphabetically |
+| `praisonai_tools_available` | `external` | Tools from `praisonai-tools` package, sorted alphabetically |
+| Registered tools (new) | `registered` | Tools from `ToolRegistry.register_function()` or entry-point plugins |
+
+<Note>
+**Registered tools are now visible.** As of [PR #2642](https://github.com/MervinPraison/PraisonAI/pull/2642), tools registered via `ToolRegistry.register_function()` and core SDK entry-point plugins appear in the doctor's output. Previously they were silently omitted — they resolved correctly at runtime but were invisible to diagnostics.
+
+See [`ToolResolver.list_available_sources()`](/docs/features/tool-resolver#configuration-options) and the [source label table](/docs/cli/tools) for full details.
+</Note>
+
+### Fallback Behaviour
+
+When `ToolResolver` cannot be imported (e.g. the `praisonai` wrapper package is not installed), the doctor falls back to:
+
+- `_get_builtin_tools()` → direct `praisonaiagents.tools.TOOL_MAPPINGS` scan (unsorted, legacy labels)
+- `_get_praisonai_tools_list()` → direct `praisonai_tools` module scan (unsorted, legacy labels)
+
+The fallback path covers the same `builtin` and `praisonai-tools` sources, but misses the `local`, `external` (resolver-filtered), and `registered` buckets. Install the `praisonai` wrapper to get full resolver-backed diagnostics.
 
 ## Python API
 
@@ -40,11 +104,13 @@ The `diagnose()` method returns a dictionary with:
 |-----|------|-------------|
 | `praisonai_tools_installed` | bool | Whether praisonai-tools package is installed |
 | `praisonaiagents_installed` | bool | Whether praisonaiagents is installed |
-| `builtin_tools` | list | List of available built-in tool names |
-| `praisonai_tools_available` | list | Tools from praisonai-tools package |
+| `builtin_tools` | list | Sorted list of available built-in tool names (resolver `builtin` bucket) |
+| `praisonai_tools_available` | list | Sorted list of tools from praisonai-tools (resolver `external` bucket) |
 | `custom_tools_dirs` | list | Status of custom tool directories |
 | `tool_dependencies` | dict | Optional dependencies for known tools |
 | `issues` | list | Detected issues with severity and hints |
+
+`builtin_tools` and `praisonai_tools_available` are **sorted alphabetically** — matching `praisonai tools list` output order. The legacy fallback path returns them in dict-iteration order (unsorted).
 
 ## Custom Tool Directories
 
@@ -83,3 +149,20 @@ for tool, deps in result["tool_dependencies"].items():
 | `error` | Critical issue preventing tool usage |
 | `warning` | Non-critical issue that may affect functionality |
 | `info` | Informational message about optional features |
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Tools Doctor CLI" icon="terminal" href="/docs/cli/tools-doctor-cli">
+  Run diagnostics from the command line
+</Card>
+<Card title="Tool Resolver" icon="wrench" href="/docs/features/tool-resolver#configuration-options">
+  list_available_sources() and source buckets
+</Card>
+<Card title="Tools" icon="wrench" href="/docs/cli/tools">
+  Source label table and CLI reference
+</Card>
+<Card title="Strict Tools Mode" icon="shield-check" href="/docs/cli/strict-tools">
+  Fail-fast dependency checking for templates
+</Card>
+</CardGroup>

--- a/docs/cli/tools-doctor.mdx
+++ b/docs/cli/tools-doctor.mdx
@@ -116,7 +116,7 @@ The `diagnose()` method returns a dictionary with:
 
 The doctor checks these default directories for custom tools:
 
-- `~/.praisonai/tools` (primary)
+- `~/.praison/tools` (primary)
 - `~/.config/praison/tools` (XDG-friendly)
 
 ```python

--- a/docs/cli/tools.mdx
+++ b/docs/cli/tools.mdx
@@ -35,7 +35,7 @@ praisonai tools info internet_search
 
 ### List Tools
 
-Each tool is attributed to one of four source categories — `builtin`, `local`, `external`, or `registered` — reflecting the exact source that `resolve()` would use at run time.
+Each tool is attributed to one of four source categories — `builtin`, `local`, `external`, or `registered` — reflecting the exact source that `resolve()` would use at run time. The same resolver-backed enumeration now powers `praisonai tools doctor` and template dependency checking — see [Tools Doctor](/docs/cli/tools-doctor) and [Strict Tools Mode](/docs/cli/strict-tools).
 
 ```bash
 praisonai tools list

--- a/docs/features/tool-resolver.mdx
+++ b/docs/features/tool-resolver.mdx
@@ -125,6 +125,10 @@ Tools appear under one of four source labels: `builtin` (`praisonaiagents.tools`
 **Custom-sources subtlety:** a resolver built with an explicit `sources=` list does **not** enumerate the default built-in / external / core-registry sources in discovery (it would misrepresent what `resolve()` can return). The wrapper `ToolRegistry` is always enumerated when present, regardless of custom sources.
 </Note>
 
+<Note>
+**All three diagnostic surfaces share the resolver.** `praisonai tools list` / `tools info`, `ToolsDoctor.diagnose()`, and `DependencyChecker.check_tool()` all consult `ToolResolver.list_available_sources()` as of [PR #2642](https://github.com/MervinPraison/PraisonAI/pull/2642). Their outputs are now guaranteed to agree with `resolve()` — a tool that resolves at run time is now visible everywhere; a tool that doesn't resolve is reported as missing everywhere. See [Tools Doctor](/docs/cli/tools-doctor) and [Strict Tools Mode](/docs/cli/strict-tools) for the updated diagnostic documentation.
+</Note>
+
 ---
 
 ## Registering Tools at Runtime


### PR DESCRIPTION
## Summary

Updates five documentation pages to reflect the resolver-first diagnostic behaviour introduced in [PR #2642](https://github.com/MervinPraison/PraisonAI/pull/2642) — where `ToolsDoctor`, `DependencyChecker`, and `praisonai tools list` all delegate to `ToolResolver.list_available_sources()` as the canonical source of truth.

### Changes

- **`docs/cli/strict-tools.mdx`** — Updated source values in inline comment and added a "Tool Source Values" table covering `local`, `builtin`, `external`, `registered`, `resolver`, `custom`, and legacy fallback labels. Added `<Note>` callout explaining that tools registered via `ToolRegistry.register_function()` and entry-point plugins are now correctly reported as `available` (previously reported as missing).

- **`docs/cli/tools-doctor.mdx`** — Added "How Tools Are Discovered" section with a mermaid flow diagram (`ToolsDoctor.diagnose()` → `_resolver_sources()` → `ToolResolver.list_available_sources()` → buckets → doctor output), bucket mapping table, fallback behaviour explanation, cross-links to `tool-resolver` and `tools`, and a Note about registered tools now appearing in doctor output.

- **`docs/cli/tools-doctor-cli.mdx`** — Updated example output to show resolver-derived counts (builtin sorted A–Z, new `Registered Tools (N):` section from resolver's `registered` bucket). Added `<Note>` explaining that this is now the same source of truth as `praisonai tools list`. Added fallback mode description.

- **`docs/cli/tools-discover.mdx`** — Rewrote around `ToolResolver.list_available_sources()` with bucket filter examples and CLI equivalents. Moved legacy `importlib` / `TOOL_MAPPINGS` pattern under a collapsed `<Accordion>` for historical context.

- **`docs/features/tool-resolver.mdx`** — Added "All three diagnostic surfaces share the resolver" `<Note>` block referencing PR #2642, cross-linking to `tools-doctor` and `strict-tools`.

- **`docs/cli/tools.mdx`** — Added one-line cross-link note under "List Tools" pointing to `tools-doctor` and `strict-tools`.

Fixes #1531

Generated with [Claude Code](https://claude.ai/code)