### PR TITLE
docs: cover standalone praisonai-bot + scheduler surfaces

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -371,6 +371,8 @@
                       "docs/features/bot-command-access-control",
                       "docs/features/bot-run-control",
                       "docs/features/bot-gateway",
+                      "docs/features/standalone-bot-gateway",
+                      "docs/features/standalone-bot-yaml",
                       "docs/features/gateway-exit-codes",
                       "docs/features/gateway-relay-transport",
                       "docs/features/bot-intentional-silence",

--- a/docs/features/async-agent-scheduler.mdx
+++ b/docs/features/async-agent-scheduler.mdx
@@ -534,6 +534,7 @@ scheduler = AsyncAgentScheduler(
 **Import paths (updated in PR #1723):**
 - **Canonical (recommended):** `from praisonai.scheduler import AsyncAgentScheduler`
 - **Explicit module path:** `from praisonai.scheduler.async_agent_scheduler import AsyncAgentScheduler`
+- **Deprecated** (still works, emits `DeprecationWarning`): `from praisonai.async_agent_scheduler import AsyncAgentScheduler`
 
 The sync `AgentScheduler` is unchanged: `from praisonai.scheduler import AgentScheduler`.
 </Note>

--- a/docs/features/async-agent-scheduler.mdx
+++ b/docs/features/async-agent-scheduler.mdx
@@ -557,6 +557,8 @@ See [Scheduler Pre-Run Gate](/docs/features/scheduler-pre-run-gate) for the full
 
 <Note>
 `RunPolicy` adds run-scoped guardrails (tool scoping, prompt scanning, durable audit) to `ScheduledAgentExecutor`. `AsyncAgentScheduler` is independent of `RunPolicy` — see [Scheduled Run Policy](/docs/features/scheduled-run-policy) for how to add guardrails when using `ScheduledAgentExecutor` or `EnhancedScheduledAgentExecutor`.
+
+`AsyncAgentScheduler` lives in the `praisonai` wrapper (`from praisonai.scheduler import AsyncAgentScheduler`). `ScheduledAgentExecutor` and `JobResult` live in the bot tier — use `from praisonai_bot.scheduler import ScheduledAgentExecutor, JobResult` when using them directly.
 </Note>
 
 <CardGroup cols={2}>

--- a/docs/features/async-agent-scheduler.mdx
+++ b/docs/features/async-agent-scheduler.mdx
@@ -534,7 +534,6 @@ scheduler = AsyncAgentScheduler(
 **Import paths (updated in PR #1723):**
 - **Canonical (recommended):** `from praisonai.scheduler import AsyncAgentScheduler`
 - **Explicit module path:** `from praisonai.scheduler.async_agent_scheduler import AsyncAgentScheduler`
-- **Deprecated** (still works, emits `DeprecationWarning`): `from praisonai.scheduler import AsyncAgentScheduler`
 
 The sync `AgentScheduler` is unchanged: `from praisonai.scheduler import AgentScheduler`.
 </Note>

--- a/docs/features/botos.mdx
+++ b/docs/features/botos.mdx
@@ -6,7 +6,7 @@ icon: "robot"
 ---
 
 ```python
-from praisonai import BotOS
+from praisonai_bot.bots import BotOS
 from praisonaiagents import Agent
 
 agent = Agent(name="assistant", instructions="You are a helpful assistant.")
@@ -48,17 +48,20 @@ BotOS lets you deploy your AI agent to **multiple messaging platforms** with jus
 <Steps>
   <Step title="Single platform">
     ```python
-    from praisonai.bots import Bot
+    from praisonai_bot.bots import Bot
     from praisonaiagents import Agent
 
     agent = Agent(name="assistant", instructions="Be helpful")
     bot = Bot("telegram", agent=agent)
     bot.run()
     ```
+    <Tip>
+    `from praisonai.bots import Bot` also works when the `praisonai` wrapper is installed (backward-compatible shim).
+    </Tip>
   </Step>
   <Step title="Multiple platforms">
     ```python
-    from praisonai.bots import BotOS
+    from praisonai_bot.bots import BotOS
     from praisonaiagents import Agent
 
     agent = Agent(name="assistant", instructions="Be helpful")
@@ -68,7 +71,7 @@ BotOS lets you deploy your AI agent to **multiple messaging platforms** with jus
   </Step>
   <Step title="YAML config">
     ```python
-    from praisonai.bots import BotOS
+    from praisonai_bot.bots import BotOS
 
     botos = BotOS.from_config("botos.yaml")
     botos.run()

--- a/docs/features/botos.mdx
+++ b/docs/features/botos.mdx
@@ -162,6 +162,10 @@ bot = Bot("telegram", agent=agent, token="your-token-here")
 
 ## Usage Examples
 
+<Tip>
+Examples below use `from praisonai.bots import Bot, BotOS` — the wrapper aliases. Replace with `from praisonai_bot.bots import Bot, BotOS` when using the standalone `praisonai-bot` package without the wrapper.
+</Tip>
+
 ### Single Agent on Telegram
 
 ```python

--- a/docs/features/botos.mdx
+++ b/docs/features/botos.mdx
@@ -168,8 +168,10 @@ Examples below use `from praisonai.bots import Bot, BotOS` — the wrapper alias
 
 ### Single Agent on Telegram
 
+<Tip>`from praisonai_bot.bots import Bot` is the canonical bot-tier import. `from praisonai.bots import Bot` is a backward-compatible shim when the `praisonai` wrapper is installed.</Tip>
+
 ```python
-from praisonai.bots import Bot
+from praisonai_bot.bots import Bot
 from praisonaiagents import Agent
 
 agent = Agent(
@@ -185,7 +187,7 @@ bot.run()  # Blocks until Ctrl+C
 ### AgentTeam on Discord
 
 ```python
-from praisonai.bots import Bot
+from praisonai_bot.bots import Bot
 from praisonaiagents import Agent, AgentTeam, Task
 
 researcher = Agent(name="researcher", instructions="Research topics thoroughly")
@@ -203,7 +205,7 @@ bot.run()
 ### AgentFlow on Multiple Platforms
 
 ```python
-from praisonai.bots import BotOS, Bot
+from praisonai_bot.bots import BotOS, Bot
 from praisonaiagents import Agent, AgentFlow, Task
 
 analyst = Agent(name="analyst", instructions="Analyze data")
@@ -241,7 +243,7 @@ platforms:
 Then load and run:
 
 ```python
-from praisonai.bots import BotOS
+from praisonai_bot.bots import BotOS
 
 botos = BotOS.from_config("botos.yaml")
 botos.run()

--- a/docs/features/gateway-cli.mdx
+++ b/docs/features/gateway-cli.mdx
@@ -33,7 +33,9 @@ praisonai gateway start --config gateway.yaml
 ```
 
 <Note>
-This page documents the **WebSocket multi-agent Gateway daemon** (`praisonai gateway start`). For the **UI-Gateway** (Pattern C integration), see [`praisonai serve ui-gateway`](/docs/cli/serve#ui-gateway-server-options).
+This page documents the **WebSocket multi-agent Gateway daemon**. The canonical CLI command is `praisonai-bot gateway start` (bot-tier package). When the `praisonai` wrapper is co-installed, `praisonai gateway start` works as a convenience alias.
+
+For the **UI-Gateway** (Pattern C integration), see [`praisonai serve ui-gateway`](/docs/cli/serve#ui-gateway-server-options).
 
 For detailed information about channel resilience and operator controls, see [Channel Supervision](/docs/features/gateway-channel-supervision).
 </Note>
@@ -63,15 +65,19 @@ graph LR
 ## Quick Start
 
 <Note>
-**Important**: `praisonai gateway start` runs in the **foreground**. The daemon is installed by `praisonai gateway install` (or automatically by `praisonai onboard`).
+The gateway runs in the **foreground**. The daemon is installed by `praisonai-bot gateway install` (or automatically by `praisonai-bot onboard`).
 </Note>
 
 <Steps>
 <Step title="Start Gateway">
 ```bash
+# Canonical (bot-tier, no wrapper required)
+praisonai-bot gateway start
+
+# Wrapper alias (requires pip install praisonai)
 praisonai gateway start
 ```
-<Tip>Only one gateway can run per host:port. Stop the existing one with `praisonai gateway stop` first, or use a different port.</Tip>
+<Tip>Only one gateway can run per host:port. Stop the existing one with `praisonai-bot gateway stop` first, or use a different port.</Tip>
 </Step>
 
 <Step title="Check Status">

--- a/docs/features/scheduled-run-policy.mdx
+++ b/docs/features/scheduled-run-policy.mdx
@@ -73,6 +73,9 @@ executor = ScheduledAgentExecutor(
     run_policy=RunPolicy(),
 )
 ```
+<Tip>
+`from praisonai.scheduler.executor import ScheduledAgentExecutor` works as a backward-compatible shim when `praisonai` is installed alongside `praisonai-bot`.
+</Tip>
 `RunPolicy()` with no arguments denies `cronjob` and `messaging-interactive` tools and scans every prompt automatically.
 </Step>
 
@@ -402,7 +405,7 @@ A job can complete successfully but fail to reach the delivery target. Check bot
 
 ```python
 result = executor.run_job(job)
-if result.status == "success" and result.delivery_error:
+if result.status == "succeeded" and result.delivery_error:
     print(f"Job ran OK but delivery failed: {result.delivery_error}")
     print(f"Full output saved at: {result.audit_path}")
 ```

--- a/docs/features/scheduled-run-policy.mdx
+++ b/docs/features/scheduled-run-policy.mdx
@@ -9,7 +9,8 @@ icon: "shield-halved"
 
 ```python
 from praisonaiagents import Agent
-from praisonai.scheduler import ScheduledAgentExecutor, RunPolicy
+from praisonai_bot.scheduler import ScheduledAgentExecutor
+from praisonai.scheduler import RunPolicy
 
 agent = Agent(
     name="NewsBot",
@@ -245,12 +246,26 @@ graph TB
 | `ok` | `bool` | `True` | `True` if the prompt passed the scan. |
 | `reason` | `Optional[str]` | `None` | Human-readable reason when `ok` is `False`. |
 
-### New `JobResult` Fields
+### `JobResult` Reference
+
+```python
+from praisonai_bot.scheduler import JobResult
+```
+
+<Tip>
+`from praisonai.scheduler.executor import JobResult` also works when the `praisonai` wrapper is installed (backward-compatible shim).
+</Tip>
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `delivery_error` | `Optional[str]` | `None` | Delivery failure message, separate from execution `error`. |
-| `audit_path` | `Optional[str]` | `None` | Local path where full output was persisted (if any). |
+| `job` | `ScheduleJob` | required | The `ScheduleJob` that was executed |
+| `result` | `Optional[str]` | `None` | Agent response, or `None` on failure |
+| `status` | `str` | `"succeeded"` | One of `"succeeded"`, `"failed"`, `"skipped"` |
+| `error` | `Optional[str]` | `None` | Error message when `status == "failed"` or skip reason when `status == "skipped"` |
+| `duration` | `float` | `0.0` | Wall-clock seconds for agent execution |
+| `delivered` | `bool` | `False` | Whether the result was delivered to a channel bot |
+| `delivery_error` | `Optional[str]` | `None` | Delivery failure message, separate from execution `error` |
+| `audit_path` | `Optional[str]` | `None` | Local path where full output was persisted (if any) |
 
 ### Built-in Injection Heuristics
 
@@ -382,13 +397,37 @@ if result.status == "success" and result.delivery_error:
 
 ---
 
+## Imports: Bot-First and Wrapper Shims
+
+<Tip>
+`praisonai_bot.scheduler` is the canonical import for `ScheduledAgentExecutor` and `JobResult`. The `praisonai.scheduler.*` paths are backward-compatible shims when the wrapper is installed.
+</Tip>
+
+```python
+# Canonical (bot-tier)
+from praisonai_bot.scheduler import ScheduledAgentExecutor, JobResult
+from praisonai_bot.scheduler.condition_gate import ShellConditionGate
+
+# Wrapper shims (require pip install praisonai)
+from praisonai.scheduler.executor import ScheduledAgentExecutor
+from praisonai.scheduler.condition_gate import ShellConditionGate
+```
+
+---
+
 ## Related
 
 <CardGroup cols={2}>
-<Card icon="clock" href="/docs/features/async-agent-scheduler">
+<Card title="Async Agent Scheduler" icon="clock" href="/docs/features/async-agent-scheduler">
   Schedule agents with cost limits and retries
 </Card>
-<Card icon="terminal" href="/docs/cli/scheduler">
+<Card title="Scheduler Pre-Run Gate" icon="filter" href="/docs/features/scheduler-pre-run-gate">
+  Cost-efficiency gate for scheduled ticks
+</Card>
+<Card title="Schedule CLI" icon="terminal" href="/docs/cli/scheduler">
   Command-line scheduling
+</Card>
+<Card title="praisonai-bot SDK" icon="comments" href="/docs/sdk/praisonai-bot/index">
+  Full bot-tier SDK reference
 </Card>
 </CardGroup>

--- a/docs/features/scheduled-run-policy.mdx
+++ b/docs/features/scheduled-run-policy.mdx
@@ -55,12 +55,17 @@ graph LR
 <Step title="Defaults (safe for unattended runs)">
 ```python
 from praisonaiagents import Agent
-from praisonai.scheduler import ScheduledAgentExecutor, RunPolicy
+from praisonaiagents.scheduler import ScheduleRunner, FileScheduleStore
+from praisonai_bot.scheduler import ScheduledAgentExecutor
+from praisonai.scheduler import RunPolicy
 
 agent = Agent(
     name="NewsBot",
     instructions="Summarise today's AI news in 3 bullets.",
 )
+
+store = FileScheduleStore()
+runner = ScheduleRunner(store)
 
 executor = ScheduledAgentExecutor(
     runner=runner,
@@ -74,17 +79,21 @@ executor = ScheduledAgentExecutor(
 <Step title="With audit and fail-closed delivery">
 ```python
 from praisonaiagents import Agent
-from praisonai.scheduler import ScheduledAgentExecutor, RunPolicy
+from praisonaiagents.scheduler import ScheduleRunner, FileScheduleStore
+from praisonai_bot.scheduler import ScheduledAgentExecutor
+from praisonai.scheduler import RunPolicy
 
 agent = Agent(
     name="ReportBot",
     instructions="Generate a daily summary report.",
 )
 
+store = FileScheduleStore()
+runner = ScheduleRunner(store)
+
 executor = ScheduledAgentExecutor(
     runner=runner,
     agent_resolver=lambda _id: agent,
-    delivery_handler=deliver,
     run_policy=RunPolicy(
         audit_dir="/var/log/praisonai/runs",
         deliver_on_failure=True,
@@ -97,7 +106,9 @@ Every run writes full output to `/var/log/praisonai/runs`. On failure, a compact
 <Step title="Strict allow-list with custom scanner">
 ```python
 from praisonaiagents import Agent
-from praisonai.scheduler import ScheduledAgentExecutor, RunPolicy
+from praisonaiagents.scheduler import ScheduleRunner, FileScheduleStore
+from praisonai_bot.scheduler import ScheduledAgentExecutor
+from praisonai.scheduler import RunPolicy
 
 def my_scanner(prompt):
     return "secret" not in prompt.lower()
@@ -106,6 +117,9 @@ agent = Agent(
     name="SecureBot",
     instructions="Process financial data safely.",
 )
+
+store = FileScheduleStore()
+runner = ScheduleRunner(store)
 
 executor = ScheduledAgentExecutor(
     runner=runner,

--- a/docs/features/scheduler-pre-run-gate.mdx
+++ b/docs/features/scheduler-pre-run-gate.mdx
@@ -225,7 +225,7 @@ Use a callable resolver for richer logic than a shell exit code.
 
 ```python
 from praisonaiagents import Agent
-from praisonaiagents.scheduler import ScheduleJob, Schedule
+from praisonaiagents.scheduler import ScheduleJob, Schedule, ScheduleRunner, FileScheduleStore
 from praisonai_bot.scheduler import ScheduledAgentExecutor
 
 class MyPythonGate:
@@ -235,6 +235,9 @@ class MyPythonGate:
         return r.json().get("pending", 0) > 0
 
 agent = Agent(name="WorkProcessor", instructions="Process pending work items.")
+
+store = FileScheduleStore()
+runner = ScheduleRunner(store)
 
 job = ScheduleJob(
     name="work-processor",

--- a/docs/features/scheduler-pre-run-gate.mdx
+++ b/docs/features/scheduler-pre-run-gate.mdx
@@ -226,7 +226,7 @@ Use a callable resolver for richer logic than a shell exit code.
 ```python
 from praisonaiagents import Agent
 from praisonaiagents.scheduler import ScheduleJob, Schedule
-from praisonai.scheduler.executor import ScheduledAgentExecutor
+from praisonai_bot.scheduler import ScheduledAgentExecutor
 
 class MyPythonGate:
     def check(self, job):
@@ -270,7 +270,7 @@ scripts/fetch_all_data_and_analyse.sh
 The default `timeout=30.0` is conservative. A runaway gate stalls that tick's slot. Set it to match your gate's expected worst case.
 
 ```python
-from praisonai.scheduler.condition_gate import ShellConditionGate
+from praisonai_bot.scheduler.condition_gate import ShellConditionGate
 
 gate = ShellConditionGate(timeout=5.0)
 ```
@@ -314,13 +314,102 @@ A gate returning non-zero records the tick as `skipped` (not `failed`) — this 
 
 ---
 
+## Skip and Failure Reasons
+
+When a tick is skipped or fails, the `JobResult.error` field contains one of these reasons:
+
+| Reason | Source | `status` |
+|--------|--------|----------|
+| `"No message configured"` | Job has no `message` field | `skipped` |
+| `"Agent resolution failed: <exception>"` | `agent_resolver` raised | `failed` |
+| `"No agent found for agent_id=<id>"` | `agent_resolver` returned `None` | `failed` |
+| `"pre-run gate: nothing to do"` | Gate exit non-zero, no stderr | `skipped` |
+| `"pre-run gate: nothing to do (exit <N>: <stderr>)"` | Gate exit non-zero with stderr | `skipped` |
+| `"pre-run gate timed out (>{timeout:.0f}s)"` | Gate exceeded timeout | `skipped` |
+| `"pre-run gate error: <exception>"` | Gate raised exception (defensive: falls back to run) | — |
+| `"Blocked by run policy: <scan.reason>"` | RunPolicy scanner blocked | `failed` |
+
+When `deliver_on_failure` is enabled on the `RunPolicy`, a failure summary is delivered to the channel:
+
+> `⚠️ Scheduled job '<name>' failed: <error>`
+
+---
+
+## `JobResult` Reference
+
+Every tick yields a `JobResult` from `praisonai_bot.scheduler`:
+
+```python
+from praisonai_bot.scheduler import JobResult
+```
+
+<Tip>
+`from praisonai.scheduler.executor import JobResult` also works when the `praisonai` wrapper is installed (backward-compatible shim).
+</Tip>
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `job` | `ScheduleJob` | required | The `ScheduleJob` that was executed |
+| `result` | `Optional[str]` | `None` | Agent response, or `None` on failure |
+| `status` | `str` | `"succeeded"` | One of `"succeeded"`, `"failed"`, `"skipped"` |
+| `error` | `Optional[str]` | `None` | Error message when `status == "failed"` or skip reason when `status == "skipped"` |
+| `duration` | `float` | `0.0` | Wall-clock seconds for agent execution |
+| `delivered` | `bool` | `False` | Whether the result was delivered to a channel bot |
+| `delivery_error` | `Optional[str]` | `None` | Delivery failure message, separate from execution `error` |
+| `audit_path` | `Optional[str]` | `None` | Local path where full output was persisted (if any) |
+
+---
+
+## Session Routing
+
+`session_target` on `ScheduleJob` controls whether a scheduled tick reuses an existing channel session or gets its own isolated context.
+
+| `job.session_target` | Behaviour |
+|----------------------|-----------|
+| `"isolated"` (default) | Each tick uses `session_id=f"cron_{job.id}"` — no shared memory across runs |
+| `"main"` | If `job.delivery.session_id` is set, that session is reused so the scheduled turn joins the channel's ongoing conversation |
+
+`session_id` is passed only when the resolved `agent.chat` accepts a `session_id` keyword argument. The executor inspects the signature before passing it.
+
+```yaml
+schedule:
+  every: 300
+  session_target: main   # join the channel's ongoing session
+```
+
+---
+
+## Imports: Bot-First and Wrapper Shims
+
+<Tip>
+`praisonai_bot.scheduler` is the canonical import for `ScheduledAgentExecutor` and `JobResult`. When the `praisonai` wrapper is installed, `from praisonai.scheduler.executor import ScheduledAgentExecutor` works as a backward-compatible shim.
+</Tip>
+
+```python
+# Canonical (bot-tier)
+from praisonai_bot.scheduler import ScheduledAgentExecutor, JobResult
+from praisonai_bot.scheduler.condition_gate import ShellConditionGate
+
+# Wrapper shims (require pip install praisonai)
+from praisonai.scheduler.executor import ScheduledAgentExecutor
+from praisonai.scheduler.condition_gate import ShellConditionGate
+```
+
+---
+
 ## Related
 
 <CardGroup cols={2}>
 <Card title="Async Agent Scheduler" icon="clock" href="/docs/features/async-agent-scheduler">
   The scheduler this gate plugs into
 </Card>
+<Card title="Scheduled Run Policy" icon="shield-halved" href="/docs/features/scheduled-run-policy">
+  Safety gate — tool scoping, prompt scan, and audit
+</Card>
 <Card title="Schedule CLI" icon="terminal" href="/docs/cli/schedule">
   CLI surface — where `--pre-run` and `--condition` are configured
+</Card>
+<Card title="praisonai-bot SDK" icon="comments" href="/docs/sdk/praisonai-bot/index">
+  Full bot-tier SDK reference
 </Card>
 </CardGroup>

--- a/docs/features/standalone-bot-gateway.mdx
+++ b/docs/features/standalone-bot-gateway.mdx
@@ -1,0 +1,230 @@
+---
+title: "Standalone Bot Gateway"
+sidebarTitle: "Standalone Gateway"
+description: "Run the WebSocket gateway without the praisonai wrapper — bot tier only"
+icon: "server"
+---
+
+Register any `Agent` on a standalone WebSocket gateway with three imports and one `asyncio.run()`.
+
+```mermaid
+graph LR
+    subgraph "Standalone Bot Gateway"
+        A[🤖 Agent] --> G[🗼 praisonai-bot\nGateway]
+        G --> C1[💬 Telegram]
+        G --> C2[🎮 Discord]
+        G --> C3[📱 Slack]
+        G --> C4[🔌 Custom Channel]
+    end
+
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef gateway fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef channel fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class A agent
+    class G gateway
+    class C1,C2,C3,C4 channel
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Install">
+```bash
+pip install praisonaiagents "praisonai-bot[gateway]"
+```
+</Step>
+
+<Step title="Set credentials">
+```bash
+export OPENAI_API_KEY=your_openai_api_key
+```
+</Step>
+
+<Step title="Register an agent on the gateway">
+```python
+import asyncio
+
+from praisonaiagents import Agent
+from praisonaiagents.gateway import GatewayConfig
+from praisonai_bot.gateway import WebSocketGateway
+
+assistant = Agent(name="assistant", instructions="You are a helpful assistant.")
+
+config = GatewayConfig(host="127.0.0.1", port=8765)
+gateway = WebSocketGateway(config=config)
+gateway.register_agent(assistant, agent_id="assistant")
+
+if __name__ == "__main__":
+    print("Gateway: ws://127.0.0.1:8765  health: http://127.0.0.1:8765/health")
+    asyncio.run(gateway.start())
+```
+</Step>
+
+<Step title="Verify the gateway is running">
+```bash
+curl http://127.0.0.1:8765/health
+```
+The response confirms the gateway is live with the registered agent.
+</Step>
+</Steps>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Channel as Channel (Telegram/Discord)
+    participant Gateway as WebSocket Gateway
+    participant Agent
+
+    User->>Channel: Send message
+    Channel->>Gateway: WebSocket message
+    Gateway->>Agent: agent.chat(message)
+    Agent-->>Gateway: response text
+    Gateway-->>Channel: WebSocket reply
+    Channel-->>User: Display response
+```
+
+The gateway routes messages from any connected channel to the registered agent. The agent never knows which channel the message came from — it just receives text and returns a response.
+
+---
+
+## Configuration Options
+
+### `GatewayConfig` fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `host` | `str` | `"127.0.0.1"` | Host to bind the WebSocket server |
+| `port` | `int` | `8765` | Port to listen on |
+
+### `WebSocketGateway.register_agent()` parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `agent` | `Agent` | required | The agent instance to register |
+| `agent_id` | `Optional[str]` | `None` | Custom ID (auto-generated UUID if not provided) |
+| `overwrite` | `bool` | `True` | If `False`, raises `ValueError` on duplicate `agent_id` |
+
+**Returns:** The `agent_id` string used for registration.
+
+---
+
+## CLI Equivalent
+
+<Note>
+`praisonai-bot gateway start` is the canonical CLI command. When the `praisonai` wrapper is co-installed, `praisonai gateway start` is an alias that delegates to the bot tier.
+</Note>
+
+```bash
+# Canonical (bot-tier only)
+praisonai-bot gateway start --host 127.0.0.1 --port 8765
+
+# Wrapper alias (requires pip install praisonai)
+praisonai gateway start --host 127.0.0.1 --port 8765
+```
+
+---
+
+## Common Patterns
+
+### Multiple agents on one gateway
+
+```python
+import asyncio
+from praisonaiagents import Agent
+from praisonaiagents.gateway import GatewayConfig
+from praisonai_bot.gateway import WebSocketGateway
+
+support = Agent(name="support", instructions="Handle customer support tickets.")
+sales = Agent(name="sales", instructions="Answer product and pricing questions.")
+
+config = GatewayConfig(host="127.0.0.1", port=8765)
+gateway = WebSocketGateway(config=config)
+gateway.register_agent(support, agent_id="support")
+gateway.register_agent(sales, agent_id="sales")
+
+asyncio.run(gateway.start())
+```
+
+### Custom agent ID
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.gateway import GatewayConfig
+from praisonai_bot.gateway import WebSocketGateway
+
+agent = Agent(name="assistant", instructions="You are helpful.")
+config = GatewayConfig(host="0.0.0.0", port=8765)
+gateway = WebSocketGateway(config=config)
+
+# Returns the registered agent_id
+aid = gateway.register_agent(agent, agent_id="my-assistant")
+print(f"Registered as: {aid}")
+```
+
+---
+
+## Imports: bot-first and wrapper shims
+
+<Tip>
+`praisonai_bot.gateway` is the canonical import for the `WebSocketGateway` class. When `praisonai` is installed alongside `praisonai-bot`, `from praisonai.gateway import WebSocketGateway` works as a backward-compatible shim.
+</Tip>
+
+```python
+# Canonical (bot-tier, no wrapper required)
+from praisonai_bot.gateway import WebSocketGateway
+
+# Wrapper shim (requires pip install praisonai)
+from praisonai.gateway import WebSocketGateway
+```
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Use agent_id for stable routing">
+Assign explicit `agent_id` values. Channel clients connect by agent ID — changing it after deployment disconnects existing sessions.
+
+```python
+gateway.register_agent(agent, agent_id="assistant-v2")
+```
+</Accordion>
+
+<Accordion title="Bind to 0.0.0.0 only on trusted networks">
+`host="127.0.0.1"` (loopback) is safe for local development. For production, bind to `0.0.0.0` only behind a reverse proxy with TLS termination.
+</Accordion>
+
+<Accordion title="Check /health before routing traffic">
+The health endpoint (`http://host:port/health`) returns `200 OK` when the gateway is ready. Use it in your load balancer or process manager health check.
+</Accordion>
+
+<Accordion title="Use YAML for declarative configuration">
+For multi-agent, multi-channel setups, use the standalone YAML format instead of Python to keep credentials and topology out of code.
+
+See [Standalone Bot YAML](/docs/features/standalone-bot-yaml) for details.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Standalone Bot YAML" icon="file-code" href="/docs/features/standalone-bot-yaml">
+  Declarative gateway + agent + channels config
+</Card>
+<Card title="Gateway CLI" icon="tower-broadcast" href="/docs/features/gateway-cli">
+  CLI commands for starting and managing the gateway
+</Card>
+<Card title="BotOS" icon="robot" href="/docs/features/botos">
+  Multi-platform bot orchestration
+</Card>
+<Card title="praisonai-bot SDK" icon="comments" href="/docs/sdk/praisonai-bot/index">
+  Full bot-tier SDK reference
+</Card>
+</CardGroup>

--- a/docs/features/standalone-bot-yaml.mdx
+++ b/docs/features/standalone-bot-yaml.mdx
@@ -1,0 +1,241 @@
+---
+title: "Standalone Bot YAML"
+sidebarTitle: "Standalone YAML"
+description: "Describe a standalone gateway + agent + channels declaratively"
+icon: "file-code"
+---
+
+Describe your agent, gateway, and channel platforms in a single YAML file — no Python required.
+
+```mermaid
+graph TB
+    subgraph "YAML Config"
+        Y[📄 bot.yaml] --> A[agent]
+        Y --> G[gateway]
+        Y --> P[platforms]
+    end
+    A --> Agent[🤖 Agent]
+    G --> GW[🗼 WebSocket\nGateway]
+    P --> C1[💬 Telegram]
+    P --> C2[🎮 Discord]
+    Agent --> GW
+    GW --> C1
+    GW --> C2
+
+    classDef yaml fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef gateway fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef channel fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Y,A,G,P yaml
+    class Agent agent
+    class GW gateway
+    class C1,C2 channel
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Install">
+```bash
+pip install praisonaiagents "praisonai-bot[gateway,bot]"
+```
+</Step>
+
+<Step title="Set credentials">
+```bash
+export OPENAI_API_KEY=your_openai_api_key
+export TELEGRAM_BOT_TOKEN=your_telegram_token
+```
+</Step>
+
+<Step title="Create bot.yaml">
+```yaml
+agent:
+  name: assistant
+  instructions: You are a helpful assistant.
+  llm: gpt-4o-mini
+
+gateway:
+  host: 127.0.0.1
+  port: 8765
+
+platforms:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+```
+</Step>
+
+<Step title="Start the gateway with your YAML">
+```bash
+praisonai-bot gateway start --config bot.yaml
+```
+The gateway registers the agent and starts all configured channel bots automatically.
+</Step>
+</Steps>
+
+---
+
+## Config Options Reference
+
+### `agent` section
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `agent.name` | `str` | required | Agent display name, used as the `agent_id` for gateway routing |
+| `agent.instructions` | `str` | required | System prompt / instructions for the agent |
+| `agent.llm` | `str` | `"gpt-4o-mini"` | LLM model identifier (e.g. `gpt-4o`, `gpt-4o-mini`) |
+
+### `gateway` section
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `gateway.host` | `str` | `"127.0.0.1"` | Host to bind the WebSocket server |
+| `gateway.port` | `int` | `8765` | Port to listen on |
+
+### `platforms` section
+
+Each key under `platforms` is a platform name. Use `${VAR_NAME}` for environment variable interpolation.
+
+| Key pattern | Type | Description |
+|-------------|------|-------------|
+| `platforms.<name>.token` | `str` | Bot token for the platform. Supports `${ENV_VAR}` substitution |
+
+**Supported platforms:** `telegram`, `discord`, `slack`, `whatsapp`, and any platform registered via entry points.
+
+---
+
+## Environment Variable Interpolation
+
+Values in the form `${VAR_NAME}` are resolved from the current environment at startup:
+
+```yaml
+platforms:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}   # reads os.environ["TELEGRAM_BOT_TOKEN"]
+  discord:
+    token: ${DISCORD_BOT_TOKEN}    # reads os.environ["DISCORD_BOT_TOKEN"]
+```
+
+Tokens stored in `~/.praisonai/.env` (written by `praisonai-bot onboard`) are loaded automatically before interpolation.
+
+---
+
+## When to Pick YAML vs Python
+
+```mermaid
+graph TB
+    Q{Who configures it?} -->|Non-developer / ops| YAML[📄 YAML config]
+    Q -->|Developer / code-first| Python[🐍 Python script]
+
+    YAML --> Y1[✅ No code to maintain]
+    YAML --> Y2[✅ Easy credential rotation]
+    YAML --> Y3[✅ Works with praisonai-bot gateway start]
+
+    Python --> P1[✅ Programmatic agent construction]
+    Python --> P2[✅ Dynamic agent_id or custom registration]
+    Python --> P3[✅ Custom middleware / hooks]
+
+    classDef yaml fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef python fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef yes fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class Q yaml
+    class YAML,Python python
+    class Y1,Y2,Y3,P1,P2,P3 yes
+```
+
+| Scenario | Use |
+|----------|-----|
+| Operations team manages tokens | **YAML** — credentials stay out of code |
+| Static single-agent setup | **YAML** — fewer moving parts |
+| Dynamic agents (created at runtime) | **Python** — full control over `register_agent()` |
+| Custom gateway middleware or hooks | **Python** — subclass or extend `WebSocketGateway` |
+| Multiple environments (dev / staging / prod) | **YAML** — per-environment files with env vars |
+
+---
+
+## Common Patterns
+
+### Multi-platform setup
+
+```yaml
+agent:
+  name: assistant
+  instructions: You are a helpful assistant.
+  llm: gpt-4o-mini
+
+gateway:
+  host: 0.0.0.0
+  port: 8765
+
+platforms:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+  discord:
+    token: ${DISCORD_BOT_TOKEN}
+  slack:
+    token: ${SLACK_BOT_TOKEN}
+```
+
+### Custom port from environment
+
+```yaml
+gateway:
+  host: 0.0.0.0
+  port: 9000
+```
+
+Or set the `GATEWAY_PORT` environment variable — the CLI reads it automatically when `--port` is not passed.
+
+---
+
+## Best Practices
+
+<AccordionGroup>
+<Accordion title="Always use ${...} for tokens">
+Never hardcode tokens in YAML. Use environment variables and store them in `~/.praisonai/.env` (written by `praisonai-bot onboard`) or your secrets manager.
+
+```yaml
+# Good
+platforms:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+
+# Never do this
+platforms:
+  telegram:
+    token: 1234567890:ABCdef...
+```
+</Accordion>
+
+<Accordion title="Run praisonai-bot gateway doctor before going live">
+```bash
+praisonai-bot gateway doctor --config bot.yaml
+```
+This validates every channel token before starting, so a bad token fails fast instead of silently reconnecting.
+</Accordion>
+
+<Accordion title="Use separate YAML files per environment">
+Keep `dev.yaml`, `staging.yaml`, and `prod.yaml` — each referencing different environment variables. Pass the right one with `--config`.
+</Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Standalone Bot Gateway (Python)" icon="server" href="/docs/features/standalone-bot-gateway">
+  Python API equivalent — register agents programmatically
+</Card>
+<Card title="Gateway CLI" icon="tower-broadcast" href="/docs/features/gateway-cli">
+  Full list of gateway CLI commands
+</Card>
+<Card title="BotOS" icon="robot" href="/docs/features/botos">
+  Multi-platform bot orchestration
+</Card>
+<Card title="praisonai-bot SDK" icon="comments" href="/docs/sdk/praisonai-bot/index">
+  Full bot-tier SDK reference
+</Card>
+</CardGroup>

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -71,6 +71,8 @@ graph TB
 
 <Note>
 For gateway hot reload (event-driven `gateway.yaml` watching via `watchdog`), install the gateway extra: `pip install "praisonai[gateway]"`.
+
+**`[claw]` extra:** `pip install "praisonai[claw]"` installs the full wrapper plus `praisonai-bot[gateway,bot]` — the WebSocket gateway and Telegram/Discord/Slack channel bots. Use this when you want the full wrapper and all channel runtime features in one command. For gateway + bots **without** the wrapper, use `pip install "praisonai-bot[gateway,bot]"` directly (see [Standalone Bot Gateway](/docs/features/standalone-bot-gateway)).
 </Note>
 
     <Steps>

--- a/docs/sdk/praisonai-bot/index.mdx
+++ b/docs/sdk/praisonai-bot/index.mdx
@@ -65,7 +65,7 @@ graph LR
 ```python
 from praisonaiagents import Agent
 from praisonaiagents.gateway import GatewayConfig
-from praisonai_bot.bots import Bot
+from praisonai_bot.bots import Bot, BotOS
 from praisonai_bot.gateway import WebSocketGateway
 
 agent = Agent(name="assistant", instructions="You are helpful.")
@@ -73,7 +73,19 @@ gateway = WebSocketGateway(config=GatewayConfig(host="127.0.0.1", port=8765))
 gateway.register_agent(agent, agent_id="assistant")
 
 # Shims: ``from praisonai.gateway import WebSocketGateway`` works when the wrapper is installed.
+# Shims: ``from praisonai.bots import Bot, BotOS`` also works when the wrapper is installed.
 ```
+
+### Scheduler imports
+
+```python
+from praisonai_bot.scheduler import ScheduledAgentExecutor, JobResult
+from praisonai_bot.scheduler.condition_gate import ShellConditionGate
+```
+
+<Tip>
+Wrapper shims for backward compatibility: `from praisonai.scheduler.executor import ScheduledAgentExecutor, JobResult` and `from praisonai.scheduler.condition_gate import ShellConditionGate` work when `praisonai` is installed alongside `praisonai-bot`.
+</Tip>
 
 ---
 

--- a/docs/sdk/praisonai/scheduler.mdx
+++ b/docs/sdk/praisonai/scheduler.mdx
@@ -176,8 +176,6 @@ from praisonai_bot.scheduler import ScheduledAgentExecutor, JobResult
 | `on_failure` | `Optional[Callable[..., None]]` | `None` | Called with `(job, error)` on failure |
 | `run_policy` | `Optional[RunPolicy]` | `None` | Wrapper safety gate — scopes tools, scans prompt, persists audit, delivers failure summary |
 | `condition_resolver` | `None \| False \| callable` | `None` | `None` = auto `ShellConditionGate` when `pre_run` set; `False` = gating disabled; callable `(job) → gate \| None` = custom resolver |
-| `owner_id` | `Optional[str]` | auto (`host:pid:uuid8`) | Stable-per-process identity for atomic job claims |
-| `lease_seconds` | `float` | `300.0` | Atomic-claim lease duration in seconds |
 
 ### Public methods
 

--- a/docs/sdk/praisonai/scheduler.mdx
+++ b/docs/sdk/praisonai/scheduler.mdx
@@ -271,4 +271,3 @@ Return type from `RunPolicy.scan_prompt()` and custom `scanner` callables.
 - [praisonai-bot SDK](/docs/sdk/praisonai-bot/index) - Bot-tier package reference
 - [Deploy Module](/docs/sdk/praisonai/deploy) - Deployment functionality
 - [CLI Scheduler](/docs/cli/scheduler) - CLI scheduling commands
-- [Scheduled Run Policy](/docs/features/scheduled-run-policy) - Run-scoped guardrails

--- a/docs/sdk/praisonai/scheduler.mdx
+++ b/docs/sdk/praisonai/scheduler.mdx
@@ -153,25 +153,76 @@ job = ScheduleJob(
 )
 ```
 
-## ScheduledAgentExecutor — condition_resolver
+## ScheduledAgentExecutor
 
-`ScheduledAgentExecutor` (in `praisonai.scheduler.executor`) gains a `condition_resolver` parameter:
+`ScheduledAgentExecutor` lives in the **bot tier** (`praisonai-bot`). The canonical import is:
+
+```python
+from praisonai_bot.scheduler import ScheduledAgentExecutor, JobResult
+```
+
+<Tip>
+`from praisonai.scheduler.executor import ScheduledAgentExecutor` works as a backward-compatible shim when the `praisonai` wrapper is installed alongside `praisonai-bot`.
+</Tip>
+
+### Constructor reference
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `runner` | `ScheduleRunner` | required | An SDK `ScheduleRunner` instance |
+| `agent_resolver` | `Callable[[Optional[str]], Any]` | required | `(agent_id) -> Agent`; may return `None` |
+| `delivery_handler` | `Optional[Callable[..., Any]]` | `None` | Async `(delivery, text) -> None`; routes to a channel bot's `send_message()` |
+| `on_success` | `Optional[Callable[..., None]]` | `None` | Called with `(job, result)` on success |
+| `on_failure` | `Optional[Callable[..., None]]` | `None` | Called with `(job, error)` on failure |
+| `run_policy` | `Optional[RunPolicy]` | `None` | Wrapper safety gate — scopes tools, scans prompt, persists audit, delivers failure summary |
+| `condition_resolver` | `None \| False \| callable` | `None` | `None` = auto `ShellConditionGate` when `pre_run` set; `False` = gating disabled; callable `(job) → gate \| None` = custom resolver |
+| `owner_id` | `Optional[str]` | auto (`host:pid:uuid8`) | Stable-per-process identity for atomic job claims |
+| `lease_seconds` | `float` | `300.0` | Atomic-claim lease duration in seconds |
+
+### Public methods
+
+| Method | Return type | Description |
+|--------|-------------|-------------|
+| `async tick()` | `AsyncIterator[JobResult]` | Check for due jobs and execute them, yielding one `JobResult` per job |
+| `async tick_all()` | `List[JobResult]` | Like `tick()` but collects all results into a list |
+| `async run_loop(interval=15.0, *, max_ticks=None)` | `None` | Convenience loop that calls `tick()` at a fixed interval |
+
+<Note>
+**Atomic claims:** When the backing store supports `claim_due`, each due job is reserved under a cross-process lock so it fires at most once across all tickers/processes/hosts. Stores without that support fall back to the non-atomic `get_due_jobs` path.
+</Note>
+
+### Example
+
+```python
+from praisonaiagents import Agent
+from praisonaiagents.scheduler import ScheduleRunner, FileScheduleStore
+from praisonai_bot.scheduler import ScheduledAgentExecutor
+
+agent = Agent(name="assistant", instructions="You are helpful.")
+store = FileScheduleStore()
+runner = ScheduleRunner(store)
+
+executor = ScheduledAgentExecutor(
+    runner=runner,
+    agent_resolver=lambda agent_id: agent,
+)
+
+import asyncio
+
+async def main():
+    async for result in executor.tick():
+        print(f"Job {result.job.name}: {result.status} ({result.duration:.1f}s)")
+
+asyncio.run(main())
+```
+
+### `condition_resolver` values
 
 | Value | Behaviour |
 |-------|-----------|
 | `None` (default) | Auto-uses `ShellConditionGate` for jobs that have `pre_run` set |
 | `False` | Gating disabled for all jobs |
 | `callable(job) -> gate \| None` | Custom resolver — return a `JobConditionProtocol` instance or `None` to skip gating |
-
-```python
-from praisonai.scheduler.executor import ScheduledAgentExecutor
-
-executor = ScheduledAgentExecutor(
-    runner=runner,
-    agent_resolver=lambda _: agent,
-    condition_resolver=False,
-)
-```
 
 ## JobConditionProtocol and GateResult
 
@@ -189,7 +240,8 @@ from praisonaiagents.scheduler import JobConditionProtocol, GateResult
 Run-scoped guardrail for unattended scheduled agent runs. Scopes the toolset, scans the assembled prompt for injection patterns, persists a durable output audit, and supports fail-closed delivery on failure.
 
 ```python
-from praisonai.scheduler import RunPolicy, PromptScanResult, ScheduledAgentExecutor
+from praisonai.scheduler import RunPolicy, PromptScanResult
+from praisonai_bot.scheduler import ScheduledAgentExecutor
 
 policy = RunPolicy(
     audit_dir="/var/log/praisonai/runs",
@@ -217,6 +269,8 @@ Return type from `RunPolicy.scan_prompt()` and custom `scanner` callables.
 ## Related
 
 - [Scheduler Pre-Run Gate](/docs/features/scheduler-pre-run-gate) - Full user-facing documentation
+- [Scheduled Run Policy](/docs/features/scheduled-run-policy) - Safety gate for unattended runs
+- [praisonai-bot SDK](/docs/sdk/praisonai-bot/index) - Bot-tier package reference
 - [Deploy Module](/docs/sdk/praisonai/deploy) - Deployment functionality
 - [CLI Scheduler](/docs/cli/scheduler) - CLI scheduling commands
 - [Scheduled Run Policy](/docs/features/scheduled-run-policy) - Run-scoped guardrails

--- a/docs/sdk/praisonai/scheduler.mdx
+++ b/docs/sdk/praisonai/scheduler.mdx
@@ -9,7 +9,7 @@ icon: "clock"
 The Scheduler module provides deployment scheduling capabilities with a provider-agnostic design.
 
 <Warning>
-The root-level `praisonai.scheduler` module is deprecated. Use `from praisonai.scheduler import ...` instead.
+The old `praisonai.scheduler` root-level import (pre-PR #1723) is deprecated. Always import from the submodule: `from praisonai.scheduler import ...`.
 </Warning>
 
 ## Import


### PR DESCRIPTION
## Summary

Implements documentation for all items listed in issue #1534 (PraisonAI#2639 follow-up).

### New pages
- `docs/features/standalone-bot-gateway.mdx` — Python quick-start for running the WebSocket gateway without the praisonai wrapper; includes sequenceDiagram, register_agent() reference, CLI equivalents
- `docs/features/standalone-bot-yaml.mdx` — Declarative bot.yaml config format (agent/gateway/platforms), env-var interpolation, Python vs YAML decision table

### Updated pages
- `docs/features/scheduler-pre-run-gate.mdx` — Bot-first imports (`praisonai_bot.scheduler`), full 8-field `JobResult` table, `session_target` section (isolated vs main), skip/failure reason table
- `docs/features/scheduled-run-policy.mdx` — Bot-first imports, full `JobResult` reference (all 8 fields), shim note
- `docs/features/async-agent-scheduler.mdx` — Note clarifying `ScheduledAgentExecutor`/`JobResult` are bot-tier; `AsyncAgentScheduler` stays wrapper-side
- `docs/features/botos.mdx` — Lead with `praisonai_bot.bots` imports; shim Tip added
- `docs/features/gateway-cli.mdx` — Note that `praisonai-bot gateway` is canonical; `praisonai gateway` is the wrapper alias
- `docs/sdk/praisonai-bot/index.mdx` — Scheduler imports section (`ScheduledAgentExecutor`, `JobResult`, `ShellConditionGate`)
- `docs/sdk/praisonai/scheduler.mdx` — Full `ScheduledAgentExecutor` constructor table (9 params), public methods table, atomic claims Note
- `docs/installation.mdx` — `[claw]` extra documented (composes `praisonai-bot[gateway,bot]`)
- `docs.json` — New pages added to Features group near `bot-gateway`

Fixes #1534

Generated with [Claude Code](https://claude.ai/code)