### PR TITLE
Fix stale-FINAL recovery + conflict auto-retry (root cause)

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -151,15 +151,34 @@ const staleComments = [
   { user: { login: 'MervinPraison' }, body: '@claude FINAL architecture reviewer', created_at: finalAt },
   { user: { login: 'praisonai-triage-agent[bot]' }, body: 'Claude finished', created_at: '2026-07-03T10:04:00Z' },
 ];
+const soonAfterNow = new Date('2026-07-03T10:10:00Z').getTime();
 assert(
-  'skip stale recovery when push soon after FINAL',
-  mg.shouldSkipStaleFinalRecovery(staleComments, pushSoonAfter, 'praisonai-triage-agent[bot]').skip
+  'skip stale recovery when push soon after FINAL (within debounce window)',
+  mg.shouldSkipStaleFinalRecovery(staleComments, pushSoonAfter, 'praisonai-triage-agent[bot]', soonAfterNow).skip
+);
+assert(
+  'debounce expires after head push ages out',
+  !mg.isPushSoonAfterLatestFinal(staleComments, pushSoonAfter, new Date('2026-07-03T10:25:00Z').getTime())
+);
+assert(
+  'stale recovery allowed after debounce window',
+  !mg.shouldSkipStaleFinalRecovery(staleComments, pushSoonAfter, null, new Date('2026-07-03T11:00:00Z').getTime()).skip
 );
 assert(
   'automation pusher skips stale recovery',
-  mg.shouldSkipStaleFinalRecovery(staleComments, pushSoonAfter, 'praisonai-triage-agent[bot]').skip
+  mg.shouldSkipStaleFinalRecovery(staleComments, pushSoonAfter, 'praisonai-triage-agent[bot]', soonAfterNow).skip
 );
 assert('isClaudeAutomationLogin triage bot', mg.isClaudeAutomationLogin('praisonai-triage-agent[bot]'));
+
+const cleanMergeConflict = {
+  user: { login: 'MervinPraison' },
+  body: '@claude this PR has merge conflicts with main',
+  created_at: '2026-07-03T10:00:00Z',
+};
+assert(
+  'conflict comment ignored when merge state is CLEAN',
+  !mg.hasRecentConflictComment([cleanMergeConflict], '2026-07-03T09:00:00Z', 'CLEAN')
+);
 
 // Cooldown: FINAL current on HEAD should not block merge gate
 const finalCompleteComments = [

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -46,8 +46,10 @@ const SECRET_PATTERNS = [
 ];
 const MERGE_GATE_ACTIVE_LABEL = 'claude-merge-gate-active';
 const MERGE_GATE_ACTIVE_STALE_MS = 45 * 60 * 1000;
+const CONFLICT_PENDING_LABEL = 'claude-conflict-pending';
+const CONFLICT_PENDING_STALE_MS = 45 * 60 * 1000;
 const BLOCK_LABELS = new Set([
-  'claude-conflict-pending',
+  CONFLICT_PENDING_LABEL,
   MERGE_GATE_ACTIVE_LABEL,
   'no-auto-merge',
   'auto-merged-by-gate',
@@ -127,7 +129,10 @@ function conflictRebaseQuiescent(comments, headPushedAt) {
   return finalClaudeCompletedOnSha(comments, headPushedAt);
 }
 
-function hasRecentConflictComment(comments, headPushedAt = null) {
+function hasRecentConflictComment(comments, headPushedAt = null, mergeStateStatus = null) {
+  const status = (mergeStateStatus || '').toUpperCase();
+  if (status && ALLOWED_MERGE_STATES.has(status)) return false;
+
   const cutoff = Date.now() - CONFLICT_COOLDOWN_MS;
   const hasRecentTrigger = comments.some((c) => {
     if (!isConflictRebaseTriggerComment(c)) return false;
@@ -223,7 +228,7 @@ function isClaudeAutomationLogin(login) {
   return lower.includes('praisonai-triage') || lower === 'github-actions[bot]';
 }
 
-function isPushSoonAfterLatestFinal(comments, headPushedAt) {
+function isPushSoonAfterLatestFinal(comments, headPushedAt, nowMs = Date.now()) {
   if (!headPushedAt) return false;
   const finals = comments.filter(isFinalClaudeTriggerComment);
   if (finals.length === 0) return false;
@@ -233,18 +238,19 @@ function isPushSoonAfterLatestFinal(comments, headPushedAt) {
   const finalTime = new Date(latestFinal.created_at).getTime();
   const headTime = new Date(headPushedAt).getTime();
   if (headTime <= finalTime) return false;
-  return headTime - finalTime < PUSH_AFTER_FINAL_DEBOUNCE_MS;
+  if (headTime - finalTime >= PUSH_AFTER_FINAL_DEBOUNCE_MS) return false;
+  return nowMs - headTime < PUSH_AFTER_FINAL_DEBOUNCE_MS;
 }
 
 /** Returns { skip: true, reason } when stale-FINAL recovery should not post. */
-function shouldSkipStaleFinalRecovery(comments, headPushedAt, headPusherLogin = null) {
+function shouldSkipStaleFinalRecovery(comments, headPushedAt, headPusherLogin = null, nowMs = Date.now()) {
   if (!isStaleFinalAfterPush(comments, headPushedAt)) {
     return { skip: true, reason: 'not stale' };
   }
   if (headPusherLogin && isClaudeAutomationLogin(headPusherLogin)) {
     return { skip: true, reason: 'head pushed by Claude automation' };
   }
-  if (isPushSoonAfterLatestFinal(comments, headPushedAt)) {
+  if (isPushSoonAfterLatestFinal(comments, headPushedAt, nowMs)) {
     return {
       skip: true,
       reason: 'head pushed soon after FINAL (wait for CI / batched fixes)',
@@ -481,6 +487,41 @@ async function reconcileMergeGateActiveLabel(github, owner, repo, prNumber, labe
     if (err.status !== 404) core?.warning?.(`Could not remove stale merge-gate label: ${err.message}`);
   }
   return { block: false, stale: true };
+}
+
+/** Drop stuck claude-conflict-pending when rebase trigger is older than grace (45 min). */
+async function reconcileConflictPendingLabel(
+  github, owner, repo, prNumber, labels, comments, mergeStateStatus, core
+) {
+  if (!labels.includes(CONFLICT_PENDING_LABEL)) return { pending: false, stale: false };
+  if ((mergeStateStatus || '').toUpperCase() !== 'DIRTY') {
+    return { pending: false, stale: false };
+  }
+  const triggers = comments.filter(isConflictRebaseTriggerComment);
+  const latest = triggers.reduce(
+    (a, b) => (new Date(a.created_at) > new Date(b.created_at) ? a : b),
+    null
+  );
+  const triggerAge = latest
+    ? Date.now() - new Date(latest.created_at).getTime()
+    : CONFLICT_PENDING_STALE_MS + 1;
+  if (triggerAge < CONFLICT_PENDING_STALE_MS) {
+    return { pending: true, stale: false };
+  }
+  try {
+    await github.rest.issues.removeLabel({
+      owner,
+      repo,
+      issue_number: prNumber,
+      name: CONFLICT_PENDING_LABEL,
+    });
+    core?.info?.(`Removed stale ${CONFLICT_PENDING_LABEL} from PR #${prNumber}`);
+  } catch (err) {
+    if (err.status !== 404) {
+      core?.warning?.(`Could not remove stale conflict-pending label: ${err.message}`);
+    }
+  }
+  return { pending: false, stale: true };
 }
 
 function shouldBlockOnMergeGateActiveLabel({ assessInProgress, lastActivityMs, nowMs = Date.now() }) {
@@ -811,7 +852,7 @@ async function evaluatePipelineQuiescent(github, owner, repo, prNumber, core, op
     reasons.push('fork PR');
   }
 
-  if (hasRecentConflictComment(ctx.comments, ctx.headPushedAt)) {
+  if (hasRecentConflictComment(ctx.comments, ctx.headPushedAt, ctx.mergeState.status)) {
     reasons.push('recent merge-conflict @claude');
   }
   if (!skipRecentClaudeCooldown && hasRecentClaudeTrigger(ctx.comments, 35)) {
@@ -969,4 +1010,7 @@ module.exports = {
   shouldBlockOnMergeGateActiveLabel,
   hasInProgressMergeGateForPr,
   reconcileMergeGateActiveLabel,
+  reconcileConflictPendingLabel,
+  CONFLICT_PENDING_LABEL,
+  CONFLICT_PENDING_STALE_MS,
 };

--- a/.github/workflows/auto-pr-comment.yml
+++ b/.github/workflows/auto-pr-comment.yml
@@ -227,6 +227,12 @@ jobs:
                   core.info(`PR #${pr.number}: skip stale — ${gate.reason}`);
                   continue;
                 }
+                const result = await review.postFinalClaudeReviewIfNeeded(
+                  github, owner, repo, pr.number, core, { resyncOnly: true }
+                );
+                if (result.posted) posted += 1;
+                await ps.syncPipelineLabels(github, owner, repo, pr.number, core);
+                continue;
               }
               const result = await chain.maybeTriggerClaudeFinal(
                 github, owner, repo, pr.number,

--- a/.github/workflows/merge-conflict-claude.yml
+++ b/.github/workflows/merge-conflict-claude.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: '45 * * * *'
 
 concurrency:
   group: merge-conflict-scan-${{ github.repository }}
@@ -44,9 +44,9 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const baseRepo = `${owner}/${repo}`;
-            const COOLDOWN_MS = 12 * 60 * 60 * 1000;
+            const RETRY_COOLDOWN_MS = mergeGate.CONFLICT_PENDING_STALE_MS;
             const AUTO_ACTORS = ['github-actions[bot]', 'MervinPraison'];
-            const LABEL = 'claude-conflict-pending';
+            const LABEL = mergeGate.CONFLICT_PENDING_LABEL;
             const COMMENT_BODY = [
               '@claude this PR has merge conflicts with `main`.',
               'Please rebase onto latest `main`, resolve conflicts (keep this PR\'s intent, merge in newer main logic),',
@@ -98,7 +98,7 @@ jobs:
             }
 
             function hasRecentAutoComment(comments) {
-              const cutoff = Date.now() - COOLDOWN_MS;
+              const cutoff = Date.now() - RETRY_COOLDOWN_MS;
               return comments.some((c) => {
                 if (!AUTO_ACTORS.includes(c.user.login)) return false;
                 const body = (c.body || '').toLowerCase();
@@ -116,7 +116,7 @@ jobs:
                 repo,
                 issue_number: prNumber,
               });
-              const labels = issue.labels.map((l) => l.name);
+              let labels = issue.labels.map((l) => l.name);
 
               if (status !== 'DIRTY' && labels.includes(LABEL)) {
                 await github.rest.issues.removeLabel({
@@ -126,6 +126,7 @@ jobs:
                   name: LABEL,
                 });
                 core.info(`Removed ${LABEL} from PR #${prNumber}`);
+                labels = labels.filter((l) => l !== LABEL);
               }
 
               if (status !== 'DIRTY') return { skipped: true, reason: 'not dirty' };
@@ -133,16 +134,18 @@ jobs:
               if (headRepo && headRepo !== baseRepo && !maintainerCanModify) {
                 return { skipped: true, reason: 'fork without maintainer edits' };
               }
-              if (labels.includes(LABEL)) {
+
+              const comments = await mergeGate.listAllComments(github, owner, repo, prNumber);
+              const conflictState = await mergeGate.reconcileConflictPendingLabel(
+                github, owner, repo, prNumber, labels, comments, status, core
+              );
+              if (conflictState.pending) {
                 return { skipped: true, reason: 'conflict resolution pending' };
               }
+              if (conflictState.stale) {
+                labels = labels.filter((l) => l !== LABEL);
+              }
 
-              const { data: comments } = await github.rest.issues.listComments({
-                owner,
-                repo,
-                issue_number: prNumber,
-                per_page: 100,
-              });
               if (hasRecentAutoComment(comments)) {
                 return { skipped: true, reason: 'recent auto comment' };
               }


### PR DESCRIPTION
## Summary
- **Root cause (stale-final):** `isPushSoonAfterLatestFinal` blocked recovery forever when head was pushed within 15 min of FINAL — not just during the debounce window. Recovery also called `maybeTriggerClaudeFinal` which skips when FINAL already exists.
- **Root cause (conflict):** `claude-conflict-pending` label blocked re-trigger indefinitely; 12h cooldown + 6h schedule meant failed rebases never retried.
- **Fix:** Time-bound debounce, use `postFinalClaudeReviewIfNeeded({ resyncOnly: true })` for stale recovery, clear conflict blockers on CLEAN PRs, stale `claude-conflict-pending` after 45 min with hourly re-scan.

## Test plan
- [x] `node .github/scripts/merge-gate-selftest.js`
- [ ] Merge with `merge-gate-ci-only` label
- [ ] Dispatch `Auto PR Comment` + `Auto Merge Conflict → Claude` after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatically clearing stale conflict-pending status when a PR remains unresolved past a grace period.
  * Improved recovery handling for stale FINAL review states with more precise timing checks.

* **Bug Fixes**
  * Reduced false positives for recent conflict activity when a PR is already in a safe merge state.
  * Updated scheduled conflict checks to run more frequently for faster response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->