### PR TITLE
docs: add page for Reusable Command-Prefix Approval Scopes (+ 3 doc updates from recent PraisonAI PRs)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -581,6 +581,7 @@
                   "docs/features/agent-max-budget",
                   "docs/features/subscription-auth",
                   "docs/features/approval",
+                  "docs/features/reusable-approval-scopes",
                   "docs/features/approval-backends",
                   "docs/features/approval-secure-backend",
                   "docs/features/durable-approvals",

--- a/docs/features/bot-platform-capabilities.mdx
+++ b/docs/features/bot-platform-capabilities.mdx
@@ -151,6 +151,25 @@ def default_capabilities(cls) -> PlatformCapabilities:
     return PlatformCapabilities(max_message_length=2000, supports_edit=True)
 ```
 
+Entry-point registrations (via `praisonai.channels`) get default capabilities unless the adapter class exposes a `default_capabilities()` classmethod. This keeps zero-config connectors functional while letting polished adapters declare exact limits:
+
+```toml
+# pyproject.toml
+[project.entry-points."praisonai.channels"]
+myplatform = "mypackage.bot:MyPlatformBot"
+```
+
+```python
+class MyPlatformBot:
+    @classmethod
+    def default_capabilities(cls):
+        from praisonaiagents.bots import PlatformCapabilities
+        return PlatformCapabilities(max_message_length=1000, supports_edit=False)
+    
+    async def start(self): ...
+    async def stop(self): ...
+```
+
 **Serialise for config files:**
 
 ```python

--- a/docs/features/bot-platform-capabilities.mdx
+++ b/docs/features/bot-platform-capabilities.mdx
@@ -37,8 +37,8 @@ graph LR
     E --> G
     F --> G
 
-    classDef agent fill:#8B0000,color:#fff
-    classDef tool fill:#189AB4,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
 
     class G agent
     class A,B,C,D,E,F tool

--- a/docs/features/bot-platform-plugins.mdx
+++ b/docs/features/bot-platform-plugins.mdx
@@ -30,8 +30,8 @@ graph LR
     B --> C[📝 BotPlatformRegistry]
     C --> D[💬 Bot - mattermost - agent=...]
 
-    classDef agent fill:#8B0000,color:#fff
-    classDef tool fill:#189AB4,color:#fff
+    classDef agent fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef tool fill:#189AB4,stroke:#7C90A0,color:#fff
 
     class D agent
     class A,B,C tool

--- a/docs/features/bot-platform-plugins.mdx
+++ b/docs/features/bot-platform-plugins.mdx
@@ -68,7 +68,7 @@ Create a pip-installable plugin using `pyproject.toml`:
 
 ```toml
 # pyproject.toml
-[project.entry-points."praisonai.bots"]
+[project.entry-points."praisonai.channels"]
 mybot = "my_pkg.bot:MyBot"
 ```
 
@@ -77,7 +77,7 @@ After installation, use the bot platform:
 ```python
 from praisonai.bots import Bot
 
-bot = Bot("mybot", agent=my_agent, token="...")
+bot = Bot("mybot", agent=my_agent)
 await bot.start()
 ```
 

--- a/docs/features/bot-platform-plugins.mdx
+++ b/docs/features/bot-platform-plugins.mdx
@@ -139,7 +139,52 @@ PraisonAI includes these built-in bot platforms:
 - `email` - Email bot integration
 - `agentmail` - AgentMail integration
 
-**Entry-point group**: `praisonai.bots`
+### Entry-point Groups
+
+| Group | Purpose |
+|-------|---------|
+| `praisonai.channels` | **Recommended** for new packaged connectors — idiomatic, zero-config auto-registration |
+| `praisonai.bots` | Legacy group — still scanned for backward compatibility |
+
+Both groups are scanned by `BotPlatformRegistry` on startup. A connector that would shadow a built-in platform is skipped with a warning.
+
+### Discovery via entry points (`praisonai.channels`)
+
+The `praisonai.channels` entry-point group is the idiomatic way to distribute a bot connector as a pip-installable package. Once installed, the platform is available with no extra Python code:
+
+```toml
+# pyproject.toml of your connector package
+[project.entry-points."praisonai.channels"]
+irc = "praisonai_irc:IRCBot"
+```
+
+After `pip install praisonai-irc`:
+
+```python
+from praisonai.bots import Bot
+
+bot = Bot("irc", agent=my_agent, server="irc.libera.chat")
+await bot.start()
+```
+
+List all registered platforms — built-in, entry-point, and custom — with the CLI:
+
+```bash
+praisonai gateway channels --available
+# => telegram, discord, slack, whatsapp, linear, email, agentmail, irc
+```
+
+Or in Python:
+
+```python
+from praisonai.bots._registry import list_platforms
+
+print(sorted(list_platforms()))
+```
+
+<Note>
+`praisonai.channels` is preferred over `praisonai.bots` for new packages. Both entry-point groups continue to work.
+</Note>
 
 ---
 

--- a/docs/features/botos.mdx
+++ b/docs/features/botos.mdx
@@ -139,7 +139,7 @@ flowchart LR
   - **Protocol-driven**: `BotOSProtocol` lives in the lightweight core SDK; heavy implementations live in the wrapper
   - **Lazy loading**: Platform libraries (telegram, discord, etc.) are only imported when `start()` is called
   - **Agent-centric**: Every bot is powered by an Agent, AgentTeam, or AgentFlow
-  - **Extensible**: Register custom platforms at runtime with `register_platform()`
+  - **Extensible**: Register custom platforms at runtime with `register_platform()`, or distribute packaged connectors via the `praisonai.channels` entry-point group for zero-code auto-registration
 </Accordion>
 
 ## Token Setup

--- a/docs/features/hook-events.mdx
+++ b/docs/features/hook-events.mdx
@@ -430,6 +430,13 @@ def after_compaction(event_data):
 
 `MESSAGE_RECEIVED` is a **first-class control point**: hooks can drop an inbound message so the agent never runs, or rewrite the message content before the agent (or memory) sees it. This is symmetric with `MESSAGE_SENDING` on the outbound side.
 
+The hook now returns a decision that every platform adapter (Telegram, Slack, Discord, WhatsApp, Email, AgentMail) honours:
+
+- `HookResult.deny(reason=...)` → the message is **dropped**; agent dispatch is skipped entirely.
+- `HookResult(modified_input={"content": "..."})` → the inbound message content is **rewritten** before dispatch.
+- `None` or `HookResult.allow()` → message passes through unchanged (default).
+- Hook errors are **non-fatal** — a raising hook logs the error and lets the message through.
+
 <Note>
 `MESSAGE_RECEIVED` and `MESSAGE_SENDING` are the two message-lifecycle events that **do gate** — `deny` drops the message entirely, `modified_input["content"]` rewrites it. The gate is safe from both sync and async adapters (Telegram, Slack, Discord, WhatsApp, Email, AgentMail) — no `async def` required in your hook. See [PraisonAI #2589](https://github.com/MervinPraison/PraisonAI/pull/2589).
 </Note>

--- a/docs/features/messaging-channels-strategy.mdx
+++ b/docs/features/messaging-channels-strategy.mdx
@@ -59,7 +59,7 @@ botos = BotOS(
     }
 )
 
-await botos.run()
+botos.run()
 ```
 
 </Step>

--- a/docs/features/messaging-channels-strategy.mdx
+++ b/docs/features/messaging-channels-strategy.mdx
@@ -321,11 +321,11 @@ bot = Bot("mattermost", agent=my_agent, server_url="https://chat.company.com")
 
 ### Distribute as a pip-installable plugin
 
-For better distribution, use Python entry points to auto-register your platform:
+For packaged connectors, use the `praisonai.channels` entry-point group — the idiomatic path for new connectors that self-register with zero Python code:
 
 ```toml
 # pyproject.toml of your community bot package
-[project.entry-points."praisonai.bots"]
+[project.entry-points."praisonai.channels"]
 mattermost = "praisonai_mattermost.bot:MattermostBot"
 ```
 
@@ -336,7 +336,25 @@ from praisonai.bots import Bot
 bot = Bot("mattermost", agent=my_agent, server_url="https://chat.company.com")
 ```
 
+And it appears in the gateway's `--available` list:
+
+```bash
+praisonai gateway channels --available
+# => agentmail, discord, email, linear, mattermost, slack, telegram, whatsapp
+```
+
+You can also accept it in `gateway.yaml`:
+
+```yaml
+channels:
+  team-chat:
+    platform: mattermost
+    token: ${MATTERMOST_TOKEN}
+    server_url: https://chat.company.com
+```
+
 <Note>
+`praisonai.channels` is preferred over `praisonai.bots` for new packages. Both groups are scanned for backward compatibility.
 See [Bot Platform Plugins](/docs/features/bot-platform-plugins) for complete documentation on creating distributable bot platform plugins.
 </Note>
 

--- a/docs/features/messaging-channels-strategy.mdx
+++ b/docs/features/messaging-channels-strategy.mdx
@@ -63,14 +63,16 @@ botos.run()
 <Step title="Add Microsoft Teams">
 
 ```python
+import os
+
 # Add Teams to existing setup
 botos = BotOS(
     agent=agent,
     platforms={
-        "telegram": {"token": telegram_token},
+        "telegram": {"token": os.environ["TELEGRAM_BOT_TOKEN"]},
         "teams": {
-            "app_id": teams_app_id,
-            "app_password": teams_password
+            "app_id": os.environ["TEAMS_APP_ID"],
+            "app_password": os.environ["TEAMS_APP_PASSWORD"]
         }
     }
 )

--- a/docs/features/messaging-channels-strategy.mdx
+++ b/docs/features/messaging-channels-strategy.mdx
@@ -52,11 +52,7 @@ agent = Agent(
 # Enable multi-platform messaging
 botos = BotOS(
     agent=agent,
-    platforms={
-        "telegram": {"token": "your-token"},
-        "discord": {"token": "your-token"},
-        "slack": {"token": "your-token"}
-    }
+    platforms=["telegram", "discord", "slack"]
 )
 
 botos.run()

--- a/docs/features/reusable-approval-scopes.mdx
+++ b/docs/features/reusable-approval-scopes.mdx
@@ -84,6 +84,7 @@ print(suggested)
 
 mgr.approve(
     target="bash:git status -s",
+    approved=True,
     scope="always",
     reusable_scope=True,
 )
@@ -288,12 +289,14 @@ mgr = PermissionManager()
 
 mgr.approve(
     target="bash:npm run build",
+    approved=True,
     scope="session",
     reusable_scope=True,
 )
 
 mgr.approve(
     target="bash:git status -s",
+    approved=True,
     scope="always",
     reusable_scope=True,
 )
@@ -385,7 +388,7 @@ print(f"This will auto-approve: {pattern}")
 A bad derived pattern that uses `always` persists across all future sessions. Use `session` by default for reusable scopes — if the pattern turns out to be safe, upgrade it to `always` deliberately:
 
 ```python
-mgr.approve(target="bash:git status -s", scope="session", reusable_scope=True)
+mgr.approve(target="bash:git status -s", approved=True, scope="session", reusable_scope=True)
 ```
 
 </Accordion>

--- a/docs/features/reusable-approval-scopes.mdx
+++ b/docs/features/reusable-approval-scopes.mdx
@@ -48,25 +48,48 @@ graph LR
 
 <Steps>
 
-<Step title="Programmatic approval with reusable scope">
+<Step title="Enable reusable scopes on your Agent">
+
+Add one line to opt in — approval fatigue drops immediately:
 
 ```python
-from praisonaiagents.permissions import PermissionManager
+from praisonaiagents import Agent
 
-manager = PermissionManager()
+agent = Agent(
+    name="Shell Assistant",
+    instructions="Run git commands the user asks for",
+    tools=["shell"],
+    approval={"reusable_scope": True},
+)
 
-approval = manager.approve(
+agent.start("Show me the status and then the last five commits")
+```
+
+The first time the agent runs `git status -s`, the user sees the prompt once. Every subsequent `git status <flags>` variant is auto-approved for the session.
+
+</Step>
+
+<Step title="Preview and store scopes programmatically">
+
+For advanced workflows — CLIs, approval UIs, or testing — call the `PermissionManager` API directly:
+
+```python
+from praisonaiagents.permissions import PermissionManager, derive_pattern
+
+mgr = PermissionManager()
+
+suggested = mgr.suggest_scope_pattern("bash:git status -s")
+print(suggested)
+# => "bash:git status *"
+
+mgr.approve(
     target="bash:git status -s",
-    approved=True,
     scope="always",
     reusable_scope=True,
 )
-
-print(approval.pattern)   # 'bash:git status *'
-print(approval.derived)   # True
 ```
 
-Future calls to `bash:git status`, `bash:git status --short`, or any `bash:git status …` variant are auto-approved without prompting.
+`suggest_scope_pattern()` lets you surface the derived pattern in your UI before committing it, so users can review what `always` will cover.
 
 </Step>
 
@@ -191,6 +214,20 @@ Multi-word keys win over their base command: `docker compose` (arity 2) keeps `d
 | `read:/etc/hosts` | `read:/etc/hosts` | non-shell prefix → literal |
 | `shell:ls -la` | `shell:ls *` | `shell:` prefix also generalised |
 
+### Extend the arity table for your own tools
+
+Pass a custom `arity_map` to `derive_pattern()` to add commands not in the built-in table:
+
+```python
+from praisonaiagents.permissions import derive_pattern
+
+my_tools = {"mytool": 2, "mytool sub": 3}
+
+pattern = derive_pattern("bash:mytool sub action --flag", arity_map=my_tools)
+print(pattern)
+# => "bash:mytool sub action *"
+```
+
 ---
 
 ## What Never Gets Generalised
@@ -242,6 +279,51 @@ approval = manager.check("bash:cd /tmp && rm x")
 print(approval.pattern)  # 'bash:cd /tmp && rm x'  — literal, not generalised
 ```
 
+### Session vs Always scope
+
+```python
+from praisonaiagents.permissions import PermissionManager
+
+mgr = PermissionManager()
+
+mgr.approve(
+    target="bash:npm run build",
+    scope="session",
+    reusable_scope=True,
+)
+
+mgr.approve(
+    target="bash:git status -s",
+    scope="always",
+    reusable_scope=True,
+)
+```
+
+Use `session` for exploratory work and `always` only for commands you trust unconditionally across all future sessions.
+
+### Preview before storing
+
+```python
+from praisonaiagents.permissions import PermissionManager
+
+mgr = PermissionManager()
+
+targets = [
+    "bash:git log --oneline",
+    "bash:npm run test",
+    "bash:docker ps",
+]
+
+for t in targets:
+    print(f"{t!r}  →  {mgr.suggest_scope_pattern(t)!r}")
+```
+
+```
+'bash:git log --oneline'  →  'bash:git log *'
+'bash:npm run test'       →  'bash:npm run *'
+'bash:docker ps'          →  'bash:docker *'
+```
+
 **Preview and override before saving**
 
 ```python
@@ -273,6 +355,7 @@ pattern = derive_pattern("bash:mycli deploy prod", arity_map=custom_map)
 print(pattern)  # "bash:mycli deploy *"
 ```
 
+
 ---
 
 ## Best Practices
@@ -283,6 +366,30 @@ print(pattern)  # "bash:mycli deploy *"
 Routine VCS and build commands (`git status`, `npm run`, `pytest`) are the best candidates. They have stable subcommand prefixes and many trailing-arg variants.
 </Accordion>
 
+<Accordion title="Preview the scope before storing">
+
+Call `suggest_scope_pattern()` in your CLI or approval UI so users can see exactly what `always` will cover before confirming. A pattern like `bash:rm *` deserves a careful second look:
+
+```python
+from praisonaiagents.permissions import PermissionManager
+
+mgr = PermissionManager()
+pattern = mgr.suggest_scope_pattern("bash:rm -rf /tmp/build")
+print(f"This will auto-approve: {pattern}")
+```
+
+</Accordion>
+
+<Accordion title="Prefer session over always for reusable scopes">
+
+A bad derived pattern that uses `always` persists across all future sessions. Use `session` by default for reusable scopes — if the pattern turns out to be safe, upgrade it to `always` deliberately:
+
+```python
+mgr.approve(target="bash:git status -s", scope="session", reusable_scope=True)
+```
+
+</Accordion>
+
 <Accordion title="Pass an explicit pattern= to override the suggestion">
 If `suggest_scope_pattern` returns a pattern that is broader or narrower than you want, override it with `pattern=`. The stored approval will have `derived=False`, keeping exact `fnmatch` semantics.
 </Accordion>
@@ -291,8 +398,28 @@ If `suggest_scope_pattern` returns a pattern that is broader or narrower than yo
 A `cd /tmp && rm x` approval covers only that exact string. If you want to reuse two operations independently, create two separate approvals — one for `cd` variants and one for `rm` variants.
 </Accordion>
 
-<Accordion title="Non-shell targets stay literal">
-`read:`, `write:`, and `write_file:` patterns are never derived. Use explicit globs for those, e.g. `pattern="read:/tmp/*"`.
+<Accordion title="Non-shell targets stay literal — that is intentional">
+
+Path approvals such as `read:/etc/hosts` or `write:/tmp/report.txt` must remain exact. File paths that look like prefixes (`read:/etc/`) would grant access to all files under `/etc/`, which is a security anti-pattern. The literal-only behaviour for non-shell targets is by design.
+
+</Accordion>
+
+<Accordion title="Extend ARITY for your own CLI tools">
+
+If your agent uses an internal tool (`mytool`) or a domain-specific CLI (`kubectl`), pass a custom `arity_map` to `derive_pattern()` so the prefix is derived correctly:
+
+```python
+from praisonaiagents.permissions import derive_pattern
+
+corp_tools = {
+    "deploy": 2,
+    "deploy rollback": 2,
+}
+
+pattern = derive_pattern("bash:deploy rollback service-a --dry-run", arity_map=corp_tools)
+# => "bash:deploy rollback *"
+```
+
 </Accordion>
 
 <Accordion title="Not a replacement for deny rules">

--- a/docs/features/reusable-approval-scopes.mdx
+++ b/docs/features/reusable-approval-scopes.mdx
@@ -74,7 +74,7 @@ The first time the agent runs `git status -s`, the user sees the prompt once. Ev
 For advanced workflows — CLIs, approval UIs, or testing — call the `PermissionManager` API directly:
 
 ```python
-from praisonaiagents.permissions import PermissionManager, derive_pattern
+from praisonaiagents.permissions import PermissionManager
 
 mgr = PermissionManager()
 

--- a/docs/features/reusable-approval-scopes.mdx
+++ b/docs/features/reusable-approval-scopes.mdx
@@ -191,29 +191,32 @@ The stored `PersistentApproval` has `derived=True`, which enables a bare-prefix 
 |----------|----------|-------|---------|
 | Version control | `git`, `gh`, `hg`, `svn` | 2 | `git status -s` → `bash:git status *` |
 | Package managers | `npm`, `yarn`, `pnpm`, `pip`, `cargo`, `go`, `poetry`, `uv`, `make` | 2 | `npm run build` → `bash:npm run *` |
-| Containers | `docker`, `docker compose`, `kubectl`, `helm` | 2 | `docker compose up -d` → `bash:docker compose *` |
-| Python tooling | `python`, `python3`, `ruff` | 2 | `ruff check .` → `bash:ruff check *` |
+| Containers | `docker` | 2 | `docker pull ubuntu` → `bash:docker pull *` |
+| Containers | `docker compose` | 2 | `docker compose up -d` → `bash:docker compose *` |
+| Containers | `kubectl`, `helm` | 2 | `kubectl get pods` → `bash:kubectl get *` |
+| Python tooling | `python`, `python3` | 2 | `python -m pytest` → `bash:python -m *` |
+| Python tooling | `ruff` | 2 | `ruff check .` → `bash:ruff check *` |
 | Python tooling | `pytest` | 1 | `pytest tests/` → `bash:pytest *` |
 | System | `apt`, `apt-get`, `brew`, `systemctl` | 2 | `apt install pkg` → `bash:apt install *` |
 | Unknown / other | — | 1 (conservative) | `foo bar baz` → `bash:foo *` (only if there are trailing args) |
 
-Multi-word keys win over their base command: `docker compose` (arity 2) keeps `docker compose`, not just `docker`.
+<Note>
+Multi-word keys win over single-word keys. `docker compose` (a 2-word key, arity 2) takes precedence over `docker` (arity 2), so `docker compose up -d` derives `bash:docker compose *`. Commands not in the table default to arity 1 — only the first token is kept.
+</Note>
 
 ### Behaviour table
 
-| Input `target` | Output | Reason |
-|----------------|--------|--------|
-| `bash:git status` | `bash:git status *` | git arity 2, appends ` *` |
-| `bash:git status -s` | `bash:git status *` | same — trailing args replaced |
-| `bash:npm run build` | `bash:npm run *` | npm arity 2 |
-| `bash:docker compose up -d` | `bash:docker compose *` | multi-word key wins |
-| `bash:git` | `bash:git` | bare single-token → literal |
-| `bash:cd /tmp && rm -rf x` | `bash:cd /tmp && rm -rf x` | `&&` → literal |
-| `bash:echo $(rm x)` | `bash:echo $(rm x)` | command substitution → literal |
-| `bash:ls \| grep x` | `bash:ls \| grep x` | pipe → literal |
-| `bash:git status *` | `bash:git status *` | already contains glob → unchanged |
-| `read:/etc/hosts` | `read:/etc/hosts` | non-shell prefix → literal |
-| `shell:ls -la` | `shell:ls *` | `shell:` prefix also generalised |
+**Escape hatches — these always stay literal:**
+
+| Condition | Example target | Stored as |
+|-----------|---------------|-----------|
+| Non-shell target | `read:/etc/hosts` | `read:/etc/hosts` |
+| Already globbed | `bash:git status *` | `bash:git status *` |
+| Contains `&&`, `\|\|`, `\|`, `;`, `&` | `bash:cd /tmp && rm -rf x` | exact string |
+| Contains `$(`, backtick, `>`, `<`, newline | `bash:echo $(whoami)` | exact string |
+| Bare single token equals the full command | `bash:git` | `bash:git` |
+
+The bare-single-token rule is the most important: approving `bash:git` stays literal — it never automatically covers `bash:git push --force`.
 
 ### Extend the arity table for your own tools
 

--- a/docs/gateway.mdx
+++ b/docs/gateway.mdx
@@ -176,6 +176,74 @@ New WebSocket clients should send a `hello` frame to negotiate protocol version,
 
 ---
 
+## Gateway YAML Configuration
+
+The `gateway.yaml` schema accepts three optional top-level blocks alongside `channels` and `agents`. All three are optional and ignored when not present.
+
+### `gateway:` block
+
+Global gateway settings — reliability preset, drain timeout, health monitor:
+
+```yaml
+gateway:
+  reliability: production    # "production" | "default" | "off"
+  drain_timeout: 15          # seconds to wait for in-flight turns on shutdown
+
+channels:
+  telegram:
+    platform: telegram
+    token: ${TELEGRAM_BOT_TOKEN}
+  discord:
+    platform: discord
+    token: ${DISCORD_BOT_TOKEN}
+```
+
+### `hooks:` block
+
+Register shell-command hooks that fire at gateway and message lifecycle events:
+
+```yaml
+hooks:
+  - event: message_received
+    command: /usr/local/bin/rate-check.sh
+  - event: gateway_start
+    command: "curl -s https://monitoring.example.com/ping"
+```
+
+### `BotOS.from_config` and tool names
+
+`BotOS.from_config("botos.yaml")` now routes tool names through the standard `ToolResolver` chain:
+
+1. Local `tools.py` in the working directory
+2. Wrapper `ToolRegistry`
+3. `praisonaiagents` built-in tools
+4. `praisonai-tools` package
+5. Installed plugins
+
+This means a YAML bot referencing a `praisonai-tools` symbol or a local `tools.py` function just works — no ad-hoc `importlib` lookup required:
+
+```yaml
+# botos.yaml
+agent:
+  name: assistant
+  instructions: You are a helpful assistant.
+  tools:
+    - web_search          # resolved via praisonai-tools
+    - my_custom_tool      # resolved from local tools.py
+platforms:
+  telegram:
+    token: ${TELEGRAM_BOT_TOKEN}
+```
+
+```python
+from praisonai.bots import BotOS
+
+botos = BotOS.from_config("botos.yaml")
+botos.run()
+```
+
+---
+
 ## Gateway Agent Defaults
 
 Gateway agents loaded from YAML use chat-optimised defaults that differ from the Python SDK.


### PR DESCRIPTION
Fixes #1456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for reusable approval scopes, including previewing patterns, choosing session vs always approvals, and extending command scope rules.
  * Added clearer setup and registration examples for bot platform and messaging channel plugins, including the preferred entry-point path for new connectors.
  * Documented gateway configuration options, hook settings, and tool name resolution behavior.
  * Clarified hook event behavior and platform capability defaults.
  * Updated navigation to include the reusable approval scopes guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->