### PR TITLE
Fix conflict auto-resolve scan crash

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -180,6 +180,14 @@ assert(
   !mg.hasRecentConflictComment([cleanMergeConflict], '2026-07-03T09:00:00Z', 'CLEAN')
 );
 
+// reconcileConflictPendingLabel: reduce must not use null initial (crashes on first element)
+const oneTrigger = [cleanMergeConflict];
+const latestOne = oneTrigger.length === 0
+  ? null
+  : oneTrigger.reduce((a, b) => (new Date(a.created_at) > new Date(b.created_at) ? a : b));
+assert('conflict trigger reduce with one item', latestOne === oneTrigger[0]);
+assert('conflict trigger reduce with empty', [].length === 0);
+
 // Cooldown: FINAL current on HEAD should not block merge gate
 const finalCompleteComments = [
   { user: { login: 'MervinPraison' }, body: '@claude FINAL architecture reviewer', created_at: '2026-07-03T10:00:00Z' },

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -498,10 +498,11 @@ async function reconcileConflictPendingLabel(
     return { pending: false, stale: false };
   }
   const triggers = comments.filter(isConflictRebaseTriggerComment);
-  const latest = triggers.reduce(
-    (a, b) => (new Date(a.created_at) > new Date(b.created_at) ? a : b),
-    null
-  );
+  const latest = triggers.length === 0
+    ? null
+    : triggers.reduce((a, b) =>
+        new Date(a.created_at) > new Date(b.created_at) ? a : b
+      );
   const triggerAge = latest
     ? Date.now() - new Date(latest.created_at).getTime()
     : CONFLICT_PENDING_STALE_MS + 1;
@@ -837,7 +838,16 @@ async function evaluatePipelineQuiescent(github, owner, repo, prNumber, core, op
   if (ctx.pr.state !== 'open') reasons.push('not open');
   if (ctx.labels.includes('auto-merged-by-gate')) reasons.push('already merged by gate');
   if (ctx.labels.includes('no-auto-merge')) reasons.push('no-auto-merge label');
-  if (ctx.labels.includes('claude-conflict-pending')) reasons.push('claude-conflict-pending');
+  if (ctx.labels.includes(CONFLICT_PENDING_LABEL)) {
+    const conflict = await reconcileConflictPendingLabel(
+      github, owner, repo, prNumber, ctx.labels, ctx.comments, ctx.mergeState.status, core
+    );
+    if (conflict.pending) {
+      reasons.push('claude-conflict-pending');
+    } else {
+      ctx.labels = ctx.labels.filter((l) => l !== CONFLICT_PENDING_LABEL);
+    }
+  }
   if (!forMergeStep && ctx.labels.includes(MERGE_GATE_ACTIVE_LABEL)) {
     const gate = await reconcileMergeGateActiveLabel(
       github, owner, repo, prNumber, ctx.labels, core

--- a/.github/scripts/pipeline-status.js
+++ b/.github/scripts/pipeline-status.js
@@ -190,8 +190,24 @@ async function dispatchMergeGateForOldestReady(github, owner, repo, readyCandida
   return 0;
 }
 
+async function dispatchMergeConflictScan(github, owner, repo, core) {
+  try {
+    await github.rest.actions.createWorkflowDispatch({
+      owner,
+      repo,
+      workflow_id: 'merge-conflict-claude.yml',
+      ref: 'main',
+    });
+    core?.info?.('Dispatched merge-conflict-claude workflow');
+    return true;
+  } catch (err) {
+    core?.warning?.(`Could not dispatch merge-conflict scan: ${err.message}`);
+    return false;
+  }
+}
+
 async function syncOpenPullRequests(github, owner, repo, options, core) {
-  const { maxPrs = 20, dispatchMergeGate = true } = options || {};
+  const { maxPrs = 20, dispatchMergeGate = true, dispatchConflictScan = true } = options || {};
   await ensurePipelineLabels(github, owner, repo, core);
   let prs;
   if (maxPrs <= 100) {
@@ -211,11 +227,15 @@ async function syncOpenPullRequests(github, owner, repo, options, core) {
   }
   let synced = 0;
   const readyCandidates = [];
+  let dirtyConflict = false;
   for (const pr of prs) {
     if (synced >= maxPrs) break;
     if (pr.draft) continue;
     if (pr.head?.repo?.full_name && pr.head.repo.full_name !== `${owner}/${repo}`) continue;
     const result = await syncPipelineLabels(github, owner, repo, pr.number, core);
+    if ((result.reasons || []).some((r) => r === 'mergeState=DIRTY' || r.includes('claude-conflict-pending'))) {
+      dirtyConflict = true;
+    }
     if (result.ready) {
       readyCandidates.push({
         prNumber: pr.number,
@@ -230,6 +250,9 @@ async function syncOpenPullRequests(github, owner, repo, options, core) {
     dispatched = await dispatchMergeGateForOldestReady(
       github, owner, repo, readyCandidates, core
     );
+  }
+  if (dispatchConflictScan && dirtyConflict) {
+    await dispatchMergeConflictScan(github, owner, repo, core);
   }
   core?.info?.(`Pipeline label sync complete (${synced} PR(s), dispatched=${dispatched || 'none'})`);
   return synced;
@@ -246,4 +269,5 @@ module.exports = {
   syncPipelineLabels,
   syncOpenPullRequests,
   dispatchMergeGateForOldestReady,
+  dispatchMergeConflictScan,
 };

--- a/.github/workflows/merge-conflict-claude.yml
+++ b/.github/workflows/merge-conflict-claude.yml
@@ -184,7 +184,12 @@ jobs:
 
             const results = [];
             for (const num of prNumbers) {
-              results.push({ pr: num, ...(await processPR(num)) });
+              try {
+                results.push({ pr: num, ...(await processPR(num)) });
+              } catch (err) {
+                core.error(`PR #${num}: ${err.message}`);
+                results.push({ pr: num, error: err.message });
+              }
             }
             core.summary.addRaw('```json\n' + JSON.stringify(results, null, 2) + '\n```');
             await core.summary.write();


### PR DESCRIPTION
## Root cause
reconcileConflictPendingLabel used Array.reduce with null initial value — crashes on the first conflict trigger. Every scheduled conflict scan since #1536 failed on PR #1546 and never reached the other DIRTY PRs.

## Fix
- Safe reduce when picking latest conflict trigger
- Reconcile claude-conflict-pending during pipeline label sync
- Dispatch merge-conflict-claude from pipeline sync when DIRTY PRs remain
- Per-PR try/catch so one failure does not abort the scan

## Test plan
- [x] node .github/scripts/merge-gate-selftest.js
- [ ] Merge with merge-gate-ci-only
- [ ] Dispatch Auto Merge Conflict → Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically runs an additional merge-conflict scan when open pull requests appear to be in a conflicted or dirty merge state.
  * Pipeline checks now better coordinate gating labels so eligible pull requests can continue without unnecessary blocking.

* **Bug Fixes**
  * Prevented a crash when no conflict trigger comments exist.
  * Improved handling of edge cases with empty or single-item conflict checks.
  * Individual pull request processing now continues even if one item fails, instead of stopping the whole run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->