### PR TITLE
Fix conflict scan GraphQL and stale CI blockers

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -278,4 +278,9 @@ assert(
 assert('merge gate job name matches PR', mg.mergeGateJobTargetsPr('claude-assess (1460, abc123)', 1460));
 assert('merge gate job name rejects other PR', !mg.mergeGateJobTargetsPr('claude-assess (1461, abc123)', 1460));
 
+assert('ignores removed claude-final-on-sync failure', mg.isIgnorableStaleCheckRun('claude-final-on-sync', 'failure'));
+assert('ignores removed detect-and-trigger cancelled', mg.isIgnorableStaleCheckRun('detect-and-trigger', 'cancelled'));
+assert('does not ignore mintlify failure', !mg.isIgnorableStaleCheckRun('Mintlify Deployment', 'failure'));
+assert('does not ignore removed job success', !mg.isIgnorableStaleCheckRun('claude-final-on-sync', 'success'));
+
 process.exit(failed ? 1 : 0);

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -361,6 +361,23 @@ async function getMergeState(github, owner, repo, prNumber) {
   };
 }
 
+const REMOVED_AUTO_PR_COMMENT_CHECKS = new Set([
+  'detect-and-trigger',
+  'claude-final-on-sync',
+  'claude-after-prior-reviewers',
+  'stale-final-recovery',
+  'claude-after-gemini',
+  'claude-after-copilot',
+  'claude-after-copilot-qodo',
+  'copilot-after-coderabbit',
+  'copilot-after-qodo',
+]);
+
+function isIgnorableStaleCheckRun(name, conclusion) {
+  if (!REMOVED_AUTO_PR_COMMENT_CHECKS.has(name || '')) return false;
+  return ['failure', 'cancelled', 'timed_out', 'action_required'].includes(conclusion || '');
+}
+
 async function allChecksGreenOnSha(github, owner, repo, sha, core, options = {}) {
   const mergeStateStatus = (options.mergeStateStatus || '').toUpperCase();
   const ignoreWhenClean = new Set(['detect-and-trigger']);
@@ -382,6 +399,10 @@ async function allChecksGreenOnSha(github, owner, repo, sha, core, options = {})
     }
     const ok = ['success', 'neutral', 'skipped'].includes(run.conclusion);
     if (!ok) {
+      if (isIgnorableStaleCheckRun(run.name, run.conclusion)) {
+        core?.info?.(`Ignoring removed workflow check: ${run.name} (${run.conclusion})`);
+        continue;
+      }
       if (mergeStateStatus === 'CLEAN' && ignoreWhenClean.has(run.name || '')) {
         core?.info?.(`Ignoring stale failed check on CLEAN PR: ${run.name}`);
         continue;
@@ -963,6 +984,8 @@ module.exports = {
   finalClaudeCompletedOnSha,
   getMergeState,
   allChecksGreenOnSha,
+  isIgnorableStaleCheckRun,
+  REMOVED_AUTO_PR_COMMENT_CHECKS,
   hasInProgressClaudeAssistant,
   claudeRunBlocksPr,
   hasBlockingClaudeRunForPr,

--- a/.github/workflows/merge-conflict-claude.yml
+++ b/.github/workflows/merge-conflict-claude.yml
@@ -75,7 +75,8 @@ jobs:
                       mergeStateStatus
                       maintainerCanModify
                       isDraft
-                      headRef { repository { nameWithOwner } name oid }
+                      headRefOid
+                      headRef { repository { nameWithOwner } name }
                     }
                   }
                 }
@@ -90,7 +91,7 @@ jobs:
                     isDraft: prGql.isDraft,
                     headRepo: prGql.headRef?.repository?.nameWithOwner,
                     headRef: prGql.headRef?.name,
-                    headSha: prGql.headRef?.oid,
+                    headSha: prGql.headRefOid,
                     maintainerCanModify: prGql.maintainerCanModify === true,
                   };
                 }


### PR DESCRIPTION
## Summary
- Fixes conflict rebase scan GraphQL (`headRefOid` instead of invalid `headRef.oid`) — unblocks 12 DIRTY PRs
- Merge gate ignores failed/cancelled checks from removed `auto-pr-comment.yml` jobs — unblocks #1541, #1509, #1451, #1443 stuck as UNSTABLE

## Test plan
- [x] `node .github/scripts/merge-gate-selftest.js`
- [ ] After merge: pipeline sync should mark clean PRs merge-ready and conflict scan should queue rebases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merge checks now ignore certain removed workflow results, preventing outdated failures from blocking merges.
  * Improved PR state detection so the latest branch head is read more reliably during conflict checks.
* **Tests**
  * Added coverage for ignored and non-ignored check-run scenarios to protect merge-gate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->