### PR TITLE
Reduce GitHub API usage in merge pipeline

### DIFF
--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -805,32 +805,6 @@ async function listAllComments(github, owner, repo, issueNumber) {
   return data;
 }
 
-async function getHeadCommitDate(github, owner, repo, prNumber) {
-  try {
-    let commits;
-    if (typeof github.paginate === 'function') {
-      commits = await github.paginate(github.rest.pulls.listCommits, {
-        owner,
-        repo,
-        pull_number: prNumber,
-        per_page: 100,
-      });
-    } else {
-      const { data } = await github.rest.pulls.listCommits({
-        owner,
-        repo,
-        pull_number: prNumber,
-        per_page: 100,
-      });
-      commits = data;
-    }
-    const last = commits[commits.length - 1];
-    return last?.commit?.committer?.date || last?.commit?.author?.date || null;
-  } catch {
-    return null;
-  }
-}
-
 async function loadPrContext(github, owner, repo, prNumber) {
   const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
   const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: prNumber });
@@ -843,8 +817,6 @@ async function loadPrContext(github, owner, repo, prNumber) {
   });
   const mergeState = await getMergeState(github, owner, repo, prNumber);
   const headSha = mergeState.headSha || pr.head.sha;
-  const headCommitDate = await getHeadCommitDate(github, owner, repo, prNumber);
-  const headPushedAt = headCommitDate || pr.updated_at;
 
   return {
     pr,
@@ -853,7 +825,7 @@ async function loadPrContext(github, owner, repo, prNumber) {
     reviews,
     mergeState,
     headSha,
-    headPushedAt,
+    headPushedAt: pr.updated_at,
     labels: issue.labels.map((l) => l.name),
     baseRepo: `${owner}/${repo}`,
   };
@@ -954,6 +926,7 @@ async function selectMergeGateCandidates(github, owner, repo, prNumbers, maxCand
     const result = await evaluatePipelineQuiescent(github, owner, repo, num, core);
     if (result.ready) {
       readyList.push({ pr_number: num, head_sha: result.headSha });
+      if (readyList.length >= maxCandidates) break;
     } else {
       skipped.push({ pr: num, reasons: result.reasons });
     }
@@ -1028,7 +1001,6 @@ module.exports = {
   secretScanReasons,
   sdkTestChecksReason,
   listAllComments,
-  getHeadCommitDate,
   isStaleFinalAfterPush,
   needsStaleFinalRecovery,
   shouldSkipFinalRecovery,

--- a/.github/scripts/pipeline-status-selftest.js
+++ b/.github/scripts/pipeline-status-selftest.js
@@ -73,4 +73,27 @@ assert(
   )
 );
 
+const now = Date.parse('2026-07-06T18:00:00Z');
+assert(
+  'skip conflict dispatch when scan in progress',
+  ps.shouldSkipConflictScanDispatch(
+    { id: 1, status: 'in_progress', created_at: '2026-07-06T17:45:00Z' },
+    now
+  )
+);
+assert(
+  'skip conflict dispatch when scan finished recently',
+  ps.shouldSkipConflictScanDispatch(
+    { id: 2, status: 'completed', created_at: '2026-07-06T17:50:00Z' },
+    now
+  )
+);
+assert(
+  'allow conflict dispatch when last run is stale',
+  !ps.shouldSkipConflictScanDispatch(
+    { id: 3, status: 'completed', created_at: '2026-07-06T17:00:00Z' },
+    now
+  )
+);
+
 process.exit(failed ? 1 : 0);

--- a/.github/scripts/pipeline-status.js
+++ b/.github/scripts/pipeline-status.js
@@ -189,8 +189,33 @@ async function dispatchMergeGateForOldestReady(github, owner, repo, readyCandida
   return 0;
 }
 
+const CONFLICT_SCAN_DEBOUNCE_MS = 30 * 60 * 1000;
+const CONFLICT_SCAN_RECENT_DONE_MS = 15 * 60 * 1000;
+
+function shouldSkipConflictScanDispatch(latestRun, nowMs = Date.now()) {
+  if (!latestRun) return false;
+  const age = nowMs - new Date(latestRun.created_at).getTime();
+  if (age >= CONFLICT_SCAN_DEBOUNCE_MS) return false;
+  const active = ['in_progress', 'queued', 'waiting', 'pending'].includes(latestRun.status);
+  if (active) return true;
+  return latestRun.status === 'completed' && age < CONFLICT_SCAN_RECENT_DONE_MS;
+}
+
 async function dispatchMergeConflictScan(github, owner, repo, core) {
   try {
+    const { data } = await github.rest.actions.listWorkflowRuns({
+      owner,
+      repo,
+      workflow_id: 'merge-conflict-claude.yml',
+      per_page: 1,
+    });
+    const latest = data.workflow_runs?.[0];
+    if (shouldSkipConflictScanDispatch(latest)) {
+      core?.info?.(
+        `Skip conflict scan dispatch — recent run #${latest.id} (${latest.status})`
+      );
+      return false;
+    }
     await github.rest.actions.createWorkflowDispatch({
       owner,
       repo,
@@ -269,4 +294,6 @@ module.exports = {
   syncOpenPullRequests,
   dispatchMergeGateForOldestReady,
   dispatchMergeConflictScan,
+  shouldSkipConflictScanDispatch,
+  CONFLICT_SCAN_DEBOUNCE_MS,
 };

--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -134,7 +134,6 @@ jobs:
           script: |
             const path = require('path');
             const mergeGate = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/merge-gate.js'));
-            const ps = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/pipeline-status.js'));
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const maxCandidates = parseInt(process.env.MAX_CANDIDATES || '5', 10);
@@ -194,8 +193,6 @@ jobs:
                 body: '**Merge gate scan** — eligible for assessment. Claude merge gate will assess and may auto-merge if `MERGE_GATE_VERDICT: APPROVE`.',
               });
             }
-
-            await ps.syncOpenPullRequests(github, owner, repo, { maxPrs: 20 }, core);
 
   claude-assess:
     needs: scan-candidates

--- a/.github/workflows/pipeline-status-sync.yml
+++ b/.github/workflows/pipeline-status-sync.yml
@@ -39,5 +39,5 @@ jobs:
             const ps = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/pipeline-status.js'));
             await ps.syncOpenPullRequests(
               github, context.repo.owner, context.repo.repo,
-              { maxPrs: 50, dispatchMergeGate: true }, core
+              { maxPrs: 20, dispatchMergeGate: true }, core
             );


### PR DESCRIPTION
Cuts REST calls to stay under GitHub 5000/hr limit. See commit message for details.