### PR TITLE
docs: cover standalone `praisonai-code` CLI + wrapper-bridge degradation model (PraisonAI PR #2547, C7 phase 1)

### DIFF
--- a/docs/cli/version.mdx
+++ b/docs/cli/version.mdx
@@ -4,11 +4,12 @@ description: "Version information and update checking"
 icon: "code-branch"
 ---
 
-The `version` command displays version information and checks for updates.
+The `version` command displays version information and checks for updates. Available from both `praisonai-code` (standalone) and `praisonai` (full wrapper).
 
 ## Usage
 
 ```bash
+praisonai-code version [OPTIONS] COMMAND [ARGS]...
 praisonai version [OPTIONS] COMMAND [ARGS]...
 ```
 
@@ -16,32 +17,83 @@ praisonai version [OPTIONS] COMMAND [ARGS]...
 
 | Command | Description |
 |---------|-------------|
-| `show` | Show version information |
-| `check` | Check for updates |
+| `show` | Show version information (default when no subcommand given) |
+| `check` | Check PyPI for a newer release |
 
 ## Examples
 
-### Show version
+### Show version panel
 
 ```bash
-praisonai version show
+praisonai-code version
+praisonai-code version show
 ```
+
+Output (text mode):
+
+```
+╭─ Version Information ─────────────────────────────╮
+│ PraisonAI Code: 0.0.4                             │
+│ PraisonAI Wrapper: 1.x.x  ← only when installed  │
+│ PraisonAI Agents: 1.6.x                           │
+│ Python: 3.12.x                                    │
+╰───────────────────────────────────────────────────╯
+```
+
+The `PraisonAI Wrapper` line is omitted when `praisonai` is not installed.
+
+### Show version as JSON
+
+```bash
+praisonai-code version show --json
+```
+
+JSON output keys:
+
+```json
+{
+  "praisonai-code": "0.0.4",
+  "praisonai": "1.x.x",
+  "praisonaiagents": "1.6.x",
+  "python": "3.12.x"
+}
+```
+
+The `praisonai` key is omitted when the wrapper package is not installed.
 
 ### Check for updates
 
 ```bash
-praisonai version check
+praisonai-code version check
 ```
 
-### Quick version check
+Queries `https://pypi.org/pypi/praisonai-code/json` and returns:
+
+```json
+{
+  "current": "0.0.4",
+  "latest": "0.0.5",
+  "update_available": true
+}
+```
+
+<Note>
+`version check` requires outbound HTTPS access to PyPI. In air-gapped environments, the command exits with an error message instead.
+</Note>
+
+### Quick version flag
 
 ```bash
+praisonai-code --version
 praisonai --version
 ```
+
+Prints only the `praisonai-code` package version string and exits immediately.
 
 ## See Also
 
 - [Doctor](/docs/cli/doctor) - Health checks
+- [PraisonAI Code CLI](/docs/features/praisonai-code-cli) - Standalone CLI overview
 
 
 ## Standalone `praisonai-code` binary

--- a/docs/features/praisonai-code-cli.mdx
+++ b/docs/features/praisonai-code-cli.mdx
@@ -21,11 +21,11 @@ The user runs a terminal prompt; `praisonai-code` executes the agent and streams
 
 ```mermaid
 graph LR
-    subgraph "pip install praisonai-code"
-        A[praisonai-code CLI] --> A1[run · chat · code · doctor · version · …]
+    subgraph pip_code["pip install praisonai-code"]
+        A[praisonai-code CLI] --> A1[run · chat · code · runtime · doctor · version]
     end
-    subgraph "pip install praisonai"
-        B[praisonai CLI] --> B1[gateway · bot · daemon · onboard · pairing · identity · kanban · claw · dashboard]
+    subgraph pip_wrapper["pip install praisonai"]
+        B[praisonai CLI] --> B1[gateway · bot · onboard · pairing · identity · kanban · claw · dashboard]
         B --> A
     end
     A --> C[praisonaiagents core]
@@ -50,6 +50,14 @@ Both `praisonai-code` (console script) and `python -m praisonai_code` call the s
     ```
 
     The panel lists **PraisonAI Code**, **PraisonAI Agents**, and **Python**. When the full wrapper is installed, a **PraisonAI Wrapper** line appears as well.
+
+    Use `--version` for a quick one-liner (package version only, no panel):
+
+    ```bash
+    praisonai-code --version
+    ```
+
+    Run your first agent:
 
     ```bash
     praisonai-code run "Summarise the top 3 arXiv papers on RAG this week"
@@ -90,6 +98,8 @@ sequenceDiagram
 
 Hard imports through the bridge raise the same hint: `Install the full wrapper: pip install praisonai`.
 
+The vendored `_registry` module means plugins work even without the wrapper installed. Version resolution reads from the `praisonai-code` package metadata directly, not the wrapper.
+
 ## Command matrix
 
 | Standalone (`pip install praisonai-code`) | Wrapper-only (`pip install praisonai`) |
@@ -122,19 +132,55 @@ pip install praisonai
 | `LOGLEVEL` | Read on CLI entry via `configure_cli_logging` (default `WARNING`). Controls root log verbosity for standalone runs. |
 | `praisonai-code version check` | Compares your installed version with PyPI (`https://pypi.org/pypi/praisonai-code/json`). |
 
-<Note>
-`praisonai-code version check` needs outbound HTTPS to PyPI.
-</Note>
+### Version commands
 
-JSON output for `praisonai-code version check`:
+```bash
+praisonai-code version
+```
+
+Shows the full version panel:
+
+```
+PraisonAI Code: 0.0.4
+PraisonAI Wrapper: 1.x.x   ← only shown when praisonai is installed
+PraisonAI Agents: 1.6.x
+Python: 3.12.x
+```
+
+```bash
+praisonai-code version --json
+```
+
+Returns structured JSON:
+
+```json
+{
+  "praisonai-code": "0.0.4",
+  "praisonai": "1.x.x",
+  "praisonaiagents": "1.6.x",
+  "python": "3.12.x"
+}
+```
+
+The `praisonai` key is omitted when the wrapper is not installed.
+
+```bash
+praisonai-code version check
+```
+
+Queries PyPI and returns update status:
 
 ```json
 {
   "current": "0.0.4",
-  "latest": "0.0.4",
-  "update_available": false
+  "latest": "0.0.5",
+  "update_available": true
 }
 ```
+
+<Note>
+`praisonai-code version check` needs outbound HTTPS to PyPI.
+</Note>
 
 ## Best practices
 
@@ -147,6 +193,9 @@ JSON output for `praisonai-code version check`:
   </Accordion>
   <Accordion title="Monorepo dev install order">
     In dev, `pip install -e src/praisonai-agents && pip install -e src/praisonai-code && pip install -e src/praisonai` (this exact order) — matches the release publish order in `pypi-release.yml`.
+  </Accordion>
+  <Accordion title="AgentApp is a silent alias for AgentOS">
+    `from praisonai import AgentOS` and `from praisonai import AgentApp` both work — `AgentApp` is a backward-compat silent alias for `AgentOS`. No deprecation warning is emitted.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -319,6 +319,29 @@ Each layer depends on the one to its left. Installing `praisonai` pulls all thre
 Generate your OpenAI API key from [OpenAI](https://platform.openai.com/api-keys)
 You can also use other LLM providers like Anthropic, Google, etc. Please refer to the [Models](/models) for more information.
 
+## Which Install Do You Need?
+
+<CardGroup cols={2}>
+  <Card
+    title="Terminal-only (smaller)"
+    icon="terminal"
+    href="/docs/features/praisonai-code-cli"
+  >
+    `pip install praisonai-code` — agentic CLI: run, chat, code, runtime. No bots or gateway.
+  </Card>
+  <Card
+    title="Full (default)"
+    icon="package"
+    href="/docs/installation"
+  >
+    `pip install praisonai` — everything: bots, gateway, kanban, dashboard, and the agentic CLI.
+  </Card>
+</CardGroup>
+
+<Note>
+`pip install praisonai` transitively installs `praisonai-code` and `praisonaiagents`. You do not need to install them separately.
+</Note>
+
 ## Next Steps
 
 <CardGroup cols={2}>


### PR DESCRIPTION
Fixes #1363

CI: opened missing PR for orphan branch `claude/issue-1363-20260701-1732`.