### PR TITLE
docs: document top-level `praisonai doctor fix` (Typer CLI) — new in PraisonAI PR #2555

### DIFF
--- a/docs/cli/doctor.mdx
+++ b/docs/cli/doctor.mdx
@@ -81,7 +81,6 @@ All existing subcommands (`env`, `mcp`, `runtime`, etc.) are unchanged, and the 
 | `metadata-store` | Check metadata store configuration |
 | `fix` | Safe auto-remediation for common setup issues (dry-run by default). Phase-1 scope: migrate deprecated `cli_backend` YAML. |
 | `runtime` | Runtime preflight for team YAML (`--team`) and migrate legacy `cli_backend` settings (`--fix`) |
-| `fix` | Safe auto-remediation for common setup issues (dry-run by default). Currently migrates deprecated `cli_backend` YAML. |
 
 ## Global Flags
 
@@ -378,6 +377,15 @@ praisonai doctor fix --execute --no-backup
 # Target a specific file
 praisonai doctor fix --file ./teams/agents.yaml
 ```
+
+<Note>
+`praisonai doctor fix` and `praisonai doctor runtime --fix` share the same underlying migration logic (`_run_fix_mode`) but expose different flag shapes and backup formats:
+
+- `doctor fix` — `--dry-run`/`--execute` toggle · `.bak` backup file
+- `doctor runtime --fix` — `--fix` + `--execute` · `<stem>.backup.<YYYYMMDD_HHMMSS>.yaml` backup
+
+Prefer `doctor fix` for new usage; `runtime --fix` remains supported.
+</Note>
 
 See also: [Runtime Config Migration](/docs/features/doctor-runtime-migration) — describes the `cli_backend`→`runtime` mapping that `fix` currently automates.
 


### PR DESCRIPTION
Fixes #1388

CI: opened missing PR for orphan branch `claude/issue-1388-20260702-0645`.