### PR TITLE
fix: merge-gate throughput for waiting pipeline/merge-ready PRs

### DIFF
--- a/.github/scripts/pipeline-status.js
+++ b/.github/scripts/pipeline-status.js
@@ -164,10 +164,13 @@ async function syncPipelineLabels(github, owner, repo, prNumber, core) {
   };
 }
 
-async function dispatchMergeGateForOldestReady(github, owner, repo, readyCandidates, core) {
+async function dispatchMergeGateForOldestReady(github, owner, repo, readyCandidates, core, options = {}) {
+  const maxDispatches = Math.max(1, options.maxDispatches ?? 3);
   if (!readyCandidates.length) return 0;
   readyCandidates.sort((a, b) => a.createdAt - b.createdAt);
+  let dispatched = 0;
   for (const cand of readyCandidates) {
+    if (dispatched >= maxDispatches) break;
     if ((cand.labels || []).includes('claude-merge-gate-active')) {
       const gate = await mergeGate.reconcileMergeGateActiveLabel(
         github, owner, repo, cand.prNumber, cand.labels || [], core
@@ -184,9 +187,9 @@ async function dispatchMergeGateForOldestReady(github, owner, repo, readyCandida
       client_payload: { pr_number: cand.prNumber },
     });
     core?.info?.(`Dispatched merge gate for ready PR #${cand.prNumber}`);
-    return cand.prNumber;
+    dispatched += 1;
   }
-  return 0;
+  return dispatched;
 }
 
 const CONFLICT_SCAN_DEBOUNCE_MS = 30 * 60 * 1000;
@@ -230,8 +233,53 @@ async function dispatchMergeConflictScan(github, owner, repo, core) {
   }
 }
 
+async function shouldRunScheduledMergeGateScan(github, owner, repo, core) {
+  try {
+    const { data } = await github.rest.actions.listWorkflowRuns({
+      owner,
+      repo,
+      workflow_id: 'claude-merge-gate.yml',
+      event: 'schedule',
+      per_page: 1,
+    });
+    const latest = data.workflow_runs?.[0];
+    if (!latest) return true;
+    const ageMs = Date.now() - new Date(latest.created_at).getTime();
+    if (ageMs > 20 * 60 * 1000) {
+      core?.info?.(`Merge gate schedule stale (${Math.round(ageMs / 60000)}m) — triggering scan`);
+      return true;
+    }
+    return false;
+  } catch (err) {
+    core?.warning?.(`Could not check merge gate schedule: ${err.message}`);
+    return false;
+  }
+}
+
+async function triggerMergeGateScan(github, owner, repo, core) {
+  try {
+    await github.rest.actions.createWorkflowDispatch({
+      owner,
+      repo,
+      workflow_id: 'claude-merge-gate.yml',
+      ref: 'main',
+    });
+    core?.info?.('Dispatched claude-merge-gate workflow_dispatch scan');
+    return true;
+  } catch (err) {
+    core?.warning?.(`Could not dispatch merge gate scan: ${err.message}`);
+    return false;
+  }
+}
+
 async function syncOpenPullRequests(github, owner, repo, options, core) {
-  const { maxPrs = 20, dispatchMergeGate = true, dispatchConflictScan = true } = options || {};
+  const {
+    maxPrs = 20,
+    dispatchMergeGate = true,
+    dispatchConflictScan = true,
+    maxGateDispatches = 3,
+    fallbackMergeGateScan = true,
+  } = options || {};
   await ensurePipelineLabels(github, owner, repo, core);
   let prs;
   if (maxPrs <= 100) {
@@ -272,8 +320,12 @@ async function syncOpenPullRequests(github, owner, repo, options, core) {
   let dispatched = 0;
   if (dispatchMergeGate && readyCandidates.length) {
     dispatched = await dispatchMergeGateForOldestReady(
-      github, owner, repo, readyCandidates, core
+      github, owner, repo, readyCandidates, core, { maxDispatches: maxGateDispatches }
     );
+  }
+  if (fallbackMergeGateScan && readyCandidates.length > dispatched) {
+    const stale = await shouldRunScheduledMergeGateScan(github, owner, repo, core);
+    if (stale) await triggerMergeGateScan(github, owner, repo, core);
   }
   if (dispatchConflictScan && dirtyConflict) {
     await dispatchMergeConflictScan(github, owner, repo, core);
@@ -293,6 +345,8 @@ module.exports = {
   syncPipelineLabels,
   syncOpenPullRequests,
   dispatchMergeGateForOldestReady,
+  shouldRunScheduledMergeGateScan,
+  triggerMergeGateScan,
   dispatchMergeConflictScan,
   shouldSkipConflictScanDispatch,
   CONFLICT_SCAN_DEBOUNCE_MS,

--- a/.github/workflows/auto-pr-comment.yml
+++ b/.github/workflows/auto-pr-comment.yml
@@ -34,6 +34,10 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Trigger CodeRabbit, Qodo, and Gemini reviews
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/bot-pr-recovery.yml
+++ b/.github/workflows/bot-pr-recovery.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   pull-requests: write
   issues: write
+  actions: write
 
 jobs:
   recover:
@@ -62,4 +63,9 @@ jobs:
               if (!(pr.head?.ref || '').startsWith('claude/')) continue;
               await ps.syncPipelineLabels(github, owner, repo, pr.number, core);
             }
+            await ps.syncOpenPullRequests(
+              github, owner, repo,
+              { maxPrs: 50, dispatchMergeGate: true, maxGateDispatches: 3, fallbackMergeGateScan: true },
+              core
+            );
             core.info(`Recovery complete (${orphans} orphan PR(s))`);

--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -37,7 +37,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-  MAX_CANDIDATES: 3
+  MAX_CANDIDATES: 8
   DISPATCH_PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.client_payload.pr_number || '' }}
 
 permissions:
@@ -257,7 +257,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
-          model: claude-opus-4-8
+          model: claude-sonnet-4-6
           trigger_phrase: '@claude-merge-gate-internal'
           direct_prompt: |
             You are the MERGE GATE reviewer for PraisonAIDocs PR #${{ matrix.pr_number }}.

--- a/.github/workflows/pipeline-status-sync.yml
+++ b/.github/workflows/pipeline-status-sync.yml
@@ -39,5 +39,5 @@ jobs:
             const ps = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/pipeline-status.js'));
             await ps.syncOpenPullRequests(
               github, context.repo.owner, context.repo.repo,
-              { maxPrs: 20, dispatchMergeGate: true }, core
+              { maxPrs: 50, dispatchMergeGate: true, maxGateDispatches: 3 }, core
             );


### PR DESCRIPTION
## Summary
- Raise `MAX_CANDIDATES` from 3 → 8 in `claude-merge-gate.yml` scan
- Use `claude-sonnet-4-6` for merge-gate assess (faster than Opus)
- Fix `bot-pr-trigger-reviews` missing `actions/checkout` (was breaking review chain)
- `pipeline-status.js`: dispatch up to 3 merge gates per sync cycle (not just 1)
- `pipeline-status-sync`: scan 50 PRs per run
- `bot-pr-recovery`: fallback sync + stale merge-gate scan dispatch every 30m

## Test plan
- [x] `actionlint` on changed workflows
- [ ] Merge and run `pipeline-status-sync` + `claude-merge-gate` workflow_dispatch
- [ ] Confirm `#1586–#1608` merge-ready PRs start merging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved background synchronization to handle more open pull requests at once, while limiting how many merge-gate actions are triggered per run.
  * Added a fallback scan when additional ready pull requests remain, helping ensure merge-gate checks continue to progress.

* **Bug Fixes**
  * Recovery and auto-comment workflows now better support repository access, improving reliability of automated PR processing.
  * Updated merge-gate scanning to consider more candidates and use the latest evaluation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->