### PR TITLE
fix: auto-promote draft claude PRs for merge gate

### DIFF
--- a/.github/scripts/pipeline-status.js
+++ b/.github/scripts/pipeline-status.js
@@ -301,6 +301,20 @@ async function syncOpenPullRequests(github, owner, repo, options, core) {
   const readyCandidates = [];
   let dirtyConflict = false;
   for (const pr of prs) {
+    if (pr.draft && (pr.head?.ref || '').startsWith('claude/') &&
+        pr.head?.repo?.full_name === `${owner}/${repo}`) {
+      try {
+        await github.rest.pulls.update({
+          owner, repo, pull_number: pr.number, draft: false,
+        });
+        pr.draft = false;
+        core?.info?.(`Promoted draft claude PR #${pr.number} to ready for review`);
+      } catch (err) {
+        core?.warning?.(`Could not promote draft PR #${pr.number}: ${err.message}`);
+      }
+    }
+  }
+  for (const pr of prs) {
     if (synced >= maxPrs) break;
     if (pr.draft) continue;
     if (pr.head?.repo?.full_name && pr.head.repo.full_name !== `${owner}/${repo}`) continue;

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -312,6 +312,7 @@ jobs:
             - git push -u origin "$BRANCH"
             CRITICAL: Immediately after push, run exactly:
             gh pr create --base main --head "$BRANCH" --title "docs: <title>" --body "Fixes #$ISSUE_NUMBER"
+            Do NOT use --draft. Create a normal ready-for-review PR (draft PRs are skipped by the merge gate).
             Do NOT stop after push. Do NOT ask a human to open a PR. Do NOT finish until gh pr create returns a PR URL.
             If gh pr create fails, read the error, fix (auth, duplicate PR, wrong head), and retry until it succeeds.
             Reuse the same $BRANCH for any follow-up commits — never create a second branch with a new date.


### PR DESCRIPTION
## Summary
- Claude prompt: explicit no --draft on gh pr create
- pipeline-status.js: auto-promote draft claude/* PRs to ready for review

Draft PRs were skipped by merge-gate and pipeline sync.