### PR TITLE
Fix remaining docs 404 pages (assign-agents, tool-parameter-types)

### DIFF
--- a/docs/developers/local-development.mdx
+++ b/docs/developers/local-development.mdx
@@ -1,7 +1,9 @@
 ---
 title: 'Local Development'
 description: 'Set up local development environment with Docker and live reload'
----<Note>
+---
+
+<Note>
 The PraisonAI monorepo includes sibling packages `praisonai-agents`, `praisonai-code`, and `praisonai`. See [praisonai-code Migration](/docs/guides/praisonai-code-migration) for how the agentic terminal CLI is being extracted (C0–C6).
 </Note>
 

--- a/docs/features/tool-parameter-types.mdx
+++ b/docs/features/tool-parameter-types.mdx
@@ -2,7 +2,7 @@
 title: "Tool Parameter Types"
 sidebarTitle: "Parameter Types"
 description: "Use Optional, Union, Literal, Enum, List and Dict in tool signatures and the agent sees the right schema"
-icon: "shapes"
+icon: "sliders"
 ---
 
 Use expressive Python type annotations in tool signatures and agents understand exactly what parameters they can pass.

--- a/docs/guides/platform/assign-agents.mdx
+++ b/docs/guides/platform/assign-agents.mdx
@@ -82,10 +82,8 @@ async def create_code_review_agent():
         - [actionable recommendations]
         
         ### Code Examples
-        ```[language]
-        // Improved version
-        [your suggested code]
-        ```
+        # [language] example
+        # Improved version of the suggested code
         """,
         model="gpt-4o",
         auto_assign_labels=["code-reviewed", "ai-analyzed"],
@@ -116,17 +114,15 @@ async def assign_code_review():
         description="""
         Current authentication middleware has performance issues and security concerns.
         
-        Current implementation:
-        ```python
-        def auth_middleware(request):
-            token = request.headers.get('Authorization')
-            if token:
-                user = decode_token(token)  # Expensive DB call on every request
-                if user and user.is_active:
-                    request.user = user
-                    return True
-            return False
-        ```
+        Current implementation (simplified):
+        # def auth_middleware(request):
+        #     token = request.headers.get("Authorization")
+        #     if token:
+        #         user = decode_token(token)
+        #         if user and user.is_active:
+        #             request.user = user
+        #             return True
+        #     return False
         
         Issues:
         - Database call on every request


### PR DESCRIPTION
## Summary
- Fix `guides/platform/assign-agents` MDX build failure caused by nested triple-backtick fences inside Python examples (`on_assign: True` was parsed as JSX).
- Fix `developers/local-development` frontmatter (`---` must be on its own line before `<Note>`).
- Refresh `tool-parameter-types` page metadata (icon) to trigger Mintlify rebuild for a page that never appeared in the sitemap.

## Test plan
- [x] `@mdx-js/mdx` compile passes for all three files
- [ ] After Mintlify deploy, confirm 200 for `/docs/guides/platform/assign-agents` and `/docs/features/tool-parameter-types`
- [ ] `python3 scripts/audit_docs_links.py --nav-only` shows 0 live broken pages


Made with [Cursor](https://cursor.com)