### PR TITLE
docs(gateway): five-tier diagnostics and inbound verification

### DIFF
--- a/docs/features/gateway-readiness.mdx
+++ b/docs/features/gateway-readiness.mdx
@@ -11,6 +11,35 @@ Use this checklist before starting a gateway or relying on a Slack/Telegram bot 
 ``praisonai gateway test --turn`` and ``praisonai gateway doctor --turn`` run an **offline** agent turn via ``BotSessionManager.chat``. They do **not** exercise Slack Bolt/socket handlers or @mention routing. A passing turn test does **not** guarantee live @mention delivery.
 </Warning>
 
+## Five-tier diagnostics
+
+```mermaid
+flowchart TB
+  subgraph tier1 [Tier 1 offline]
+    lint["doctor / config"]
+    shellWire["shell wiring"]
+  end
+  subgraph tier2 [Tier 2 credential probe]
+    probe["auth.test per channel"]
+  end
+  subgraph tier3 [Tier 3 runtime]
+    runtime["/health /ready /live"]
+  end
+  subgraph tier4 [Tier 4 inbound proof]
+    inbound["--check-inbound logs"]
+    dup["--check-duplicates"]
+  end
+  subgraph tier5 [Tier 5 conversation ops]
+    sessions["gateway sessions list/show"]
+    dlq["bot dlq list --path ..."]
+  end
+  tier1 --> tier2 --> tier3 --> tier4 --> tier5
+```
+
+<Note>
+**Sessions ≠ liveness.** ``gateway sessions list`` shows stored conversation history only. Use ``--check-inbound`` to verify live Slack delivery.
+</Note>
+
 ## Three-tier checklist
 
 <Steps>
@@ -45,8 +74,23 @@ Combines credential probes + offline shell wiring. Add optional flags:
 praisonai gateway test --config /path/to/bot.yaml --channel slack \
   --turn "run uname -a with execute_command and reply with raw output only"
 
-# Verify running gateway REST /info
-praisonai gateway test --config /path/to/bot.yaml --check-running
+# Verify running gateway runtime endpoints
+praisonai gateway test --config /path/to/bot.yaml --check-runtime
+
+# Scan for duplicate gateways / shared tokens
+praisonai gateway test --config /path/to/bot.yaml --check-duplicates
+
+# After messaging Slack — prove inbound delivery
+praisonai gateway test --config /path/to/bot.yaml --check-inbound --since 5m
+```
+</Step>
+
+<Step title="Extended status and sessions">
+```bash
+praisonai gateway status --deep --config /path/to/bot.yaml
+praisonai gateway status --probe --config /path/to/bot.yaml
+praisonai gateway sessions list --platform slack
+praisonai gateway sessions show U08R1HK9PJS --tail 20
 ```
 </Step>
 
@@ -74,6 +118,11 @@ If the turn test passes but Slack is silent, check for duplicate bots, stale ses
 | Config + shell wiring offline | `praisonai doctor bots --file PATH` |
 | Live tokens | `praisonai gateway doctor --config PATH` |
 | Onboarding one-shot | `praisonai gateway test --config PATH` |
+| Runtime endpoints | `praisonai gateway test --config PATH --check-runtime` |
+| Inbound delivery proof | `praisonai gateway test --config PATH --check-inbound --since 5m` |
+| Duplicate gateway scan | `praisonai gateway test --config PATH --check-duplicates` |
+| Session history | `praisonai gateway sessions list` / `show ID` |
+| Deep status + DLQ hint | `praisonai gateway status --deep --config PATH` |
 | Pre-Slack shell smoke | `praisonai gateway test --config PATH --channel slack --turn "..."` |
 | Automated start gate | `praisonai gateway start --preflight` |
 | After start | `praisonai gateway status` + log check |
@@ -87,7 +136,7 @@ praisonai gateway test --config bot.yaml --json
 praisonai gateway doctor --config bot.yaml --json --channel slack --turn "Say OK"
 ```
 
-Keys: `probes`, `secrets` (optional), `shell` (test only), `running` (with `--check-running`), `turn` (with `--turn`).
+Keys: `probes`, `secrets` (optional), `shell`, `runtime` (with `--check-runtime`), `running` (with `--check-running`), `inbound` (with `--check-inbound`), `duplicates` (with `--check-duplicates`), `turn` (with `--turn`).
 
 ### Sub-object schema
 
@@ -95,11 +144,14 @@ Each top-level key maps to a per-channel or per-check sub-object:
 
 ```json
 {
-  "probes":  { "<channel>": { "ok": bool, "platform": str, "bot_username": str?, "error": str? } },
-  "secrets": { "<channel>": { "<field>": "available" | "configured-but-unavailable" | "configured" | "missing" } },
-  "shell":   { "ok": bool, "message": str, "issues": [str] },
-  "running": { "ok": bool, "message": str },
-  "turn":    { "channel": str, "ok": bool, "response": str },
+  "probes":     { "<channel>": { "ok": bool, "platform": str, "bot_username": str?, "error": str? } },
+  "secrets":    { "<channel>": { "<field>": "available" | "configured-but-unavailable" | "configured" | "missing" } },
+  "shell":      { "ok": bool, "message": str, "issues": [str] },
+  "runtime":    { "ok": bool, "message": str },
+  "running":    { "ok": bool, "message": str },
+  "inbound":    { "ok": bool, "message": str, "events": [str] },
+  "duplicates": { "ok": bool, "message": str, "duplicates": [str] },
+  "turn":       { "channel": str, "ok": bool, "response": str },
   "gateway_auth_token": "weak"?
 }
 ```
@@ -109,7 +161,10 @@ Each top-level key maps to a per-channel or per-check sub-object:
 | `probes` | Always. |
 | `secrets` | Any channel uses a [secret reference](/docs/features/gateway-secret-references) or credential field. |
 | `shell` | `gateway test` only (not `gateway doctor`). |
+| `runtime` | `--check-runtime` is passed. |
 | `running` | `--check-running` is passed. |
+| `inbound` | `--check-inbound` is passed. |
+| `duplicates` | `--check-duplicates` is passed. |
 | `turn` | `--turn` is passed. |
 | `gateway_auth_token` | The gateway's own `auth_token` is weak. |
 


### PR DESCRIPTION
## Summary
- Document five-tier gateway diagnostics model (offline → probe → runtime → inbound → sessions)
- Add command matrix for `--check-runtime`, `--check-inbound`, `--check-duplicates`, sessions CLI, and `status --deep`
- Explicit callout: sessions reflect stored history; use `--check-inbound` for live delivery proof

## Test plan
- [x] Mintlify page renders (gateway-readiness.mdx)
- [x] Companion to PraisonAI PR for gateway diagnostics upgrade