### PR TITLE
Remove explicit canonical metatag to fix double /docs/docs/ URLs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7418,7 +7418,6 @@
   "seo": {
     "indexing": "navigable",
     "metatags": {
-      "canonical": "https://praison.ai",
       "og:site_name": "PraisonAI",
       "og:locale": "en_GB",
       "twitter:card": "summary_large_image",


### PR DESCRIPTION
## Summary
- Removes the global `seo.metatags.canonical` override from `docs/docs.json`
- Lets Mintlify auto-generate canonical URLs from page paths (same logic as the sitemap, which is already correct)
- Fixes live HTML canonical / og:url / JSON-LD still showing `https://praison.ai/docs/docs/...` after PR #2564

## Context
With docs hosted at `/docs` subpath, setting `canonical: "https://praison.ai"` caused Mintlify to prepend `/docs` again, producing double `/docs/docs/` in meta tags. Sitemap URLs were unaffected.

## Test plan
- [ ] Wait for Mintlify deploy after merge
- [ ] `curl -sL "https://praison.ai/docs/introduction" | grep canonical` → `https://praison.ai/docs/introduction`
- [ ] `curl -sL "https://praison.ai/docs/introduction" | grep 'docs/docs'` → no matches (PASS)

Made with [Cursor](https://cursor.com)