### PR TITLE
fix(seo): restore canonical origin base for subpath hosting

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7418,6 +7418,7 @@
   "seo": {
     "indexing": "navigable",
     "metatags": {
+      "canonical": "https://praison.ai",
       "og:site_name": "PraisonAI",
       "og:locale": "en_GB",
       "twitter:card": "summary_large_image",


### PR DESCRIPTION
## Summary
- Restores `seo.metatags.canonical: "https://praison.ai"` in `docs/docs.json`
- Reverts #2565 (removing canonical did not fix live HTML; production never deployed #2564/#2565)
- Live site is still on the #2563 build with `canonical: "https://praison.ai/docs"`, which produces double `/docs/docs/` paths

## Why
Mintlify appends each page's public path to the canonical base. With subpath hosting:
- `https://praison.ai/docs` + `/docs/introduction` → **broken** (`/docs/docs/introduction`)
- `https://praison.ai` + `/docs/introduction` → **correct** (`/docs/introduction`)

Sitemap is already correct after #2563; this aligns canonical/og:url/JSON-LD with it.

## Test plan
- [ ] Mintlify deploy succeeds on merge
- [ ] `curl -sL "https://praison.ai/docs/introduction" | grep canonical` → `https://praison.ai/docs/introduction`
- [ ] `curl -sL "https://praison.ai/docs/introduction" | grep docs/docs` → no matches

Made with [Cursor](https://cursor.com)