### PR TITLE
fix(seo): canonical base https://praison.ai/docs for subpath hosting

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7418,7 +7418,7 @@
   "seo": {
     "indexing": "navigable",
     "metatags": {
-      "canonical": "https://praison.ai",
+      "canonical": "https://praison.ai/docs",
       "og:site_name": "PraisonAI",
       "og:locale": "en_GB",
       "twitter:card": "summary_large_image",


### PR DESCRIPTION
## Summary
- Sets `seo.metatags.canonical` to `https://praison.ai/docs` (not origin-only)
- Matches Mintlify subpath SEO pattern ([supaschema PR #26](https://github.com/jmclaughlin724/supaschema/pull/26)): Mintlify appends `/introduction` → `https://praison.ai/docs/introduction`

## Why docs are down / SEO broken
After #2563 nav migration, page slugs no longer include a `docs/` prefix. Using `https://praison.ai` alone produced wrong canonicals; pairing with the old nginx `/docs/docs/` rewrite caused 404s on praison.ai/docs.

## Test plan
- [ ] Mintlify deploy succeeds after merge
- [ ] After helmcharts nginx fix is deployed: `curl -sI https://praison.ai/docs/introduction` → 200
- [ ] Canonical: `https://praison.ai/docs/introduction`

Made with [Cursor](https://cursor.com)