### PR TITLE
feat: document delegation and HITL limitations

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -750,6 +750,7 @@
                   "features/delegate-task",
                   "features/named-agent-delegation",
                   "features/cli-subagent-delegation",
+                  "features/delegation-hitl-limitations",
                   "features/managed-config-layer",
                   "features/upgrade-uninstall",
                   "features/job-completed-hook",

--- a/docs/features/delegation-hitl-limitations.mdx
+++ b/docs/features/delegation-hitl-limitations.mdx
@@ -1,0 +1,87 @@
+---
+title: "Delegation & HITL Limitations"
+sidebarTitle: "Delegation Limitations"
+description: "Current behavior and known limitations of delegated sub-agent runs and human-in-the-loop (HITL) approval pauses"
+icon: "triangle-exclamation"
+---
+
+This page describes the current behavior of delegated sub-agent runs and the known limitations around human-in-the-loop (HITL) approval pauses.
+
+<Warning>
+Do not assume delegated sub-agent runs are durable, restart-safe, or resumable after a HITL pause. The pieces required for resumable delegation are listed below.
+</Warning>
+
+## Current behavior
+
+`delegate_task` is wired to real sub-agent creation, but delegated children still execute as synchronous, blocking, in-memory runs.
+
+That means:
+
+- A parent tool call can block while the delegated child runs.
+- A delegated child is not guaranteed to survive a process restart.
+- If a child reaches an approval pause, the parent has no durable way to resume that child in place.
+- There is no stable child-run result contract for `pending`, `completed`, and `halted` states.
+
+## Supported workaround
+
+For long-running or potentially blocking sub-agent work, use the background sub-agent path instead of synchronous delegation:
+
+```python
+job = spawn_subagent(..., background=True)
+result = subagent_result(job['job_id'], wait=True)
+```
+
+`subagent_result` defaults to `wait=False`, which returns immediately with a
+`{"status": "running", ...}` handle if the job has not finished. Pass `wait=True`
+(or poll until `status` is terminal) to collect the completed output.
+
+This avoids blocking the parent turn, but it is not a full HITL resume flow. Background polling does not yet provide durable approval routing or continuation of a paused child.
+
+## Missing pieces for resumable delegation
+
+The following pieces are required before delegated children can be considered resumable:
+
+1. Durable child session persistence through the session store.
+2. A child-run result-state contract, for example `pending`, `completed`, `failed`, and `halted`.
+3. HITL bubble-up from child to parent, so an approval pause creates a durable pending handle.
+4. A `drive_child` or equivalent continuation seam to resume the paused child.
+5. Ownership and lifecycle rules for cancellation, timeouts, and result collection.
+
+## Recommended next step
+
+Prefer a core-first increment: introduce an internal `v0` child-run pause/resume contract before designing the full gateway UX. The first contract should be explicitly internal and anti-freeze: the resume handle should remain opaque so later metadata such as approval IDs, gateway routing, or cancellation state can be added without changing the parent-facing shape.
+
+A possible `v0` state shape is:
+
+```python
+from typing import Any, Literal, TypedDict
+
+class ChildRunStateV0(TypedDict):
+    schema_version: Literal['v0']
+    child_run_id: str
+    parent_run_id: str
+    status: Literal['pending', 'completed', 'failed', 'halted']
+    pause_reason: Literal['approval_required'] | None
+    resume_token: str | None
+    result: Any | None
+    error: str | None
+```
+
+Semantics:
+
+- `pending`: the child reached a HITL approval pause; the parent should receive a
+  durable handle rather than block indefinitely. `pause_reason` is set (e.g.
+  `approval_required`) and `resume_token` is non-null so the parent can continue
+  the child. `result` and `error` are null.
+- `completed`: the child reached a terminal **success** state; the parent can
+  collect the output from `result`. `pause_reason`, `resume_token`, and `error`
+  are null.
+- `failed`: the child reached a terminal **failure** state; failure details are
+  available in `error`. `pause_reason`, `resume_token`, and `result` are null.
+- `halted`: the child was cancelled or stopped in a non-resumable way that is not
+  a normal success/failure (e.g. timeout or explicit cancellation). `pause_reason`
+  and `resume_token` are null.
+
+Separating `completed` (success) from `failed` (failure) lets consumers classify
+terminal outcomes consistently and know exactly where to read the result or the
+failure reason.


### PR DESCRIPTION
Fixes MervinPraison/PraisonAI#3761

Adds documentation for delegated sub-agent behavior and current HITL limitations. Content was originally proposed in MervinPraison/PraisonAI#3888 but belongs in the docs repo per AGENTS.md routing.

## Changes
- New page features/delegation-hitl-limitations.mdx (registered in docs.json under the delegation group).
- Documents synchronous, non-durable delegated runs and HITL pause limitations.
- Background-subagent workaround uses subagent_result with wait=True (Greptile P1 fix; default wait=False returns a running handle).
- ChildRunStateV0 now distinguishes terminal success (completed) from terminal failure (failed), with explicit result/error fields and documented null semantics for pause_reason/resume_token (CodeRabbit fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on delegated sub-agent and human-in-the-loop limitations.
  * Documented synchronous execution, pause and resume constraints, and child-run result behavior.
  * Added a background sub-agent workaround, including polling behavior and remaining limitations.
  * Proposed requirements and state semantics for resumable delegation.
  * Added the new page to the Safety & Control documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->