### PR TITLE
Document Context.dev tools

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2290,6 +2290,7 @@
                   "tools/spider_tools",
                   "tools/newspaper_tools",
                   "tools/trafilatura",
+                  "tools/external/context",
                   "tools/external/firecrawl",
                   "tools/external/crawl4ai",
                   "tools/external/agentql-toolkit",

--- a/docs/tools/external/context.mdx
+++ b/docs/tools/external/context.mdx
@@ -1,0 +1,214 @@
+---
+title: "Context.dev"
+sidebarTitle: "Context.dev"
+description: "Live web search, scraping, extraction, brand intelligence, monitors, and batches for PraisonAI agents"
+icon: "globe"
+---
+
+Give a PraisonAI agent current web data and structured website intelligence through Context.dev.
+
+```python
+from praisonaiagents import Agent
+from praisonai_tools import ContextToolkit
+
+agent = Agent(
+    name="web-researcher",
+    instructions="Use Context.dev for current web research and cite source URLs.",
+    tools=ContextToolkit().get_tools(),
+)
+
+agent.start("Find Context.dev's latest public product updates and summarize them.")
+```
+
+```mermaid
+graph LR
+    User[User] --> Agent[PraisonAI Agent]
+    Agent --> Tool[Context.dev Tool]
+    Tool --> API[Live Web and Context API]
+    API --> Result[Grounded Result]
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef process fill:#189AB4,stroke:#7C90A0,color:#fff
+    classDef output fill:#10B981,stroke:#7C90A0,color:#fff
+
+    class User,Agent input
+    class Tool,API process
+    class Result output
+```
+
+## Quick Start
+
+<Steps>
+<Step title="Install the integration">
+
+```bash
+pip install "praisonai-tools[context]"
+```
+
+</Step>
+<Step title="Configure your API key">
+
+```bash
+export CONTEXT_DEV_API_KEY="your-context-api-key"
+```
+
+Create an API key in the [Context.dev dashboard](https://app.context.dev/).
+
+</Step>
+<Step title="Add Context.dev to an agent">
+
+```python
+from praisonaiagents import Agent
+from praisonai_tools import ContextSearch, ContextScrape
+
+agent = Agent(
+    name="researcher",
+    instructions="Search first, then scrape the most useful sources.",
+    tools=[ContextSearch(), ContextScrape()],
+)
+
+agent.start("What did Stripe launch most recently? Include source links.")
+```
+
+</Step>
+</Steps>
+
+## Choose the Tools You Need
+
+Use focused tools for small agents:
+
+```python
+from praisonai_tools import (
+    ContextCrawl,
+    ContextExtract,
+    ContextParse,
+    ContextScrape,
+    ContextSearch,
+    ContextSitemap,
+)
+
+tools = [
+    ContextSearch(),
+    ContextScrape(),
+    ContextCrawl(),
+    ContextSitemap(),
+    ContextExtract(),
+    ContextParse(),
+]
+```
+
+Use a toolkit when an agent needs a broader capability set:
+
+| Toolkit | Capabilities |
+|---|---|
+| `ContextWebToolkit` | Search, scraping, crawling, sitemap discovery, extraction, screenshots, and document parsing |
+| `ContextBrandToolkit` | Brand profiles, style guides, fonts, NAICS, and SIC classification |
+| `ContextMonitorToolkit` | Website monitors, runs, changes, and usage |
+| `ContextBatchToolkit` | Large asynchronous jobs and result retrieval |
+| `ContextToolkit` | The complete public Context.dev catalog |
+
+The combined toolkit exposes 26 safe tools by default. Monitor and batch operations that change external state require an explicit opt-in:
+
+```python
+from praisonai_tools import ContextToolkit
+
+tools = ContextToolkit(
+    include_write_tools=True,
+    allow_browser_actions=True,
+).get_tools()
+```
+
+## Common Workflows
+
+<AccordionGroup>
+<Accordion title="Search the live web">
+
+```python
+from praisonai_tools import ContextSearch
+
+result = ContextSearch().run(
+    query="latest official Stripe product announcements",
+    numResults=10,
+    includeDomains=["stripe.com"],
+    freshness="month",
+)
+```
+
+</Accordion>
+<Accordion title="Extract structured data">
+
+```python
+from praisonai_tools import ContextExtract
+
+result = ContextExtract().run(
+    url="https://www.context.dev/pricing",
+    schema={
+        "type": "object",
+        "properties": {
+            "plans": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "price": {"type": "string"},
+                    },
+                    "required": ["name", "price"],
+                },
+            }
+        },
+        "required": ["plans"],
+    },
+)
+```
+
+</Accordion>
+<Accordion title="Parse a local document">
+
+```python
+from praisonai_tools import ContextParse
+
+result = ContextParse().run(
+    file_path="./report.pdf",
+    extension="pdf",
+    includeLinks=True,
+)
+```
+
+</Accordion>
+<Accordion title="Process a large URL list">
+
+```python
+from praisonai_tools import ContextBatchToolkit
+
+batch_tools = ContextBatchToolkit(include_write_tools=True).get_tools()
+```
+
+Pass `batch_tools` to an agent that needs to submit a job, check its status, and page through its results.
+
+</Accordion>
+</AccordionGroup>
+
+## Safety Defaults
+
+- Browser actions are omitted from scrape tool schemas unless `allow_browser_actions=True`.
+- Tools that create, update, run, cancel, or delete monitors and batches are omitted unless `include_write_tools=True`.
+- API credentials are read from `CONTEXT_DEV_API_KEY`; `CONTEXT_API_KEY` remains supported as a legacy alias.
+- Tool responses omit internal debug and request metadata before they reach the agent.
+
+## Related Resources
+
+<CardGroup cols={2}>
+  <Card title="Context.dev API documentation" icon="book" href="https://docs.context.dev">
+    Explore endpoint inputs, outputs, and usage examples.
+  </Card>
+  <Card title="Tools overview" icon="wrench" href="/tools/tools">
+    Learn how PraisonAI agents call tools.
+  </Card>
+  <Card title="Firecrawl" icon="fire" href="/tools/external/firecrawl">
+    Compare another web scraping integration.
+  </Card>
+  <Card title="Exa" icon="brain" href="/tools/external/exa">
+    Compare another web search integration.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- document Context.dev setup for PraisonAI agents
- cover focused tools, the four capability toolkits, safe defaults, and common search, extraction, parsing, and batch workflows
- add the page to the external tools navigation

Companion tools PR: https://github.com/MervinPraison/PraisonAI-Tools/pull/87

## Validation

- `python3 -m json.tool docs/docs.json`
- `git diff --check`
- `npx mintlify validate`

Mintlify reaches full build validation. It reports the same three warnings on a clean `upstream/main` checkout: existing MDX parse warnings in `features/checkpoints.mdx` and `train.mdx`, plus the existing generated Rust `LLMMessage` navigation warning. The new Context.dev page adds no warnings.