### PR TITLE
docs: add gateway cost routing example

### DIFF
--- a/docs/features/llm-gateways.mdx
+++ b/docs/features/llm-gateways.mdx
@@ -135,6 +135,110 @@ graph TD
 
 ---
 
+## Route Gateway Models by Cost
+
+Use custom `ModelProfile` entries when one OpenAI-compatible gateway exposes
+multiple models. The router selects a model name from your metadata; `LLM`
+then sends the request to the shared endpoint.
+
+```mermaid
+graph LR
+    Task[Task] --> Router[Model Router]
+    Router --> Model[Selected Model]
+    Model --> Gateway[OpenAI-compatible Gateway]
+
+    classDef input fill:#8B0000,stroke:#7C90A0,color:#fff
+    classDef router fill:#F59E0B,stroke:#7C90A0,color:#fff
+    classDef model fill:#6366F1,stroke:#7C90A0,color:#fff
+    classDef gateway fill:#189AB4,stroke:#7C90A0,color:#fff
+
+    class Task input
+    class Router router
+    class Model model
+    class Gateway gateway
+```
+
+<Steps>
+
+<Step title="Set gateway credentials">
+
+Keep the endpoint and key outside your source code:
+
+```bash
+export OPENAI_BASE_URL="${OPENAI_BASE_URL:?Set OPENAI_BASE_URL in your shell}"
+export OPENAI_API_KEY="${OPENAI_API_KEY:?Set OPENAI_API_KEY in your shell}"
+export GATEWAY_FAST_MODEL="${GATEWAY_FAST_MODEL:?Set GATEWAY_FAST_MODEL in your shell}"
+export GATEWAY_REASONING_MODEL="${GATEWAY_REASONING_MODEL:?Set GATEWAY_REASONING_MODEL in your shell}"
+```
+
+</Step>
+
+<Step title="Describe the available models">
+
+Replace the placeholder capabilities and costs with values published by your
+gateway. PraisonAI does not maintain gateway-specific pricing.
+
+```python
+import os
+
+from praisonaiagents import Agent
+from praisonaiagents.llm import (
+    LLM,
+    ModelProfile,
+    ModelRouter,
+    TaskComplexity,
+)
+
+gateway_url = os.environ["OPENAI_BASE_URL"]
+gateway_key = os.environ["OPENAI_API_KEY"]
+fast_model = os.environ["GATEWAY_FAST_MODEL"]
+reasoning_model = os.environ["GATEWAY_REASONING_MODEL"]
+
+models = [
+    ModelProfile(
+        name=f"openai/{fast_model}",
+        provider="gateway",
+        complexity_range=(TaskComplexity.SIMPLE, TaskComplexity.MODERATE),
+        cost_per_1k_tokens=0.001,
+        strengths=["speed", "summarization"],
+        capabilities=["text"],
+        context_window=32_000,
+    ),
+    ModelProfile(
+        name=f"openai/{reasoning_model}",
+        provider="gateway",
+        complexity_range=(TaskComplexity.MODERATE, TaskComplexity.VERY_COMPLEX),
+        cost_per_1k_tokens=0.01,
+        strengths=["reasoning", "analysis"],
+        capabilities=["text", "function-calling"],
+        context_window=128_000,
+    ),
+]
+
+task = "Summarize this support conversation"
+router = ModelRouter(models=models)
+selected_model = router.select_model(task, budget_conscious=True)
+
+llm = LLM(
+    model=selected_model,
+    base_url=gateway_url,
+    api_key=gateway_key,
+)
+agent = Agent(name="assistant", llm=llm)
+agent.start(task)
+```
+
+</Step>
+
+</Steps>
+
+<Note>
+`ModelProfile` stores selection metadata only. Configure `base_url` and
+`api_key` on `LLM`; they are not fields on the profile.
+</Note>
+
+---
+
 ## How It Works
 
 ```mermaid


### PR DESCRIPTION
## Summary

- document provider-neutral OpenAI-compatible gateway configuration
- show custom `ModelProfile` entries for cost-aware model routing
- keep endpoint, credentials, and model IDs in environment variables
- clarify that routing metadata is separate from `LLM` connection settings

## Validation

- verified `ModelProfile`, `ModelRouter`, `TaskComplexity`, and `LLM`
  against the synced SDK source
- ran the model-routing selection logic
- validated the Bash and Python examples
- ran `python3 scripts/check_nav.py`
- ran `git diff --check`
- ran the merge-gate self-tests

Addresses MervinPraison/PraisonAI#4015.